### PR TITLE
Improve error checking

### DIFF
--- a/src/gl_device/lib.rs
+++ b/src/gl_device/lib.rs
@@ -158,8 +158,14 @@ impl GlDevice {
     }
 
     /// Fails during a debug build if the implementation's error flag was set.
-    fn check(&mut self) {
-        debug_assert_eq!(self.get_error(), Ok(()));
+    fn check(&mut self, cmd: &::Command) {
+        if cfg!(not(ndebug)) {
+            match self.get_error() {
+                Ok(())   => (),
+                Err(err) =>
+                    fail!("Error after executing command {}: {}", cmd, err)
+            }
+        }
     }
 
     /// Get the OpenGL-specific driver information
@@ -459,7 +465,7 @@ impl GlDevice {
                 );
             },
         }
-        self.check();
+        self.check(cmd);
     }
 }
 


### PR DESCRIPTION
Print more useful error messages, if unexpected errors occur.
