### PR TITLE
Gamma correctness

### DIFF
--- a/examples/blend/main.rs
+++ b/examples/blend/main.rs
@@ -19,7 +19,7 @@ extern crate glutin;
 
 extern crate image;
 
-pub use gfx::format::Rgba8;
+pub use gfx::format::{Rgba8, Srgb8, DepthStencil};
 use gfx::traits::{Device, Factory, FactoryExt};
 
 gfx_vertex_struct!( Vertex {
@@ -41,7 +41,7 @@ gfx_pipeline!( pipe {
     lena: gfx::TextureSampler<[f32; 4]> = "t_Lena",
     tint: gfx::TextureSampler<[f32; 4]> = "t_Tint",
     blend: gfx::Global<i32> = "i_Blend",
-    out: gfx::RenderTarget<Rgba8> = "o_Color",
+    out: gfx::RenderTarget<Srgb8> = "o_Color",
 });
 
 fn load_texture<R, F>(factory: &mut F, data: &[u8])
@@ -61,7 +61,7 @@ pub fn main() {
             .with_title("Blending example".to_string())
             .with_dimensions(800, 600);
     let (window, mut device, mut factory, main_color, _) =
-        gfx_window_glutin::init::<Rgba8>(builder);
+        gfx_window_glutin::init::<Srgb8, DepthStencil>(builder);
     let mut encoder = factory.create_encoder();
 
     // fullscreen quad
@@ -132,7 +132,7 @@ pub fn main() {
         }
 
         encoder.reset();
-        encoder.clear(&data.out, [0.0; 4]);
+        encoder.clear(&data.out, [0.0; 3]);
         encoder.draw(&slice, &pso, &data);
 
         device.submit(encoder.as_buffer());

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -40,7 +40,7 @@ extern crate noise;
 use rand::Rng;
 use cgmath::{SquareMatrix, Matrix4, Point3, Vector3, EuclideanVector, deg};
 use cgmath::{Transform, AffineMatrix3};
-pub use gfx::format::{Depth, I8Scaled, Rgba8};
+pub use gfx::format::{Depth, I8Scaled, Srgb8};
 use gfx::traits::{Device, Factory, FactoryExt};
 use genmesh::{Vertices, Triangulate};
 use genmesh::generators::{SharedVertex, IndexedPolygon};
@@ -72,7 +72,7 @@ gfx_pipeline!( terrain {
     out_position: gfx::RenderTarget<GFormat> = "o_Position",
     out_normal: gfx::RenderTarget<GFormat> = "o_Normal",
     out_color: gfx::RenderTarget<GFormat> = "o_Color",
-    out_depth: gfx::DepthTarget<gfx::format::Depth> =
+    out_depth: gfx::DepthTarget<Depth> =
         gfx::preset::depth::LESS_EQUAL_WRITE,
 });
 
@@ -124,7 +124,7 @@ gfx_vertex_struct!( BlitVertex {
 gfx_pipeline!( blit {
     vbuf: gfx::VertexBuffer<BlitVertex> = (),
     tex: gfx::TextureSampler<[f32; 4]> = "u_Tex",
-    out: gfx::RenderTarget<Rgba8> = "o_Color",
+    out: gfx::RenderTarget<Srgb8> = "o_Color",
 });
 
 pub static BLIT_VERTEX_SRC: &'static [u8] = b"
@@ -169,7 +169,7 @@ gfx_pipeline!( light {
     tex_diffuse: gfx::TextureSampler<[f32; 4]> = "u_TexDiffuse",
     out_color: gfx::BlendTarget<GFormat> =
         ("o_Color", gfx::state::MASK_ALL, gfx::preset::blend::ADD),
-    out_depth: gfx::DepthTarget<gfx::format::Depth> =
+    out_depth: gfx::DepthTarget<Depth> =
         gfx::preset::depth::LESS_EQUAL_TEST,
 });
 
@@ -235,7 +235,7 @@ gfx_pipeline!( emitter {
     radius: gfx::Global<f32> = "u_Radius",
     out_color: gfx::BlendTarget<GFormat> =
         ("o_Color", gfx::state::MASK_ALL, gfx::preset::blend::ADD),
-    out_depth: gfx::DepthTarget<gfx::format::Depth> =
+    out_depth: gfx::DepthTarget<Depth> =
         gfx::preset::depth::LESS_EQUAL_TEST,
 });
 
@@ -343,7 +343,7 @@ fn create_g_buffer<R: gfx::Resources, F: Factory<R>>(
 pub fn main() {
     env_logger::init().unwrap();
     let (window, mut device, mut factory, main_color, _) =
-        gfx_window_glutin::init::<Rgba8>(glutin::WindowBuilder::new()
+        gfx_window_glutin::init::<Srgb8, Depth>(glutin::WindowBuilder::new()
             .with_title("Deferred rendering example with gfx-rs".to_string())
             .with_dimensions(800, 600)
             .with_gl(glutin::GL_CORE)
@@ -623,7 +623,6 @@ pub fn main() {
         };
         blit_data.tex = (blit_tex.clone(), sampler.clone());
         // Show the result
-        encoder.clear(&main_color, [0.0, 0.0, 0.0, 1.0]);
         encoder.draw(&blit_slice, &blit_pso, &blit_data);
 
         device.submit(encoder.as_buffer());

--- a/examples/flowmap/main.rs
+++ b/examples/flowmap/main.rs
@@ -22,7 +22,7 @@ extern crate glutin;
 extern crate image;
 
 use std::io::Cursor;
-pub use gfx::format::Rgba8;
+pub use gfx::format::{Rgba8, Srgb8, Depth};
 
 gfx_vertex_struct!( Vertex {
     pos: [f32; 2] = "a_Pos",
@@ -45,7 +45,7 @@ gfx_pipeline!( pipe {
     noise: gfx::TextureSampler<[f32; 4]> = "t_Noise",
     offset0: gfx::Global<f32> = "f_Offset0",
     offset1: gfx::Global<f32> = "f_Offset1",
-    out: gfx::RenderTarget<Rgba8> = "o_Color",
+    out: gfx::RenderTarget<Srgb8> = "o_Color",
 });
 
 fn load_texture<R, F>(factory: &mut F, data: &[u8])
@@ -67,7 +67,7 @@ pub fn main() {
             .with_title("Flowmap example".to_string())
             .with_dimensions(800, 600);
     let (window, mut device, mut factory, main_color, _) =
-        gfx_window_glutin::init::<Rgba8>(builder);
+        gfx_window_glutin::init::<Srgb8, Depth>(builder);
     let mut encoder = factory.create_encoder();
 
     let vertex_data = [
@@ -140,7 +140,7 @@ pub fn main() {
         }
 
         encoder.reset();
-        encoder.clear(&data.out, [0.3, 0.3, 0.3, 1.0]);
+        encoder.clear(&data.out, [0.3, 0.3, 0.3]);
 
         data.offset0 = cycle0;
         data.offset1 = cycle1;

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -44,7 +44,7 @@ gfx_pipeline!(pipe {
     vertex: gfx::VertexBuffer<Vertex> = (),
     instance: gfx::InstanceBuffer<Instance> = (),
     scale: gfx::Global<f32> = "u_Scale",
-    out: gfx::RenderTarget<gfx::format::Rgba8> = "o_Color",
+    out: gfx::RenderTarget<gfx::format::Srgb8> = "o_Color",
 });
 
 const MAX_INSTANCE_COUNT: usize = 2048;
@@ -56,7 +56,7 @@ fn main() {
         .with_dimensions(800, 600)
         .with_title("Instancing example".to_string());
     let (window, mut device, mut factory, main_color, _) =
-        gfx_window_glutin::init::<gfx::format::Rgba8>(builder);
+        gfx_window_glutin::init::<gfx::format::Srgb8, gfx::format::Depth>(builder);
     let mut encoder = factory.create_encoder();
 
     let pso = factory.create_pipeline_simple(
@@ -122,7 +122,7 @@ fn main() {
         }
 
         encoder.reset();
-        encoder.clear(&data.out, [0.1, 0.2, 0.3, 1.0]);
+        encoder.clear(&data.out, [0.1, 0.2, 0.3]);
         encoder.draw(&slice, &pso, &data);
 
         device.submit(encoder.as_buffer());

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -17,7 +17,7 @@ extern crate gfx;
 extern crate gfx_window_glutin;
 extern crate glutin;
 
-pub use gfx::format::Rgba8;
+pub use gfx::format::{Srgb8, Depth};
 
 gfx_vertex_struct!( Vertex {
     pos: [f32; 2] = "a_Pos",
@@ -36,7 +36,7 @@ impl Vertex {
 gfx_pipeline!(pipe {
     vbuf: gfx::VertexBuffer<Vertex> = (),
     tex: gfx::TextureSampler<[f32; 3]> = "t_Tex",
-    out: gfx::RenderTarget<Rgba8> = "o_Color",
+    out: gfx::RenderTarget<Srgb8> = "o_Color",
 });
 
 // Larger red dots
@@ -84,7 +84,7 @@ pub fn main() {
         .with_title("Mipmap example".to_string())
         .with_dimensions(800, 600);
     let (window, mut device, mut factory, main_color, _) =
-        gfx_window_glutin::init::<Rgba8>(builder);
+        gfx_window_glutin::init::<Srgb8, Depth>(builder);
     let mut encoder = factory.create_encoder();
 
     let pso = factory.create_pipeline_simple(
@@ -129,7 +129,7 @@ pub fn main() {
         }
 
         encoder.reset();
-        encoder.clear(&data.out, [0.1, 0.2, 0.3, 1.0]);
+        encoder.clear(&data.out, [0.1, 0.2, 0.3]);
         encoder.draw(&slice, &pso, &data);
 
         device.submit(encoder.as_buffer());

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -20,7 +20,7 @@ extern crate gfx_window_glutin;
 extern crate glutin;
 
 use std::sync::{Arc, RwLock};
-pub use gfx::format::{Depth, Rgba8, I8Scaled};
+pub use gfx::format::{Depth, Srgb8, I8Scaled};
 use gfx::traits::*;
 
 // Section-1: vertex formats and shader parameters
@@ -55,7 +55,7 @@ gfx_pipeline!( forward {
     num_lights: gfx::Global<i32> = "u_NumLights",
     light_buf: gfx::ConstantBuffer<LightParam> = "b_Lights",
     shadow: gfx::TextureSampler<f32> = "t_Shadow",
-    out_color: gfx::RenderTarget<Rgba8> = "o_Color",
+    out_color: gfx::RenderTarget<Srgb8> = "o_Color",
     out_depth: gfx::DepthTarget<Depth> = gfx::preset::depth::LESS_EQUAL_WRITE,
 });
 
@@ -171,7 +171,7 @@ struct Scene<R: gfx::Resources, C: gfx::CommandBuffer<R>> {
 
 /// Create a full scene
 fn create_scene<R: gfx::Resources, F: gfx::Factory<R>>(factory: &mut F,
-                out_color: gfx::handle::RenderTargetView<R, Rgba8>,
+                out_color: gfx::handle::RenderTargetView<R, Srgb8>,
                 out_depth: gfx::handle::DepthStencilView<R, Depth>,
                 shadow_pso: gfx::PipelineState<R, shadow::Meta>)
                 -> Scene<R, F::CommandBuffer>
@@ -386,7 +386,7 @@ pub fn main() {
             .with_gl(glutin::GL_CORE)
             .with_depth_buffer(24); //TODO: derive automatically
     let (window, mut device, mut factory, main_color, main_depth) =
-        gfx_window_glutin::init::<Rgba8, Depth>(builder);
+        gfx_window_glutin::init::<Srgb8, Depth>(builder);
     let mut encoder = factory.create_encoder();
 
     // create PSOs
@@ -512,7 +512,7 @@ pub fn main() {
         }
 
         // draw entities with forward pass
-        encoder.clear(&main_color, [0.1, 0.2, 0.3, 1.0]);
+        encoder.clear(&main_color, [0.1, 0.2, 0.3]);
         encoder.clear_depth(&main_depth, 1.0);
 
         let mx_vp = {

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -23,7 +23,7 @@ extern crate cgmath;
 extern crate image;
 
 use std::io::Cursor;
-pub use gfx::format::Rgba8;
+pub use gfx::format::{Srgb8, Depth, Rgba8};
 use gfx::tex::{CubeFace, Kind, ImageInfoCommon};
 
 use cgmath::{AffineMatrix3, SquareMatrix, Matrix4, Transform, Vector3, Point3};
@@ -45,7 +45,7 @@ gfx_pipeline!( pipe {
     cubemap: gfx::TextureSampler<[f32; 4]> = "t_Cubemap",
     inv_proj: gfx::Global<[[f32; 4]; 4]> = "u_Proj",
     view: gfx::Global<[[f32; 4]; 4]> = "u_WorldToCamera",
-    out: gfx::RenderTarget<Rgba8> = "o_Color",
+    out: gfx::RenderTarget<Srgb8> = "o_Color",
 });
 
 struct CubemapData<'a> {
@@ -119,7 +119,7 @@ pub fn main() {
             .with_dimensions(800, 600)
             .with_gl(glutin::GL_CORE);
     let (window, mut device, mut factory, main_color, _) =
-        gfx_window_glutin::init::<Rgba8>(builder);
+        gfx_window_glutin::init::<Srgb8, Depth>(builder);
     let (w, h) = window.get_inner_size().unwrap();
 
     let mut encoder = factory.create_encoder();
@@ -189,7 +189,7 @@ pub fn main() {
         }
 
         encoder.reset();
-        encoder.clear(&data.out, [0.3, 0.3, 0.3, 1.0]);
+        encoder.clear(&data.out, [0.3, 0.3, 0.3]);
 
         encoder.draw(&slice, &pso, &data);
 

--- a/examples/terrain/main.rs
+++ b/examples/terrain/main.rs
@@ -25,7 +25,7 @@ extern crate noise;
 use rand::Rng;
 use cgmath::{SquareMatrix, Matrix4, Point3, Vector3};
 use cgmath::{Transform, AffineMatrix3};
-pub use gfx::format::{DepthStencil, Rgba8};
+pub use gfx::format::{DepthStencil, Srgb8};
 use genmesh::{Vertices, Triangulate};
 use genmesh::generators::{Plane, SharedVertex, IndexedPolygon};
 use time::precise_time_s;
@@ -42,7 +42,7 @@ gfx_pipeline!(pipe {
     model: gfx::Global<[[f32; 4]; 4]> = "u_Model",
     view: gfx::Global<[[f32; 4]; 4]> = "u_View",
     proj: gfx::Global<[[f32; 4]; 4]> = "u_Proj",
-    out_color: gfx::RenderTarget<Rgba8> = "o_Color",
+    out_color: gfx::RenderTarget<Srgb8> = "o_Color",
     out_depth: gfx::DepthTarget<DepthStencil> =
         gfx::preset::depth::LESS_EQUAL_WRITE,
 });
@@ -65,7 +65,7 @@ pub fn main() {
     let builder = glutin::WindowBuilder::new()
         .with_title("Terrain example".to_string());
     let (window, mut device, mut factory, main_color, main_depth) =
-        gfx_window_glutin::init::<Rgba8>(builder);
+        gfx_window_glutin::init::<Srgb8, DepthStencil>(builder);
     let mut encoder = factory.create_encoder();
 
     let rand_seed = rand::thread_rng().gen();
@@ -132,7 +132,7 @@ pub fn main() {
         );
 
         encoder.reset();
-        encoder.clear(&data.out_color, [0.3, 0.3, 0.3, 1.0]);
+        encoder.clear(&data.out_color, [0.3, 0.3, 0.3]);
         encoder.clear_depth(&data.out_depth, 1.0);
 
         data.view = view.mat.into();

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -24,7 +24,7 @@ gfx_vertex_struct!( Vertex {
 
 gfx_pipeline!(pipe {
     vbuf: gfx::VertexBuffer<Vertex> = (),
-    out: gfx::RenderTarget<gfx::format::Rgba8> = "o_Color",
+    out: gfx::RenderTarget<gfx::format::Srgb8> = "o_Color",
 });
 
 pub fn main() {
@@ -33,7 +33,7 @@ pub fn main() {
     let builder = glutin::WindowBuilder::new()
         .with_title("Triangle example".to_string());
     let (window, mut device, mut factory, main_color, _) =
-        gfx_window_glutin::init::<gfx::format::Rgba8>(builder);
+        gfx_window_glutin::init::<gfx::format::Srgb8, gfx::format::Depth>(builder);
     let mut encoder = factory.create_encoder();
 
     let pso = factory.create_pipeline_simple(
@@ -65,7 +65,7 @@ pub fn main() {
         }
 
         encoder.reset();
-        encoder.clear(&data.out, [0.1, 0.2, 0.3, 1.0]);
+        encoder.clear(&data.out, [0.1, 0.2, 0.3]);
         encoder.draw(&slice, &pso, &data);
 
         device.submit(encoder.as_buffer());

--- a/examples/ubo_tilemap/main.rs
+++ b/examples/ubo_tilemap/main.rs
@@ -27,7 +27,7 @@ use std::io::Cursor;
 
 use glutin::{PollEventsIterator, Event, VirtualKeyCode, ElementState};
 
-pub use gfx::format::{DepthStencil, Rgba8};
+pub use gfx::format::{DepthStencil, Srgb8, Rgba8};
 use gfx::traits::{FactoryExt};
 
 use cgmath::{SquareMatrix, Matrix4, AffineMatrix3};
@@ -141,7 +141,7 @@ gfx_pipeline!(pipe {
     tilesheet_size: gfx::Global<[f32; 4]> = "u_TilesheetSize",
     offsets: gfx::Global<[f32; 2]> = "u_TileOffsets",
     // output
-    out_color: gfx::RenderTarget<Rgba8> = "o_Color",
+    out_color: gfx::RenderTarget<Srgb8> = "o_Color",
     out_depth: gfx::DepthTarget<DepthStencil> =
         gfx::preset::depth::LESS_EQUAL_WRITE,
 });
@@ -157,7 +157,7 @@ pub struct TileMapPlane<R> where R: gfx::Resources {
 
 impl<R> TileMapPlane<R> where R: gfx::Resources {
     pub fn new<F>(factory: &mut F, width: usize, height: usize, tile_size: usize,
-                  main_color: &gfx::handle::RenderTargetView<R, Rgba8>,
+                  main_color: &gfx::handle::RenderTargetView<R, Srgb8>,
                   main_depth: &gfx::handle::DepthStencilView<R, DepthStencil>,
                   aspect_ratio: f32)
                -> TileMapPlane<R> where F: gfx::Factory<R> {
@@ -265,7 +265,7 @@ pub struct TileMap<R> where R: gfx::Resources {
 
 impl<R: gfx::Resources> TileMap<R> {
     pub fn new<F>(factory: &mut F, tilemap_size: [usize; 2], charmap_size: [usize; 2], tile_size: usize,
-                  main_color: &gfx::handle::RenderTargetView<R, Rgba8>,
+                  main_color: &gfx::handle::RenderTargetView<R, Srgb8>,
                   main_depth: &gfx::handle::DepthStencilView<R, DepthStencil>,
                   aspect_ratio: f32)
                   -> TileMap<R> where F: gfx::Factory<R> {
@@ -434,11 +434,11 @@ pub fn main() {
     let builder = glutin::WindowBuilder::new()
         .with_title("Tilemap example".to_string());
     let (window, mut device, mut factory, main_color, main_depth) =
-        gfx_window_glutin::init::<Rgba8>(builder);
+        gfx_window_glutin::init::<Srgb8, DepthStencil>(builder);
     let mut encoder = factory.create_encoder();
 
     // clear window contents
-    encoder.clear(&main_color, [0.0, 0.0, 0.0, 1.0]);
+    encoder.clear(&main_color, [0.0, 0.0, 0.0]);
     device.submit(encoder.as_buffer());
     window.swap_buffers().unwrap();
 
@@ -523,7 +523,7 @@ pub fn main() {
 
         encoder.reset();
         encoder.clear(&main_color,
-            [16.0 / 256.0, 14.0 / 256.0, 22.0 / 256.0, 1.0]);
+            [16.0 / 256.0, 14.0 / 256.0, 22.0 / 256.0]);
         encoder.clear_depth(&main_depth, 1.0);
 
         tilemap.update(&view, &mut encoder);

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -170,27 +170,32 @@ pub fn create<F>(fn_proc: F) -> (Device, Factory) where
 
 /// Create the proxy target views (RTV and DSV) for the attachments of the
 /// main framebuffer. These have GL names equal to 0.
-pub fn create_main_targets<Tc, Td>(dim: d::tex::Dimensions)
-                           -> (handle::RenderTargetView<Resources, Tc>,
-                               handle::DepthStencilView<Resources, Td>)
-where
-    Tc: d::format::RenderFormat,
-    Td: d::format::DepthFormat,
-{
+/// Not supposed to be used by the users directly.
+pub fn create_main_targets(dim: d::tex::Dimensions, color_format: d::format::SurfaceType, depth_format: d::format::SurfaceType)
+                           -> (handle::RawRenderTargetView<Resources>, handle::RawDepthStencilView<Resources>) {
     use gfx_core::handle::Producer;
     let mut temp = handle::Manager::new();
-    let texture = temp.make_texture(
+    let color_tex = temp.make_texture(
         NewTexture::Surface(0),
         d::tex::Descriptor {
             levels: 1,
             kind: d::tex::Kind::D2(dim.0, dim.1, dim.3),
-            format: d::format::SurfaceType::R8_G8_B8_A8,
+            format: color_format,
             bind: d::factory::RENDER_TARGET,
         },
     );
-    let m_color = temp.make_rtv(TargetView::Surface(0), &texture, dim);
-    let m_ds = temp.make_dsv(TargetView::Surface(0), &texture, dim);
-    (d::factory::Phantom::new(m_color), d::factory::Phantom::new(m_ds))
+    let depth_tex = temp.make_texture(
+        NewTexture::Surface(0),
+        d::tex::Descriptor {
+            levels: 1,
+            kind: d::tex::Kind::D2(dim.0, dim.1, dim.3),
+            format: depth_format,
+            bind: d::factory::RENDER_TARGET,
+        },
+    );
+    let m_color = temp.make_rtv(TargetView::Surface(0), &color_tex, dim);
+    let m_ds = temp.make_dsv(TargetView::Surface(0), &depth_tex, dim);
+    (m_color, m_ds)
 }
 
 /// Internal struct of shared data between the device and its factories.

--- a/src/core/src/format.rs
+++ b/src/core/src/format.rs
@@ -60,7 +60,7 @@ impl_channel_type! {
 }
 
 macro_rules! impl_formats {
-    { $($name:ident : $container:ident < $($channel:ident),* > = $data_type:ty [ $($imp_trait:ident),* ] ,)* } => {
+    { $($name:ident : $container:ident < $($channel:ident),* > = $data_type:ty {$alpha_bits:expr} [ $($imp_trait:ident),* ] ,)* } => {
         /// Type of the allocated texture surface. It is supposed to only
         /// carry information about the number of bits per each channel.
         /// The actual types are up to the views to decide and interpret.
@@ -73,10 +73,16 @@ macro_rules! impl_formats {
         }
         impl SurfaceType {
             /// Return the total number of bits for this format.
-            pub fn get_bit_size(&self) -> u8 {
+            pub fn get_total_bits(&self) -> u8 {
                 use std::mem::size_of;
                 match *self {
                     $( SurfaceType::$name => (size_of::<$data_type>() * 8) as u8, )*
+                }
+            }
+            /// Return the number of bits allocated for alpha and stencil.
+            pub fn get_alpha_stencil_bits(&self) -> u8  {
+                match *self {
+                    $( SurfaceType::$name => $alpha_bits, )*
                 }
             }
         }
@@ -106,43 +112,43 @@ macro_rules! impl_formats {
 
 
 impl_formats! {
-    R3_G3_B2        : Vec3<Unorm> = u8  [TextureSurface],
-    R4_G4           : Vec2<Unorm> = u8  [TextureSurface, RenderSurface],
-    R4_G4_B4_A4     : Vec4<Unorm> = u16 [TextureSurface, RenderSurface],
-    R5_G5_B5_A1     : Vec4<Unorm> = u16 [TextureSurface, RenderSurface],
-    R5_G6_B5        : Vec3<Unorm> = u16 [TextureSurface, RenderSurface],
-    R8              : Vec1<Int, Uint, Inorm, Unorm, Iscaled, Uscaled> = u8
+    R3_G3_B2        : Vec3<Unorm> = u8 {2} [TextureSurface],
+    R4_G4           : Vec2<Unorm> = u8 {0}  [TextureSurface, RenderSurface],
+    R4_G4_B4_A4     : Vec4<Unorm> = u16 {4} [TextureSurface, RenderSurface],
+    R5_G5_B5_A1     : Vec4<Unorm> = u16 {1} [TextureSurface, RenderSurface],
+    R5_G6_B5        : Vec3<Unorm> = u16 {0} [TextureSurface, RenderSurface],
+    R8              : Vec1<Int, Uint, Inorm, Unorm, Iscaled, Uscaled> = u8 {0}
         [BufferSurface, TextureSurface, RenderSurface],
-    R8_G8           : Vec2<Int, Uint, Inorm, Unorm, Iscaled, Uscaled> = [u8; 2]
+    R8_G8           : Vec2<Int, Uint, Inorm, Unorm, Iscaled, Uscaled> = [u8; 2] {0}
         [BufferSurface, TextureSurface, RenderSurface],
-    R8_G8_B8        : Vec3<Int, Uint, Inorm, Unorm, Iscaled, Uscaled, Srgb> = [u8; 3]
+    R8_G8_B8        : Vec3<Int, Uint, Inorm, Unorm, Iscaled, Uscaled, Srgb> = [u8; 3] {0}
         [BufferSurface, TextureSurface, RenderSurface],
-    R8_G8_B8_A8     : Vec4<Int, Uint, Inorm, Unorm, Iscaled, Uscaled, Srgb> = [u8; 4]
+    R8_G8_B8_A8     : Vec4<Int, Uint, Inorm, Unorm, Iscaled, Uscaled, Srgb> = [u8; 4] {8}
         [BufferSurface, TextureSurface, RenderSurface],
-    R10_G10_B10_A2  : Vec4<Uint, Unorm> = u32
+    R10_G10_B10_A2  : Vec4<Uint, Unorm> = u32 {2}
         [BufferSurface, TextureSurface, RenderSurface],
-    R11_G11_B10     : Vec4<Unorm, Float> = u32
+    R11_G11_B10     : Vec4<Unorm, Float> = u32 {0}
         [BufferSurface, TextureSurface, RenderSurface],
-    R16             : Vec1<Int, Uint, Inorm, Unorm, Float> = u16
+    R16             : Vec1<Int, Uint, Inorm, Unorm, Float> = u16 {0}
         [BufferSurface, TextureSurface, RenderSurface],
-    R16_G16         : Vec2<Int, Uint, Inorm, Unorm, Float> = [u16; 2]
+    R16_G16         : Vec2<Int, Uint, Inorm, Unorm, Float> = [u16; 2] {0}
         [BufferSurface, TextureSurface, RenderSurface],
-    R16_G16_B16     : Vec2<Int, Uint, Inorm, Unorm, Float> = [u16; 3]
+    R16_G16_B16     : Vec2<Int, Uint, Inorm, Unorm, Float> = [u16; 3] {0}
         [BufferSurface, TextureSurface, RenderSurface],
-    R16_G16_B16_A16 : Vec2<Int, Uint, Inorm, Unorm, Float> = [u16; 4]
+    R16_G16_B16_A16 : Vec2<Int, Uint, Inorm, Unorm, Float> = [u16; 4] {16}
         [BufferSurface, TextureSurface, RenderSurface],
-    R32             : Vec1<Int, Uint, Float> = u32
+    R32             : Vec1<Int, Uint, Float> = u32 {0}
         [BufferSurface, TextureSurface, RenderSurface],
-    R32_G32         : Vec2<Int, Uint, Float> = [u32; 2]
+    R32_G32         : Vec2<Int, Uint, Float> = [u32; 2] {0}
         [BufferSurface, TextureSurface, RenderSurface],
-    R32_G32_B32     : Vec2<Int, Uint, Float> = [u32; 3]
+    R32_G32_B32     : Vec2<Int, Uint, Float> = [u32; 3] {0}
         [BufferSurface, TextureSurface, RenderSurface],
-    R32_G32_B32_A32 : Vec2<Int, Uint, Float> = [u32; 4]
+    R32_G32_B32_A32 : Vec2<Int, Uint, Float> = [u32; 4] {32}
         [BufferSurface, TextureSurface, RenderSurface],
-    D16             : Vec1<Unorm> = F16 [TextureSurface, DepthSurface],
-    D24             : Vec1<Unorm> = f32 [TextureSurface, DepthSurface],
-    D24_S8          : Vec1<Unorm> = (f32, u8) [TextureSurface, DepthSurface, StencilSurface],
-    D32             : Vec1<Unorm, Float> = f32 [TextureSurface, DepthSurface],
+    D16             : Vec1<Unorm> = F16 {0} [TextureSurface, DepthSurface],
+    D24             : Vec1<Unorm> = f32 {8} [TextureSurface, DepthSurface], //hacky stencil bits
+    D24_S8          : Vec1<Unorm> = f32 {8} [TextureSurface, DepthSurface, StencilSurface],
+    D32             : Vec1<Unorm, Float> = f32 {0} [TextureSurface, DepthSurface],
 }
 
 
@@ -331,6 +337,8 @@ pub type Vec4<T> = [T; 4];
 
 /// Standard 8bits RGBA format.
 pub type Rgba8 = (R8_G8_B8_A8, Unorm);
+/// Standard gamma-encoding RGB format.
+pub type Srgb8 = (R8_G8_B8, Srgb);
 /// Standard HDR floating-point format with 10 bits for RGB components
 /// and 2 bits for the alpha.
 pub type Rgb10a2F = (R10_G10_B10_A2, Float);

--- a/src/window/glfw/Cargo.toml
+++ b/src/window/glfw/Cargo.toml
@@ -27,5 +27,5 @@ name = "gfx_window_glfw"
 
 [dependencies]
 glfw = "0.3"
-gfx = { path = "../../render", version = "0.9" }
+gfx_core = { path = "../../core", version = "0.1" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.8" }

--- a/src/window/glfw/src/lib.rs
+++ b/src/window/glfw/src/lib.rs
@@ -14,25 +14,29 @@
 
 #[deny(missing_docs)]
 
-extern crate gfx;
+extern crate gfx_core;
 extern crate gfx_device_gl;
 extern crate glfw;
 
-use gfx::tex::{AaMode, Size};
+use gfx_core::format::{Rgba8, DepthStencil, SurfaceType};
+use gfx_core::handle;
+use gfx_core::tex::{AaMode, Size};
 use glfw::Context;
 
 /// Initialize with a window.
 pub fn init(window: &mut glfw::Window) -> (gfx_device_gl::Device, gfx_device_gl::Factory,
-            gfx::handle::RenderTargetView<gfx_device_gl::Resources, gfx::format::Rgba8>,
-            gfx::handle::DepthStencilView<gfx_device_gl::Resources, gfx::format::DepthStencil>)
+            handle::RenderTargetView<gfx_device_gl::Resources, Rgba8>,
+            handle::DepthStencilView<gfx_device_gl::Resources, DepthStencil>)
 {
+    use gfx_core::factory::Phantom;
     window.make_current();
     let (device, factory) = gfx_device_gl::create(|s|
         window.get_proc_address(s) as *const std::os::raw::c_void);
     // create the main color/depth targets
     let (width, height) = window.get_framebuffer_size();
     let dim = (width as Size, height as Size, 1, AaMode::Single);
-    let (color_view, ds_view) = gfx_device_gl::create_main_targets(dim);
+    let (color_view, ds_view) = gfx_device_gl::create_main_targets(
+        dim, SurfaceType::R8_G8_B8_A8, SurfaceType::D24);
     // done
-    (device, factory, color_view, ds_view)
+    (device, factory, Phantom::new(color_view), Phantom::new(ds_view))
 }

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -27,5 +27,5 @@ name = "gfx_window_glutin"
 
 [dependencies]
 glutin = ">=0.4.2"
-gfx = { path = "../../render", version = "0.9" }
+gfx_core = { path = "../../core", version = "0.1" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.8" }

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -14,32 +14,49 @@
 
 #[deny(missing_docs)]
 
-extern crate gfx;
+extern crate gfx_core;
 extern crate gfx_device_gl;
 extern crate glutin;
 
-use gfx::tex::Size;
+use gfx_core::tex::Size;
 
 /// Initialize with a window builder.
-pub fn init<
-    Cf: gfx::format::RenderFormat = gfx::format::Rgba8,
-    Df: gfx::format::DepthFormat = gfx::format::DepthStencil,
->(  builder: glutin::WindowBuilder) -> (glutin::Window,
-    gfx_device_gl::Device, gfx_device_gl::Factory,
-    gfx::handle::RenderTargetView<gfx_device_gl::Resources, Cf>,
-    gfx::handle::DepthStencilView<gfx_device_gl::Resources, Df>)
+pub fn init<Cf, Df>(builder: glutin::WindowBuilder) ->
+    (glutin::Window, gfx_device_gl::Device, gfx_device_gl::Factory,
+    gfx_core::handle::RenderTargetView<gfx_device_gl::Resources, Cf>,
+    gfx_core::handle::DepthStencilView<gfx_device_gl::Resources, Df>)
+where
+    Cf: gfx_core::format::RenderFormat,
+    Df: gfx_core::format::DepthFormat,
 {
-    // TODO: set the color/depth/stencil bits according to Cf and Df
-    let window = builder.build().unwrap();
+    use gfx_core::factory::Phantom;
+
+    let window = {
+        let format = Cf::get_format();
+        let color_total_bits = format.0.get_total_bits();
+        let alpha_bits = format.0.get_alpha_stencil_bits();
+        let depth_total_bits = Df::get_format().0.get_total_bits();
+        let stencil_bits = Df::get_format().0.get_alpha_stencil_bits();
+        builder
+            .with_depth_buffer(depth_total_bits - stencil_bits)
+            .with_stencil_buffer(stencil_bits)
+            .with_pixel_format(color_total_bits - alpha_bits, alpha_bits)
+            .with_srgb(Some(format.1 == gfx_core::format::ChannelType::Srgb))
+            .build()
+    }.unwrap();
+
     unsafe { window.make_current().unwrap() };
     let (device, factory) = gfx_device_gl::create(|s|
         window.get_proc_address(s) as *const std::os::raw::c_void);
+
     // create the main color/depth targets
     let (width, height) = window.get_inner_size().unwrap();
     let aa = window.get_pixel_format().multisampling
-                   .unwrap_or(0) as gfx::tex::NumSamples;
+                   .unwrap_or(0) as gfx_core::tex::NumSamples;
     let dim = (width as Size, height as Size, 1, aa.into());
-    let (color_view, ds_view) = gfx_device_gl::create_main_targets(dim);
+    let (color_view, ds_view) = gfx_device_gl::create_main_targets(
+        dim, Cf::get_format().0, Df::get_format().0);
+
     // done
-    (window, device, factory, color_view, ds_view)
+    (window, device, factory, Phantom::new(color_view), Phantom::new(ds_view))
 }


### PR DESCRIPTION
Breaking change.
Fixes #872 , fixes #858 
Removes the default parameters of glutin window `init()` for them being deprecated in the next Rust version.
Switches our examples to use Srgb8.
Switches the windowing backends to depend on gfx_core only.
Changes GL's `create_main_targets` to operate on raw data.