### PR TITLE
update to new glfw key event function to fix compile error

### DIFF
--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -229,7 +229,7 @@ fn main() {
         glfw.poll_events();
         for (_, event) in glfw::flush_messages(&events) {
             match event {
-                glfw::KeyEvent(glfw::Key::Escape, _, glfw::Press, _) =>
+                glfw::WindowEvent::Key(glfw::Key::Escape, _, glfw::Press, _) =>
                     window.set_should_close(true),
                 _ => {},
             }

--- a/examples/performance/main.rs
+++ b/examples/performance/main.rs
@@ -138,7 +138,7 @@ fn gfx_main(glfw: glfw::Glfw,
         glfw.poll_events();
         for (_, event) in glfw::flush_messages(&events) {
             match event {
-                glfw::KeyEvent(glfw::Key::Escape, _, glfw::Press, _) =>
+                glfw::WindowEvent::Key(glfw::Key::Escape, _, glfw::Press, _) =>
                     window.set_should_close(true),
                 _ => {},
             }

--- a/examples/terrain/main.rs
+++ b/examples/terrain/main.rs
@@ -216,7 +216,7 @@ fn main() {
         glfw.poll_events();
         for (_, event) in glfw::flush_messages(&events) {
             match event {
-                glfw::KeyEvent(glfw::Key::Escape, _, glfw::Press, _) =>
+                glfw::WindowEvent::Key(glfw::Key::Escape, _, glfw::Press, _) =>
                     window.set_should_close(true),
                 _ => {},
             }

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -126,7 +126,7 @@ fn main() {
         glfw.poll_events();
         for (_, event) in glfw::flush_messages(&events) {
             match event {
-                glfw::KeyEvent(glfw::Key::Escape, _, glfw::Press, _) =>
+                glfw::WindowEvent::Key(glfw::Key::Escape, _, glfw::Press, _) =>
                     window.set_should_close(true),
                 _ => {},
             }


### PR DESCRIPTION
As the new glfw-rs change the fn KeyEvent into WindowEvent::Key (https://github.com/bjz/glfw-rs/commit/60f8481e7dcaa4a8905013f06963e6bb794f89f0 && https://github.com/bjz/glfw-rs/commit/1c21628d628cbc3eccbea4c93bc8dc789ffb9b6d), need to update to fix compile error.
