### PR TITLE
Make cargo generate dylib for gfx_macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ authors = [
 name = "gfx"
 path = "src/gfx/lib.rs"
 
-[[lib]]
-name = "gfx_macros"
+[dependencies.gfx_macros]
 path = "src/gfx_macros"
 
 [dependencies.device]

--- a/src/gfx_macros/Cargo.toml
+++ b/src/gfx_macros/Cargo.toml
@@ -8,3 +8,4 @@ authors = [
 [[lib]]
 name = "gfx_macros"
 path = "lib.rs"
+crate-type = [ "dylib" ]


### PR DESCRIPTION
This also changes gfx_macros to be marked as a dependency of gfx so you don't have to depend on gfx-rs twice to build things.
