### PR TITLE
Fix shaders! not actaully using the `extern crate` import it does locally

### DIFF
--- a/src/gfx_macros/lib.rs
+++ b/src/gfx_macros/lib.rs
@@ -81,7 +81,7 @@ macro_rules! shaders {
         {
             mod foo {
                 extern crate gfx;
-                pub use gfx as g;
+                pub use self::gfx as g;
             }
             foo::g::ShaderSource {
                 glsl_120: Some(::gfx::StaticBytes($v)),
@@ -93,7 +93,7 @@ macro_rules! shaders {
         {
             mod foo {
                 extern crate gfx;
-                pub use gfx as g;
+                pub use self::gfx as g;
             }
             foo::g::ShaderSource {
                 glsl_150: Some(::gfx::StaticBytes($v)),
@@ -105,7 +105,7 @@ macro_rules! shaders {
         {
             mod foo {
                 extern crate gfx;
-                pub use gfx as g;
+                pub use self::gfx as g;
             }
             foo::g::ShaderSource {
                 glsl_120: None,

--- a/src/tests/vertex_format.rs
+++ b/src/tests/vertex_format.rs
@@ -32,7 +32,7 @@ struct MyVertex {
 
 #[test]
 fn test_vertex_format() {
-    use a = gfx::attrib;
+    use gfx::attrib as a;
 
     let buf = device::make_fake_buffer();
     let mesh = gfx::Mesh::from::<MyVertex>(buf, 0);


### PR DESCRIPTION
This is a silly bug caused by me forgetting about `use` using a absolute path per default. :smile: 
