### PR TITLE
`ProgramShell` typedef for `#[shader_param]`

### DIFF
--- a/src/tests/shader_param.rs
+++ b/src/tests/shader_param.rs
@@ -26,4 +26,6 @@ struct MyParam {
     b: [f32, ..4],
     c: gfx::shade::TextureParam,
     d: gfx::BufferHandle,
+    #[unused]
+    e: f32,
 }


### PR DESCRIPTION
This introduces a type that implements `ProgramShell` with a name given by the user:

``` rust
#[shader_param(MyShell)]
struct MyParam {
...
}
```

This type hides the associated link structure. It is also what `renderer.connect_program` returns, so the user can now safely store this type in an external structure without worrying about the implementation details. Note that both the link structure and `ProgramShell` typedef are inheriting visibility from the original struct, and because of that I had to construct these `Item` things manually.

The PR also implements the `#[unused]` attribute (thus, closing #151) to mark the fields that are excluded from parameter linkage. Might be helpful when experimenting with the shader and having already a logic in place to modify these parameters.
