### PR TITLE
Fixed macros and bitfields to compile on latest

### DIFF
--- a/src/device/state.rs
+++ b/src/device/state.rs
@@ -299,7 +299,6 @@ impl fmt::Show for Blend {
 
 bitflags!(
     #[allow(missing_docs)]
-    #[deriving(Copy)]
     flags ColorMask: u32 {  //u8 is preferred, but doesn't seem to work well
         const RED     = 0x1,
         const GREEN   = 0x2,

--- a/src/device/target.rs
+++ b/src/device/target.rs
@@ -42,7 +42,6 @@ pub type ColorValue = [f32, ..4];
 
 bitflags!(
     #[allow(missing_docs)]
-    #[deriving(Copy)]
     flags Mask: u32 {  //u8 is preferred, but doesn't seem to work well
         const COLOR     = 0x01,
         const COLOR0    = 0x01,

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -62,7 +62,7 @@ pub struct Graphics<D, C: device::draw::CommandBuffer> {
 impl<D: device::Device<C>, C: device::draw::CommandBuffer> Graphics<D, C> {
     /// Create a new graphics wrapper.
     pub fn new(mut device: D) -> Graphics<D, C> {
-        let rend = Renderer::new(&mut device);
+        let rend = device.create_renderer();
         Graphics {
             device: device,
             renderer: rend,

--- a/src/gfx_macros/shader_param.rs
+++ b/src/gfx_macros/shader_param.rs
@@ -416,7 +416,7 @@ pub fn expand(context: &mut ext::base::ExtCtxt, span: codemap::Span,
             },
         ],
     };
-    let fixup = |item| {
+    let fixup = |: item| {
         push(super::fixup_extern_crate_paths(item, path_root))
     };
     trait_def.expand(context, meta_item, item, fixup);

--- a/src/gfx_macros/vertex_format.rs
+++ b/src/gfx_macros/vertex_format.rs
@@ -230,7 +230,7 @@ pub fn expand(context: &mut ext::base::ExtCtxt, span: codemap::Span,
               push: |P<ast::Item>|) {
     // Insert the `gfx` reexport module
     let path_root = super::extern_crate_hack(context, span, |i| push(i));
-    let fixup = |item| {
+    let fixup = |: item| {
         push(super::fixup_extern_crate_paths(item, path_root))
     };
 

--- a/src/render/mesh.rs
+++ b/src/render/mesh.rs
@@ -184,7 +184,7 @@ impl ToSlice for BufferHandle<u32> {
 }
 
 /// Describes kinds of errors that may occur in the mesh linking
-#[deriving(Clone, Show)]
+#[deriving(Clone, Copy, Show)]
 pub enum LinkError {
     /// An attribute index is out of supported bounds
     MeshAttribute(uint),
@@ -197,6 +197,7 @@ const MAX_SHADER_INPUTS: uint = 64 / BITS_PER_ATTRIBUTE;
 const MESH_ATTRIBUTE_MASK: uint = (1u << BITS_PER_ATTRIBUTE) - 1;
 
 /// An iterator over mesh attributes.
+#[deriving(Copy)]
 pub struct AttributeIndices {
     value: u64,
 }
@@ -210,6 +211,7 @@ impl Iterator<uint> for AttributeIndices {
 }
 
 /// Holds a remapping table from shader inputs to mesh attributes.
+#[deriving(Copy)]
 pub struct Link {
     table: u64,
 }


### PR DESCRIPTION
"cargo test" still fails due to some `glutin` stuff.
