### PR TITLE
Add program::Builder

### DIFF
--- a/src/backend/gl/src/factory.rs
+++ b/src/backend/gl/src/factory.rs
@@ -22,6 +22,7 @@ use gfx::device as d;
 use gfx::device::handle;
 use gfx::device::handle::Producer;
 use gfx::device::mapping::Builder;
+use gfx::device::program;
 use gfx::tex::Size;
 
 use {Buffer, Share};
@@ -215,12 +216,12 @@ impl d::Factory<R> for Factory {
                 .map(|sh| self.share.handles.borrow_mut().make_shader(sh, stage))
     }
 
-    fn create_program(&mut self, shaders: &[handle::Shader<R>], targets: Option<&[&str]>)
+    fn create_program(&mut self, builder: &program::Builder<R>)
                       -> Result<handle::Program<R>, d::shade::CreateProgramError> {
         let frame_handles = &mut self.frame_handles;
         let mut handles = self.share.handles.borrow_mut();
-        ::shade::create_program(&self.share.context, &self.share.capabilities, targets,
-            shaders.iter().map(|h| frame_handles.ref_shader(h)))
+        ::shade::create_program(&self.share.context, &self.share.capabilities, Some(&builder.targets[..]),
+            builder.shaders.iter().map(|h| frame_handles.ref_shader(h)))
                 .map(|(name, info)| handles.make_program(name, info))
     }
 

--- a/src/core/src/device/mod.rs
+++ b/src/core/src/device/mod.rs
@@ -30,6 +30,7 @@ pub mod handle;
 pub mod mapping;
 pub mod shade;
 pub mod tex;
+pub mod program;
 
 mod arc;
 
@@ -212,7 +213,7 @@ pub trait Factory<R: Resources> {
     fn create_array_buffer(&mut self) -> Result<handle::ArrayBuffer<R>, NotSupported>;
     fn create_shader(&mut self, stage: shade::Stage, code: &[u8]) ->
                      Result<handle::Shader<R>, shade::CreateShaderError>;
-    fn create_program(&mut self, shaders: &[handle::Shader<R>], targets: Option<&[&str]>)
+    fn create_program(&mut self, builder: &program::Builder<R>)
                       -> Result<handle::Program<R>, shade::CreateProgramError>;
     fn create_frame_buffer(&mut self) -> Result<handle::FrameBuffer<R>, NotSupported>;
     fn create_surface(&mut self, tex::SurfaceInfo) -> Result<handle::Surface<R>, tex::SurfaceError>;

--- a/src/core/src/device/program.rs
+++ b/src/core/src/device/program.rs
@@ -1,0 +1,104 @@
+// Copyright 2015 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+//! Program creating and modification
+
+
+use super::Resources;
+use handle;
+
+/// A program builder is used to `bind` shader/target/transform_vearyings
+/// together
+pub struct Builder<'a, R>
+    where R: Resources+'a,
+          R::Buffer: 'a,
+          R::ArrayBuffer: 'a,
+          R::Shader: 'a,
+          R::Program: 'a,
+          R::FrameBuffer: 'a,
+          R::Surface: 'a,
+          R::Texture: 'a,
+          R::Sampler: 'a,
+          R::Fence: 'a
+
+{
+    /// The shaders bound to the program
+    pub shaders: Vec<&'a handle::Shader<R>>,
+    /// the targets for the output
+    pub targets: Vec<&'a str>,
+
+    /* TODO
+    /// the transform_varyings for transform feedback
+    pub transform_varyings: Vec<&'a str>
+    */
+}
+
+impl<'a, R> Builder<'a, R>
+    where R: Resources+'a,
+          R::Buffer: 'a,
+          R::ArrayBuffer: 'a,
+          R::Shader: 'a,
+          R::Program: 'a,
+          R::FrameBuffer: 'a,
+          R::Surface: 'a,
+          R::Texture: 'a,
+          R::Sampler: 'a,
+          R::Fence: 'a
+{
+    /// Create's a new program builder
+    pub fn new() -> Builder<'a, R> {
+        Builder{
+            shaders: Vec::new(),
+            targets: Vec::new(),
+            //transform_varyings: Vec::new()
+        }
+    }
+
+    /// add a shader into to the program
+    pub fn add_shader(mut self, shader: &'a handle::Shader<R>) -> Builder<'a, R> {
+        self.shaders.push(shader);
+        self
+    }
+
+    /// add multiple shaders
+    pub fn add_shaders(mut self, shaders: &[&'a handle::Shader<R>]) -> Builder<'a, R> {
+        for s in shaders {
+            self = self.add_shader(s);
+        }
+        self
+    }
+
+    /// add a target to the shader
+    pub fn add_target(mut self, target: &'a str) -> Builder<'a, R> {
+        self.targets.push(target);
+        self
+    }
+
+    /// add multiple targets
+    pub fn add_targets(mut self, targets: &[&'a str]) -> Builder<'a, R> {
+        for t in targets {
+            self = self.add_target(t);
+        }
+        self
+    }
+
+    /* TODO
+    /// add a transform varying binding point
+    pub fn add_transform_varying(mut self, varying: &'a str) -> Builder<'a, R> {
+        self.transform_varyings.push(varying);
+        self
+    }
+    */
+}

--- a/src/core/src/extra/factory.rs
+++ b/src/core/src/extra/factory.rs
@@ -34,6 +34,7 @@ pub trait FactoryExt<R: device::Resources>: device::Factory<R> {
     /// Create a simple program given a vertex shader with a fragment one.
     fn link_program(&mut self, vs_code: &[u8], fs_code: &[u8])
                     -> Result<handle::Program<R>, ProgramError> {
+
         let vs = match self.create_shader(Stage::Vertex, vs_code) {
             Ok(s) => s,
             Err(e) => return Err(ProgramError::Vertex(e)),
@@ -43,7 +44,10 @@ pub trait FactoryExt<R: device::Resources>: device::Factory<R> {
             Err(e) => return Err(ProgramError::Fragment(e)),
         };
 
-        self.create_program(&[vs, fs], None)
+        let builder = device::program::Builder::new()
+            .add_shaders(&[&vs, &fs]);
+
+        self.create_program(&builder)
             .map_err(|e| ProgramError::Link(e))
     }
 
@@ -69,7 +73,12 @@ pub trait FactoryExt<R: device::Resources>: device::Factory<R> {
             Ok(s) => s,
             Err(e) => return Err(ProgramError::Fragment(e)),
         };
-        self.create_program(&[vs, fs], Some(fs_src.targets))
+
+        let builder = device::program::Builder::new()
+            .add_shaders(&[&vs, &fs])
+            .add_targets(fs_src.targets);
+
+        self.create_program(&builder)
             .map_err(|e| ProgramError::Link(e))
     }
 


### PR DESCRIPTION
This is a breaking change.

This adds a program-builder for creation of shader programs. This exists to avoid new parameters each time we add support for new features that may require new options when calling create_program. 