### PR TITLE
Special index for gl_FragColor for GLSL 120 to 140 shaders

### DIFF
--- a/src/backend/gl/src/shade.rs
+++ b/src/backend/gl/src/shade.rs
@@ -389,8 +389,12 @@ fn query_outputs(gl: &gl::Gl, prog: super::Program) -> (Vec<s::OutputVar>, bool)
         // special index reported for GLSL 120 to 140 shaders
         if index == !0 {
             if name.starts_with("gl_FragData") {
-                let index = (name.chars().nth(12).unwrap() as i32) - ('0' as i32);
+                index = (name.chars().nth(12).unwrap() as i32) - ('0' as i32);
                 name = format!("Target{}", index);
+            }else
+            if &name == "gl_FragColor" {
+                index = 0;
+                name = "Target0".to_owned();
             }else
             if &name == "gl_FragDepth" {
                 out_depth = true;


### PR DESCRIPTION
This PR fixes an issue when `gfx` was not working properly with `gl` backend if you are using 120-140 versions of shaders.
Also this fixes `index` variable redefinition in `if name.starts_with("gl_FragData") {` branch.