### PR TITLE
Vulkan: Working on swapchain creation

### DIFF
--- a/src/backend/dx11/src/data.rs
+++ b/src/backend/dx11/src/data.rs
@@ -117,6 +117,10 @@ pub fn map_format(format: Format, is_target: bool) -> Option<DXGI_FORMAT> {
             Float => DXGI_FORMAT_R32G32B32A32_FLOAT,
             _ => return None,
         },
+        B8_G8_R8_A8 => match format.1 {
+            Unorm => DXGI_FORMAT_B8G8R8A8_UNORM,
+            _ => return None,
+        },
         D16 => match (is_target, format.1) {
             (true, _)      => DXGI_FORMAT_D16_UNORM,
             (false, Unorm) => DXGI_FORMAT_R16_UNORM,
@@ -158,6 +162,7 @@ pub fn map_surface(surface: SurfaceType) -> Option<DXGI_FORMAT> {
         R32_G32         => DXGI_FORMAT_R32G32_TYPELESS,
         R32_G32_B32     => DXGI_FORMAT_R32G32B32_TYPELESS,
         R32_G32_B32_A32 => DXGI_FORMAT_R32G32B32A32_TYPELESS,
+        B8_G8_R8_A8     => DXGI_FORMAT_B8G8R8A8_TYPELESS,
         D16             => DXGI_FORMAT_R16_TYPELESS,
         D24 | D24_S8    => DXGI_FORMAT_R24G8_TYPELESS,
         D32             => DXGI_FORMAT_R32_TYPELESS,

--- a/src/backend/gl/src/tex.rs
+++ b/src/backend/gl/src/tex.rs
@@ -67,6 +67,7 @@ fn format_to_glpixel(format: NewFormat) -> GLenum {
         S::R4_G4_B4_A4 | S::R5_G5_B5_A1 | S::R10_G10_B10_A2 => rgba,
         S::D24_S8 => gl::DEPTH_STENCIL,
         S::D16 | S::D24 | S::D32 => gl::DEPTH,
+        S::B8_G8_R8_A8 => unimplemented!(), // TODO
     }
 }
 
@@ -91,6 +92,7 @@ fn format_to_gltype(format: NewFormat) -> Result<GLenum, ()> {
         S::R11_G11_B10 => return Err(()),
         S::R16 | S::R16_G16 | S::R16_G16_B16 | S::R16_G16_B16_A16 => fm16,
         S::R32 | S::R32_G32 | S::R32_G32_B32 | S::R32_G32_B32_A32 => fm32,
+        S::B8_G8_R8_A8 => return Err(()), // TODO
         S::D16 => gl::UNSIGNED_SHORT,
         S::D24 => gl::UNSIGNED_INT,
         S::D24_S8 => gl::UNSIGNED_INT_24_8,
@@ -206,6 +208,7 @@ fn format_to_glfull(format: NewFormat) -> Result<GLenum, ()> {
             C::Float => gl::RGBA32F,
             _ => return Err(()),
         },
+        S::B8_G8_R8_A8 => return Err(()), // TODO
         // depth-stencil
         S::D16 => gl::DEPTH_COMPONENT16,
         S::D24 => gl::DEPTH_COMPONENT24,

--- a/src/backend/metal/src/map.rs
+++ b/src/backend/metal/src/map.rs
@@ -267,6 +267,7 @@ pub fn map_format(format: Format, is_target: bool) -> Option<MTLPixelFormat> {
             Float => RGBA32Float,
             _ => return None,
         },
+        B8_G8_R8_A8 => return None,
         D16 => return None,
         D24 => match (is_target, format.1) {
             // TODO: stencil?
@@ -298,6 +299,7 @@ pub fn map_channel_hint(hint: SurfaceType) -> Option<ChannelType> {
         R8 | R8_G8 | R8_G8_B8_A8 | R10_G10_B10_A2 | R16 | R16_G16 |
         R16_G16_B16_A16 | R32 | R32_G32 | R32_G32_B32_A32 => Uint,
         R11_G11_B10 => Float,
+        B8_G8_R8_A8 => Unorm,
         D24 => Unorm,
         D24_S8 => Unorm,
         D32 => Float,

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -294,6 +294,10 @@ impl GraphicsQueue {
     pub fn get_queue(&self) -> vk::Queue {
         self.queue
     }
+    #[doc(hidden)]
+    pub fn get_family(&self) -> u32 {
+        self.family
+    }
 }
 
 impl core::Device for GraphicsQueue {

--- a/src/backend/vulkan/src/data.rs
+++ b/src/backend/vulkan/src/data.rs
@@ -241,6 +241,10 @@ pub fn map_format(surface: SurfaceType, chan: ChannelType) -> Option<vk::Format>
             Float => vk::FORMAT_R32G32B32A32_SFLOAT,
             _ => return None,
         },
+        B8_G8_R8_A8 => match chan {
+            Unorm => vk::FORMAT_B8G8R8A8_UNORM,
+            _ => return None,
+        },
         D16 => match chan {
             Unorm  => vk::FORMAT_D16_UNORM,
             _ => return None,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -205,7 +205,8 @@ pub fn create(app_name: &str, app_version: u32, layers: &[&str], extensions: &[&
     info!("Chosen physical device {:?} with queue family {}", dev.device, qf_id);
 
     let mvid_id = dev.memory.memoryTypes.iter().take(dev.memory.memoryTypeCount as usize)
-                            .position(|mt| mt.propertyFlags & vk::MEMORY_PROPERTY_DEVICE_LOCAL_BIT != 0)
+                            .position(|mt| (mt.propertyFlags & vk::MEMORY_PROPERTY_DEVICE_LOCAL_BIT != 0)
+                                        && (mt.propertyFlags & vk::MEMORY_PROPERTY_HOST_VISIBLE_BIT != 0))
                             .unwrap() as u32;
     let msys_id = dev.memory.memoryTypes.iter().take(dev.memory.memoryTypeCount as usize)
                             .position(|mt| mt.propertyFlags & vk::MEMORY_PROPERTY_HOST_COHERENT_BIT != 0)

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -80,6 +80,7 @@ pub struct Share {
     inst_pointers: vk::InstancePointers,
     device: vk::Device,
     dev_pointers: vk::DevicePointers,
+    physical_device: vk::PhysicalDevice,
     handles: RefCell<gfx_core::handle::Manager<Resources>>,
 }
 
@@ -91,6 +92,9 @@ impl Share {
     }
     pub fn get_device(&self) -> (vk::Device, &vk::DevicePointers) {
         (self.device, &self.dev_pointers)
+    }
+    pub fn get_physical_device(&self) -> vk::PhysicalDevice {
+        self.physical_device
     }
 }
 
@@ -273,6 +277,7 @@ pub fn create(app_name: &str, app_version: u32, layers: &[&str], extensions: &[&
         inst_pointers: inst_pointers,
         device: device,
         dev_pointers: dev_pointers,
+        physical_device: dev.device,
         handles: RefCell::new(gfx_core::handle::Manager::new()),
     });
     let gfx_device = command::GraphicsQueue::new(share.clone(), queue, qf_id as u32);

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -153,16 +153,11 @@ pub fn create(app_name: &str, app_version: u32, layers: &[&str], extensions: &[&
     };
 
     // Check our surface extensions against the available extensions
-    let surface_extensions = SURFACE_EXTENSIONS.iter().filter(|ext| {
-        for inst_ext in instance_extensions.iter() {
-            unsafe {
-                if CStr::from_ptr(inst_ext.extensionName.as_ptr()) == CStr::from_ptr(ext.as_ptr() as *const i8) {
-                    return true;
-                }
-            }
-        }
-        false
-    }).map(|s| *s).collect::<Vec<_>>();
+    let surface_extensions = SURFACE_EXTENSIONS.iter().filter_map(|ext| {
+        instance_extensions.iter().find(|inst_ext| {
+            unsafe { CStr::from_ptr(inst_ext.extensionName.as_ptr()) == CStr::from_ptr(ext.as_ptr() as *const i8) }
+        }).and_then(|_| Some(*ext))
+    }).collect::<Vec<&str>>();
     
     let instance = {
         let cstrings = layers.iter().chain(extensions.iter())

--- a/src/core/src/format.rs
+++ b/src/core/src/format.rs
@@ -142,7 +142,7 @@ impl_formats! {
     R32_G32_B32_A32 : Vec4<Int, Uint, Float> = [u32; 4] {32}
         [BufferSurface, TextureSurface, RenderSurface],
     B8_G8_R8_A8     : Vec4<Unorm> = [u8; 4] {32}
-        [RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface],
     D16             : Vec1<Unorm> = F16 {0} [TextureSurface, DepthSurface],
     D24             : Vec1<Unorm> = f32 {8} [TextureSurface, DepthSurface], //hacky stencil bits
     D24_S8          : Vec1<Unorm, Uint> = u32 {8} [TextureSurface, DepthSurface, StencilSurface],

--- a/src/core/src/format.rs
+++ b/src/core/src/format.rs
@@ -141,6 +141,8 @@ impl_formats! {
         [BufferSurface, TextureSurface, RenderSurface],
     R32_G32_B32_A32 : Vec4<Int, Uint, Float> = [u32; 4] {32}
         [BufferSurface, TextureSurface, RenderSurface],
+    B8_G8_R8_A8     : Vec4<Unorm> = [u8; 4] {32}
+        [RenderSurface],
     D16             : Vec1<Unorm> = F16 {0} [TextureSurface, DepthSurface],
     D24             : Vec1<Unorm> = f32 {8} [TextureSurface, DepthSurface], //hacky stencil bits
     D24_S8          : Vec1<Unorm, Uint> = u32 {8} [TextureSurface, DepthSurface, StencilSurface],
@@ -344,6 +346,8 @@ pub type Rgb10a2F = (R10_G10_B10_A2, Float);
 pub type Rgba16F = (R16_G16_B16_A16, Float);
 /// Standard 32-bit floating-point RGBA format.
 pub type Rgba32F = (R32_G32_B32_A32, Float);
+/// Standard 8bits BGRA format.
+pub type Bgra8 = (B8_G8_R8_A8, Unorm);
 /// Standard 24-bit depth format.
 pub type Depth = (D24, Unorm);
 /// Standard 24-bit depth format with 8-bit stencil.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,10 @@ extern crate gfx_window_vulkan;
 
 pub mod shade;
 
-
+#[cfg(not(feature = "vulkan"))]
 pub type ColorFormat = gfx::format::Rgba8;
+#[cfg(feature = "vulkan")]
+pub type ColorFormat = gfx::format::Bgra8;
 
 #[cfg(target_os = "macos")]
 pub type DepthFormat = gfx::format::Depth32F;

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -114,11 +114,9 @@ const LAYERS_DEBUG: &'static [&'static str] = &[
 ];
 const EXTENSIONS: &'static [&'static str] = &[
     "VK_KHR_surface",
-    "VK_KHR_xcb_surface",
 ];
 const EXTENSIONS_DEBUG: &'static [&'static str] = &[
     "VK_KHR_surface",
-    "VK_KHR_xcb_surface",
     "VK_EXT_debug_report",
 ];
 const DEV_EXTENSIONS: &'static [&'static str] = &[


### PR DESCRIPTION
The backend will now load the required extensions for each platform for the surface creation. Additionally improved the swapchain creation to address serveral validation layer errors (checking for support of formats, capabilities, etc.).
Additionally switched to the (more common?) BGRA8 color format for the swapchain images.

I assume we need to shift some responsibilities for the the swapchain creation to the application to select its prefered formats and settings depending on the capabilities offered by the GPU.
(e.g. my system doesn't support RGBA8 for swapchains nor D24_S8 as depth-stencil format)