### PR TITLE
Allow writing shaders in GLSL 1.30 and 1.40

### DIFF
--- a/src/device/shade.rs
+++ b/src/device/shade.rs
@@ -336,6 +336,8 @@ impl Bytes {
 #[deriving(Clone, PartialEq, Show)]
 pub struct ShaderSource {
     pub glsl_120: Option<Bytes>,
+    pub glsl_130: Option<Bytes>,
+    pub glsl_140: Option<Bytes>,
     pub glsl_150: Option<Bytes>,
     // TODO: hlsl_sm_N...
 }

--- a/src/gfx_macros/lib.rs
+++ b/src/gfx_macros/lib.rs
@@ -183,6 +183,30 @@ macro_rules! shaders {
             }
         }
     };
+    (GLSL_130: $v:expr $($t:tt)*) => {
+        {
+            mod __gfx_extern_crate_hack {
+                extern crate "gfx" as gfx_;
+                pub use self::gfx_ as gfx;
+            }
+            __gfx_extern_crate_hack::gfx::ShaderSource {
+                glsl_130: Some(__gfx_extern_crate_hack::gfx::StaticBytes($v)),
+                ..shaders!($($t)*)
+            }
+        }
+    };
+    (GLSL_140: $v:expr $($t:tt)*) => {
+        {
+            mod __gfx_extern_crate_hack {
+                extern crate "gfx" as gfx_;
+                pub use self::gfx_ as gfx;
+            }
+            __gfx_extern_crate_hack::gfx::ShaderSource {
+                glsl_140: Some(__gfx_extern_crate_hack::gfx::StaticBytes($v)),
+                ..shaders!($($t)*)
+            }
+        }
+    };
     (GLSL_150: $v:expr $($t:tt)*) => {
         {
             mod __gfx_extern_crate_hack {
@@ -203,6 +227,8 @@ macro_rules! shaders {
             }
             __gfx_extern_crate_hack::gfx::ShaderSource {
                 glsl_120: None,
+                glsl_130: None,
+                glsl_140: None,
                 glsl_150: None,
             }
         }

--- a/src/gl_device/lib.rs
+++ b/src/gl_device/lib.rs
@@ -530,7 +530,7 @@ impl Device<GlCommandBuffer> for GlDevice {
 
     fn create_shader(&mut self, stage: ::shade::Stage, code: ::shade::ShaderSource)
                      -> Result<::ShaderHandle, ::shade::CreateShaderError> {
-        let (name, info) = shade::create_shader(&self.gl, stage, code, self.get_capabilities().shader_model);
+        let (name, info) = shade::create_shader(&self.gl, stage, code, self.info.shading_language);
         info.map(|info| {
             let level = if name.is_err() { log::ERROR } else { log::WARN };
             log!(level, "\tShader compile log: {}", info);

--- a/src/gl_device/shade.rs
+++ b/src/gl_device/shade.rs
@@ -14,8 +14,9 @@
 
 use super::super::shade as s;
 use super::gl;
+use super::info::Version;
 
-pub fn create_shader(gl: &gl::Gl, stage: s::Stage, data: s::ShaderSource, model: s::ShaderModel)
+pub fn create_shader(gl: &gl::Gl, stage: s::Stage, data: s::ShaderSource, lang: Version)
         -> (Result<super::Shader, s::CreateShaderError>, Option<String>) {
     let target = match stage {
         s::Vertex => gl::VERTEX_SHADER,
@@ -24,8 +25,10 @@ pub fn create_shader(gl: &gl::Gl, stage: s::Stage, data: s::ShaderSource, model:
     };
     let name = gl.CreateShader(target);
     let data = match data {
-        s::ShaderSource { glsl_150: Some(ref s), .. } if model >= s::Model40 => s.as_slice(),
-        s::ShaderSource { glsl_120: Some(ref s), .. } if model >= s::Model30 => s.as_slice(),
+        s::ShaderSource { glsl_150: Some(ref s), .. } if lang >= Version::new(1, 50, None, "") => s.as_slice(),
+        s::ShaderSource { glsl_140: Some(ref s), .. } if lang >= Version::new(1, 40, None, "") => s.as_slice(),
+        s::ShaderSource { glsl_130: Some(ref s), .. } if lang >= Version::new(1, 30, None, "") => s.as_slice(),
+        s::ShaderSource { glsl_120: Some(ref s), .. } if lang >= Version::new(1, 20, None, "") => s.as_slice(),
         _ => return (Err(s::NoSupportedShaderProvided),
                      Some("[gfx-rs] No supported GLSL shader provided!".to_string())),
     };


### PR DESCRIPTION
Add them to ShaderSource and the shader! macro, and directly pass info.shading_language instead of the shader_model to create_shader in the gl_device, since the ShaderModel isn't detailed enough.
