### PR TITLE
Use glGetStringi to get extensions on OpenGL 3.0+

### DIFF
--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -181,7 +181,7 @@ impl Info {
         let platform_name = PlatformName::get(gl);
         let version = Version::parse(get_string(gl, gl::VERSION)).unwrap();
         let shading_language = Version::parse(get_string(gl, gl::SHADING_LANGUAGE_VERSION)).unwrap();
-        let extensions = if version >= Version::new(3, 2, None, "") {
+        let extensions = if version >= Version::new(3, 0, None, "") {
             let num_exts = get_usize(gl, gl::NUM_EXTENSIONS) as gl::types::GLuint;
             (0..num_exts)
                 .map(|i| unsafe { c_str_as_static_str(gl.GetStringi(gl::EXTENSIONS, i) as *const i8) })


### PR DESCRIPTION
glGetString(GL_EXTENSIONS) is obsolete since OpenGL 3.0, and not
support for it was removed in 3.1.

On Mesa, this can be tested by setting MESA_GL_VERSION_OVERRIDE to
different values. Before this patch, both 3.0FC and 3.1 fail, while 3.0
does not, as expected.

Fixes #778 