### PR TITLE
Fix name of gl_init

### DIFF
--- a/src/examples/triangle/main.rs
+++ b/src/examples/triangle/main.rs
@@ -7,7 +7,7 @@ extern crate getopts;
 extern crate gfx;
 extern crate glfw;
 extern crate glfw_platform;
-extern crate glinit = "gl-init-rs";
+extern crate gl_init;
 extern crate gl_init_platform;
 extern crate native;
 
@@ -69,7 +69,7 @@ fn start(argc: int, argv: *const *const u8) -> int {
 
 fn main() {
     // checking for the --gl-init flag
-    let use_glinit = {
+    let use_gl_init = {
         use std::os;
         use getopts::{optflag, getopts};
 
@@ -92,7 +92,7 @@ fn main() {
         matches.opt_present("i")
     };
 
-    if use_glinit {
+    if use_gl_init {
         let window = gl_init_platform::Window::new().unwrap();
         window.set_title("[gl-init] Triangle example #gfx-rs!");
         unsafe { window.make_current() };
@@ -110,8 +110,8 @@ fn main() {
             // quit when Esc is pressed.
             for event in window.poll_events() {
                 match event {
-                    glinit::Pressed(glinit::Escape) => break 'main,
-                    glinit::Closed => break 'main,
+                    gl_init::Pressed(gl_init::Escape) => break 'main,
+                    gl_init::Closed => break 'main,
                     _ => {},
                 }
             }

--- a/src/gl_init_platform/Cargo.toml
+++ b/src/gl_init_platform/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 name = "gl_init_platform"
 path = "lib.rs"
 
-[dependencies.gl-init-rs]
+[dependencies.gl_init]
 git = "https://github.com/tomaka/gl-init-rs.git"
 
 [dependencies.device]

--- a/src/gl_init_platform/lib.rs
+++ b/src/gl_init_platform/lib.rs
@@ -20,19 +20,19 @@
 
 #![feature(macro_rules, phase)]
 
-extern crate glinit = "gl-init-rs";
+extern crate gl_init;
 #[phase(plugin, link)]
 extern crate log;
 extern crate libc;
 
 extern crate device;
 
-pub struct Window(glinit::Window);
+pub struct Window(gl_init::Window);
 
 impl Window {
     #[inline]
     pub fn new() -> Option<Window> {
-        let win = match glinit::Window::new() {
+        let win = match gl_init::Window::new() {
             Err(_) => return None,
             Ok(w) => w
         };
@@ -41,7 +41,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn from_builder(builder: glinit::WindowBuilder) -> Option<Window> {
+    pub fn from_builder(builder: gl_init::WindowBuilder) -> Option<Window> {
         let win = match builder.build() {
             Err(_) => return None,
             Ok(w) => w
@@ -51,7 +51,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn from_existing(win: glinit::Window) -> Window {
+    pub fn from_existing(win: gl_init::Window) -> Window {
         Window(win)
     }
 }
@@ -75,8 +75,8 @@ impl<'a> device::GraphicsContext<device::GlBackEnd> for &'a Window {
     }
 }
 
-impl Deref<glinit::Window> for Window {
-    fn deref(&self) -> &glinit::Window {
+impl Deref<gl_init::Window> for Window {
+    fn deref(&self) -> &gl_init::Window {
         let &Window(ref win) = self;
         win
     }


### PR DESCRIPTION
`gl-init-rs` has been renamed to `gl_init` (see https://github.com/tomaka/gl-init-rs/commit/ca83db39c71b81fa10901b1b066ad27686229187)

This PR mirrors the changes.
(also the `Cargo.toml` file had bad line endings)
