### PR TITLE
Support i686-windows-msvc rustc target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ gfx_window_dxgi = { path = "src/window/dxgi", version = "0.2" }
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.2" }
 gfx_window_dxgi = { path = "src/window/dxgi", version = "0.2" }
 
+[target.i686-pc-windows-msvc.dependencies]
+gfx_device_dx11 = { path = "src/backend/dx11", version = "0.2" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.2" }
+
 [[example]]
 name = "blend"
 path = "examples/blend/main.rs"

--- a/src/window/dxgi/src/window.rs
+++ b/src/window/dxgi/src/window.rs
@@ -20,18 +20,6 @@ use user32;
 use winapi::*;
 
 
-unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: UINT, wp: WPARAM, lp: LPARAM) -> LRESULT {
-    match msg {
-        WM_CREATE => {
-            // Set the window pointer into the creation parameters
-            let cs: &CREATESTRUCTW = mem::transmute(lp);
-            user32::SetWindowLongPtrW(hwnd, GWLP_USERDATA, mem::transmute(cs.lpCreateParams));
-            0
-        },
-        _ => user32::DefWindowProcW(hwnd, msg, wp, lp)
-    }
-}
-
 pub fn create(name: &str, width: INT, height: INT) -> Result<HWND, ()> {
     let class_name = name.to_wide_null();
     let window_name = name.to_wide_null();
@@ -40,7 +28,7 @@ pub fn create(name: &str, width: INT, height: INT) -> Result<HWND, ()> {
 
         user32::RegisterClassW(&WNDCLASSW {
             style: CS_DBLCLKS | CS_HREDRAW | CS_VREDRAW,
-            lpfnWndProc: Some(wnd_proc),
+            lpfnWndProc: Some(user32::DefWindowProcW),
             cbWndExtra: 0,
             hInstance: hinst,
             lpszClassName: class_name.as_ptr(),


### PR DESCRIPTION
Actually, it worked well time ago and became official in Rust stable since 1.8.0.