### PR TITLE
Raw PSO components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ gfx_gl = "0.1"
 rand = "0.3"
 genmesh = "0.4"
 noise = "0.1"
-image = "0.7"
+image = "0.6"
 
 [target.x86_64-pc-linux-gnu.dev_dependencies]
 glfw = "0.3"

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -55,7 +55,8 @@ pub use pso::buffer::{VertexBuffer, InstanceBuffer,
 pub use pso::resource::{ShaderResource, UnorderedAccess,
                         Sampler, TextureSampler};
 pub use pso::target::{DepthStencilTarget, DepthTarget, StencilTarget,
-                      RenderTarget, BlendTarget, BlendRef, Scissor};
+                      RenderTarget, BlendTarget, BlendRef, Scissor,
+                      RawRenderTarget};
 
 /// Render commands encoder
 mod encoder;

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -52,11 +52,10 @@ pub use mesh::{Slice, ToIndexSlice, SliceKind};
 pub use pso::{PipelineState};
 pub use pso::buffer::{VertexBuffer, InstanceBuffer,
                       ConstantBuffer, Global};
-pub use pso::resource::{ShaderResource, UnorderedAccess,
+pub use pso::resource::{ShaderResource, RawShaderResource, UnorderedAccess,
                         Sampler, TextureSampler};
 pub use pso::target::{DepthStencilTarget, DepthTarget, StencilTarget,
-                      RenderTarget, BlendTarget, BlendRef, Scissor,
-                      RawRenderTarget};
+                      RenderTarget, RawRenderTarget, BlendTarget, BlendRef, Scissor};
 
 /// Render commands encoder
 mod encoder;

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -50,7 +50,7 @@ pub use encoder::{Encoder, UpdateError};
 pub use factory::PipelineStateError;
 pub use mesh::{Slice, ToIndexSlice, SliceKind};
 pub use pso::{PipelineState};
-pub use pso::buffer::{VertexBuffer, InstanceBuffer,
+pub use pso::buffer::{VertexBuffer, InstanceBuffer, RawVertexBuffer,
                       ConstantBuffer, Global};
 pub use pso::resource::{ShaderResource, RawShaderResource, UnorderedAccess,
                         Sampler, TextureSampler};

--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -238,6 +238,7 @@ macro_rules! gfx_pipeline_base {
     }) => {
         pub mod $module {
             use $crate;
+            #[allow(unused_imports)]
             use super::*;
             gfx_pipeline_inner!{ $(
                 $field: $ty,
@@ -253,6 +254,7 @@ macro_rules! gfx_pipeline {
     }) => {
         pub mod $module {
             use $crate;
+            #[allow(unused_imports)]
             use super::*;
             gfx_pipeline_inner!{ $(
                 $field: $ty,

--- a/src/render/src/pso/target.rs
+++ b/src/render/src/pso/target.rs
@@ -28,7 +28,7 @@ pub struct RenderTarget<T>(Option<ColorSlot>, PhantomData<T>);
 /// Render target component with active blending mode.
 /// - init: (`&str`, `ColorMask`, `Blend` = blending state)
 /// - data: `RenderTargetView<T>`
-pub struct BlendTarget<T>(Option<ColorSlot>, PhantomData<T>);
+pub struct BlendTarget<T>(RawRenderTarget, PhantomData<T>);
 /// Raw (untyped) render target component with optional blending.
 /// - init: (`&str`, `Format`, `ColorMask`, `Option<Blend>`)
 /// - data: `RawRenderTargetView`
@@ -88,33 +88,21 @@ impl<R: Resources, T> DataBind<R> for RenderTarget<T> {
 impl<'a, T: format::BlendFormat> DataLink<'a> for BlendTarget<T> {
     type Init = (&'a str, state::ColorMask, state::Blend);
     fn new() -> Self {
-        BlendTarget(None, PhantomData)
+        BlendTarget(RawRenderTarget(None), PhantomData)
     }
     fn is_active(&self) -> bool {
-        self.0.is_some()
+        self.0.is_active()
     }
     fn link_output(&mut self, out: &OutputVar, init: &Self::Init) ->
                    Option<Result<pso::ColorTargetDesc, format::Format>> {
-        if out.name.is_empty() || &out.name == init.0 {
-            self.0 = Some(out.slot);
-            let desc = (T::get_format(), pso::ColorInfo {
-                mask: init.1,
-                color: Some(init.2.color),
-                alpha: Some(init.2.alpha),
-            });
-            Some(Ok(desc))
-        }else {
-            None
-        }
+        self.0.link_output(out, &(init.0, T::get_format(), init.1, Some(init.2)))
     }
 }
 
 impl<R: Resources, T> DataBind<R> for BlendTarget<T> {
     type Data = handle::RenderTargetView<R, T>;
     fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
-        if let Some(slot) = self.0 {
-            out.pixel_targets.add_color(slot, man.ref_rtv(data.raw()), data.raw().get_dimensions());
-        }
+        self.0.bind_to(out, data.raw(), man)
     }
 }
 

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -26,6 +26,7 @@ gfx_pipeline!( testpipe {
     _const_locals: gfx::ConstantBuffer<Local> = "Locals",
     _global: gfx::Global<[f32; 4]> = "Global",
     tex_diffuse: gfx::ShaderResource<[f32; 4]> = "Diffuse",
+    raw_tex: gfx::RawShaderResource = "Specular",
     sampler_linear: gfx::Sampler = "Linear",
     buf_frequency: gfx::UnorderedAccess<[f32; 4]> = "Frequency",
     pixel_color: gfx::RenderTarget<fm::Rgba8> = "Color",

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate gfx;
+pub use gfx::format as fm;
 
 gfx_vertex_struct!(Vertex {
     _x: i8 = "x",
@@ -27,9 +28,12 @@ gfx_pipeline!( testpipe {
     tex_diffuse: gfx::ShaderResource<[f32; 4]> = "Diffuse",
     sampler_linear: gfx::Sampler = "Linear",
     buf_frequency: gfx::UnorderedAccess<[f32; 4]> = "Frequency",
-    pixel_color: gfx::RenderTarget<gfx::format::Rgba8> = "Color",
+    pixel_color: gfx::RenderTarget<fm::Rgba8> = "Color",
     blend_target: gfx::BlendTarget<Rg16> =
         ("o_Color1", gfx::state::MASK_ALL, gfx::preset::blend::ADD),
+    raw_target: gfx::RawRenderTarget = ("o_Color2",
+        fm::Format(fm::SurfaceType::R8_G8_B8_A8, fm::ChannelType::Unorm),
+        gfx::state::MASK_ALL, None),
     depth: gfx::DepthTarget<gfx::format::DepthStencil> =
         gfx::preset::depth::LESS_EQUAL_TEST,
     blend_ref: gfx::BlendRef = (),

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -21,32 +21,55 @@ pub struct Rg16;
 gfx_format!(Rg16: R16_G16 = Vec2<Float>);
 
 gfx_pipeline!( testpipe {
-    _vertex: gfx::VertexBuffer<Vertex> = (),
-    _instance: gfx::InstanceBuffer<Instance> = (),
-    _const_locals: gfx::ConstantBuffer<Local> = "Locals",
-    _global: gfx::Global<[f32; 4]> = "Global",
+    vertex: gfx::VertexBuffer<Vertex> = (),
+    instance: gfx::InstanceBuffer<Instance> = (),
+    const_locals: gfx::ConstantBuffer<Local> = "Locals",
+    global: gfx::Global<[f32; 4]> = "Global",
     tex_diffuse: gfx::ShaderResource<[f32; 4]> = "Diffuse",
-    raw_tex: gfx::RawShaderResource = "Specular",
     sampler_linear: gfx::Sampler = "Linear",
     buf_frequency: gfx::UnorderedAccess<[f32; 4]> = "Frequency",
     pixel_color: gfx::RenderTarget<fm::Rgba8> = "Color",
     blend_target: gfx::BlendTarget<Rg16> =
         ("o_Color1", gfx::state::MASK_ALL, gfx::preset::blend::ADD),
-    raw_target: gfx::RawRenderTarget = ("o_Color2",
-        fm::Format(fm::SurfaceType::R8_G8_B8_A8, fm::ChannelType::Unorm),
-        gfx::state::MASK_ALL, None),
     depth: gfx::DepthTarget<gfx::format::DepthStencil> =
         gfx::preset::depth::LESS_EQUAL_TEST,
     blend_ref: gfx::BlendRef = (),
     scissor: gfx::Scissor = (),
 });
 
-fn _test_pso<R, F>(factory: &mut F)
-             -> gfx::PipelineState<R, testpipe::Meta>  where
+fn _test_pso<R, F>(factory: &mut F) -> gfx::PipelineState<R, testpipe::Meta> where
     R: gfx::Resources,
     F: gfx::traits::FactoryExt<R>,
 {
     factory.create_pipeline_simple(&[], &[],
         gfx::state::CullFace::Nothing, testpipe::new()
+        ).unwrap()
+}
+
+
+gfx_pipeline_base!( testraw {
+    vertex: gfx::RawVertexBuffer,
+    tex: gfx::RawShaderResource,
+    target: gfx::RawRenderTarget,
+});
+
+fn _test_raw<R, F>(factory: &mut F) -> gfx::PipelineState<R, testraw::Meta> where
+    R: gfx::Resources,
+    F: gfx::traits::FactoryExt<R>,
+{
+    let special = gfx::pso::buffer::Element {
+        format: fm::Format(fm::SurfaceType::R32, fm::ChannelType::Float),
+        offset: 0,
+        stride: 12,
+    };
+    let init = testraw::Init {
+        vertex: &[("a_Special", special, 0)],
+        tex: "Specular",
+        target: ("o_Color2",
+            fm::Format(fm::SurfaceType::R8_G8_B8_A8, fm::ChannelType::Unorm),
+            gfx::state::MASK_ALL, None),
+    };
+    factory.create_pipeline_simple(&[], &[],
+        gfx::state::CullFace::Nothing, init
         ).unwrap()
 }


### PR DESCRIPTION
This implements a solid part of #853 
It will allow some stuff to be loaded at run-time without any prior compile-time knowledge, like:
 - your vertex layout
 - format of the textures, like you don't know if your texture is RGBA or RGB or something else
 - output target format, like you may want to configure the precision and sRGB properties
 - blending