### PR TITLE
Renamed DrawList to Renderer

### DIFF
--- a/src/examples/cube/main.rs
+++ b/src/examples/cube/main.rs
@@ -117,7 +117,7 @@ fn main() {
     let frame = gfx::Frame::new(w as u16, h as u16);
 
     let mut device = gfx::GlDevice::new(|s| glfw.get_proc_address(s));
-    let mut list = device.create_draw_list();
+    let mut renderer = device.create_renderer();
 
     let state = gfx::DrawState::new().depth(gfx::state::LessEqual, true);
 
@@ -219,8 +219,8 @@ fn main() {
             }
         }
         // render
-        list.reset();
-        list.clear(
+        renderer.reset();
+        renderer.clear(
             gfx::ClearData {
                 color: Some(gfx::Color([0.3, 0.3, 0.3, 1.0])),
                 depth: Some(1.0),
@@ -230,8 +230,8 @@ fn main() {
         );
         m_model.x.x = 1.0;
         data.u_ModelViewProj = m_viewproj.mul_m(&m_model).into_fixed();
-        list.draw(&mesh, slice, &frame, (&prog, &data), &state).unwrap();
-        device.submit(list.as_slice());
+        renderer.draw(&mesh, slice, &frame, (&prog, &data), &state).unwrap();
+        device.submit(renderer.as_buffer());
         window.swap_buffers();
     }
 }

--- a/src/examples/gl-init/main.rs
+++ b/src/examples/gl-init/main.rs
@@ -25,9 +25,9 @@ fn main() {
     let (w, h) = window.get_inner_size().unwrap();
 
     let mut device = gfx::GlDevice::new(|s| window.get_proc_address(s));
-    let mut list = device.create_draw_list();
+    let mut renderer = device.create_renderer();
 
-    list.clear(
+    renderer.clear(
         gfx::ClearData {
             color: Some(gfx::Color([0.3, 0.3, 0.3, 1.0])),
             depth: None,
@@ -45,7 +45,7 @@ fn main() {
                 _ => {},
             }
         }
-        device.submit(list.as_slice());
+        device.submit(renderer.as_buffer());
         window.swap_buffers();
     }
 }

--- a/src/examples/triangle/main.rs
+++ b/src/examples/triangle/main.rs
@@ -82,7 +82,7 @@ fn main() {
     let frame = gfx::Frame::new(w as u16, h as u16);
 
     let mut device = gfx::GlDevice::new(|s| glfw.get_proc_address(s));
-    let mut list = device.create_draw_list();
+    let mut renderer = device.create_renderer();
 
     let state = gfx::DrawState::new();
     let vertex_data = vec![
@@ -94,7 +94,7 @@ fn main() {
     let program: gfx::shade::EmptyProgram = device.link_program(
         VERTEX_SRC.clone(), FRAGMENT_SRC.clone()).unwrap();
 
-    list.clear(
+    renderer.clear(
         gfx::ClearData {
             color: Some(gfx::Color([0.3, 0.3, 0.3, 1.0])),
             depth: None,
@@ -102,7 +102,7 @@ fn main() {
         },
         &frame
     );
-    list.draw(&mesh, mesh.get_slice(), &frame, &program, &state)
+    renderer.draw(&mesh, mesh.get_slice(), &frame, &program, &state)
         .unwrap();
 
     while !window.should_close() {
@@ -115,7 +115,7 @@ fn main() {
                 _ => {},
             }
         }
-        device.submit(list.as_slice());
+        device.submit(renderer.as_buffer());
         window.swap_buffers();
     }
 }

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -30,7 +30,7 @@ extern crate render;
 
 // public re-exports
 pub use render::front;
-pub use render::front::{DeviceHelper, DrawList};
+pub use render::front::{DeviceHelper, Renderer};
 pub use render::mesh::{Attribute, Mesh, VertexFormat, Slice, VertexSlice,
     IndexSlice8, IndexSlice16, IndexSlice32};
 pub use render::state::{DrawState, BlendAdditive, BlendAlpha};


### PR DESCRIPTION
This is important to avoid confusion with the higher-level library that is gonna cull/sort its own draw lists.
