### PR TITLE
Add CI tests for subpackages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
-sudo: false
+sudo: required
 language: rust
 rust:
-- stable
-- nightly
+  - stable
+  - nightly
 before_script:
-- pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 notifications:
   webhooks:
     urls:
-    - https://webhooks.gitter.im/e/7479b6691b7e5e40716a
+      - https://webhooks.gitter.im/e/7479b6691b7e5e40716a
     on_success: always
     on_failure: always
     on_start: false
@@ -18,24 +18,31 @@ before_install:
 addons:
   apt:
     sources:
-    # install a newer cmake since at this time Travis only has version 2.8.7
-    - kalakris-cmake
+      # install a newer cmake since at this time Travis only has version 2.8.7
+      - kalakris-cmake
+      # add a repository for libsdl2-dev
+      - sourceline: 'ppa:zoogie/sdl2-snapshots'
     packages:
-    - xdotool
-    - cmake
-    - libxxf86vm-dev
-    - libxinerama-dev
-    - libxinerama1
-    - libxcursor-dev
-    - libxcursor1
+      - xdotool
+      - cmake
+      - libxxf86vm-dev
+      - libxinerama-dev
+      - libxinerama1
+      - libxcursor-dev
+      - libxcursor1
+      - libsdl2-dev
 script:
-- |
-  travis-cargo build &&
-  travis-cargo test &&
-  travis-cargo bench &&
-  travis-cargo doc -- -j 1
+  - travis-cargo build
+  - travis-cargo test -- -p gfx_core
+  - travis-cargo test -- -p gfx
+  - travis-cargo test -- -p gfx_device_gl
+  - travis-cargo test -- -p gfx_window_glutin
+  - travis-cargo test -- -p gfx_window_glfw
+  - travis-cargo test -- -p gfx_window_sdl
+  - travis-cargo test
 after_success:
-- travis-cargo --only nightly doc-upload
+  - travis-cargo doc -- -j 1
+  - travis-cargo --only nightly doc-upload
 env:
   global:
-  - secure: eYm18Lr7+FYFgY9Cj/LFyL0WaC/zesBE8pywho9c+ByUEMwaZ9QCbsaX3H+IBNQCTSCImiKj+zuj+uIPyOTIiC5OPY0cvziWcBvyAlrwnwT7oBm8X9CPDCuspRVGO52CoksI1oYNkEc1xaL9PIUw6GMXhVCAIkQI7tMbq+kWxDQ=
+    - secure: eYm18Lr7+FYFgY9Cj/LFyL0WaC/zesBE8pywho9c+ByUEMwaZ9QCbsaX3H+IBNQCTSCImiKj+zuj+uIPyOTIiC5OPY0cvziWcBvyAlrwnwT7oBm8X9CPDCuspRVGO52CoksI1oYNkEc1xaL9PIUw6GMXhVCAIkQI7tMbq+kWxDQ=

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ authors = ["The Gfx-rs Developers"]
 [features]
 unstable = []
 
-
 [lib]
 name = "gfx_app"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,26 @@
 environment:
   matrix:
-  - TARGET: 1.8.0-x86_64-pc-windows-msvc
-  - TARGET: 1.8.0-x86_64-pc-windows-gnu
-  - TARGET: nightly-x86_64-pc-windows-msvc
+    - TARGET: 1.9.0-x86_64-pc-windows
+      COMPILER: gnu
+    - TARGET: 1.9.0-x86_64-pc-windows
+      COMPILER: msvc
+    - TARGET: nightly-x86_64-pc-windows
+      COMPILER: msvc
 install:
-  - choco install -y mingw
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}.exe" -FileName "rust-install.exe"
+  - if %COMPILER%==gnu choco install mingw
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}-${env:COMPILER}.exe" -FileName "rust-install.exe"
   - ps: .\rust-install.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null
   - ps: $env:PATH="$env:PATH;C:\rust\bin;C:\tools\mingw64\bin"
-  - gcc -v
+  - if %COMPILER%==gnu gcc -v
   - rustc -vV
   - cargo -vV
 build_script:
   - cargo build
 test_script:
+  - cargo test -p gfx_core
+  - cargo test -p gfx
+  - cargo test -p gfx_device_dx11
+  - cargo test -p gfx_window_dxgi
+  - cargo test -p gfx_device_gl
+  - cargo test -p gfx_window_glutin
   - cargo test

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -229,7 +229,6 @@ pub fn get(gl: &gl::Gl) -> (Info, Capabilities, PrivateCaps) {
 #[cfg(test)]
 mod tests {
     use super::Version;
-    use super::to_shader_model;
 
     #[test]
     fn test_version_parse() {
@@ -244,15 +243,5 @@ mod tests {
         assert_eq!(Version::parse("1.2. h3l1o. W0rld"), Ok(Version::new(1, 2, None, "h3l1o. W0rld")));
         assert_eq!(Version::parse("1.2.3.h3l1o. W0rld"), Ok(Version::new(1, 2, Some(3), "W0rld")));
         assert_eq!(Version::parse("1.2.3 h3l1o. W0rld"), Ok(Version::new(1, 2, Some(3), "h3l1o. W0rld")));
-    }
-
-    #[test]
-    fn test_shader_model() {
-        use gfx_core::shade::ShaderModel;
-        assert_eq!(to_shader_model(&Version::parse("1.10").unwrap()), ShaderModel::Unsupported);
-        assert_eq!(to_shader_model(&Version::parse("1.20").unwrap()), ShaderModel::Version30);
-        assert_eq!(to_shader_model(&Version::parse("1.50").unwrap()), ShaderModel::Version40);
-        assert_eq!(to_shader_model(&Version::parse("3.00").unwrap()), ShaderModel::Version41);
-        assert_eq!(to_shader_model(&Version::parse("4.30").unwrap()), ShaderModel::Version50);
     }
 }

--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -306,26 +306,13 @@ impl From<TargetViewError> for CombinedError {
 /// with. 
 ///
 /// # Construction and Handling
-/// A `Factory` is created by using the appropriate functions of the desired graphics backend.
-/// An example using the OpenGL backend and Glutin.
-/// 
-/// ```
-/// extern crate gfx;
-/// extern crate gfx_device_gl;
-/// extern crate gfx_window_glutin;
-/// extern crate glutin;
-///
-/// use gfx::format::{DepthStencil, Rgba8};
-///
-/// let builder = glutin::WindowBuilder::new().with_title("Factory Construction".to_string());
-/// let (window, device, factory, rtv, stv) =
-///     gfx_window_glutin::init::<Rgba8, DepthStencil>(builder);
-/// ```
+/// A `Factory` is typically created along with other objects using a helper function of the
+/// appropriate gfx_window module (e.g. gfx_window_glutin::init()).
 ///
 /// This factory structure can then be used to create and manage different resources, like buffers,
 /// shader programs and textures. See the individual methods for more information.
 ///
-/// Also see `FactoryExt` inside the `gfx` trait for additional methods.
+/// Also see the `FactoryExt` trait inside the `gfx` module for additional methods.
 #[allow(missing_docs)]
 pub trait Factory<R: Resources> {
     /// Associated mapper type

--- a/src/window/glfw/src/lib.rs
+++ b/src/window/glfw/src/lib.rs
@@ -27,7 +27,7 @@ use glfw::Context;
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// extern crate gfx_window_glfw;
 /// extern crate glfw;
 /// 

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -23,6 +23,25 @@ use gfx_device_gl::Resources as R;
 
 /// Initialize with a window builder.
 /// Generically parametrized version over the main framebuffer format.
+///
+/// # Example
+///
+/// ```no_run
+/// extern crate gfx_core;
+/// extern crate gfx_device_gl;
+/// extern crate gfx_window_glutin;
+/// extern crate glutin;
+///
+/// use gfx_core::format::{DepthStencil, Rgba8};
+///
+/// fn main() {
+///     let builder = glutin::WindowBuilder::new().with_title("Example".to_string());
+///     let (window, device, factory, rtv, stv) =
+///         gfx_window_glutin::init::<Rgba8, DepthStencil>(builder);
+///
+///     // your code
+/// }
+/// ```
 pub fn init<Cf, Df>(builder: glutin::WindowBuilder) ->
             (glutin::Window, gfx_device_gl::Device, gfx_device_gl::Factory,
             handle::RenderTargetView<R, Cf>, handle::DepthStencilView<R, Df>)

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -24,7 +24,7 @@ use gfx_device_gl::Resources;
 ///
 /// # Example
 ///
-/// ```
+/// ```no_run
 /// extern crate gfx_window_sdl;
 /// extern crate sdl2;
 /// 


### PR DESCRIPTION
Changes to appveyor and travis scripts to include testing of submodules.
Changes to appveyor script to only download and install mingw when targetting mingw toolchain.
Code example moved from factory documentation into gfx_window_glutin.
Removed an outdated test, added no_run to some tests to prevent them from failing on CI builds.

fixes #961 