### PR TITLE
Avoid warning; if_let now part of language.

### DIFF
--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase, if_let)]
+#![feature(phase)]
 #![feature(phase, unsafe_destructor)]
 #![deny(missing_docs)]
 


### PR DESCRIPTION
Fixed warning:
"warning: feature has been added to Rust, directive not necessary"
