### PR TITLE
Renamed Platform trait to GraphicsContext

### DIFF
--- a/src/gfx/device/mod.rs
+++ b/src/gfx/device/mod.rs
@@ -20,7 +20,7 @@ use std::comm;
 use std::comm::DuplexStream;
 use std::kinds::marker;
 
-use Platform;
+use GraphicsContext;
 
 #[cfg(gl)] mod gl;
 
@@ -121,11 +121,11 @@ pub struct Server<P> {
     no_send: marker::NoSend,
     no_share: marker::NoShare,
     stream: DuplexStream<Reply, Request>,
-    platform: P,
+    graphics_context: P,
     device: Device,
 }
 
-impl<Api, P: Platform<Api>> Server<P> {
+impl<Api, P: GraphicsContext<Api>> Server<P> {
     /// Update the platform. The client must manually update this on the main
     /// thread.
     pub fn update(&mut self) -> bool {
@@ -173,7 +173,7 @@ impl<Api, P: Platform<Api>> Server<P> {
                 Err(comm::Disconnected) => return false,
             }
         }
-        self.platform.swap_buffers();
+        self.graphics_context.swap_buffers();
         true
     }
 }
@@ -181,7 +181,7 @@ impl<Api, P: Platform<Api>> Server<P> {
 #[deriving(Show)]
 pub enum InitError {}
 
-pub fn init<Api, P: Platform<Api>>(platform: P, options: super::Options)
+pub fn init<Api, P: GraphicsContext<Api>>(graphics_context: P, options: super::Options)
         -> Result<(Client, Server<P>), InitError> {
     let (client_stream, server_stream) = comm::duplex();
 
@@ -193,7 +193,7 @@ pub fn init<Api, P: Platform<Api>>(platform: P, options: super::Options)
         no_send: marker::NoSend,
         no_share: marker::NoShare,
         stream: server_stream,
-        platform: platform,
+        graphics_context: graphics_context,
         device: dev,
     };
 

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -65,7 +65,7 @@ extern crate libc;
 pub use Renderer = render::Client;
 pub use Device = device::Server;
 pub use device::InitError;
-pub use platform::Platform;
+pub use platform::GraphicsContext;
 pub use render::target::ClearData;
 
 pub type Options<'a> = &'a platform::GlProvider;
@@ -74,9 +74,9 @@ mod device;
 mod render;
 pub mod platform;
 
-pub fn start<Api, P: Platform<Api>>(platform: P, options: Options)
+pub fn start<Api, P: GraphicsContext<Api>>(graphics_context: P, options: Options)
         -> Result<(Renderer, Device<P>), InitError> {
-    device::init(platform, options).map(|(server, client)| {
+    device::init(graphics_context, options).map(|(server, client)| {
         ((render::start(options, server), client))
     })
 }

--- a/src/gfx/platform/glfw.rs
+++ b/src/gfx/platform/glfw.rs
@@ -16,20 +16,20 @@ extern crate glfw;
 
 use self::glfw::Context;
 
-use platform::{GlApi, Platform};
+use platform::{GlApi, GraphicsContext};
 
-pub struct GlfwPlatform<C> {
+pub struct GlfwGraphicsContext<C> {
     pub context: C,
 }
 
-impl<C: Context> GlfwPlatform<C> {
-    pub fn new(context: C) -> GlfwPlatform<C> {
+impl<C: Context> GlfwGraphicsContext<C> {
+    pub fn new(context: C) -> GlfwGraphicsContext<C> {
         context.make_current();
-        GlfwPlatform { context: context }
+        GlfwGraphicsContext { context: context }
     }
 }
 
-impl<C: Context> Platform<GlApi> for GlfwPlatform<C> {
+impl<C: Context> GraphicsContext<GlApi> for GlfwGraphicsContext<C> {
     fn swap_buffers(&self) {
         self.context.swap_buffers();
     }

--- a/src/gfx/platform/mod.rs
+++ b/src/gfx/platform/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(glfw)] pub use Glfw = self::glfw::GlfwPlatform;
+#[cfg(glfw)] pub use Glfw = self::glfw::GlfwGraphicsContext;
 // #[cfg(sdl2)] pub use Sdl2 = sdl2::Sdl2Platform; // TODO
 // #[cfg(d3d)] pub use D3d = d3d::D3dPlatform; // TODO
 //
@@ -23,7 +23,7 @@
 pub enum GlApi {}
 pub enum D3dApi {}
 
-pub trait Platform<Api> {
+pub trait GraphicsContext<Api> {
     fn swap_buffers(&self);
 }
 


### PR DESCRIPTION
I feel like this more clearly indicates the focus of this trait. By renaming this to GraphicsContext we're free to keep another trait named Platform in our app or engine that's concerned with window management, input, signaling shutdown and so on. We don't really want to put that kind of detail into this crate.
