### PR TITLE
Strongly typed texture View

### DIFF
--- a/src/device/gl/tex.rs
+++ b/src/device/gl/tex.rs
@@ -20,14 +20,15 @@ use Blob;
 /// with a GL-compatibility sampler settings in `bind_sampler`
 pub struct BindAnchor(GLenum);
 
-fn kind_to_gl(t: ::tex::TextureKind) -> GLenum {
-    match t {
+fn kind_to_gl(k: ::tex::TextureKind) -> GLenum {
+    match k {
         ::tex::Texture1D => gl::TEXTURE_1D,
         ::tex::Texture1DArray => gl::TEXTURE_1D_ARRAY,
         ::tex::Texture2D => gl::TEXTURE_2D,
         ::tex::Texture2DArray => gl::TEXTURE_2D_ARRAY,
-        ::tex::TextureCube => gl::TEXTURE_CUBE_MAP,
         ::tex::Texture3D => gl::TEXTURE_3D,
+        ::tex::TextureCube => gl::TEXTURE_CUBE_MAP,
+        ::tex::TextureCubeArray => gl::TEXTURE_CUBE_MAP_ARRAY,
     }
 }
 
@@ -92,7 +93,8 @@ fn format_to_glpixel(t: ::tex::Format) -> GLenum {
 }
 
 fn format_to_gltype(t: ::tex::Format) -> Result<GLenum, ()> {
-    use tex::{Float, Integer, Unsigned};
+    use
+    tex::{Float, Integer, Unsigned};
     match t {
         Float(_, ::attrib::F32) => Ok(gl::FLOAT),
         Integer(_, 8, _)   => Ok(gl::BYTE),
@@ -205,7 +207,6 @@ pub fn make_without_storage(info: &::tex::TextureInfo) -> Result<Texture, ::Text
                     ::std::ptr::null(),
                 );
             },
-            ::tex::TextureCube => unimplemented!(),
             ::tex::Texture2DArray | ::tex::Texture3D => {
                 gl::TexImage3D(
                     target,
@@ -220,6 +221,7 @@ pub fn make_without_storage(info: &::tex::TextureInfo) -> Result<Texture, ::Text
                     ::std::ptr::null(),
                 );
             },
+            ::tex::TextureCube | ::tex::TextureCubeArray => unimplemented!(),
         }
     }
 
@@ -283,7 +285,6 @@ pub fn make_with_storage(info: &::tex::TextureInfo) -> Result<Texture, ::Texture
                 info.height as GLsizei,
             );
         },
-        ::tex::TextureCube => unimplemented!(),
         ::tex::Texture2DArray => {
             gl::TexStorage3D(
                 target,
@@ -304,6 +305,7 @@ pub fn make_with_storage(info: &::tex::TextureInfo) -> Result<Texture, ::Texture
                 info.depth as GLsizei,
             );
         },
+        ::tex::TextureCube | ::tex::TextureCubeArray => unimplemented!(),
     }
 
     set_mipmap_range(target, info.mipmap_range);
@@ -387,7 +389,6 @@ pub fn update_texture(kind: ::tex::TextureKind, name: Texture, img: &::tex::Imag
                     data,
                 );
             },
-            ::tex::TextureCube => unimplemented!(),
             ::tex::Texture2DArray | ::tex::Texture3D => {
                 gl::TexSubImage3D(
                     target,
@@ -403,6 +404,7 @@ pub fn update_texture(kind: ::tex::TextureKind, name: Texture, img: &::tex::Imag
                     data,
                 );
             },
+            ::tex::TextureCube | ::tex::TextureCubeArray => unimplemented!(),
         }
     }
 

--- a/src/device/tex.rs
+++ b/src/device/tex.rs
@@ -23,6 +23,8 @@
 
 use std::default::Default;
 
+pub use attrib::{FloatSize, F16, F32, IntSubType, IntRaw, IntNormalized, IntAsFloat};
+
 /// Number of bits per component
 pub type Bits = u8;
 
@@ -45,11 +47,11 @@ pub enum Components {
 #[deriving(Eq, Ord, PartialEq, PartialOrd, Hash, Clone, Show)]
 pub enum Format {
     /// Floating point.
-    Float(Components, ::attrib::FloatSize),
+    Float(Components, FloatSize),
     /// Signed integer.
-    Integer(Components, Bits, ::attrib::IntSubType),
+    Integer(Components, Bits, IntSubType),
     /// Unsigned integer.
-    Unsigned(Components, Bits, ::attrib::IntSubType),
+    Unsigned(Components, Bits, IntSubType),
     /// Normalized integer, with 3 bits for R and G, but only 2 for B.
     R3G3B2,
     /// 5 bits each for RGB, 1 for Alpha.
@@ -123,12 +125,14 @@ pub enum TextureKind {
     /// An array of 2D textures. Equivalent to Texture3D except that texels in
     /// a different depth level are not sampled.
     Texture2DArray,
+    /// A volume texture, with each 2D layer arranged contiguously.
+    Texture3D,
     /// A set of 6 2D textures, one for each face of a cube.
     // TODO: implement this, and document it better. cmr doesn't really understand them well enough
     // to explain without rambling.
     TextureCube,
-    /// A volume texture, with each 2D layer arranged contiguously.
-    Texture3D,
+    /// An array of Cube textures.
+    TextureCubeArray,
     // TODO: Multisampling?
 }
 

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -30,15 +30,18 @@ extern crate render;
 
 // public re-exports
 pub use render::{BufferHandle, ShaderHandle, ProgramHandle, SurfaceHandle, TextureHandle, SamplerHandle};
+pub use render::{TextureView};
 pub use render::Renderer;
 pub use render::mesh::{Attribute, Mesh, VertexFormat, Slice, VertexSlice, IndexSlice};
 pub use render::state::{DrawState, BlendAdditive, BlendAlpha};
 pub use render::shade;
 pub use render::target::{Frame, Plane, PlaneEmpty, PlaneSurface, PlaneTexture};
+pub use ttex = render::tex;
 pub use device::{attrib, state, tex};
 pub use device::target::{Color, ClearData, Layer, Level};
 pub use device::{Blob, Device, GlBackEnd, GlProvider, GraphicsContext, InitError, QueueSize};
 pub use device::shade::{UniformValue, ValueI32, ValueF32, ValueI32Vec, ValueF32Vec, ValueF32Matrix};
+pub use device::shade::{IsArray, Array, NoArray};
 pub use device::shade::{ShaderSource, StaticBytes};
 
 /// The empty variant of a type-level option.

--- a/src/render/lib.rs
+++ b/src/render/lib.rs
@@ -58,6 +58,9 @@ pub struct TextureHandle(Token);
 #[deriving(Clone, PartialEq, Show)]
 pub struct SamplerHandle(Token);
 
+/// A type-safe wrapper for the texture handle
+pub struct TextureView<K, C, A, T>(TextureHandle);
+
 /// Meshes
 pub mod mesh;
 /// Resources
@@ -355,7 +358,16 @@ impl Renderer {
         SurfaceHandle(token)
     }
 
-    /// Create a new texture.
+    /// Create a new texture view, given the strongly-typed format
+    pub fn create_texture_view<K: tex::ToKind, C: tex::ToComponents, A, T: tex::ToFormat>
+    (&mut self, format: tex::Format<K, C, A, T>) -> TextureView<K, C, A, T> {
+        use tex::ToTextureInfo;
+        let info = format.into_texture_info();
+        let handle = self.create_texture(info);
+        TextureView(handle)
+    }
+
+    /// Create a new texture, given the raw TextureInfo.
     pub fn create_texture(&mut self, info: device::tex::TextureInfo) -> TextureHandle {
         let token = self.dispatcher.resource.textures.add((Pending, info.clone()));
         self.device_tx.send(device::Call(token, device::CreateTexture(info)));

--- a/src/render/tex.rs
+++ b/src/render/tex.rs
@@ -14,37 +14,115 @@
 
 //! Safe texture types
 
+use device::shade::{IsArray, Array, NoArray};
 use device::tex;
 
 // Dimension size
 pub type Size = u16;
-
-/// A type-safe wrapper for the texture handle
-pub struct View<Kind, Comp, Aa, Texel>(super::TextureHandle);
+pub type Layers = u16;
 
 /// The texture format received from the user
 pub struct Format<Kind, Comp, Aa, Texel>(pub Kind, pub Comp, pub Aa, pub Texel);
 
 /// Convertable to TextureInfo
 pub trait ToTextureInfo {
-	/// Convert to TextureInfo
-    fn to_texture_info(&self) -> tex::TextureInfo;
+	/// Convert into TextureInfo
+    fn into_texture_info(self) -> tex::TextureInfo;
 }
-impl<Kind, Comp, Aa, Texel> ToTextureInfo for Format<Kind, Comp, Aa, Texel> {
-    fn to_texture_info(&self) -> tex::TextureInfo {
-        unimplemented!()
+impl<
+    Kind: ToKind,
+    Comp: ToComponents,
+    Aa,
+    Texel: ToFormat
+> ToTextureInfo
+for Format<Kind, Comp, Aa, Texel> {
+    fn into_texture_info(self) -> tex::TextureInfo {
+        let Format(kind, comp, _aa, texel) = self;
+        let (kind, w, h, d) = kind.into_kind();
+        let comp = comp.into_components();
+        let format = texel.into_format(comp);
+        tex::TextureInfo {
+            width: w,
+            height: h,
+            depth: d,
+            mipmap_range: (0, -1),
+            kind: kind,
+            format: format,
+        }
     }
 }
 
 // Kind
 /// 1D texture
 pub struct Tex1D(pub Size);
+/// An array of 1D textures
+pub struct Tex1DArray(pub Size, pub Layers);
 /// 2D texture or 1D array
 pub struct Tex2D(pub Size, pub Size);
+/// An array of 2D textures
+pub struct Tex2DArray(pub Size, pub Size, pub Layers);
 /// 3D texture or 2D array
 pub struct Tex3D(pub Size, pub Size, pub Size);
 /// Cube texture
 pub struct TexCube(pub Size);
+/// An array of Cube textures
+pub struct TexCubeArray(pub Size, pub Layers);
+
+/// Convertible to TextureKind and sizes
+pub trait ToKind {
+    /// Convert into TextureKind
+    fn into_kind(self) -> (tex::TextureKind, Size, Size, Size);
+}
+
+impl ToKind for Tex1D {
+    fn into_kind(self) -> (tex::TextureKind, Size, Size, Size) {
+        let Tex1D(w) = self;
+        (tex::Texture1D, w, 0, 0)
+    }
+}
+
+impl ToKind for Tex1DArray {
+    fn into_kind(self) -> (tex::TextureKind, Size, Size, Size) {
+        let Tex1DArray(w, d) = self;
+        (tex::Texture1DArray, w, 0, d)
+    }
+}
+
+impl ToKind for Tex2D {
+    fn into_kind(self) -> (tex::TextureKind, Size, Size, Size) {
+        let Tex2D(w, h) = self;
+        (tex::Texture2D, w, h, 0)
+    }
+}
+
+impl ToKind for Tex2DArray {
+    fn into_kind(self) -> (tex::TextureKind, Size, Size, Size) {
+        let Tex2DArray(w, h, d) = self;
+        (tex::Texture2DArray, w, h, d)
+    }
+}
+
+impl ToKind for Tex3D {
+    fn into_kind(self) -> (tex::TextureKind, Size, Size, Size) {
+        let Tex3D(w, h, d) = self;
+        (tex::Texture3D, w, h, d)
+    }
+}
+
+impl ToKind for TexCube {
+    fn into_kind(self) -> (tex::TextureKind, Size, Size, Size) {
+        let TexCube(s) = self;
+        (tex::TextureCube, s, s, 0)
+    }
+}
+
+impl ToKind for TexCubeArray {
+    fn into_kind(self) -> (tex::TextureKind, Size, Size, Size) {
+        let TexCubeArray(s, d) = self;
+        (tex::TextureCubeArray, s, s, d)
+    }
+}
+
 
 // Comp
 /// Red only
@@ -55,6 +133,36 @@ pub struct RG;
 pub struct RGB;
 /// Red, green, blue, alpha
 pub struct RGBA;
+
+/// Convertible to texture Components
+pub trait ToComponents {
+    /// Convert into Components
+    fn into_components(self) -> tex::Components;
+}
+
+impl ToComponents for R {
+    fn into_components(self) -> tex::Components {
+        tex::R
+    }
+}
+
+impl ToComponents for RG {
+    fn into_components(self) -> tex::Components {
+        tex::RG
+    }
+}
+
+impl ToComponents for RGB {
+    fn into_components(self) -> tex::Components {
+        tex::RGB
+    }
+}
+
+impl ToComponents for RGBA {
+    fn into_components(self) -> tex::Components {
+        tex::RGBA
+    }
+}
 
 // Aa
 /// No anti-aliasing
@@ -69,3 +177,27 @@ pub struct TexelFloat;
 pub struct TexelInteger;
 /// Unsigned integer values
 pub struct TexelUnsigned;
+
+/// Convertible to texture Format
+pub trait ToFormat {
+    /// Convert into Format
+    fn into_format(self, c: tex::Components) -> tex::Format;
+}
+
+impl ToFormat for TexelFloat {
+    fn into_format(self, c: tex::Components) -> tex::Format {
+        tex::Float(c, tex::F16)
+    }
+}
+
+impl ToFormat for TexelInteger {
+    fn into_format(self, c: tex::Components) -> tex::Format {
+        tex::Integer(c, 8, tex::IntNormalized)
+    }
+}
+
+impl ToFormat for TexelUnsigned {
+    fn into_format(self, c: tex::Components) -> tex::Format {
+        tex::Unsigned(c, 8, tex::IntNormalized)
+    }
+}


### PR DESCRIPTION
It is optional, since I don't think we can force it. The shader params are also not using it yet.
It's also unclear how to use the type information in the render target bindings.
