### PR TITLE
Rename gl-init references to glutin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,10 +74,10 @@ git = "https://github.com/bjz/noise-rs.git"
 
 
 [[example]]
-name = "gl-init"
-path = "examples/gl-init/main.rs"
+name = "glutin"
+path = "examples/glutin/main.rs"
 
-[dev_dependencies.gl_init]
+[dev_dependencies.glutin]
 git = "https://github.com/tomaka/gl-init-rs.git"
 
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ git = "http://github.com/gfx-rs/gfx-rs"
 
 See the [triangle example](./examples/triangle) for a typical context
 initialization with [glfw](https://github.com/bjz/glfw-rs/), or
-[gl-init example](./examples/gl-init) for [gl-init](https://github.com/tomaka/gl-init-rs/).
+[glutin example](./examples/glutin) for [glutin](https://github.com/tomaka/gl-init-rs/).
 
 ## Crate hierarchy
 

--- a/diagrams/dot/dependencies.dot
+++ b/diagrams/dot/dependencies.dot
@@ -36,8 +36,8 @@ digraph gfx {
     "cube" -> "glfw";
     "terrain" -> "gfx";
     "terrain" -> "glfw";
-    "gl-init" -> "gfx";
-    "gl-init" -> "gl_init";
+    "glutin" -> "gfx";
+    "glutin" -> "glutin";
     "performance" -> "gfx";
     "performance" -> "glfw";
     "performance" -> "gfx_gl";

--- a/examples/glutin/main.rs
+++ b/examples/glutin/main.rs
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #![feature(phase)]
-#![crate_name = "gl-init"]
+#![crate_name = "glutin"]
 
 //! Demonstrates how to initialize gfx-rs using the gl-init-rs library.
 
 extern crate gfx;
 #[phase(plugin)]
 extern crate gfx_macros;
-extern crate gl_init;
+extern crate glutin;
 extern crate native;
 
 use gfx::{Device, DeviceHelper};
@@ -33,8 +33,8 @@ fn start(argc: int, argv: *const *const u8) -> int {
 }
 
 fn main() {
-    let window = gl_init::Window::new().unwrap();
-    window.set_title("gl-init-rs initialization example");
+    let window = glutin::Window::new().unwrap();
+    window.set_title("glutin initialization example");
     unsafe { window.make_current() };
     let (w, h) = window.get_inner_size().unwrap();
 
@@ -55,8 +55,8 @@ fn main() {
         // quit when Esc is pressed.
         for event in window.poll_events() {
             match event {
-                gl_init::KeyboardInput(_, _, Some(gl_init::Escape), _) => break 'main,
-                gl_init::Closed => break 'main,
+                glutin::KeyboardInput(_, _, Some(glutin::Escape), _) => break 'main,
+                glutin::Closed => break 'main,
                 _ => {},
             }
         }


### PR DESCRIPTION
In my attempt to build `gfx-rs` for the first time, I hit an error in referencing `gl-init-rs`. From tomaka/gl-init-rs#42, we can see the Cargo crate for `gl-init-rs` was renamed to `glutin`, causing the cargo failure.

I've renamed the folders/references in this PR, but I'm a rust n00b so I may have done something wrong :)

_Of note, I can't actually test the gl-init example on my computer since it won't execute gl-init-rs on OS X (stated in its readme), so probably wise to test build/run on your own computer. But I can confirm it does compile!_
