### PR TITLE
Made glfw window creation use a proper builder pattern

### DIFF
--- a/src/examples/triangle/main.rs
+++ b/src/examples/triangle/main.rs
@@ -51,8 +51,10 @@ fn start(argc: int, argv: *const *const u8) -> int {
 fn main() {
     let glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
-    let (mut window, events) =
-        gfx::glfw::create_default_window(&glfw, 300, 300, "Hello this is window", glfw::Windowed)
+    let (mut window, events) = gfx::glfw::WindowBuilder::new(&glfw)
+        .title("Hello this is window")
+        .try_modern_context_hints()
+        .create()
         .expect("Failed to create GLFW window.");
 
     glfw.set_error_callback(glfw::FAIL_ON_ERRORS);

--- a/src/glfw_platform/lib.rs
+++ b/src/glfw_platform/lib.rs
@@ -63,70 +63,155 @@ impl<C: Context> device::GraphicsContext<device::GlBackEnd> for Platform<C> {
     }
 }
 
-pub fn create_window<'glfw, 'title, 'monitor, 'hints>(
+/// Builder for a GLFW window.
+///
+/// Its lifetime paramters correspond to different attributes:
+///
+/// - `'glfw`: The `&'glfw Glfw` value the `WindowBuilder` got constructed with.
+/// - `'title`: The `&'title str` choosen as an title, if any.
+/// - `'monitor`: The `WindowMode<'monitor>` choosen for the window, if any.
+///
+pub struct WindowBuilder<'glfw, 'title, 'monitor> {
     glfw: &'glfw glfw::Glfw,
-    width: u32,
-    height: u32,
-    title: &'title str,
-    mode: glfw::WindowMode<'monitor>,
-    preferred_setup: &'hints [glfw::WindowHint],
-) -> CreateWindow<'glfw, 'title, 'monitor, 'hints> {
-    CreateWindow {
-        glfw: glfw,
-        args: (width, height, title, mode),
-        hints: vec![preferred_setup],
+    size: Option<(u32, u32)>,
+    title: Option<&'title str>,
+    mode: Option<glfw::WindowMode<'monitor>>,
+    common_hints: Vec<glfw::WindowHint>,
+    try_hints: Vec<Vec<glfw::WindowHint>>,
+}
+
+impl<'glfw, 'title, 'monitor> WindowBuilder<'glfw, 'title, 'monitor> {
+    /// Creates a new `WindowBuilder` for a existing `Glfw` value
+    pub fn new(glfw: &'glfw glfw::Glfw) -> WindowBuilder<'glfw, 'title, 'monitor> {
+        WindowBuilder {
+            glfw: glfw,
+            size: None,
+            title: None,
+            mode: None,
+            try_hints: vec![],
+            common_hints: vec![],
+        }
     }
 }
 
-pub fn create_default_window(
-    glfw: &glfw::Glfw,
-    width: u32,
-    height: u32,
-    title: &str,
-    mode: glfw::WindowMode
-) -> Option<(glfw::Window, Receiver<(f64, glfw::WindowEvent)>)> {
-    create_window(glfw, width, height, title, mode, [
-        glfw::ContextVersion(3, 2),
-        glfw::OpenglForwardCompat(true),
-        glfw::OpenglProfile(glfw::OpenGlCoreProfile),
-    ])
-    .fallback([
-        glfw::ContextVersion(2, 1),
-    ])
-    .init().map(|(window, events)| {
-        info!("[glfw_platform] Initialized with context version {}", window.get_context_version());
-        (window, events)
-    })
-}
-
-pub struct CreateWindow<'glfw, 'title, 'monitor, 'hints> {
-    glfw: &'glfw glfw::Glfw,
-    args: (u32, u32, &'title str, glfw::WindowMode<'monitor>),
-    hints: Vec<&'hints [glfw::WindowHint]>,
-}
-
-impl<'glfw, 'title, 'monitor, 'hints> CreateWindow<'glfw, 'title, 'monitor, 'hints> {
-    pub fn fallback(mut self, f: &'hints [glfw::WindowHint])
-    -> CreateWindow<'glfw, 'title, 'monitor, 'hints> {
-        self.hints.push(f);
+impl<'glfw, 'title, 'monitor, 'hints> WindowBuilder<'glfw, 'title, 'monitor> {
+    /// Sets the size of the GLFW window to `width x height`.
+    /// Defaults to `640 x 480` if not given.
+    pub fn size(mut self, width: u32, height: u32)
+    -> WindowBuilder<'glfw, 'title, 'monitor> {
+        self.size = Some((width, height));
         self
     }
-    pub fn init(self) -> Option<(glfw::Window, Receiver<(f64, glfw::WindowEvent)>)> {
-        let CreateWindow {
-            glfw,
-            mut hints,
-            args: (width, height, title, mode),
-        } = self;
+
+    /// Sets the title of the GLFW window to `title`.
+    /// Defaults to `"GLFW Window"` if not given.
+    pub fn title(mut self, title: &'title str)
+    -> WindowBuilder<'glfw, 'title, 'monitor> {
+        self.title = Some(title);
+        self
+    }
+
+    /// Sets the mode of the GLFW window to `mode`.
+    /// Defaults to `Windowed` if not given.
+    pub fn mode(mut self, mode: glfw::WindowMode<'monitor>)
+    -> WindowBuilder<'glfw, 'title, 'monitor> {
+        self.mode = Some(mode);
+        self
+    }
+
+    /// Adds a list of `WindowHint`s to try creating a window with.
+    ///
+    /// If multiple `try_hints()` calls are present, then only one of them
+    /// will be applied (the first that lead to a successful window creation).
+    ///
+    /// This method works in combination with `common_hints()` to create
+    /// a list of fallback window configurations to try initializing with.
+    /// For details, see `create()`.
+    pub fn try_hints(mut self, hints: &[glfw::WindowHint])
+    -> WindowBuilder<'glfw, 'title, 'monitor> {
+        self.try_hints.push(hints.iter().map(|&x| x).collect());
+        self
+    }
+
+    /// Adds a list of `WindowHint`s for the window to be created.
+    ///
+    /// If multiple `common_hints()` calls are present, they will all be
+    /// applied for the created window in the order they where given.
+    ///
+    /// This method works in combination with `try_hints()` to create
+    /// a list of fallback window configurations to try initializing with.
+    /// For details, see `create()`.
+    pub fn common_hints(mut self, hints: &[glfw::WindowHint])
+    -> WindowBuilder<'glfw, 'title, 'monitor> {
+        self.common_hints.extend(hints.iter().map(|&x| x));
+        self
+    }
+
+    /// Applies a number of `try_hints()` with the goal of getting
+    /// a modern OpenGL context version.
+    ///
+    /// Modern in this context is defined as providing
+    /// GLSL support, and providing as many extensions as possible,
+    /// ideally approaching version 3.2 or higher.
+    ///
+    /// Specifically, this adds two `try_hints()` calls that try for 3.2 core and 2.0,
+    /// in that order.
+    ///
+    /// This method exists as a cross-platform compatible way to get a context that
+    /// supports newer OpenGL feature under OS X, as 10.7+ supports OpenGL
+    /// 3.2 but defaults to a 2.1 context that does _not_ expose the additional
+    /// extensions.
+    pub fn try_modern_context_hints(self)
+    -> WindowBuilder<'glfw, 'title, 'monitor> {
+        self.try_hints([
+            glfw::ContextVersion(3, 2),
+            glfw::OpenglForwardCompat(true),
+            glfw::OpenglProfile(glfw::OpenGlCoreProfile),
+        ])
+        .try_hints([
+            glfw::ContextVersion(2, 0),
+        ])
+    }
+
+    /// Try to create the window.
+    ///
+    /// This method tries each of the possible window hints given
+    /// with `try_hints()` in order, returning the first one that succeeds.
+    ///
+    /// In order for that to work, it has to disable the `Glfw` error callback,
+    /// so you'll have to rebind it afterwards.
+    ///
+    /// For every set of window hints given with a `try_hints()`, this method
+    ///
+    /// - Applies the window hints of all `common_hints()` given.
+    /// - Applies the window hints of the current `try_hints()`.
+    /// - Tries to call `glfw.create_window()` with the given arguments
+    ///   (or default values).
+    /// - Returns on successful window creation.
+    pub fn create(self) -> Option<(glfw::Window, Receiver<(f64, glfw::WindowEvent)>)> {
+        let WindowBuilder { glfw, common_hints, try_hints, size, title, mode } = self;
+
+        let (width, height) = size.unwrap_or((640, 480));
+        let title = title.unwrap_or("GLFW Window");
+        let mode = mode.unwrap_or(glfw::Windowed);
 
         glfw.set_error_callback::<()>(None);
-        for setup in hints.mut_iter() {
+        for setup in try_hints.iter() {
             glfw.default_window_hints();
+            for hint in common_hints.iter() {
+                glfw.window_hint(*hint);
+            }
             for hint in setup.iter() {
                 glfw.window_hint(*hint);
             }
             let r = glfw.create_window(width, height, title, mode);
-            if r.is_some() {
-                return r;
+            match r {
+                Some((window, events)) => {
+                    info!("[glfw_platform] Initialized with context version {}",
+                          window.get_context_version());
+                    return Some((window, events));
+                },
+                None => (),
             }
         }
         None


### PR DESCRIPTION
The main reason I changed this stuff yet again is that I tried to actually used it, and found it to be too restricted in practice. ;)

Specifically, with the previous `create_default_window()` it was impossible to add additional window hints to glfw, like for example making the window re-sizable.

With the new design, you can specify common window hints that should be applied regardless of which setup lead to an window creation, and you can also add custom fallbacks before and after the provided shortcut function.
