### PR TITLE
Remove libc dependency

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -28,7 +28,6 @@ name = "gfx_device_gl"
 
 [dependencies]
 log = "0.3"
-libc = "0.2"
 gfx_gl = "0.3"
 
 [dependencies.gfx]

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -29,7 +29,7 @@ name = "gfx_device_gl"
 [dependencies]
 log = "0.3"
 libc = "0.2"
-gfx_gl = "0.2"
+gfx_gl = "0.3"
 
 [dependencies.gfx]
 path = "../../core"

--- a/src/backend/gl/src/factory.rs
+++ b/src/backend/gl/src/factory.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use libc;
 use std::rc::Rc;
 use std::slice;
 
@@ -142,7 +141,7 @@ impl Factory {
 #[allow(raw_pointer_derive)]
 #[derive(Copy, Clone)]
 pub struct RawMapping {
-    pub pointer: *mut libc::c_void,
+    pub pointer: *mut ::std::os::raw::c_void,
     target: gl::types::GLenum,
 }
 
@@ -329,7 +328,7 @@ impl d::Factory<R> for Factory {
             d::MapAccess::Readable => gl::READ_ONLY,
             d::MapAccess::Writable => gl::WRITE_ONLY,
             d::MapAccess::RW => gl::READ_WRITE
-        }) } as *mut libc::c_void;
+        }) } as *mut ::std::os::raw::c_void;
         RawMapping {
             pointer: ptr,
             target: gl::ARRAY_BUFFER

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -20,7 +20,6 @@
 
 #[macro_use]
 extern crate log;
-extern crate libc;
 extern crate gfx_gl as gl;
 extern crate gfx;
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -150,7 +150,7 @@ fn target_to_gl(target: Target) -> gl::types::GLenum {
 
 /// Create a new device with a factory.
 pub fn create<F>(fn_proc: F) -> (Device, Factory) where
-    F: FnMut(&str) -> *const ::libc::c_void
+    F: FnMut(&str) -> *const std::os::raw::c_void
 {
     let device = Device::new(fn_proc);
     let factory = Factory::new(device.share.clone());
@@ -179,7 +179,7 @@ impl Device {
     /// Create a new device. There can be only one!
     /// Also, load OpenGL symbols and detect driver information.
     fn new<F>(fn_proc: F) -> Device where
-        F: FnMut(&str) -> *const ::libc::c_void
+        F: FnMut(&str) -> *const std::os::raw::c_void
     {
         use gfx::device::handle::Producer;
         let gl = gl::Gl::load_with(fn_proc);

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -35,4 +35,3 @@ version = "0.7"
 
 [dependencies]
 glutin = ">=0.4.2"
-libc = "0.2"

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -17,7 +17,6 @@
 extern crate gfx;
 extern crate gfx_device_gl;
 extern crate glutin;
-extern crate libc;
 
 use gfx::tex::Size;
 
@@ -85,7 +84,7 @@ pub fn init(window: glutin::Window) -> Success {
     use gfx::traits::StreamFactory;
     unsafe { window.make_current().unwrap() };
     let format = window.get_pixel_format();
-    let (device, mut factory) = gfx_device_gl::create(|s| window.get_proc_address(s) as *const libc::c_void);
+    let (device, mut factory) = gfx_device_gl::create(|s| window.get_proc_address(s) as *const std::os::raw::c_void);
     let out = Output {
         window: window,
         frame: factory.get_main_frame_buffer(),


### PR DESCRIPTION
This patch replaces all occurrences of ``libc::c_void`` with ``std::os::raw::c_void``. This type is required for parts that interact with gfx_gl (where it comes from gl_generator), and the rest was changed to the same type for consistency.