### PR TITLE
Clarify role of vertex data in examples

### DIFF
--- a/src/examples/cube/main.rs
+++ b/src/examples/cube/main.rs
@@ -20,6 +20,8 @@ use glfw::Context;
 
 #[vertex_format]
 struct Vertex {
+    // The attributes in here should match up with the attribute/in arguments of
+    // the vertex shader.
     #[as_float]
     a_Pos: [i8, ..3],
     #[as_float]

--- a/src/examples/triangle/main.rs
+++ b/src/examples/triangle/main.rs
@@ -12,6 +12,8 @@ use glfw::Context;
 
 #[vertex_format]
 struct Vertex {
+    // The attributes in here should match up with the attribute/in arguments of
+    // the vertex shader.
     pos: [f32, ..2],
     color: [f32, ..3],
 }


### PR DESCRIPTION
This adds a simple comment that clarifies how the data in the
vertex_format struct relates to the shader.
I struggled a bit before I understood this, so maybe it will be helpful
for others to have that piece of information in the examples (at least
until more comprehensive documentation exists).
