### PR TITLE
Switch from static gl generator to struct

### DIFF
--- a/src/device/Cargo.toml
+++ b/src/device/Cargo.toml
@@ -9,5 +9,5 @@ authors = [
 name = "device"
 path = "lib.rs"
 
-[dependencies.gl]
+[dependencies.gl_generator]
 git = "https://github.com/bjz/gl-rs.git"


### PR DESCRIPTION
The struct gl generator is cleaner, and using it will probably fix some possible crashes when using multiple GL contexts on Windows.

Directly invoking `generate_gl_bindings` also allows you to directly specify which GL extensions you may wish to use in the future.

I had to remove some commas because of https://github.com/rust-lang/rust/issues/14240

Note: I could only try the `gl-init` example (which doesn't draw anything on the screen), but I don't see any reason why the examples would break.
