### PR TITLE
Vulkan: Some groundwork for windows vulkan support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ script:
   - travis-cargo test -- -p gfx_window_glutin
   - travis-cargo test -- -p gfx_window_glfw
   - travis-cargo test -- -p gfx_window_sdl
-# - travis-cargo test -- -p gfx_device_vulkan
-# - travis-cargo test -- -p gfx_window_vulkan
-  - travis-cargo test
+  - travis-cargo test -- -p gfx_device_vulkan --features vulkan
+  - travis-cargo test -- -p gfx_window_vulkan --features vulkan
+  - travis-cargo test -- --features vulkan
 after_success:
   - travis-cargo doc -- -j 1
   - travis-cargo --only nightly doc-upload

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - rustc -vV
   - cargo -vV
 build_script:
-  - cargo build
+  - cargo build --features vulkan
 test_script:
   - cargo test -p gfx_core
   - cargo test -p gfx
@@ -23,4 +23,6 @@ test_script:
   - cargo test -p gfx_window_dxgi
   - cargo test -p gfx_device_gl
   - cargo test -p gfx_window_glutin
-  - cargo test
+  - cargo test -p gfx_device_vulkan --features vulkan
+  - cargo test -p gfx_window_vulkan --features vulkan
+  - cargo test --features vulkan

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -97,7 +97,13 @@ pub fn create(app_name: &str, app_version: u32, layers: &[&str], extensions: &[&
     use std::ffi::CString;
     use std::path::Path;
 
-    let dynamic_lib = DynamicLibrary::open(Some(Path::new("libvulkan.so.1"))).unwrap();
+    let dynamic_lib = DynamicLibrary::open(Some(
+            if cfg!(target_os = "windows") {
+                Path::new("vulkan-1.dll")
+            } else {
+                Path::new("libvulkan.so.1")
+            }
+        )).expect("Unable to open vulkan shared library");
     let lib = vk::Static::load(|name| unsafe {
         let name = name.to_str().unwrap();
         dynamic_lib.symbol(name).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,7 @@ impl<
             }
 
             let mut frame = win.start_frame();
+            app.render(frame.get_queue());
             frame.get_queue().cleanup();
             harness.bump();
         }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -13,7 +13,11 @@ name = "gfx_window_vulkan"
 
 [dependencies]
 winit = "0.5"
-xcb = "0.7"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 gfx_core = { path = "../../core", version = "0.5" }
 gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.1" }
+
+[target.'cfg(unix)'.dependencies]
+xcb = "0.7"
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "0.2.2"

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -27,6 +27,8 @@ use std::ptr;
 use std::os::raw;
 use gfx_core::format;
 
+#[cfg(unix)]
+use winit::os::unix::WindowExt;
 #[cfg(target_os = "windows")]
 use winit::os::windows::WindowExt;
 
@@ -249,14 +251,14 @@ fn create_surface(backend: gfx_device_vulkan::SharePointer, window: &winit::Wind
 }
 
 #[cfg(unix)]
-fn create_surface(backend: gfx_device_vulkan::SharePointer, win: &winit::Window) -> vk::SurfaceKHR {
+fn create_surface(backend: gfx_device_vulkan::SharePointer, window: &winit::Window) -> vk::SurfaceKHR {
     let (inst, vk) = backend.get_instance();
     let info = vk::XcbSurfaceCreateInfoKHR {
         sType: vk::STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR,
         pNext: ptr::null(),
         flags: 0,
-        connection: window.get_xcb_connection() as *const _,
-        window: window.get_xlib_window() as *const _,
+        connection: window.get_xcb_connection().unwrap() as *const _,
+        window: window.get_xlib_window().unwrap() as *const _,
     };
     let mut out = 0;
     assert_eq!(vk::SUCCESS, unsafe {


### PR DESCRIPTION
Correctly locate the vulkan dynamic library on windows, use winit for window handling and implement surface creation.

NOT tested on an unix system so far with xcb.
Setting the correct `"VK_KHR_*_surface` extensions for each platform is left as future work for the moment.
