### PR TITLE
Fix IntSubType::Raw in vertex_format macro

### DIFF
--- a/src/gfx_macros/vertex_format.rs
+++ b/src/gfx_macros/vertex_format.rs
@@ -111,7 +111,7 @@ fn decode_type(cx: &mut ext::base::ExtCtxt, span: codemap::Span,
                 if ty_str.starts_with("i") { "Signed" } else { "Unsigned" }
             });
             let kind = cx.ident_of(match modifier {
-                None => "IntSubType::Raw",
+                None => "Raw",
                 Some(Modifier::Normalized) => "Normalized",
                 Some(Modifier::AsFloat) => "AsFloat",
                 Some(Modifier::AsDouble) => {


### PR DESCRIPTION
This fixes #449

This was my fault. I should've caught it when I was fixing all of this earlier, but I missed it. Sorry!
