### PR TITLE
Multiplied hidpi_factor on window glutin to get correct resolution on retina displays

### DIFF
--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -39,7 +39,7 @@ fn get_window_dimensions(window: &glutin::Window) -> tex::Dimensions {
     let (width, height) = window.get_inner_size().unwrap();
     let aa = window.get_pixel_format().multisampling
                    .unwrap_or(0) as tex::NumSamples;
-    (width as tex::Size, height as tex::Size, 1, aa.into())
+    ((width as f32 * window.hidpi_factor()) as tex::Size, (height as f32 * window.hidpi_factor()) as tex::Size, 1, aa.into())
 }
 
 /// Initialize with a window builder. Raw version.


### PR DESCRIPTION
Hello,

I've had troubles with GFX and the resolution on my retina display. I found out we needed to multiply the results of a function called hidpi_factor from Glutin Window.

Cheers