### PR TITLE
Publish 0.8 w/ the libc fix

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 
 name = "gfx_device_gl"
-version = "0.6.0"
+version = "0.6.1"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.8.0"
+version = "0.8.1"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/glfw/Cargo.toml
+++ b/src/window/glfw/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glfw"
-version = "0.4.0"
+version = "0.4.1"
 description = "GLFW window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
First set of cherry-picked changes to backport onto 0.8.

Includes:
- https://github.com/gfx-rs/gfx/pull/812
- https://github.com/gfx-rs/gfx/pull/818
