### PR TITLE
Rename iter_errors to errors

### DIFF
--- a/src/examples/triangle/main.rs
+++ b/src/examples/triangle/main.rs
@@ -103,7 +103,7 @@ fn main() {
             renderer.clear(cdata, frame);
             renderer.draw(&mesh, gfx::mesh::VertexSlice(0, 3), frame, &bundle, state).unwrap();
             renderer.end_frame();
-            for err in renderer.iter_errors() {
+            for err in renderer.errors() {
                 println!("Renderer error: {}", err);
             }
         }

--- a/src/render/lib.rs
+++ b/src/render/lib.rs
@@ -168,7 +168,7 @@ impl Renderer {
         self.should_finish.check()
     }
 
-    pub fn iter_errors(&mut self) -> MoveItems<DeviceError> {
+    pub fn errors(&mut self) -> MoveItems<DeviceError> {
         let errors = self.dispatcher.errors.clone();
         self.dispatcher.errors.clear();
         errors.move_iter()


### PR DESCRIPTION
According to the guidelines, methods returning an iterator should
not have extra prefixes, just a plural noun.
