### PR TITLE
Update to latest rust nightly

### DIFF
--- a/examples/performance/main.rs
+++ b/examples/performance/main.rs
@@ -37,7 +37,7 @@ use std::mem;
 use std::ptr;
 use std::str;
 use std::os;
-use std::from_str::FromStr;
+use std::str::FromStr;
 
 #[vertex_format]
 struct Vertex {

--- a/src/gfx_macros/shader_param.rs
+++ b/src/gfx_macros/shader_param.rs
@@ -125,7 +125,7 @@ fn method_create(cx: &mut ext::base::ExtCtxt, span: codemap::Span,
         },
         _ => {
             cx.span_err(span, "Unable to implement `ShaderParam::create_link()` on a non-structure");
-            cx.expr_lit(span, ast::LitNil)
+            cx.expr_tuple(span, vec![])
         },
     }
 }
@@ -203,7 +203,7 @@ fn method_fill(cx: &mut ext::base::ExtCtxt, span: codemap::Span,
         },
         _ => {
             cx.span_err(span, "Unable to implement `ShaderParam::bind()` on a non-structure");
-            cx.expr_lit(span, ast::LitNil)
+            cx.expr_tuple(span, vec![])
         }
     }
 }

--- a/src/gfx_macros/vertex_format.rs
+++ b/src/gfx_macros/vertex_format.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::fmt;
-use std::from_str::FromStr;
+use std::str::FromStr;
 use syntax::{ast, ext};
 use syntax::ext::build::AstBuilder;
 use syntax::ext::deriving::generic;
@@ -131,12 +131,12 @@ fn decode_type(cx: &mut ext::base::ExtCtxt, span: codemap::Span,
                                       not supported, but found: `{}`. Use an \
                                       integer component with an explicit size \
                                       instead.", ty_str).as_slice());
-            cx.expr_lit(span, ast::LitNil)
+            cx.expr_tuple(span, vec![])
         },
         ty_str => {
             cx.span_err(span, format!("Unrecognized component type: `{}`",
                                       ty_str).as_slice());
-            cx.expr_lit(span, ast::LitNil)
+            cx.expr_tuple(span, vec![])
         },
     }
 }
@@ -157,13 +157,13 @@ fn decode_count_and_type(cx: &mut ext::base::ExtCtxt, span: codemap::Span,
             _ => {
                 cx.span_err(span, format!("Unsupported fixed vector sub-type: \
                                           `{}`",pty.node).as_slice());
-                cx.expr_lit(span, ast::LitNil)
+                cx.expr_tuple(span, vec![])
             },
         }),
         _ => {
             cx.span_err(span, format!("Unsupported attribute type: `{}`",
                                       field.node.ty.node).as_slice());
-            (cx.expr_lit(span, ast::LitNil), cx.expr_lit(span, ast::LitNil))
+            (cx.expr_tuple(span, vec![]), cx.expr_tuple(span, vec![]))
         },
     }
 }
@@ -218,7 +218,7 @@ fn method_body(cx: &mut ext::base::ExtCtxt, span: codemap::Span,
         _ => {
             cx.span_err(span, "Unable to implement `gfx::VertexFormat::generate` \
                               on a non-structure");
-            cx.expr_lit(span, ast::LitNil)
+            cx.expr_tuple(span, vec![])
         }
     }
 }


### PR DESCRIPTION
The exact version is rustc 0.13.0-dev (0b7b4f075 2014-11-16 22:36:50 +0000) and the relevant upstream issues are rust-lang/rust#18752 and rust-lang/rust#18976.

Fixes #439.

I have tested this using huonw/compile_msg#7, but until it is merged the test suite won't compile without manually forking `compile_msg`.
