### PR TITLE
travis: make sure example runs and terminates correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,12 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
+before_install:
+    - "export DISPLAY=:99.0"
+    - "sh -e /etc/init.d/xvfb start"
 install:
   # glfw3
-  - sudo apt-get install libXxf86vm-dev
+  - sudo apt-get install libXxf86vm-dev xdotool
   - git clone https://github.com/glfw/glfw.git
   - cd glfw
   - git checkout 3.0.3
@@ -40,5 +43,8 @@ install:
 script:
   - make deps
   - make test
+  - make examples
+  - sh -c "sleep 5; xdotool key --window \"$(xdotool search --name Hello)\" Escape" &
+  - ./examples/main
   - make clean
   - make clean deps


### PR DESCRIPTION
Uses a headless X server and mesa's software rasterizer. Supports 2.1 with
many extensions. When travis updates their ubuntu version, I think we'll get
3.2.
