### PR TITLE
Move Bundle out of pipeline macro.

### DIFF
--- a/examples/blend/main.rs
+++ b/examples/blend/main.rs
@@ -19,6 +19,7 @@ extern crate image;
 
 pub use gfx_app::ColorFormat;
 pub use gfx::format::{Rgba8, DepthStencil};
+use gfx::Bundle;
 
 gfx_vertex_struct!( Vertex {
     pos: [f32; 2] = "a_Pos",
@@ -72,7 +73,7 @@ const BLENDS: [&'static str; 9] = [
 ];
 
 struct App<R: gfx::Resources>{
-    bundle: pipe::Bundle<R>,
+    bundle: Bundle<R, pipe::Data<R>>,
     id: u8,
 }
 
@@ -134,7 +135,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         };
 
         App {
-            bundle: pipe::bundle(slice, pso, data),
+            bundle: Bundle::new(slice, pso, data),
             id: 0,
         }
     }

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -18,6 +18,7 @@ extern crate gfx;
 extern crate gfx_app;
 
 pub use gfx_app::{ColorFormat, DepthFormat};
+use gfx::Bundle;
 
 // Declare the vertex format suitable for drawing.
 // Notice the use of FixedPoint.
@@ -52,7 +53,7 @@ gfx_pipeline!( pipe {
 
 //----------------------------------------
 struct App<R: gfx::Resources>{
-    bundle: pipe::Bundle<R>,
+    bundle: Bundle<R, pipe::Data<R>>,
 }
 
 impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
@@ -151,7 +152,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         };
 
         App {
-            bundle: pipe::bundle(slice, pso, data),
+            bundle: Bundle::new(slice, pso, data),
         }
     }
 

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -42,6 +42,7 @@ use cgmath::{SquareMatrix, Matrix4, Point3, Vector3, EuclideanVector, deg};
 use cgmath::{Transform, AffineMatrix3};
 pub use gfx::format::Depth;
 pub use gfx_app::ColorFormat;
+use gfx::Bundle;
 use genmesh::{Vertices, Triangulate};
 use genmesh::generators::{SharedVertex, IndexedPolygon};
 use time::precise_time_s;
@@ -368,10 +369,10 @@ fn create_g_buffer<R: gfx::Resources, F: gfx::Factory<R>>(
 
 
 struct App<R: gfx::Resources> {
-    terrain: terrain::Bundle<R>,
-    blit: blit::Bundle<R>,
-    light: light::Bundle<R>,
-    emitter: emitter::Bundle<R>,
+    terrain: Bundle<R, terrain::Data<R>>,
+    blit: Bundle<R, blit::Data<R>>,
+    light: Bundle<R, light::Data<R>>,
+    emitter: Bundle<R, emitter::Data<R>>,
     intermediate: ViewPair<R, GFormat>,
     light_pos_vec: Vec<LightInfo>,
     seed: Seed,
@@ -447,7 +448,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
                 out_depth: depth_target.clone(),
             };
 
-            terrain::bundle(slice, pso, data)
+            Bundle::new(slice, pso, data)
         };
 
         let blit = {
@@ -482,7 +483,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
                 out: init.color,
             };
 
-            blit::bundle(slice, pso, data)
+            Bundle::new(slice, pso, data)
         };
 
         let light_pos_buffer = factory.create_constant_buffer(NUM_LIGHTS);
@@ -564,7 +565,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
                 out_depth: depth_target.clone(),
             };
 
-            light::bundle(light_slice.clone(), pso, data)
+            Bundle::new(light_slice.clone(), pso, data)
         };
 
         let emitter = {
@@ -593,7 +594,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
                 out_depth: depth_target.clone(),
             };
 
-            emitter::bundle(light_slice, pso, data)
+            Bundle::new(light_slice, pso, data)
         };
 
         App {

--- a/examples/flowmap/main.rs
+++ b/examples/flowmap/main.rs
@@ -21,6 +21,7 @@ extern crate image;
 use std::io::Cursor;
 pub use gfx::format::{Rgba8, Depth};
 pub use gfx_app::ColorFormat;
+use gfx::Bundle;
 
 gfx_vertex_struct!( Vertex {
     pos: [f32; 2] = "a_Pos",
@@ -63,7 +64,7 @@ fn load_texture<R, F>(factory: &mut F, data: &[u8])
 }
 
 struct App<R: gfx::Resources>{
-    bundle: pipe::Bundle<R>,
+    bundle: Bundle<R, pipe::Data<R>>,
     cycles: [f32; 2],
     time_start: f64,
 }
@@ -121,7 +122,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         };
 
         App {
-            bundle: pipe::bundle(slice, pso, data),
+            bundle: Bundle::new(slice, pso, data),
             cycles: [0.0, 0.5],
             time_start: time::precise_time_s(),
         }

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -24,6 +24,7 @@ extern crate image;
 use std::io::Cursor;
 pub use gfx_app::ColorFormat;
 pub use gfx::format::{Depth, Rgba8};
+use gfx::Bundle;
 
 gfx_vertex_struct!( Vertex {
     pos: [f32; 2] = "a_Pos",
@@ -79,7 +80,7 @@ fn load_cubemap<R, F>(factory: &mut F, data: CubemapData) -> Result<gfx::handle:
 }
 
 struct App<R: gfx::Resources>{
-    bundle: pipe::Bundle<R>,
+    bundle: Bundle<R, pipe::Data<R>>,
     projection: cgmath::Matrix4<f32>,
 }
 
@@ -133,7 +134,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         };
 
         App {
-            bundle: pipe::bundle(slice, pso, data),
+            bundle: Bundle::new(slice, pso, data),
             projection: proj,
         }
     }

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -56,6 +56,7 @@ pub use pso::resource::{ShaderResource, RawShaderResource, UnorderedAccess,
                         Sampler, TextureSampler};
 pub use pso::target::{DepthStencilTarget, DepthTarget, StencilTarget,
                       RenderTarget, RawRenderTarget, BlendTarget, BlendRef, Scissor};
+pub use pso::bundle::{Bundle};
 
 /// Render commands encoder
 mod encoder;

--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -204,33 +204,6 @@ macro_rules! gfx_pipeline_inner {
                 )*
             }
         }
-
-        #[allow(dead_code)]
-        pub struct Bundle<R: $crate::Resources> {
-            pub slice: $crate::Slice<R>,
-            pub pso: $crate::PipelineState<R, Meta>,
-            pub data: Data<R>,
-        }
-
-        #[allow(dead_code)]
-        pub fn bundle<R: $crate::Resources>(slice: $crate::Slice<R>,
-                      pso: $crate::PipelineState<R, Meta>, data: Data<R>)
-                      -> Bundle<R>
-        {
-            Bundle {
-                slice: slice,
-                pso: pso,
-                data: data,
-            }
-        }
-
-        #[allow(dead_code)]
-        impl<R: $crate::Resources> Bundle<R> {
-            pub fn encode<C>(&self, encoder: &mut $crate::Encoder<R, C>) where
-                C: $crate::CommandBuffer<R> {
-                encoder.draw(&self.slice, &self.pso, &self.data);
-            }
-        }
     }
 }
 

--- a/src/render/src/pso/bundle.rs
+++ b/src/render/src/pso/bundle.rs
@@ -1,0 +1,34 @@
+//! Combine mesh data with pipeline state.
+//!
+//! Suitable for use when PSO is always used with the same one mesh.
+
+use { Resources, Slice, PipelineState, Encoder, CommandBuffer };
+use super::PipelineData;
+
+/// Mesh-PSO bundle.
+pub struct Bundle<R: Resources, Data: PipelineData<R>> {
+    /// Mesh slice
+    pub slice: Slice<R>,
+    /// Pipeline state
+    pub pso: PipelineState<R, Data::Meta>,
+    /// Pipeline data for mesh
+    pub data: Data,
+}
+
+impl<R: Resources, Data: PipelineData<R>> Bundle<R, Data> {
+    /// Create new Bundle
+    pub fn new(slice: Slice<R>, pso: PipelineState<R, Data::Meta>, data: Data) -> Self
+    {
+        Bundle {
+            slice: slice,
+            pso: pso,
+            data: data,
+        }
+    }
+
+    /// Draw bundle using encoder.
+    pub fn encode<C>(&self, encoder: &mut Encoder<R, C>) where
+        C: CommandBuffer<R> {
+        encoder.draw(&self.slice, &self.pso, &self.data);
+    }
+}

--- a/src/render/src/pso/mod.rs
+++ b/src/render/src/pso/mod.rs
@@ -30,6 +30,7 @@
 pub mod buffer;
 pub mod resource;
 pub mod target;
+pub mod bundle;
 
 use std::default::Default;
 use gfx_core as d;


### PR DESCRIPTION
Makes it opt-in without allow(dead_code), also opens way up for multiple
implementations.

Fixes #925.