### PR TITLE
Added initial support for different Shader languages.

### DIFF
--- a/src/device/gl/mod.rs
+++ b/src/device/gl/mod.rs
@@ -29,12 +29,14 @@ pub type Surface        = gl::types::GLuint;
 pub type Texture        = gl::types::GLuint;
 pub type Sampler        = gl::types::GLuint;
 
-pub struct Device;
+// We don't want this to be created without calling new(),
+// so we give it a private field
+pub struct Device(());
 
 impl Device {
     pub fn new(provider: &super::GlProvider) -> Device {
         gl::load_with(|s| provider.get_proc_address(s));
-        Device
+        Device(())
     }
 
     #[allow(dead_code)]
@@ -62,7 +64,7 @@ impl super::DeviceTask for Device {
         name
     }
 
-    fn create_shader(&mut self, stage: super::shade::Stage, code: &[u8]) -> Result<Shader, ()> {
+    fn create_shader(&mut self, stage: super::shade::Stage, code: super::shade::ShaderSource) -> Result<Shader, super::shade::CreateShaderError> {
         let (name, info) = shade::create_shader(stage, code);
         info.map(|info| {
             let level = if name.is_err() { log::ERROR } else { log::WARN };

--- a/src/device/shade.rs
+++ b/src/device/shade.rs
@@ -210,3 +210,53 @@ impl UniformVar {
         }
     }
 }
+
+#[deriving(Show, Clone)]
+pub enum DeviceShader {
+    StaticBytes(&'static [u8]),
+    OwnedBytes(Vec<u8>),
+    NotProvided
+}
+
+impl DeviceShader {
+    pub fn as_ref<'a>(&'a self) -> Option<&'a [u8]> {
+        match *self {
+            StaticBytes(ref b) => Some(b.as_slice()),
+            OwnedBytes(ref b) => Some(b.as_slice()),
+            NotProvided => None
+        }
+    }
+    pub fn is_provided(&self) -> bool {
+        match *self {
+            NotProvided => false,
+            _ => true
+        }
+    }
+}
+
+#[deriving(Show, Clone)]
+pub struct ShaderSource {
+    pub glsl_120: DeviceShader,
+    pub glsl_150: DeviceShader,
+    // TODO: hlsl_sm_N...
+}
+
+pub static NOT_PROVIDED: ShaderSource = ShaderSource {
+    glsl_120: NotProvided,
+    glsl_150: NotProvided
+};
+
+impl ShaderSource {
+    pub fn as_bytes(&self) -> &'static [u8] {
+        match self.glsl_120 {
+            StaticBytes(b) => b,
+            _ => fail!("Expected static bytes")
+        }
+    }
+}
+
+#[deriving(Show)]
+pub enum CreateShaderError {
+    NoSupportedShaderProvided,
+    ShaderCompilationFailed
+}

--- a/src/examples/triangle/main.rs
+++ b/src/examples/triangle/main.rs
@@ -1,7 +1,20 @@
+#![feature(phase)]
+
+#[phase(link, plugin)]
 extern crate gfx;
 extern crate glfw;
 
-static VERTEX_SRC: &'static [u8] = b"
+static VERTEX_SRC: gfx::ShaderSource = shaders! {
+GLSL_120: b"
+    #version 120
+    attribute vec2 a_Pos;
+    varying vec4 v_Color;
+    void main() {
+        v_Color = vec4(a_Pos+0.5, 0.0, 1.0);
+        gl_Position = vec4(a_Pos, 0.0, 1.0);
+    }
+"
+GLSL_150: b"
     #version 150 core
     in vec2 a_Pos;
     out vec4 v_Color;
@@ -9,16 +22,26 @@ static VERTEX_SRC: &'static [u8] = b"
         v_Color = vec4(a_Pos+0.5, 0.0, 1.0);
         gl_Position = vec4(a_Pos, 0.0, 1.0);
     }
-";
+"
+};
 
-static FRAGMENT_SRC: &'static [u8] = b"
+static FRAGMENT_SRC: gfx::ShaderSource = shaders! {
+GLSL_120: b"
+    #version 120
+    varying vec4 v_Color;
+    void main() {
+        gl_FragColor = v_Color;
+    }
+"
+GLSL_150: b"
     #version 150 core
     in vec4 v_Color;
     out vec4 o_Color;
     void main() {
         o_Color = v_Color;
     }
-";
+"
+};
 
 #[start]
 fn start(argc: int, argv: *const *const u8) -> int {
@@ -47,8 +70,8 @@ fn main() {
     spawn(proc() {
         let mut renderer = renderer.unwrap();
         let program = renderer.create_program(
-            VERTEX_SRC.to_owned(),
-            FRAGMENT_SRC.to_owned());
+            VERTEX_SRC.clone(),
+            FRAGMENT_SRC.clone());
         let frame = gfx::Frame::new();
         let mut env = gfx::Environment::new();
         env.add_uniform("color", gfx::ValueF32Vec([0.1, 0.1, 0.1, 0.1]));

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -41,6 +41,7 @@ pub use device::target::{Color, ClearData, Plane, TextureLayer, TextureLevel};
 pub use device::target::{PlaneEmpty, PlaneSurface, PlaneTexture, PlaneTextureLayer};
 pub use device::{GraphicsContext, InitError, Options};
 pub use device::shade::{UniformValue, ValueI32, ValueF32, ValueI32Vec, ValueF32Vec, ValueF32Matrix};
+pub use device::shade::{ShaderSource, StaticBytes, NOT_PROVIDED};
 #[cfg(glfw)] pub use GlfwPlatform = platform::Glfw;
 
 #[allow(visible_private_types)]
@@ -49,4 +50,24 @@ pub fn start<Api, P: GraphicsContext<Api>, T: device::GlProvider>(graphics_conte
     device::init(graphics_context, options).map(|(tx, rx, server, ack)| {
         (Renderer::new(tx, rx, ack), server)
     })
+}
+
+// This should live in `device`, but macro reexporting does not work yet.
+#[macro_export]
+macro_rules! shaders {
+    (GLSL_120: $v:expr $($t:tt)*) => {
+        ::gfx::ShaderSource {
+            glsl_120: ::gfx::StaticBytes($v),
+            ..shaders!($($t)*)
+        }
+    };
+    (GLSL_150: $v:expr $($t:tt)*) => {
+        ::gfx::ShaderSource {
+            glsl_150: ::gfx::StaticBytes($v),
+            ..shaders!($($t)*)
+        }
+    };
+    () => {
+        ::gfx::NOT_PROVIDED
+    }
 }

--- a/src/render/lib.rs
+++ b/src/render/lib.rs
@@ -25,7 +25,7 @@ extern crate device;
 
 use std::sync::Future;
 
-use device::shade::{ProgramMeta, Vertex, Fragment, UniformValue};
+use device::shade::{ProgramMeta, Vertex, Fragment, UniformValue, ShaderSource};
 use device::target::{ClearData, TargetColor, TargetDepth, TargetStencil};
 use envir::BindableStorage;
 pub use BufferHandle = device::dev::Buffer;
@@ -142,7 +142,7 @@ impl Renderer {
         self.swap_ack.recv();  //wait for acknowlegement
     }
 
-    pub fn create_program(&mut self, vs_src: Vec<u8>, fs_src: Vec<u8>) -> ProgramHandle {
+    pub fn create_program(&mut self, vs_src: ShaderSource, fs_src: ShaderSource) -> ProgramHandle {
         self.device_tx.send(device::CallNewShader(Vertex, vs_src));
         self.device_tx.send(device::CallNewShader(Fragment, fs_src));
         let h_vs = match self.device_rx.recv() {


### PR DESCRIPTION
Instead of a `&[u8]` or `Vec<u8>`, shaders are now represented by a
`ShaderSource` type that can contain different shader source
languages. The device then selects the right one at runtime.
