### PR TITLE
Exporting shader stages

### DIFF
--- a/src/render/shade.rs
+++ b/src/render/shade.rs
@@ -19,6 +19,8 @@ use std::fmt;
 use device::shade;
 use device::{RawBufferHandle, ProgramHandle, TextureHandle, SamplerHandle};
 
+pub use device::shade::{Stage, CreateShaderError, Vertex, Geometry, Fragment};
+
 /// Helper trait to transform base types into their corresponding uniforms
 pub trait ToUniform {
     /// Create a `UniformValue` representing this value.


### PR DESCRIPTION
I wonder why we are not seeing any warnings about private types being exposed.
