### PR TITLE
Re-export GlCommandBuffer

### DIFF
--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -40,7 +40,7 @@ pub use render::shade;
 pub use render::target::{Frame, Plane, PlaneEmpty, PlaneSurface, PlaneTexture};
 pub use device::Device;
 // when cargo is ready, re-enable the cfgs
-/* #[cfg(gl)] */ pub use device::GlDevice;
+/* #[cfg(gl)] */ pub use device::{GlDevice, GlCommandBuffer};
 pub use device::{attrib, state, tex};
 pub use device::{BufferHandle, BufferInfo, RawBufferHandle, ShaderHandle,
     ProgramHandle, SurfaceHandle, TextureHandle};


### PR DESCRIPTION
Like GlDevice, GlCommandBuffer is needed by application code whenever
gfx::Graphics is used in a context where the type cannot be inferred.
