### PR TITLE
Use parse() instead of deprecated from_str()

### DIFF
--- a/src/gfx_macros/vertex_format.rs
+++ b/src/gfx_macros/vertex_format.rs
@@ -68,7 +68,7 @@ fn find_modifier(cx: &mut ext::base::ExtCtxt, span: codemap::Span,
     attributes.iter().fold(None, |modifier, attribute| {
         match attribute.node.value.node {
             ast::MetaWord(ref word) => {
-                from_str(word.get()).and_then(|new_modifier| {
+                word.get().parse().and_then(|new_modifier| {
                     attr::mark_used(attribute);
                     modifier.map_or(Some(new_modifier), |modifier| {
                         cx.span_warn(span, format!(

--- a/src/gl_device/info.rs
+++ b/src/gl_device/info.rs
@@ -85,9 +85,9 @@ impl Version {
         // TODO: make this even more lenient so that we can also accept
         // `<major> "." <minor> [<???>]`
         let mut it = version.split('.');
-        let major = it.next().and_then(from_str);
-        let minor = it.next().and_then(from_str);
-        let revision = it.next().and_then(from_str);
+        let major = it.next().and_then(|s| s.parse());
+        let minor = it.next().and_then(|s| s.parse());
+        let revision = it.next().and_then(|s| s.parse());
 
         match (major, minor, revision) {
             (Some(major), Some(minor), revision) => Ok(Version {


### PR DESCRIPTION
from_str was deprecated in rust: https://github.com/rust-lang/rust/commit/4908017d59da8694b9ceaf743baf1163c1e19086
