### PR TITLE
Fixed `Encoder::update_texture`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_app"
-version = "0.1.0"
+version = "0.1.1"
 description = "GFX example application framework"
 homepage = "https://github.com/gfx-rs/gfx"
 keywords = ["graphics", "gamedev"]
@@ -22,10 +22,10 @@ glutin = "0.4.8"
 gfx_core = { path = "src/core", version = "0.2" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.9" }
 gfx_window_glutin = { path = "src/window/glutin", version = "0.10" }
-gfx = { path = "src/render", version = "0.10" }
+gfx = { path = "src/render", version = "0.10.1" }
 
 [target.x86_64-pc-linux-gnu.dependencies]
-gfx_window_glfw = { path = "src/window/glfw", version = "0.8" }
+gfx_window_glfw = { path = "src/window/glfw", version = "0.9" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.1" }

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.10.0"
+version = "0.10.1"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -113,7 +113,7 @@ impl<R: Resources, C: draw::CommandBuffer<R>> Encoder<R, C> {
     }
 
     /// Update the contents of a texture.
-    pub fn update_texture<S, T>(&mut self, tex: &handle::Texture<R, T>,
+    pub fn update_texture<S, T>(&mut self, tex: &handle::Texture<R, T::Surface>,
                           face: Option<tex::CubeFace>,
                           img: tex::NewImageInfo, data: &[S::DataType])
                           -> Result<(), UpdateError<[tex::Size; 3]>>

--- a/src/window/glfw/Cargo.toml
+++ b/src/window/glfw/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glfw"
-version = "0.8.0"
+version = "0.9.0"
 description = "GLFW window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -26,6 +26,6 @@ authors = ["The Gfx-rs Developers"]
 name = "gfx_window_glfw"
 
 [dependencies]
-glfw = "0.3"
+glfw = "0.4"
 gfx_core = { path = "../../core", version = "0.2" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.9" }


### PR DESCRIPTION
Closes https://github.com/gfx-rs/gfx/issues/911

- Bumped gfx_app to 0.1.1
- Bumped gfx to 0.10.1
- Bumped gfx_window_glfw to 0.9.0