### PR TITLE
Fix built-in filter on buggy drivers.

### DIFF
--- a/src/gl_device/shade.rs
+++ b/src/gl_device/shade.rs
@@ -188,7 +188,7 @@ fn query_attributes(gl: &gl::Gl, prog: super::Program) -> Vec<s::Attribute> {
             base_type: base,
             container: container,
         }
-    }).filter(|a| a.location != -1) // remove built-ins
+    }).filter(|a| !a.name.starts_with("gl_")) // remove built-ins
     .collect()
 }
 


### PR DESCRIPTION
OS X v10.7 GMA 950 driver reports gl_InstanceID on location != -1, even should built-ins should always be at -1.
Need to work around this in the gfx-rs...
