### PR TITLE
Add OUTPUTS: to shader! macro for specifying fragment shader outputs.

### DIFF
--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -374,7 +374,8 @@ pub trait Device<C: draw::CommandBuffer> {
     fn create_array_buffer(&mut self) -> Result<ArrayBufferHandle, ()>;
     fn create_shader(&mut self, stage: shade::Stage, code: shade::ShaderSource) ->
                      Result<ShaderHandle, shade::CreateShaderError>;
-    fn create_program(&mut self, shaders: &[ShaderHandle]) -> Result<ProgramHandle, ()>;
+    fn shader_outputs<'a>(&mut self, code: &'a ::shade::ShaderSource) -> Vec<&'a str>;
+    fn create_program(&mut self, shaders: &[ShaderHandle], outputs: &[&str]) -> Result<ProgramHandle, ()>;
     fn create_frame_buffer(&mut self) -> FrameBufferHandle;
     fn create_surface(&mut self, info: tex::SurfaceInfo) -> Result<SurfaceHandle, tex::SurfaceError>;
     fn create_texture(&mut self, info: tex::TextureInfo) -> Result<TextureHandle, tex::TextureError>;

--- a/src/device/shade.rs
+++ b/src/device/shade.rs
@@ -322,6 +322,7 @@ pub struct ShaderSource<'a> {
     pub glsl_140: Option<&'a [u8]>,
     pub glsl_150: Option<&'a [u8]>,
     // TODO: hlsl_sm_N...
+    pub glsl_130plus_outputs: Option<[&'a str, ..4]>,
 }
 
 /// An error type for creating programs.

--- a/src/gfx_macros/lib.rs
+++ b/src/gfx_macros/lib.rs
@@ -219,6 +219,18 @@ macro_rules! shaders {
             }
         }
     };
+    (OUTPUTS: $v:expr $($t:tt)*) => {
+        {
+            mod __gfx_extern_crate_hack {
+                extern crate "gfx" as gfx_;
+                pub use self::gfx_ as gfx;
+            }
+            __gfx_extern_crate_hack::gfx::ShaderSource {
+                glsl_130plus_outputs: Some($v),
+                ..shaders!($($t)*)
+            }
+        }
+    };
     () => {
         {
             mod __gfx_extern_crate_hack {
@@ -230,6 +242,7 @@ macro_rules! shaders {
                 glsl_130: None,
                 glsl_140: None,
                 glsl_150: None,
+                glsl_130plus_outputs: None,
             }
         }
     }

--- a/src/gl_device/lib.rs
+++ b/src/gl_device/lib.rs
@@ -620,8 +620,12 @@ impl Device<GlCommandBuffer> for GlDevice {
         name.map(|sh| ::Handle(sh, stage))
     }
 
-    fn create_program(&mut self, shaders: &[::ShaderHandle]) -> Result<::ProgramHandle, ()> {
-        let (prog, log) = shade::create_program(&self.gl, &self.caps, shaders);
+    fn shader_outputs<'a>(&mut self, code: &'a ::shade::ShaderSource) -> Vec<&'a str> {
+        shade::shader_outputs(code, self.info.shading_language)
+    }
+
+    fn create_program(&mut self, shaders: &[::ShaderHandle], outputs: &[&str]) -> Result<::ProgramHandle, ()> {
+        let (prog, log) = shade::create_program(&self.gl, &self.caps, shaders, outputs);
         log.map(|log| {
             let level = if prog.is_err() { log::ERROR } else { log::WARN };
             log!(level, "\tProgram link log: {}", log);

--- a/src/render/lib.rs
+++ b/src/render/lib.rs
@@ -498,6 +498,7 @@ impl<D: device::Device<C>, C: CommandBuffer> DeviceHelper<C> for D {
             Ok(s) => s,
             Err(e) => return Err(ProgramError::Fragment(e)),
         };
-        self.create_program(&[vs, fs]).map_err(|e| ProgramError::Link(e))
+        let outputs = self.shader_outputs(&fs_src);
+        self.create_program(&[vs, fs], outputs.as_slice()).map_err(|e| ProgramError::Link(e))
     }
 }


### PR DESCRIPTION
Provides a way to specify multiple outputs from a fragment shader. The names will be bound to indices according to their place in the OUTPUTS array. 

Used like this:

```
static MY_FRAGMENT_SRC: gfx::ShaderSource<'static> = shaders! {
GLSL_150: b"
  #version 150 core
...
  out vec4 o_Color;
  out vec4 o_Emittance;
...
  void main() {
    o_Diffuse   = texture(u_Tex0, v_TexCoord);
    o_Emittance = texture(u_Tex1, v_TexCoord);
  }
"
OUTPUTS: ["o_Diffuse", "o_Emittance", "", ""]
};
```

I couldn't figure out how to make OUTPUTS an array of variable length. Perhaps somebody with better rust-fu can help with that.
