### PR TITLE
Remove Color type to make ClearData cleaner

### DIFF
--- a/src/device/gl/mod.rs
+++ b/src/device/gl/mod.rs
@@ -170,7 +170,7 @@ impl GlDevice {
             ::Clear(ref data) => {
                 let mut flags = match data.color {
                     //self.gl.ColorMask(gl::TRUE, gl::TRUE, gl::TRUE, gl::TRUE);
-                    Some(::target::Color([r,g,b,a])) => {
+                    Some([r, g, b, a]) => {
                         self.gl.ClearColor(r, g, b, a);
                         gl::COLOR_BUFFER_BIT
                     },

--- a/src/device/gl/state.rs
+++ b/src/device/gl/state.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::super::state as s;
-use super::super::target::{Color, Rect};
+use super::super::target::Rect;
 use super::gl;
 
 pub fn bind_primitive(gl: &gl::Gl, p: s::Primitive) {
@@ -183,7 +183,7 @@ pub fn bind_blend(gl: &gl::Gl, blend: Option<s::Blend>) {
                 map_factor(b.alpha.source),
                 map_factor(b.alpha.destination)
             );
-            let Color([r, g, b, a]) = b.value;
+            let [r, g, b, a] = b.value;
             gl.BlendColor(r, g, b, a);
         },
         None => gl.Disable(gl::BLEND),

--- a/src/device/state.rs
+++ b/src/device/state.rs
@@ -252,7 +252,6 @@ impl Default for BlendChannel {
 }
 
 #[allow(missing_doc)]
-#[deriving(Clone, PartialEq, Show)]
 pub struct Blend {
     pub color: BlendChannel,
     pub alpha: BlendChannel,
@@ -264,8 +263,33 @@ impl Default for Blend {
         Blend {
             color: Default::default(),
             alpha: Default::default(),
-            value: Default::default(),
+            value: [0.0, 0.0, 0.0, 0.0],
         }
+    }
+}
+
+impl PartialEq for Blend {
+    fn eq(&self, other: &Blend) -> bool {
+        self.color == other.color &&
+        self.alpha == other.alpha &&
+        self.value == other.value
+    }
+}
+
+impl Clone for Blend {
+    fn clone(&self) -> Blend {
+        Blend {
+            color: self.color.clone(),
+            alpha: self.alpha.clone(),
+            value: self.value,
+        }
+    }
+}
+
+impl fmt::Show for Blend {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Blend {{ color: {}, alpha: {}, value: {} }}",
+               self.color, self.alpha, self.value.as_slice())
     }
 }
 

--- a/src/device/target.rs
+++ b/src/device/target.rs
@@ -37,47 +37,9 @@ pub struct Rect {
     pub h: u16,
 }
 
-/// A color with floating-point components. Used for `ClearData`.
-pub struct Color(pub [f32, ..4]);
+/// A color with floating-point components.
+pub type Color = [f32, ..4];
 
-// manual impls due to array...
-
-impl Color {
-    /// Returns black.
-    pub fn new() -> Color {
-        Color([0.0, 0.0, 0.0, 0.0])
-    }
-}
-
-impl Clone for Color {
-    fn clone(&self) -> Color {
-        let Color(ref x) = *self;
-        Color([x[0], x[1], x[2], x[3]])
-    }
-}
-
-impl PartialEq for Color {
-    fn eq(&self, other: &Color) -> bool {
-        let Color(ref x) = *self;
-        let Color(ref y) = *other;
-        x[0] == y[0] && x[1] == y[1] && x[2] == y[2] && x[3] == y[3]
-    }
-}
-
-impl fmt::Show for Color {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Color([r,g,b,a]) = *self;
-        write!(f, "Color({}, {}, {}, {})", r, g, b, a)
-    }
-}
-
-impl default::Default for Color {
-    fn default() -> Color {
-        Color([0.0, 0.0, 0.0, 0.0])
-    }
-}
-
-#[deriving(Clone, Show)]
 /// How to clear a frame.
 pub struct ClearData {
     /// If set, the color buffer of the frame will be cleared to this.
@@ -86,6 +48,27 @@ pub struct ClearData {
     pub depth: Option<Depth>,
     /// If set, the stencil buffer of the frame will be cleared to this.
     pub stencil: Option<Stencil>,
+}
+
+impl Clone for ClearData {
+    fn clone(&self) -> ClearData {
+        ClearData {
+            color: self.color,
+            depth: self.depth,
+            stencil: self.stencil,
+        }
+    }
+}
+
+impl fmt::Show for ClearData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "ClearData {{ color: "));
+        match self.color {
+            Some(ref c) => try!(write!(f, "Some({})", c.as_slice())),
+            None => try!(write!(f, "None")),
+        }
+        write!(f, ", depth: {}, stencil: {} }}", self.depth, self.stencil)
+    }
 }
 
 /// When rendering, each "output" of the fragment shader goes to a specific target. A `Plane` can

--- a/src/examples/cube/main.rs
+++ b/src/examples/cube/main.rs
@@ -228,7 +228,7 @@ fn main() {
         renderer.reset();
         renderer.clear(
             gfx::ClearData {
-                color: Some(gfx::Color([0.3, 0.3, 0.3, 1.0])),
+                color: Some([0.3, 0.3, 0.3, 1.0]),
                 depth: Some(1.0),
                 stencil: None,
             },

--- a/src/examples/gl-init/main.rs
+++ b/src/examples/gl-init/main.rs
@@ -29,7 +29,7 @@ fn main() {
 
     renderer.clear(
         gfx::ClearData {
-            color: Some(gfx::Color([0.3, 0.3, 0.3, 1.0])),
+            color: Some([0.3, 0.3, 0.3, 1.0]),
             depth: None,
             stencil: None,
         },

--- a/src/examples/terrain/main.rs
+++ b/src/examples/terrain/main.rs
@@ -202,7 +202,7 @@ fn main() {
         renderer.reset();
         renderer.clear(
             gfx::ClearData {
-                color: Some(gfx::Color([0.3, 0.3, 0.3, 1.0])),
+                color: Some([0.3, 0.3, 0.3, 1.0]),
                 depth: Some(1.),
                 stencil: None,
             },

--- a/src/examples/triangle/main.rs
+++ b/src/examples/triangle/main.rs
@@ -98,7 +98,7 @@ fn main() {
 
     renderer.clear(
         gfx::ClearData {
-            color: Some(gfx::Color([0.3, 0.3, 0.3, 1.0])),
+            color: Some([0.3, 0.3, 0.3, 1.0]),
             depth: None,
             stencil: None,
         },

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -109,7 +109,7 @@ impl DrawState {
                     source: s::Factor(s::Inverse, s::Zero),
                     destination: s::Factor(s::Inverse, s::Zero),
                 },
-                value: Color::new(),
+                value: [0.0, 0.0, 0.0, 0.0],
             },
             BlendAlpha => s::Blend {
                 color: s::BlendChannel {
@@ -122,7 +122,7 @@ impl DrawState {
                     source: s::Factor(s::Inverse, s::Zero),
                     destination: s::Factor(s::Inverse, s::Zero),
                 },
-                value: Color::new(),
+                value: [0.0, 0.0, 0.0, 0.0],
             },
         });
         self


### PR DESCRIPTION
We can't currently derive from fixed length arrays, but I think it's better to have an API that is consistent with our goals of mathematics library agnosticism.
