### PR TITLE
Ignore built-in uniforms.

### DIFF
--- a/src/backend/gl/src/shade.rs
+++ b/src/backend/gl/src/shade.rs
@@ -253,6 +253,9 @@ fn query_parameters(gl: &gl::Gl, caps: &d::Capabilities, prog: super::Program)
             gl.GetUniformLocation(prog, raw as *const gl::types::GLchar)
         };
         let real_name = name[..length as usize].to_string();
+        if real_name.starts_with("gl_") {
+            continue;
+        }
         match StorageType::new(storage) {
             StorageType::Var(base, container) => {
                 info!("\t\tUniform[{}] = {:?}\t{:?}\t{:?}", loc, real_name, base, container);


### PR DESCRIPTION
OpenGL reports built-in uniforms alongside user defined ones, but they
can not be linked with user data and we can just skip over them.

All built-in uniforms have names that start with reserved prefix OpenGL,
which can be used to distinguish them from user-defined ones.

Fixes #840 