### PR TITLE
Add fence suppot

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -647,6 +647,7 @@ impl gfx::Device for Device {
             |gl, v| unsafe { gl.DeleteRenderbuffers(1, v) },
             |gl, v| unsafe { gl.DeleteTextures(1, v) },
             |gl, v| unsafe { gl.DeleteSamplers(1, v) },
+            |gl, v| unsafe { gl.DeleteSync(v.0) },
         );
     }
 }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -666,10 +666,10 @@ impl gfx::traits::DeviceFence<Resources> for Device {
 
         self.submit(info);
 
-        unsafe {
-            let fence = self.share.context.FenceSync(gl::SYNC_GPU_COMMANDS_COMPLETE, 0);
-            self.frame_handles.make_fence(Fence(fence))
-        }
+        let fence = unsafe {
+            self.share.context.FenceSync(gl::SYNC_GPU_COMMANDS_COMPLETE, 0)
+        };
+        self.frame_handles.make_fence(Fence(fence))
     }
 
     fn fence_wait(&mut self, fence: &handle::Fence<Resources>) {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -52,6 +52,12 @@ pub type Surface        = gl::types::GLuint;
 pub type Sampler        = gl::types::GLuint;
 pub type Texture        = gl::types::GLuint;
 
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Fence(gl::types::GLsync);
+
+unsafe impl Send for Fence {}
+unsafe impl Sync for Fence {}
+
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Resources {}
 
@@ -64,6 +70,7 @@ impl gfx::Resources for Resources {
     type Surface        = Surface;
     type Texture        = Texture;
     type Sampler        = Sampler;
+    type Fence          = Fence;
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/src/core/src/device/dummy.rs
+++ b/src/core/src/device/dummy.rs
@@ -33,6 +33,7 @@ impl Resources for DummyResources {
     type Surface        = ();
     type Texture        = ();
     type Sampler        = ();
+    type Fence          = ();
 }
 
 impl DummyDevice {

--- a/src/core/src/device/handle.rs
+++ b/src/core/src/device/handle.rs
@@ -195,6 +195,8 @@ pub trait Producer<R: Resources> {
     fn make_surface(&mut self, R::Surface, tex::SurfaceInfo) -> Surface<R>;
     fn make_texture(&mut self, R::Texture, tex::TextureInfo) -> Texture<R>;
     fn make_sampler(&mut self, R::Sampler, tex::SamplerInfo) -> Sampler<R>;
+    fn make_fence(&mut self, name: R::Fence) -> Fence<R>;
+
     /// Walk through all the handles, keep ones that are reference elsewhere
     /// and call the provided delete function (resource-specific) for others
     fn clean_with<T,
@@ -257,6 +259,12 @@ impl<R: Resources> Producer<R> for Manager<R> {
         let r = Arc::new(name);
         self.samplers.push(r.clone());
         Sampler(r, info)
+    }
+
+    fn make_fence(&mut self, name: R::Fence) -> Fence<R> {
+        let r = Arc::new(name);
+        self.fences.push(r.clone());
+        Fence(r)
     }
 
     fn clean_with<T,
@@ -384,5 +392,11 @@ impl<R: Resources> Manager<R> {
     pub fn ref_sampler(&mut self, handle: &Sampler<R>) -> R::Sampler {
         self.samplers.push(handle.0.clone());
         *handle.0.deref()
+    }
+
+    /// Reference a fence
+    pub fn ref_fence(&mut self, fence: &Fence<R>) -> R::Fence {
+        self.fences.push(fence.0.clone());
+        *fence.0.deref()
     }
 }

--- a/src/core/src/device/handle.rs
+++ b/src/core/src/device/handle.rs
@@ -163,7 +163,7 @@ impl<R: Resources> Sampler<R> {
     }
 }
 
-/// Sampler Handle
+/// Fence Handle
 #[derive(Clone, Debug, PartialEq)]
 pub struct Fence<R: Resources>(Arc<R::Fence>);
 

--- a/src/core/src/device/mod.rs
+++ b/src/core/src/device/mod.rs
@@ -186,6 +186,7 @@ pub trait Resources:           Clone + Hash + fmt::Debug + Eq + PartialEq {
     type Surface:       Copy + Clone + Hash + fmt::Debug + Eq + PartialEq + Send + Sync;
     type Texture:       Copy + Clone + Hash + fmt::Debug + Eq + PartialEq + Send + Sync;
     type Sampler:       Copy + Clone + Hash + fmt::Debug + Eq + PartialEq + Send + Sync;
+    type Fence:         Copy + Clone + Hash + fmt::Debug + Eq + PartialEq + Send + Sync;
 }
 
 #[allow(missing_docs)]

--- a/src/core/src/device/mod.rs
+++ b/src/core/src/device/mod.rs
@@ -284,3 +284,16 @@ pub trait Device {
     /// Cleanup unused resources, to be called between frames.
     fn cleanup(&mut self);
 }
+
+/// Extension to the Device that allows for submitting of commands
+/// around a fence
+pub trait DeviceFence<R: Resources>: Device<Resources=R> {
+    /// Submit a command buffer to the stream creating a fence
+    /// the fence is signaled after the GPU has executed all commands
+    /// in the buffer
+    fn fenced_submit(&mut self, SubmitInfo<Self>, after: Option<handle::Fence<R>>) -> handle::Fence<R>;
+
+    /// Wait on the supplied fence stalling the current thread until
+    /// the fence is satisfied
+    fn fence_wait(&mut self, fence: &handle::Fence<R>);
+}

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -24,7 +24,7 @@ extern crate num;
 
 /// public re-exported traits
 pub mod traits {
-    pub use device::{Device, Factory};
+    pub use device::{Device, Factory, DeviceFence};
     pub use extra::factory::FactoryExt;
     pub use extra::stream::{Stream, StreamFactory};
     pub use render::RenderFactory;

--- a/tests/handle.rs
+++ b/tests/handle.rs
@@ -15,6 +15,7 @@ impl gfx::Resources for TestResources {
     type Surface = ();
     type Texture = ();
     type Sampler = ();
+    type Fence = ();
 }
 
 fn mock_buffer<T>(len: usize) -> Buffer<TestResources, T> {
@@ -51,6 +52,7 @@ fn test_cleanup() {
         |_,_| (),
         |_,_| (),
         |b,_| { *b += 1; },
+        |_,_| (),
         |_,_| (),
         |_,_| (),
         |_,_| ()


### PR DESCRIPTION
Solves #688

This exposes the command fences to the developer. Via the `DeviceFence` trait. Fences are managed much like other resources and are added as an associated type. This api adds two abilities, the fence can block the device server by using `fenced_submit`. Or the user may synchronize in the client cpu by using  `fence_wait`.