### PR TITLE
Set color buffer outputs when using multiple color targets.

### DIFF
--- a/src/device/draw.rs
+++ b/src/device/draw.rs
@@ -99,6 +99,7 @@ pub trait CommandBuffer {
     fn bind_uniform(&mut self, shade::Location, shade::UniformValue);
     fn bind_texture(&mut self, ::TextureSlot, tex::TextureKind, back::Texture,
                     Option<::SamplerHandle>);
+    fn set_draw_color_buffers(&mut self, uint);
     fn set_primitive(&mut self, ::state::Primitive);
     fn set_viewport(&mut self, target::Rect);
     fn set_multi_sample(&mut self, Option<::state::MultiSample>);

--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -333,6 +333,7 @@ pub enum Command {
     BindUniformBlock(back::Program, UniformBufferSlot, UniformBlockIndex, back::Buffer),
     BindUniform(shade::Location, shade::UniformValue),
     BindTexture(TextureSlot, tex::TextureKind, back::Texture, Option<SamplerHandle>),
+    SetDrawColorBuffers(uint),
     SetPrimitiveState(state::Primitive),
     SetViewport(target::Rect),
     SetMultiSampleState(Option<state::MultiSample>),

--- a/src/gl_device/draw.rs
+++ b/src/gl_device/draw.rs
@@ -87,6 +87,10 @@ impl ::draw::CommandBuffer for GlCommandBuffer {
         self.buf.push(Command::BindTexture(slot, kind, tex, sampler));
     }
 
+    fn set_draw_color_buffers(&mut self, num: uint) {
+        self.buf.push(Command::SetDrawColorBuffers(num));
+    }
+
     fn set_primitive(&mut self, prim: ::state::Primitive) {
         self.buf.push(Command::SetPrimitiveState(prim));
     }

--- a/src/gl_device/lib.rs
+++ b/src/gl_device/lib.rs
@@ -375,6 +375,9 @@ impl GlDevice {
                     (_, _, _) => (),
                 }
             },
+            Command::SetDrawColorBuffers(num) => {
+                state::bind_draw_color_buffers(&self.gl, num);
+            },
             Command::SetPrimitiveState(prim) => {
                 state::bind_primitive(&self.gl, prim);
             },

--- a/src/gl_device/state.rs
+++ b/src/gl_device/state.rs
@@ -64,6 +64,18 @@ pub fn bind_multi_sample(gl: &gl::Gl, ms: Option<s::MultiSample>) {
     }
 }
 
+pub fn bind_draw_color_buffers(gl: &gl::Gl, num: uint) {
+    unsafe { gl.DrawBuffers(
+        num as i32,
+        [gl::COLOR_ATTACHMENT0,  gl::COLOR_ATTACHMENT1,  gl::COLOR_ATTACHMENT2,
+         gl::COLOR_ATTACHMENT3,  gl::COLOR_ATTACHMENT4,  gl::COLOR_ATTACHMENT5,
+         gl::COLOR_ATTACHMENT6,  gl::COLOR_ATTACHMENT7,  gl::COLOR_ATTACHMENT8,
+         gl::COLOR_ATTACHMENT9,  gl::COLOR_ATTACHMENT10, gl::COLOR_ATTACHMENT11,
+         gl::COLOR_ATTACHMENT12, gl::COLOR_ATTACHMENT13, gl::COLOR_ATTACHMENT14,
+         gl::COLOR_ATTACHMENT15].as_ptr()
+    )};
+}
+
 pub fn bind_viewport(gl: &gl::Gl, rect: Rect) {
     unsafe { gl.Viewport(
         rect.x as gl::types::GLint,

--- a/src/render/lib.rs
+++ b/src/render/lib.rs
@@ -288,6 +288,8 @@ impl<C: CommandBuffer> Renderer<C> {
                     *cur = *new;
                 }
             }
+            // activate the color targets that were just bound
+            self.command_buffer.set_draw_color_buffers(frame.colors.len());
             // append new planes
             for (i, new) in frame.colors.iter().enumerate()
                                  .skip(self.render_state.frame.colors.len()) {


### PR DESCRIPTION
This is to make sure binding color buffers is followed by an appropriate glDrawBuffers call.

This is to enable writing to multiple color targets.
