### PR TITLE
Remove gfx_app dependency from triangle example

### DIFF
--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -49,8 +49,7 @@ pub fn main() {
         .with_vsync();
     let (window, mut device, mut factory, main_color, _main_depth) =
         gfx_window_glutin::init::<ColorFormat, DepthFormat>(builder);
-    let command_buffer = factory.create_command_buffer();
-    let mut encoder: gfx::Encoder<_, _> = command_buffer.into();
+    let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
     let pso = factory.create_pipeline_simple(
         include_bytes!("shader/triangle_150.glslv"),
         include_bytes!("shader/triangle_150.glslf"),

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -34,15 +34,13 @@ gfx_pipeline!(pipe {
     out: gfx::RenderTarget<ColorFormat> = "Target0",
 });
 
-fn triangle() -> [Vertex; 3] { [
+const TRIANGLE: [Vertex; 3] = [
     Vertex { pos: [ -0.5, -0.5 ], color: [1.0, 0.0, 0.0] },
     Vertex { pos: [  0.5, -0.5 ], color: [0.0, 1.0, 0.0] },
-    Vertex { pos: [  0.0,  0.5 ], color: [0.0, 0.0, 1.0] },
-] }
+    Vertex { pos: [  0.0,  0.5 ], color: [0.0, 0.0, 1.0] }
+];
 
-fn clear_color() -> [f32; 4] {
-    [0.1, 0.2, 0.3, 1.0]
-}
+const CLEAR_COLOR: [f32; 4] = [0.1, 0.2, 0.3, 1.0];
 
 pub fn main() {
     let builder = glutin::WindowBuilder::new()
@@ -59,7 +57,7 @@ pub fn main() {
         gfx::state::CullFace::Nothing,
         pipe::new()
     ).unwrap();
-    let (vertex_buffer, slice) = factory.create_vertex_buffer(&triangle());
+    let (vertex_buffer, slice) = factory.create_vertex_buffer(&TRIANGLE);
     let data = pipe::Data {
         vbuf: vertex_buffer,
         out: main_color
@@ -75,7 +73,7 @@ pub fn main() {
             }
         }
         // draw a frame
-        encoder.clear(&data.out, clear_color());
+        encoder.clear(&data.out, CLEAR_COLOR);
         encoder.draw(&slice, &pso, &data);
         window.swap_buffers().unwrap();
         device.cleanup();

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -74,8 +74,8 @@ pub fn main() {
         // draw a frame
         encoder.clear(&data.out, CLEAR_COLOR);
         encoder.draw(&slice, &pso, &data);
+        encoder.flush(&mut device);
         window.swap_buffers().unwrap();
         device.cleanup();
-        encoder.flush(&mut device);
     }
 }


### PR DESCRIPTION
This dependency is convenient for re-using code between example. However, it makes it also harder for a user to follow and figure out, what they actually have to implement themselves when using gfx.

Raised in #922.