### PR TITLE
Use a more natural swap_ack implementation

### DIFF
--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -165,7 +165,7 @@ pub struct Device<T, B, C> {
     reply_tx: Sender<Reply<T>>,
     graphics_context: C,
     back_end: B,
-    swap_ack: Sender<Ack>,
+    frame_done: Receiver<Ack>,
     close: comm::Close,
 }
 
@@ -231,7 +231,7 @@ impl<T: Send, B: ApiBackEnd, C: GraphicsContext<B>> Device<T, B, C> {
                 Ok(Cast(cast)) => self.back_end.process(cast),
                 Ok(SwapBuffers) => {
                     self.graphics_context.swap_buffers();
-                    self.swap_ack.send(Ack);
+                    self.frame_done.recv();
                     break;
                 },
                 Err(()) => return,
@@ -258,15 +258,11 @@ pub type QueueSize = u8;
 // TODO: Generalise for different back-ends
 #[allow(visible_private_types)]
 pub fn init<T: Send, C: GraphicsContext<GlBackEnd>, P: GlProvider>(graphics_context: C, provider: P, queue_size: QueueSize)
-        -> Result<(Sender<Request<T>>, Receiver<Reply<T>>, Device<T, GlBackEnd, C>, Receiver<Ack>, comm::ShouldClose), InitError> {
+        -> Result<(Sender<Request<T>>, Receiver<Reply<T>>, Device<T, GlBackEnd, C>, SyncSender<Ack>, comm::ShouldClose), InitError> {
     let (request_tx, request_rx) = channel();
     let (reply_tx, reply_rx) = channel();
-    let (swap_tx, swap_rx) = channel();
+    let (swap_tx, swap_rx) = sync_channel(queue_size as uint);
     let (close, should_close) = comm::close_stream();
-
-    for _ in range(0, queue_size) {
-        swap_tx.send(Ack);
-    }
 
     let gl = GlBackEnd::new(&provider);
     let device = Device {
@@ -275,9 +271,9 @@ pub fn init<T: Send, C: GraphicsContext<GlBackEnd>, P: GlProvider>(graphics_cont
         reply_tx: reply_tx,
         graphics_context: graphics_context,
         back_end: gl,
-        swap_ack: swap_tx,
+        frame_done: swap_rx,
         close: close,
     };
 
-    Ok((request_tx, reply_rx, device, swap_rx, should_close))
+    Ok((request_tx, reply_rx, device, swap_tx, should_close))
 }

--- a/src/render/lib.rs
+++ b/src/render/lib.rs
@@ -131,7 +131,7 @@ impl Dispatcher {
 pub struct Renderer {
     dispatcher: Dispatcher,
     device_tx: Sender<device::Request<Token>>,
-    swap_ack: Receiver<device::Ack>,
+    frame_finished: SyncSender<device::Ack>,
     should_finish: comm::ShouldClose,
     /// the default FBO for drawing
     default_frame_buffer: backend::FrameBuffer,
@@ -143,7 +143,7 @@ impl Renderer {
     /// Create a new `Renderer` using given channels for communicating with the device. Generally,
     /// you want to use `gfx::start` instead.
     pub fn new(device_tx: Sender<device::Request<Token>>, device_rx: Receiver<device::Reply<Token>>,
-            swap_rx: Receiver<device::Ack>, should_finish: comm::ShouldClose) -> Renderer {
+            frame_finished: SyncSender<device::Ack>, should_finish: comm::ShouldClose) -> Renderer {
         // Request the creation of the common array buffer and frame buffer
         let mut res = resource::Cache::new();
         res.array_buffers.push(Pending);
@@ -158,7 +158,7 @@ impl Renderer {
                 resource: res,
             },
             device_tx: device_tx,
-            swap_ack: swap_rx,
+            frame_finished: frame_finished,
             should_finish: should_finish,
             default_frame_buffer: 0,
             state: State {
@@ -255,7 +255,7 @@ impl Renderer {
     /// queue size passed to `gfx::start`.
     pub fn end_frame(&self) {
         self.device_tx.send(device::SwapBuffers);
-        self.swap_ack.recv();  //wait for acknowlegement
+        self.frame_finished.send(device::Ack);  //wait for acknowlegement
     }
 
     /// Create a new program from the given vertex and fragment shaders.


### PR DESCRIPTION
I find myself unable to explain how it worked before, but now the renderer
sends a message when it finishes a frame, and the device will receive on this.
We use a `SyncSender` so that it will block if it tries to send more than the
configured amount of frames.
