### PR TITLE
Persistent mapping: work in progress

### DIFF
--- a/examples/blend/main.rs
+++ b/examples/blend/main.rs
@@ -152,7 +152,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
     fn render<C: gfx::CommandBuffer<R>>(&mut self, encoder: &mut gfx::Encoder<R, C>) {
         let locals = Locals { blend: self.id as i32 };
-        encoder.update_constant_buffer(&self.bundle.data.locals, &locals);
+        encoder.update_constant_buffer(&self.bundle.data.locals, &locals).unwrap();
         encoder.clear(&self.bundle.data.out, [0.0; 4]);
         self.bundle.encode(encoder);
     }

--- a/examples/blend/main.rs
+++ b/examples/blend/main.rs
@@ -152,7 +152,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
     fn render<C: gfx::CommandBuffer<R>>(&mut self, encoder: &mut gfx::Encoder<R, C>) {
         let locals = Locals { blend: self.id as i32 };
-        encoder.update_constant_buffer(&self.bundle.data.locals, &locals).unwrap();
+        encoder.update_constant_buffer(&self.bundle.data.locals, &locals);
         encoder.clear(&self.bundle.data.out, [0.0; 4]);
         self.bundle.encode(encoder);
     }

--- a/examples/blend/main.rs
+++ b/examples/blend/main.rs
@@ -58,7 +58,7 @@ fn load_texture<R, F>(factory: &mut F, data: &[u8])
     let img = image::load(Cursor::new(data), image::PNG).unwrap().to_rgba();
     let (width, height) = img.dimensions();
     let kind = t::Kind::D2(width as t::Size, height as t::Size, t::AaMode::Single);
-    let (_, view) = factory.create_texture_const_u8::<Rgba8>(kind, &[&img]).unwrap();
+    let (_, view) = factory.create_texture_immutable_u8::<Rgba8>(kind, &[&img]).unwrap();
     Ok(view)
 }
 

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -167,7 +167,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
     fn render<C: gfx::CommandBuffer<R>>(&mut self, encoder: &mut gfx::Encoder<R, C>) {
         let locals = Locals { transform: self.bundle.data.transform };
-        encoder.update_constant_buffer(&self.bundle.data.locals, &locals).unwrap();
+        encoder.update_constant_buffer(&self.bundle.data.locals, &locals);
         encoder.clear(&self.bundle.data.out_color, [0.1, 0.2, 0.3, 1.0]);
         encoder.clear_depth(&self.bundle.data.out_depth, 1.0);
         self.bundle.encode(encoder);

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -130,7 +130,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         let (vbuf, slice) = factory.create_vertex_buffer_with_slice(&vertex_data, index_data);
 
         let texels = [[0x20, 0xA0, 0xC0, 0x00]];
-        let (_, texture_view) = factory.create_texture_const::<gfx::format::Rgba8>(
+        let (_, texture_view) = factory.create_texture_immutable::<gfx::format::Rgba8>(
             gfx::tex::Kind::D2(1, 1, gfx::tex::AaMode::Single), &[&texels]
             ).unwrap();
 

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -167,7 +167,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
     fn render<C: gfx::CommandBuffer<R>>(&mut self, encoder: &mut gfx::Encoder<R, C>) {
         let locals = Locals { transform: self.bundle.data.transform };
-        encoder.update_constant_buffer(&self.bundle.data.locals, &locals);
+        encoder.update_constant_buffer(&self.bundle.data.locals, &locals).unwrap();
         encoder.clear(&self.bundle.data.out_color, [0.1, 0.2, 0.3, 1.0]);
         encoder.clear_depth(&self.bundle.data.out_depth, 1.0);
         self.bundle.encode(encoder);

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -491,7 +491,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
             view: view.mat.into(),
             proj: proj.into(),
         };
-        encoder.update_constant_buffer(&self.terrain.data.locals, &terrain_locals);
+        encoder.update_constant_buffer(&self.terrain.data.locals, &terrain_locals).unwrap();
 
         let light_locals = LightLocals {
             cam_pos_and_radius: [cam_pos.x, cam_pos.y, cam_pos.z,
@@ -503,9 +503,9 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
             transform: (proj * view.mat).into(),
             radius: LIGHT_RADIUS,
         };
-        encoder.update_constant_buffer(&self.light.data.locals_vs, &cube_locals);
+        encoder.update_constant_buffer(&self.light.data.locals_vs, &cube_locals).unwrap();
         cube_locals.radius = EMITTER_RADIUS;
-        encoder.update_constant_buffer(&self.emitter.data.locals, &cube_locals);
+        encoder.update_constant_buffer(&self.emitter.data.locals, &cube_locals).unwrap();
 
         // Update light positions
         for (i, d) in self.light_pos_vec.iter_mut().enumerate() {

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -491,7 +491,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
             view: view.mat.into(),
             proj: proj.into(),
         };
-        encoder.update_constant_buffer(&self.terrain.data.locals, &terrain_locals).unwrap();
+        encoder.update_constant_buffer(&self.terrain.data.locals, &terrain_locals);
 
         let light_locals = LightLocals {
             cam_pos_and_radius: [cam_pos.x, cam_pos.y, cam_pos.z,
@@ -503,9 +503,9 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
             transform: (proj * view.mat).into(),
             radius: LIGHT_RADIUS,
         };
-        encoder.update_constant_buffer(&self.light.data.locals_vs, &cube_locals).unwrap();
+        encoder.update_constant_buffer(&self.light.data.locals_vs, &cube_locals);
         cube_locals.radius = EMITTER_RADIUS;
-        encoder.update_constant_buffer(&self.emitter.data.locals, &cube_locals).unwrap();
+        encoder.update_constant_buffer(&self.emitter.data.locals, &cube_locals);
 
         // Update light positions
         for (i, d) in self.light_pos_vec.iter_mut().enumerate() {

--- a/examples/flowmap/main.rs
+++ b/examples/flowmap/main.rs
@@ -152,7 +152,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         self.bundle.data.offset0 = self.cycles[0];
         self.bundle.data.offset1 = self.cycles[1];
         let locals = Locals { offsets: self.cycles };
-        encoder.update_constant_buffer(&self.bundle.data.locals, &locals);
+        encoder.update_constant_buffer(&self.bundle.data.locals, &locals).unwrap();
 
         encoder.clear(&self.bundle.data.out, [0.3, 0.3, 0.3, 1.0]);
         self.bundle.encode(encoder);

--- a/examples/flowmap/main.rs
+++ b/examples/flowmap/main.rs
@@ -152,7 +152,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         self.bundle.data.offset0 = self.cycles[0];
         self.bundle.data.offset1 = self.cycles[1];
         let locals = Locals { offsets: self.cycles };
-        encoder.update_constant_buffer(&self.bundle.data.locals, &locals).unwrap();
+        encoder.update_constant_buffer(&self.bundle.data.locals, &locals);
 
         encoder.clear(&self.bundle.data.out, [0.3, 0.3, 0.3, 1.0]);
         self.bundle.encode(encoder);

--- a/examples/flowmap/main.rs
+++ b/examples/flowmap/main.rs
@@ -61,7 +61,7 @@ fn load_texture<R, F>(factory: &mut F, data: &[u8])
     let img = image::load(Cursor::new(data), image::PNG).unwrap().to_rgba();
     let (width, height) = img.dimensions();
     let kind = t::Kind::D2(width as t::Size, height as t::Size, t::AaMode::Single);
-    let (_, view) = factory.create_texture_const_u8::<Rgba8>(kind, &[&img]).unwrap();
+    let (_, view) = factory.create_texture_immutable_u8::<Rgba8>(kind, &[&img]).unwrap();
     Ok(view)
 }
 

--- a/examples/instancing/README.md
+++ b/examples/instancing/README.md
@@ -16,7 +16,8 @@
 
 # Instancing Example
 
-A simple example showing how to render a bunch of rectangles using instancing.
+A simple example showing how to render a bunch of rectangles using instancing
+and persistent mapping.
 
 ## Screenshot
 

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -93,7 +93,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         ];
         let (vbuf, slice) = factory.create_vertex_buffer_with_slice(&vertex_data, ());
 
-        let (_, texture_view) = factory.create_texture_const::<ColorFormat>(
+        let (_, texture_view) = factory.create_texture_immutable::<ColorFormat>(
             gfx::tex::Kind::D2(4, 4, gfx::tex::AaMode::Single),
             &[&L0_DATA, &L1_DATA, &L2_DATA]
             ).unwrap();

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -581,7 +581,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
                             mvp.into()
                         },
                     };
-                    self.encoder.update_constant_buffer(&batch.locals, &locals).unwrap();
+                    self.encoder.update_constant_buffer(&batch.locals, &locals);
                     self.encoder.draw(&ent.slice, &subshare.shadow_pso, &batch);
                 }
             }
@@ -604,7 +604,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
                 transform: (mx_vp * ent.mx_to_world).into(),
                 model_transform: ent.mx_to_world.into(),
             };
-            self.encoder.update_constant_buffer(&batch.vs_locals, &locals).unwrap();
+            self.encoder.update_constant_buffer(&batch.vs_locals, &locals);
             self.encoder.draw(&ent.slice, &self.forward_pso, batch);
         }
 

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -581,7 +581,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
                             mvp.into()
                         },
                     };
-                    self.encoder.update_constant_buffer(&batch.locals, &locals);
+                    self.encoder.update_constant_buffer(&batch.locals, &locals).unwrap();
                     self.encoder.draw(&ent.slice, &subshare.shadow_pso, &batch);
                 }
             }
@@ -604,7 +604,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
                 transform: (mx_vp * ent.mx_to_world).into(),
                 model_transform: ent.mx_to_world.into(),
             };
-            self.encoder.update_constant_buffer(&batch.vs_locals, &locals);
+            self.encoder.update_constant_buffer(&batch.vs_locals, &locals).unwrap();
             self.encoder.draw(&ent.slice, &self.forward_pso, batch);
         }
 

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -307,7 +307,7 @@ fn create_scene<R, F>(factory: &mut F,
     let mut fw_data = forward::Data {
         vbuf: cube_buf.clone(),
         vs_locals: factory.create_constant_buffer(1),
-        ps_locals: factory.create_buffer_const(&[locals],
+        ps_locals: factory.create_buffer_immutable(&[locals],
             gfx::BufferRole::Uniform, gfx::Bind::empty()
             ).unwrap(),
         light_buf: light_buf.clone(),
@@ -521,6 +521,8 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
 
         // fill up shadow map for each light
         if self.is_parallel {
+            unimplemented!() // FIXME: add mapping Send bound
+            /*
             use std::thread;
             use std::sync::mpsc;
 
@@ -561,6 +563,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
                 light.encoder.flush(device);
                 self.scene.lights.push(light);
             }
+            */
         } else {
             for light in self.scene.lights.iter_mut() {
                 // clear

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -160,7 +160,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
                 inv_proj: self.projection.invert().unwrap().into(),
                 view: view.mat.into(),
             };
-            encoder.update_constant_buffer(&self.bundle.data.locals, &locals);
+            encoder.update_constant_buffer(&self.bundle.data.locals, &locals).unwrap();
         }
 
         encoder.clear(&self.bundle.data.out, [0.3, 0.3, 0.3, 1.0]);

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -74,7 +74,7 @@ fn load_cubemap<R, F>(factory: &mut F, data: CubemapData) -> Result<gfx::handle:
     }).collect::<Vec<_>>();
     let data: [&[u8]; 6] = [&images[0], &images[1], &images[2], &images[3], &images[4], &images[5]];
     let kind = gfx::tex::Kind::Cube(images[0].dimensions().0 as u16);
-    match factory.create_texture_const_u8::<Rgba8>(kind, &data) {
+    match factory.create_texture_immutable_u8::<Rgba8>(kind, &data) {
         Ok((_, view)) => Ok(view),
         Err(_) => Err("Unable to create an immutable cubemap texture".to_owned()),
     }

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -160,7 +160,7 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
                 inv_proj: self.projection.invert().unwrap().into(),
                 view: view.mat.into(),
             };
-            encoder.update_constant_buffer(&self.bundle.data.locals, &locals).unwrap();
+            encoder.update_constant_buffer(&self.bundle.data.locals, &locals);
         }
 
         encoder.clear(&self.bundle.data.out, [0.3, 0.3, 0.3, 1.0]);

--- a/examples/ubo_tilemap/main.rs
+++ b/examples/ubo_tilemap/main.rs
@@ -51,7 +51,7 @@ pub fn load_texture<R, F>(factory: &mut F, data: &[u8])
     let img = image::load(Cursor::new(data), image::PNG).unwrap().to_rgba();
     let (width, height) = img.dimensions();
     let kind = t::Kind::D2(width as t::Size, height as t::Size, t::AaMode::Single);
-    let (_, view) = factory.create_texture_const_u8::<Rgba8>(kind, &[&img]).unwrap();
+    let (_, view) = factory.create_texture_immutable_u8::<Rgba8>(kind, &[&img]).unwrap();
     Ok(view)
 }
 

--- a/examples/ubo_tilemap/main.rs
+++ b/examples/ubo_tilemap/main.rs
@@ -265,11 +265,11 @@ impl<R> TileMapPlane<R> where R: gfx::Resources {
             encoder.update_buffer(&self.params.tilemap, &self.data, 0).unwrap();
         }
         if self.proj_dirty {
-            encoder.update_constant_buffer(&self.params.projection_cb, &self.proj_stuff).unwrap();
+            encoder.update_constant_buffer(&self.params.projection_cb, &self.proj_stuff);
             self.proj_dirty = false;
         }
         if self.tm_dirty {
-            encoder.update_constant_buffer(&self.params.tilemap_cb, &self.tm_stuff).unwrap();
+            encoder.update_constant_buffer(&self.params.tilemap_cb, &self.tm_stuff);
             self.tm_dirty = false;
         }
     }

--- a/examples/ubo_tilemap/main.rs
+++ b/examples/ubo_tilemap/main.rs
@@ -265,11 +265,11 @@ impl<R> TileMapPlane<R> where R: gfx::Resources {
             encoder.update_buffer(&self.params.tilemap, &self.data, 0).unwrap();
         }
         if self.proj_dirty {
-            encoder.update_constant_buffer(&self.params.projection_cb, &self.proj_stuff);
+            encoder.update_constant_buffer(&self.params.projection_cb, &self.proj_stuff).unwrap();
             self.proj_dirty = false;
         }
         if self.tm_dirty {
-            encoder.update_constant_buffer(&self.params.tilemap_cb, &self.tm_stuff);
+            encoder.update_constant_buffer(&self.params.tilemap_cb, &self.tm_stuff).unwrap();
             self.tm_dirty = false;
         }
     }

--- a/src/backend/dx11/src/data.rs
+++ b/src/backend/dx11/src/data.rs
@@ -207,12 +207,10 @@ pub fn map_bind(bind: Bind) -> D3D11_BIND_FLAG {
 
 
 pub fn map_access(access: mapping::Access) -> D3D11_CPU_ACCESS_FLAG {
-    match access {
-        mapping::READABLE => D3D11_CPU_ACCESS_READ,
-        mapping::WRITABLE => D3D11_CPU_ACCESS_WRITE,
-        mapping::RW => D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE,
-        _ => unreachable!(),
-    }
+    let mut r = D3D11_CPU_ACCESS_FLAG(0);
+    if access.contains(mapping::READABLE) { r = r | D3D11_CPU_ACCESS_READ }
+    if access.contains(mapping::WRITABLE) { r = r | D3D11_CPU_ACCESS_WRITE }
+    r
 }
 
 pub fn map_usage(usage: Usage) -> (D3D11_USAGE, D3D11_CPU_ACCESS_FLAG) {

--- a/src/backend/dx11/src/data.rs
+++ b/src/backend/dx11/src/data.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use winapi::*;
-use gfx_core::factory::{Bind, MapAccess, Usage};
+use gfx_core::mapping;
+use gfx_core::factory::{Bind, Usage};
 use gfx_core::format::{Format, SurfaceType};
 use gfx_core::state::Comparison;
 use gfx_core::tex::{AaMode, FilterMethod, WrapMode, DepthStencilFlags};
@@ -205,19 +206,21 @@ pub fn map_bind(bind: Bind) -> D3D11_BIND_FLAG {
 }
 
 
-pub fn map_access(access: MapAccess) -> D3D11_CPU_ACCESS_FLAG {
+pub fn map_access(access: mapping::Access) -> D3D11_CPU_ACCESS_FLAG {
     match access {
-        MapAccess::Readable => D3D11_CPU_ACCESS_READ,
-        MapAccess::Writable => D3D11_CPU_ACCESS_WRITE,
-        MapAccess::RW => D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE,
+        mapping::READABLE => D3D11_CPU_ACCESS_READ,
+        mapping::WRITABLE => D3D11_CPU_ACCESS_WRITE,
+        mapping::RW => D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE,
+        _ => unreachable!(),
     }
 }
 
 pub fn map_usage(usage: Usage) -> (D3D11_USAGE, D3D11_CPU_ACCESS_FLAG) {
     match usage {
         Usage::GpuOnly => (D3D11_USAGE_DEFAULT,   D3D11_CPU_ACCESS_FLAG(0)),
-        Usage::Const   => (D3D11_USAGE_IMMUTABLE, D3D11_CPU_ACCESS_FLAG(0)),
+        Usage::Immutable => (D3D11_USAGE_IMMUTABLE, D3D11_CPU_ACCESS_FLAG(0)),
         Usage::Dynamic => (D3D11_USAGE_DYNAMIC,   D3D11_CPU_ACCESS_WRITE),
+        Usage::Persistent(access) => unimplemented!(),
         Usage::CpuOnly(access) => (D3D11_USAGE_STAGING, map_access(access)),
     }
 }

--- a/src/backend/dx11/src/factory.rs
+++ b/src/backend/dx11/src/factory.rs
@@ -29,11 +29,11 @@ use native;
 
 
 #[derive(Copy, Clone, Debug)]
-pub struct RawMapping {
+pub struct MappingGate {
     pointer: *mut c_void,
 }
 
-impl core::mapping::Backend<R> for RawMapping {
+impl core::mapping::Gate<R> for MappingGate {
     unsafe fn set<T>(&self, index: usize, val: T) {
         *(self.pointer as *mut T).offset(index as isize) = val;
     }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -147,7 +147,8 @@ impl gfx_core::Resources for Resources {
     type ShaderResourceView  = native::Srv;
     type UnorderedAccessView = ();
     type Sampler             = native::Sampler;
-    type Fence               = ();
+    type Fence               = Fence;
+    type Mapping             = factory::RawMapping;
 }
 
 /// Internal struct of shared data between the device and its factories.
@@ -339,27 +340,40 @@ impl gfx_core::Device for Device {
         }
     }
 
-    fn submit(&mut self, cb: &mut Self::CommandBuffer) {
+    fn submit(&mut self,
+              cb: &mut Self::CommandBuffer,
+              _: &gfx_core::pso::AccessInfo<Resources>)
+    {
         unsafe { (*self.context).ClearState(); }
         for com in &cb.parser.0 {
             execute::process(self.context, com, &cb.parser.1);
         }
     }
 
+    fn fenced_submit(&mut self,
+                     _: &mut Self::CommandBuffer,
+                     _: &gfx_core::pso::AccessInfo<Resources>,
+                     _after: Option<h::Fence<Resources>>) -> h::Fence<Resources>
+    {
+        unimplemented!()
+    }
+
     fn cleanup(&mut self) {
         use gfx_core::handle::Producer;
+
         self.frame_handles.clear();
         self.share.handles.borrow_mut().clean_with(&mut (),
-            |_, v| unsafe { (*(v.0).0).Release(); }, //buffer
+            |_, buffer| unsafe { (*(buffer.resource.0).0).Release(); },
             |_, s| unsafe { //shader
                 (*s.object).Release();
                 (*s.reflection).Release();
             },
-            |_, p| unsafe {
+            |_, program| unsafe {
+                let p = program.resource;
                 if p.vs != ptr::null_mut() { (*p.vs).Release(); }
                 if p.gs != ptr::null_mut() { (*p.gs).Release(); }
                 if p.ps != ptr::null_mut() { (*p.ps).Release(); }
-            }, //program
+            },
             |_, v| unsafe { //PSO
                 type Child = *mut winapi::ID3D11DeviceChild;
                 (*v.layout).Release();
@@ -367,13 +381,14 @@ impl gfx_core::Device for Device {
                 (*(v.depth_stencil as Child)).Release();
                 (*(v.blend as Child)).Release();
             },
-            |_, v| unsafe { (*v.to_resource()).Release(); },  //texture
+            |_, texture| unsafe { (*texture.resource.to_resource()).Release(); },
             |_, v| unsafe { (*v.0).Release(); }, //SRV
             |_, _| {}, //UAV
             |_, v| unsafe { (*v.0).Release(); }, //RTV
             |_, v| unsafe { (*v.0).Release(); }, //DSV
             |_, v| unsafe { (*v.0).Release(); }, //sampler
-            |_, _| {}, //fence
+            |_, _fence| {},
+            |_, _mapping| {},
         );
     }
 }
@@ -396,7 +411,10 @@ impl gfx_core::Device for Deferred {
         self.0.pin_submitted_resources(man);
     }
 
-    fn submit(&mut self, cb: &mut Self::CommandBuffer) {
+    fn submit(&mut self,
+              cb: &mut Self::CommandBuffer,
+              _: &gfx_core::pso::AccessInfo<Resources>)
+    {
         let cl = match cb.parser.1 {
             Some(cl) => cl,
             None => {
@@ -421,7 +439,24 @@ impl gfx_core::Device for Deferred {
         }
     }
 
+    fn fenced_submit(&mut self,
+                     _: &mut Self::CommandBuffer,
+                     _: &gfx_core::pso::AccessInfo<Resources>,
+                     _after: Option<h::Fence<Resources>>) -> h::Fence<Resources>
+    {
+        unimplemented!()
+    }
+
     fn cleanup(&mut self) {
         self.0.cleanup();
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Fence(());
+
+impl gfx_core::Fence for Fence {
+    fn wait(&self) {
+        unimplemented!()
     }
 }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -148,7 +148,7 @@ impl gfx_core::Resources for Resources {
     type UnorderedAccessView = ();
     type Sampler             = native::Sampler;
     type Fence               = Fence;
-    type Mapping             = factory::RawMapping;
+    type Mapping             = factory::MappingGate;
 }
 
 /// Internal struct of shared data between the device and its factories.

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -15,7 +15,7 @@
 use std::{mem, ptr};
 use std::collections::hash_map::{HashMap, Entry};
 use vk;
-use gfx_core::{self as core, draw, pso, shade, target, tex};
+use gfx_core::{self as core, draw, pso, shade, target, tex, handle, mapping};
 use gfx_core::state::RefValues;
 use gfx_core::{IndexType, VertexCount};
 use native;
@@ -298,6 +298,71 @@ impl GraphicsQueue {
     pub fn get_family(&self) -> u32 {
         self.family
     }
+
+    fn place_memory_barrier(&mut self) {
+        unimplemented!()
+    }
+
+    fn place_fence(&mut self) -> handle::Fence<Resources> {
+        unimplemented!()
+    }
+
+    fn flush_mappings(&mut self, mappings: &[handle::RawMapping<Resources>]) {
+        let (dev, vk) = self.share.get_device();
+        for mapping in mappings {
+            let mut inner = mapping.access()
+                .expect("user error: mapping still in use on submit");
+
+            if inner.status.cpu {
+                let memory_range = vk::MappedMemoryRange {
+                    sType: vk::STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,
+                    pNext: ptr::null(),
+                    memory: inner.buffer.resource().memory,
+                    offset: 0,
+                    size: vk::WHOLE_SIZE,
+                };
+                assert_eq!(vk::SUCCESS, unsafe {
+                    vk.FlushMappedMemoryRanges(dev, 1, &memory_range)
+                });
+
+                inner.status.cpu = false;
+            }
+        }
+    }
+
+    fn invalidate_mappings(&mut self, mappings: &[handle::RawMapping<Resources>]) {
+        let (dev, vk) = self.share.get_device();
+        for mapping in mappings {
+            let inner = mapping.access()
+                .expect("user error: mapping still in use on submit");
+
+            if inner.access.contains(mapping::READABLE) {
+                let memory_range = vk::MappedMemoryRange {
+                    sType: vk::STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,
+                    pNext: ptr::null(),
+                    memory: inner.buffer.resource().memory,
+                    offset: 0,
+                    size: vk::WHOLE_SIZE,
+                };
+                assert_eq!(vk::SUCCESS, unsafe {
+                    vk.InvalidateMappedMemoryRanges(dev, 1, &memory_range)
+                });
+            }
+        }
+    }
+
+    fn setup_mappings_read_fence(&mut self,
+                                 mappings: &[handle::RawMapping<Resources>],
+                                 fence: &handle::Fence<Resources>) {
+        for mapping in mappings {
+            let mut inner = mapping.access()
+                .expect("user error: mapping still in use on submit");
+
+            if inner.access.contains(mapping::READABLE) {
+                inner.status.gpu = Some(fence.clone());
+            }
+        }
+    }
 }
 
 impl core::Device for GraphicsQueue {
@@ -310,12 +375,19 @@ impl core::Device for GraphicsQueue {
 
     fn pin_submitted_resources(&mut self, _: &core::handle::Manager<Resources>) {}
 
-    fn submit(&mut self, com: &mut Buffer) {
+    fn submit(&mut self,
+              com: &mut Buffer,
+              access: &core::pso::AccessInfo<Resources>)
+    {
         assert_eq!(self.family, com.family);
-        let (_, vk) = self.share.get_device();
+        let share = self.share.clone();
+        let (_, vk) = share.get_device();
         assert_eq!(vk::SUCCESS, unsafe {
             vk.EndCommandBuffer(com.inner)
         });
+
+        self.flush_mappings(access.mapped_reads());
+
         let submit_info = vk::SubmitInfo {
             sType: vk::STRUCTURE_TYPE_SUBMIT_INFO,
             commandBufferCount: 1,
@@ -325,6 +397,15 @@ impl core::Device for GraphicsQueue {
         assert_eq!(vk::SUCCESS, unsafe {
             vk.QueueSubmit(self.queue, 1, &submit_info, 0)
         });
+
+        let mapped_writes = access.mapped_writes();
+        if mapped_writes.len() > 0 {
+            self.place_memory_barrier();
+            self.invalidate_mappings(mapped_writes);
+            let fence = self.place_fence();
+            self.setup_mappings_read_fence(mapped_writes, &fence);
+        }
+
         let begin_info = vk::CommandBufferBeginInfo {
             sType: vk::STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
             pNext: ptr::null(),
@@ -336,15 +417,24 @@ impl core::Device for GraphicsQueue {
         });
     }
 
+    fn fenced_submit(&mut self,
+                     _: &mut Buffer,
+                     _: &core::pso::AccessInfo<Resources>,
+                     _after: Option<handle::Fence<Resources>>)
+                     -> handle::Fence<Resources>
+    {
+        unimplemented!()
+    }
+
     //note: this should really live elsewhere (Factory?)
     fn cleanup(&mut self) {
         let (dev, mut functions) = self.share.get_device();
         use gfx_core::handle::Producer;
         //self.frame_handles.clear();
         self.share.handles.borrow_mut().clean_with(&mut functions,
-            |vk, b| unsafe { //buffer
-                vk.DestroyBuffer(dev, b.buffer, ptr::null());
-                vk.FreeMemory(dev, b.memory, ptr::null());
+            |vk, buffer| unsafe {
+                vk.DestroyBuffer(dev, buffer.resource.buffer, ptr::null());
+                vk.FreeMemory(dev, buffer.resource.memory, ptr::null());
             },
             |vk, s| unsafe { //shader
                 vk.DestroyShaderModule(dev, *s, ptr::null());
@@ -356,10 +446,10 @@ impl core::Device for GraphicsQueue {
                 vk.DestroyDescriptorSetLayout(dev, p.desc_layout, ptr::null());
                 vk.DestroyDescriptorPool(dev, p.desc_pool, ptr::null());
             },
-            |vk, t| if t.memory != 0 {unsafe { //texture
-                vk.DestroyImage(dev, t.image, ptr::null());
-                vk.FreeMemory(dev, t.memory, ptr::null());
-            }},
+            |vk, texture| if texture.resource.memory != 0 { unsafe {
+                vk.DestroyImage(dev, texture.resource.image, ptr::null());
+                vk.FreeMemory(dev, texture.resource.memory, ptr::null());
+            } },
             |vk, v| unsafe { //SRV
                 vk.DestroyImageView(dev, v.view, ptr::null());
             },
@@ -371,7 +461,13 @@ impl core::Device for GraphicsQueue {
                 vk.DestroyImageView(dev, v.view, ptr::null());
             },
             |_, _v| (), //sampler
-            |_, _| (), //fence
+            |vk, fence| unsafe {
+                vk.DestroyFence(dev, fence.0, ptr::null());
+            },
+            |vk, raw_mapping| {
+                let inner = raw_mapping.access().unwrap();
+                unsafe { vk.UnmapMemory(dev, inner.buffer.resource().memory); }
+            }
         );
     }
 }

--- a/src/backend/vulkan/src/factory.rs
+++ b/src/backend/vulkan/src/factory.rs
@@ -25,11 +25,11 @@ use {Resources as R, SharePointer};
 
 
 #[derive(Copy, Clone, Debug)]
-pub struct RawMapping {
+pub struct MappingGate {
     pointer: *mut c_void,
 }
 
-impl mapping::Backend<R> for RawMapping {
+impl mapping::Gate<R> for MappingGate {
     unsafe fn set<T>(&self, index: usize, val: T) {
         *(self.pointer as *mut T).offset(index as isize) = val;
     }
@@ -872,8 +872,8 @@ impl core::Factory<R> for Factory {
             vk.MapMemory(dev, buf.resource().memory, offset, vk::WHOLE_SIZE, flags, &mut pointer)
         });
 
-        let m = RawMapping { pointer: pointer };
-        Ok(self.share.handles.borrow_mut().make_mapping(m, access, buf))
+        let m = MappingGate { pointer: pointer };
+        self.share.handles.borrow_mut().make_mapping(m, access, buf)
     }
 
     fn map_buffer_readable<T: Copy>(&mut self, buf: &h::Buffer<R, T>)

--- a/src/backend/vulkan/src/factory.rs
+++ b/src/backend/vulkan/src/factory.rs
@@ -14,7 +14,9 @@
 
 use std::{cell, mem, ptr, slice};
 use std::os::raw::c_void;
-use gfx_core::{self as core, handle as h, factory as f, pso, state};
+use gfx_core::{self as core, handle as h, factory as f, pso, state, mapping};
+use gfx_core::factory::Typed;
+use gfx_core::mapping::Builder;
 use gfx_core::format::ChannelType;
 use gfx_core::target::Layer;
 use vk;
@@ -22,21 +24,21 @@ use {command, data, native};
 use {Resources as R, SharePointer};
 
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct RawMapping {
     pointer: *mut c_void,
 }
 
-impl core::mapping::Raw for RawMapping {
+impl mapping::Backend<R> for RawMapping {
     unsafe fn set<T>(&self, index: usize, val: T) {
         *(self.pointer as *mut T).offset(index as isize) = val;
     }
 
-    unsafe fn to_slice<T>(&self, len: usize) -> &[T] {
+    unsafe fn slice<'a, 'b, T>(&'a self, len: usize) -> &'b [T] {
         slice::from_raw_parts(self.pointer as *const T, len)
     }
 
-    unsafe fn to_mut_slice<T>(&self, len: usize) -> &mut [T] {
+    unsafe fn mut_slice<'a, 'b, T>(&'a self, len: usize) -> &'b mut [T] {
         slice::from_raw_parts_mut(self.pointer as *mut T, len)
     }
 }
@@ -284,8 +286,6 @@ impl Drop for Factory {
 }
 
 impl core::Factory<R> for Factory {
-    type Mapper = RawMapping;
-
     fn get_capabilities(&self) -> &core::Capabilities {
         unimplemented!()
     }
@@ -296,12 +296,12 @@ impl core::Factory<R> for Factory {
         Ok(self.share.handles.borrow_mut().make_buffer(buffer, info))
     }
 
-    fn create_buffer_const_raw(&mut self, data: &[u8], stride: usize, role: f::BufferRole, bind: f::Bind)
+    fn create_buffer_immutable_raw(&mut self, data: &[u8], stride: usize, role: f::BufferRole, bind: f::Bind)
                                -> Result<h::RawBuffer<R>, f::BufferError> {
         use gfx_core::handle::Producer;
         let info = f::BufferInfo {
             role: role,
-            usage: f::Usage::Const,
+            usage: f::Usage::Immutable,
             bind: bind,
             size: data.len(),
             stride: stride,
@@ -856,26 +856,41 @@ impl core::Factory<R> for Factory {
         self.share.handles.borrow_mut().make_sampler(sampler, info)
     }
 
-    fn map_buffer_raw(&mut self, _buf: &h::RawBuffer<R>, _access: f::MapAccess) -> RawMapping {
-        unimplemented!()
+    fn map_buffer_raw(&mut self, buf: &h::RawBuffer<R>, access: mapping::Access)
+                      -> Result<h::RawMapping<R>, mapping::Error> {
+        // TODO: ensure the buffer is properly created in regard to the expected mapping
+        // (in particular VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT should be set).
+        use gfx_core::handle::Producer;
+
+        let (dev, vk) = self.share.get_device();
+        try!(buf.valid_access(access));
+
+        let offset = 0;
+        let flags = 0;
+        let mut pointer = ptr::null_mut();
+        assert_eq!(vk::SUCCESS, unsafe {
+            vk.MapMemory(dev, buf.resource().memory, offset, vk::WHOLE_SIZE, flags, &mut pointer)
+        });
+
+        let m = RawMapping { pointer: pointer };
+        Ok(self.share.handles.borrow_mut().make_mapping(m, access, buf))
     }
 
-    fn unmap_buffer_raw(&mut self, _map: RawMapping) {
-        unimplemented!()
+    fn map_buffer_readable<T: Copy>(&mut self, buf: &h::Buffer<R, T>)
+                                    -> Result<mapping::Readable<R, T>, mapping::Error> {
+        let map = try!(self.map_buffer_raw(buf.raw(), mapping::READABLE));
+        Ok(self.map_readable(map, buf.len()))
     }
 
-    fn map_buffer_readable<T: Copy>(&mut self, _buf: &h::Buffer<R, T>)
-                           -> core::mapping::Readable<T, R, Factory> {
-        unimplemented!()
+    fn map_buffer_writable<T: Copy>(&mut self, buf: &h::Buffer<R, T>)
+                                    -> Result<mapping::Writable<R, T>, mapping::Error> {
+        let map = try!(self.map_buffer_raw(buf.raw(), mapping::WRITABLE));
+        Ok(self.map_writable(map, buf.len()))
     }
 
-    fn map_buffer_writable<T: Copy>(&mut self, _buf: &h::Buffer<R, T>)
-                                    -> core::mapping::Writable<T, R, Factory> {
-        unimplemented!()
-    }
-
-    fn map_buffer_rw<T: Copy>(&mut self, _buf: &h::Buffer<R, T>)
-                              -> core::mapping::RW<T, R, Factory> {
-        unimplemented!()
+    fn map_buffer_rw<T: Copy>(&mut self, buf: &h::Buffer<R, T>)
+                              -> Result<mapping::RWable<R, T>, mapping::Error> {
+        let map = try!(self.map_buffer_raw(buf.raw(), mapping::RW));
+        Ok(self.map_read_write(map, buf.len()))
     }
 }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -332,7 +332,7 @@ impl gfx_core::Resources for Resources {
     type DepthStencilView     = native::TextureView;
     type Sampler              = vk::Sampler;
     type Fence                = Fence;
-    type Mapping              = factory::RawMapping;
+    type Mapping              = factory::MappingGate;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -331,5 +331,15 @@ impl gfx_core::Resources for Resources {
     type RenderTargetView     = native::TextureView;
     type DepthStencilView     = native::TextureView;
     type Sampler              = vk::Sampler;
-    type Fence                = vk::Fence;
+    type Fence                = Fence;
+    type Mapping              = factory::RawMapping;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Fence(vk::Fence);
+
+impl gfx_core::Fence for Fence {
+    fn wait(&self) {
+        unimplemented!()
+    }
 }

--- a/src/core/src/dummy.rs
+++ b/src/core/src/dummy.rs
@@ -56,7 +56,7 @@ impl ::Fence for DummyFence {
 #[derive(Debug)]
 pub struct DummyMapping;
 
-impl mapping::Backend<DummyResources> for DummyMapping {
+impl mapping::Gate<DummyResources> for DummyMapping {
     unsafe fn set<T>(&self, _index: usize, _val: T) { unimplemented!() }
     unsafe fn slice<'a, 'b, T>(&'a self, _len: usize) -> &'b [T] { unimplemented!() }
     unsafe fn mut_slice<'a, 'b, T>(&'a self, _len: usize) -> &'b mut [T] { unimplemented!() }

--- a/src/core/src/dummy.rs
+++ b/src/core/src/dummy.rs
@@ -120,13 +120,11 @@ impl Device for DummyDevice {
     }
     fn pin_submitted_resources(&mut self, _: &handle::Manager<DummyResources>) {}
     fn submit(&mut self, _: &mut DummyCommandBuffer,
-                         _mapped_reads: &[handle::RawMapping<Self::Resources>],
-                         _mapped_writes: &[handle::RawMapping<Self::Resources>]) {}
+                         _: &pso::AccessInfo<Self::Resources>) {}
 
     fn fenced_submit(&mut self,
                      _: &mut Self::CommandBuffer,
-                     _mapped_reads: &[handle::RawMapping<Self::Resources>],
-                     _mapped_writes: &[handle::RawMapping<Self::Resources>],
+                     _: &pso::AccessInfo<Self::Resources>,
                      _after: Option<handle::Fence<Self::Resources>>)
                      -> handle::Fence<Self::Resources> {
         unimplemented!()

--- a/src/core/src/dummy.rs
+++ b/src/core/src/dummy.rs
@@ -56,7 +56,7 @@ impl ::Fence for DummyFence {
 #[derive(Debug)]
 pub struct DummyMapping;
 
-impl mapping::Backend for DummyMapping {
+impl mapping::Backend<DummyResources> for DummyMapping {
     unsafe fn set<T>(&self, _index: usize, _val: T) { unimplemented!() }
     unsafe fn slice<'a, 'b, T>(&'a self, _len: usize) -> &'b [T] { unimplemented!() }
     unsafe fn mut_slice<'a, 'b, T>(&'a self, _len: usize) -> &'b mut [T] { unimplemented!() }

--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -48,18 +48,6 @@ pub fn cast_slice<A: Pod, B: Pod>(slice: &[A]) -> &[B] {
     }
 }
 
-/// Specifies the access allowed to a buffer mapping.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
-#[repr(u8)]
-pub enum MapAccess {
-    /// Only allow reads.
-    Readable,
-    /// Only allow writes.
-    Writable,
-    /// Allow full access.
-    RW
-}
-
 bitflags!(
     /// Bind flags
     pub flags Bind: u8 {
@@ -98,12 +86,28 @@ pub enum Usage {
     /// GPU: read + write, CPU: copy. Optimal for render targets.
     GpuOnly,
     /// GPU: read, CPU: none. Optimal for resourced textures/buffers.
-    Const,
+    Immutable,
     /// GPU: read, CPU: write.
     Dynamic,
+    /// GPU: read + write, CPU: as specified. The more accesses you use, the more synchronisation needs to be done.
+    Persistent(mapping::Access),
     /// GPU: copy, CPU: as specified. Used as a staging buffer,
     /// to be copied back and forth with on-GPU targets.
-    CpuOnly(MapAccess),
+    CpuOnly(mapping::Access),
+}
+
+impl Usage {
+    /// Is the requested mapping access matching the expected usage ?
+    pub fn valid_access(&self, access: mapping::Access) -> Result<(), mapping::Error> {
+        use self::Usage::*;
+        let invalid_access = || Err(mapping::Error::InvalidAccess(access, *self));
+        match *self {
+            GpuOnly | Immutable | CpuOnly(_) => invalid_access(),
+            Dynamic if access.contains(mapping::READABLE) => invalid_access(),
+            Persistent(a) if !a.contains(access) => invalid_access(),
+            _ => Ok(()),
+        }
+    }
 }
 
 /// An information block that is immutable and associated with each buffer.
@@ -346,19 +350,17 @@ impl From<TargetViewError> for CombinedError {
 /// Also see the `FactoryExt` trait inside the `gfx` module for additional methods.
 #[allow(missing_docs)]
 pub trait Factory<R: Resources> {
-    /// Associated mapper type
-    type Mapper: Clone + mapping::Raw;
-
     /// Returns the capabilities of this `Factory`. This usually depends on the graphics API being
     /// used.
     fn get_capabilities(&self) -> &Capabilities;
 
     // resource creation
     fn create_buffer_raw(&mut self, BufferInfo) -> Result<handle::RawBuffer<R>, BufferError>;
-    fn create_buffer_const_raw(&mut self, data: &[u8], stride: usize, BufferRole, Bind)
-                                -> Result<handle::RawBuffer<R>, BufferError>;
-    fn create_buffer_const<T: Pod>(&mut self, data: &[T], role: BufferRole, bind: Bind) -> Result<handle::Buffer<R, T>, BufferError> {
-        self.create_buffer_const_raw(cast_slice(data), mem::size_of::<T>(), role, bind)
+    fn create_buffer_immutable_raw(&mut self, data: &[u8], stride: usize, BufferRole, Bind)
+                                   -> Result<handle::RawBuffer<R>, BufferError>;
+    fn create_buffer_immutable<T: Pod>(&mut self, data: &[T], role: BufferRole, bind: Bind)
+                                       -> Result<handle::Buffer<R, T>, BufferError> {
+        self.create_buffer_immutable_raw(cast_slice(data), mem::size_of::<T>(), role, bind)
             .map(|raw| Typed::new(raw))
     }
     fn create_buffer_dynamic<T>(&mut self, num: usize, role: BufferRole, bind: Bind)
@@ -373,8 +375,20 @@ pub trait Factory<R: Resources> {
         };
         self.create_buffer_raw(info).map(|raw| Typed::new(raw))
     }
-    fn create_buffer_staging<T>(&mut self, num: usize, role: BufferRole, bind: Bind, map: MapAccess)
-                             -> Result<handle::Buffer<R, T>, BufferError> {
+    fn create_buffer_persistent<T>(&mut self, num: usize, role: BufferRole, bind: Bind, map: mapping::Access)
+                                   -> Result<handle::Buffer<R, T>, BufferError> {
+        let stride = mem::size_of::<T>();
+        let info = BufferInfo {
+            role: role,
+            usage: Usage::Persistent(map),
+            bind: bind,
+            size: num * stride,
+            stride: stride,
+        };
+        self.create_buffer_raw(info).map(Typed::new)
+    }
+    fn create_buffer_staging<T>(&mut self, num: usize, role: BufferRole, bind: Bind, map: mapping::Access)
+                                -> Result<handle::Buffer<R, T>, BufferError> {
         let stride = mem::size_of::<T>();
         let info = BufferInfo {
             role: role,
@@ -415,14 +429,14 @@ pub trait Factory<R: Resources> {
 
     fn create_sampler(&mut self, tex::SamplerInfo) -> handle::Sampler<R>;
 
-    fn map_buffer_raw(&mut self, &handle::RawBuffer<R>, MapAccess) -> Self::Mapper;
-    fn unmap_buffer_raw(&mut self, Self::Mapper);
-    fn map_buffer_readable<T: Copy>(&mut self, &handle::Buffer<R, T>) -> mapping::Readable<T, R, Self> where
-        Self: Sized;
-    fn map_buffer_writable<T: Copy>(&mut self, &handle::Buffer<R, T>) -> mapping::Writable<T, R, Self> where
-        Self: Sized;
-    fn map_buffer_rw<T: Copy>(&mut self, &handle::Buffer<R, T>) -> mapping::RW<T, R, Self> where
-        Self: Sized;
+    fn map_buffer_raw(&mut self, &handle::RawBuffer<R>, mapping::Access)
+                      -> Result<handle::RawMapping<R>, mapping::Error>;
+    fn map_buffer_readable<T: Copy>(&mut self, &handle::Buffer<R, T>)
+                                    -> Result<mapping::Readable<R, T>, mapping::Error>;
+    fn map_buffer_writable<T: Copy>(&mut self, &handle::Buffer<R, T>)
+                                    -> Result<mapping::Writable<R, T>, mapping::Error>;
+    fn map_buffer_rw<T: Copy>(&mut self, &handle::Buffer<R, T>)
+                              -> Result<mapping::RWable<R, T>, mapping::Error>;
 
     /// Create a new empty raw texture with no data. The channel type parameter is a hint,
     /// required to assist backends that have no concept of typeless formats (OpenGL).
@@ -541,8 +555,10 @@ pub trait Factory<R: Resources> {
         self.view_texture_as_depth_stencil(tex, 0, None, tex::DepthStencilFlags::empty())
     }
 
-    fn create_texture_const_u8<T: format::TextureFormat>(&mut self, kind: tex::Kind, data: &[&[u8]])
-                               -> Result<(handle::Texture<R, T::Surface>, handle::ShaderResourceView<R, T::View>), CombinedError>
+    fn create_texture_immutable_u8<T: format::TextureFormat>(&mut self, kind: tex::Kind, data: &[&[u8]])
+                                   -> Result<(handle::Texture<R, T::Surface>,
+                                              handle::ShaderResourceView<R, T::View>),
+                                             CombinedError>
     {
         let surface = <T::Surface as format::SurfaceTyped>::get_surface_type();
         let num_slices = kind.get_num_slices().unwrap_or(1) as usize;
@@ -552,7 +568,7 @@ pub trait Factory<R: Resources> {
             levels: (data.len() / (num_slices * num_faces)) as tex::Level,
             format: surface,
             bind: SHADER_RESOURCE,
-            usage: Usage::Const,
+            usage: Usage::Immutable,
         };
         let cty = <T::Channel as format::ChannelTyped>::get_channel_type();
         let raw = try!(self.create_texture_raw(desc, Some(cty), Some(data)));
@@ -562,9 +578,12 @@ pub trait Factory<R: Resources> {
         Ok((tex, view))
     }
 
-    fn create_texture_const<T: format::TextureFormat>(&mut self, kind: tex::Kind,
-                            data: &[&[<T::Surface as format::SurfaceTyped>::DataType]])
-                            -> Result<(handle::Texture<R, T::Surface>, handle::ShaderResourceView<R, T::View>), CombinedError>
+    fn create_texture_immutable<T: format::TextureFormat>(
+        &mut self,
+        kind: tex::Kind,
+        data: &[&[<T::Surface as format::SurfaceTyped>::DataType]])
+        -> Result<(handle::Texture<R, T::Surface>, handle::ShaderResourceView<R, T::View>),
+                  CombinedError>
     {
         // we can use cast_slice on a 2D slice, have to use a temporary array of slices
         let mut raw_data: [&[u8]; 0x100] = [&[]; 0x100];
@@ -572,7 +591,7 @@ pub trait Factory<R: Resources> {
         for (rd, d) in raw_data.iter_mut().zip(data.iter()) {
             *rd = cast_slice(*d);
         }
-        self.create_texture_const_u8::<T>(kind, &raw_data[.. data.len()])
+        self.create_texture_immutable_u8::<T>(kind, &raw_data[.. data.len()])
     }
 
     fn create_render_target<T: format::RenderFormat + format::TextureFormat>

--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -89,7 +89,7 @@ pub enum Usage {
     Immutable,
     /// GPU: read, CPU: write.
     Dynamic,
-    /// GPU: read + write, CPU: as specified. The more accesses you use, the more synchronisation needs to be done.
+    /// GPU: read + write, CPU: as specified.
     Persistent(mapping::Access),
     /// GPU: copy, CPU: as specified. Used as a staging buffer,
     /// to be copied back and forth with on-GPU targets.
@@ -100,12 +100,9 @@ impl Usage {
     /// Is the requested mapping access matching the expected usage ?
     pub fn valid_access(&self, access: mapping::Access) -> Result<(), mapping::Error> {
         use self::Usage::*;
-        let invalid_access = || Err(mapping::Error::InvalidAccess(access, *self));
         match *self {
-            GpuOnly | Immutable | CpuOnly(_) => invalid_access(),
-            Dynamic if access.contains(mapping::READABLE) => invalid_access(),
-            Persistent(a) if !a.contains(access) => invalid_access(),
-            _ => Ok(()),
+            Persistent(a) if a.contains(access) => Ok(()),
+            _ => Err(mapping::Error::InvalidAccess(access, *self)),
         }
     }
 }

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -171,7 +171,7 @@ pub trait Resources:          Clone + Hash + Debug + Eq + PartialEq + Any {
     type DepthStencilView:    Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync;
     type Sampler:             Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync + Copy;
     type Fence:               Clone + Hash + Debug + Eq + PartialEq + Any + Fence;
-    type Mapping:             Debug + Any + mapping::Backend<Self>;
+    type Mapping:             Debug + Any + mapping::Gate<Self>;
 }
 
 /// A `Device` is responsible for submitting `CommandBuffer`s to the GPU. 

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -190,15 +190,13 @@ pub trait Device: Sized {
 
     /// Submits a `CommandBuffer` to the GPU for execution.
     fn submit(&mut self, &mut Self::CommandBuffer,
-                         mapped_reads: &[handle::RawMapping<Self::Resources>],
-                         mapped_writes: &[handle::RawMapping<Self::Resources>]);
+                         access: &pso::AccessInfo<Self::Resources>);
 
     /// Submits a `CommandBuffer` to the GPU for execution.
     /// returns a fence that is signaled after the GPU has executed all commands
     fn fenced_submit(&mut self,
                      &mut Self::CommandBuffer,
-                     mapped_reads: &[handle::RawMapping<Self::Resources>],
-                     mapped_writes: &[handle::RawMapping<Self::Resources>],
+                     access: &pso::AccessInfo<Self::Resources>,
                      after: Option<handle::Fence<Self::Resources>>)
                      -> handle::Fence<Self::Resources>;
 

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -171,7 +171,7 @@ pub trait Resources:          Clone + Hash + Debug + Eq + PartialEq + Any {
     type DepthStencilView:    Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync;
     type Sampler:             Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync + Copy;
     type Fence:               Clone + Hash + Debug + Eq + PartialEq + Any + Fence;
-    type Mapping:             Debug + Any + mapping::Backend;
+    type Mapping:             Debug + Any + mapping::Backend<Self>;
 }
 
 /// A `Device` is responsible for submitting `CommandBuffer`s to the GPU. 

--- a/src/core/src/mapping.rs
+++ b/src/core/src/mapping.rs
@@ -23,7 +23,7 @@ use {Resources, Factory};
 use {handle, factory};
 
 /// Unsafe, backend-provided operations for a buffer mapping
-pub trait Backend<R: Resources> {
+pub trait Gate<R: Resources> {
     /// Set the element at `index` to `val`. Not bounds-checked.
     unsafe fn set<T>(&self, index: usize, val: T);
     /// Returns a slice of the specified length.
@@ -79,6 +79,8 @@ impl<R: Resources> Status<R> {
 pub enum Error {
     /// The requested mapping access did not match the expected usage.
     InvalidAccess(Access, factory::Usage),
+    /// The memory was already mapped
+    AlreadyMapped,
 }
 
 #[derive(Debug)]

--- a/src/core/src/mapping.rs
+++ b/src/core/src/mapping.rs
@@ -18,163 +18,261 @@
 
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
+use std::sync::{Mutex, MutexGuard};
 use {Resources, Factory};
+use {handle, factory};
 
-/// Unsafe operations for a buffer mapping
-pub trait Raw {
+/// Unsafe, backend-provided operations for a buffer mapping
+pub trait Backend {
     /// Set the element at `index` to `val`. Not bounds-checked.
     unsafe fn set<T>(&self, index: usize, val: T);
     /// Returns a slice of the specified length.
-    unsafe fn to_slice<T>(&self, len: usize) -> &[T];
+    unsafe fn slice<'a, 'b, T>(&'a self, len: usize) -> &'b [T];
     /// Returns a mutable slice of the specified length.
-    unsafe fn to_mut_slice<T>(&self, len: usize) -> &mut [T];
+    unsafe fn mut_slice<'a, 'b, T>(&'a self, len: usize) -> &'b mut [T];
 }
 
-/// A handle to a readable map, which can be sliced.
-pub struct Readable<'a, T: Copy + 'a, R: 'a + Resources, F: 'a + Factory<R>> where
-    F::Mapper: 'a
-{
-    raw: F::Mapper,
-    len: usize,
-    factory: &'a mut F,
-    phantom_t: PhantomData<T>
-}
-
-impl<'a, T: Copy, R: Resources, F: Factory<R>> Deref for Readable<'a, T, R, F> where
-    F::Mapper: 'a
-{
-    type Target = [T];
-
-    fn deref(&self) -> &[T] {
-        unsafe { self.raw.to_slice(self.len) }
+bitflags!(
+    /// Specifies the access allowed to a buffer mapping.
+    pub flags Access: u8 {
+        /// Allow reads.
+        const READABLE  = 0x1,
+        /// Allow writes.
+        const WRITABLE  = 0x2,
+        /// Allow full access.
+        const RW        = 0x3,
     }
+);
+
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub struct ModificationStatus<R: Resources> {
+    pub cpu: bool,
+    pub gpu: Option<handle::Fence<R>>,
 }
 
-impl<'a, T: Copy, R: Resources, F: Factory<R>> Drop for Readable<'a, T, R, F> where
-    F::Mapper: 'a
-{
-    fn drop(&mut self) {
-        self.factory.unmap_buffer_raw(self.raw.clone())
-    }
-}
-
-/// A handle to a writable map, which only allows setting elements.
-pub struct Writable<'a, T: Copy, R: 'a + Resources, F: 'a + Factory<R>> where
-    F::Mapper: 'a
-{
-    raw: F::Mapper,
-    len: usize,
-    factory: &'a mut F,
-    phantom_t: PhantomData<T>
-}
-
-impl<'a, T: Copy, R: Resources, F: Factory<R>> Writable<'a, T, R, F> where
-    F::Mapper: 'a
-{
-    /// Set a value in the buffer
-    pub fn set(&mut self, idx: usize, val: T) {
-        if idx >= self.len {
-            panic!("Tried to write out of bounds to a WritableMapping!")
+impl<R: Resources> ModificationStatus<R> {
+    fn clean() -> Self {
+        ModificationStatus {
+            cpu: false,
+            gpu: None,
         }
-        unsafe { self.raw.set(idx, val); }
     }
-    /// Returns a mutable slice of the specified length.
-    pub fn to_mut_slice(&mut self) -> &mut [T] {
-        unsafe { self.raw.to_mut_slice(self.len) }
+
+    fn read(&mut self) {
+        if let Some(fence) = self.gpu.take() {
+            fence.wait();
+        }
+    }
+
+    fn write(&mut self) {
+        self.cpu = true;
     }
 }
 
-impl<'a, T: Copy, R: Resources, F: Factory<R>> Drop for Writable<'a, T, R, F> where
-    F::Mapper: 'a
-{
+/// Error mapping a buffer.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Error {
+    /// The requested mapping access did not match the expected usage.
+    InvalidAccess(Access, factory::Usage),
+}
+
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub struct RawInner<R: Resources> {
+    pub resource: R::Mapping,
+    pub buffer: handle::RawBuffer<R>,
+    pub access: Access,
+    pub status: ModificationStatus<R>,
+}
+
+impl<R: Resources> Drop for RawInner<R> {
     fn drop(&mut self) {
-        self.factory.unmap_buffer_raw(self.raw.clone())
+        self.buffer.was_unmapped();
     }
 }
 
-/// A handle to a complete readable/writable map, which can be sliced both ways.
-pub struct RW<'a, T: Copy + 'a, R: 'a + Resources, F: 'a + Factory<R>> where
-    F::Mapper: 'a
-{
-    raw: F::Mapper,
-    len: usize,
-    factory: &'a mut F,
-    phantom_t: PhantomData<T>
+/// Raw mapping providing status tracking
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub struct Raw<R: Resources>(Mutex<RawInner<R>>);
+
+#[allow(missing_docs)]
+impl<R: Resources> Raw<R> {
+    pub fn new(res: R::Mapping, access: Access, buf: &handle::RawBuffer<R>) -> Self {
+        Raw(Mutex::new(RawInner {
+            resource: res,
+            buffer: buf.clone(),
+            access: access,
+            status: ModificationStatus::clean(),
+        }))
+    }
+
+    pub fn access(&self) -> Option<MutexGuard<RawInner<R>>> {
+        self.0.try_lock().ok()
+    }
+
+    unsafe fn read<T: Copy>(&self, len: usize) -> Reader<R, T> {
+        let mut inner = self.access().unwrap();
+        inner.status.read();
+
+        Reader {
+            slice: inner.resource.slice(len),
+            inner: inner,
+        }
+    }
+
+    unsafe fn write<T: Copy>(&self, len: usize) -> Writer<R, T> {
+        let mut inner = self.access().unwrap();
+        inner.status.write();
+
+        Writer {
+            len: len,
+            inner: inner,
+            phantom: PhantomData,
+        }
+    }
+
+    unsafe fn read_write<T: Copy>(&self, len: usize) -> RWer<R, T> {
+        let mut inner = self.access().unwrap();
+        inner.status.read();
+        inner.status.write();
+
+        RWer {
+            slice: inner.resource.mut_slice(len),
+            inner: inner,
+        }
+    }
 }
 
-impl<'a, T: Copy + 'a, R: Resources, F: Factory<R>> Deref for RW<'a, T, R, F> where
-    F::Mapper: 'a
-{
+/// Mapping reader
+pub struct Reader<'a, R: Resources, T: 'a + Copy> {
+    slice: &'a [T],
+    inner: MutexGuard<'a, RawInner<R>>,
+}
+
+impl<'a, R: Resources, T: 'a + Copy> Deref for Reader<'a, R, T> {
     type Target = [T];
 
-    fn deref(&self) -> &[T] {
-        unsafe { self.raw.to_slice(self.len) }
+    fn deref(&self) -> &[T] { self.slice }
+}
+
+/// Mapping writer
+pub struct Writer<'a, R: Resources, T: 'a + Copy> {
+    len: usize,
+    inner: MutexGuard<'a, RawInner<R>>,
+    phantom: PhantomData<T>,
+}
+
+impl<'a, R: Resources, T: 'a + Copy> Writer<'a, R, T> {
+    /// Set a value in the buffer
+    pub fn set(&mut self, index: usize, value: T) {
+        if index >= self.len {
+            panic!("tried to write out of bounds of a mapped buffer");
+        }
+        unsafe { self.inner.resource.set(index, value); }
     }
 }
 
-impl<'a, T: Copy + 'a, R: Resources, F: Factory<R>> DerefMut for RW<'a, T, R, F> where
-    F::Mapper: 'a
-{
-    fn deref_mut(&mut self) -> &mut [T] {
-        unsafe { self.raw.to_mut_slice(self.len) }
+/// Mapping reader & writer
+pub struct RWer<'a, R: Resources, T: 'a + Copy> {
+    slice: &'a mut [T],
+    inner: MutexGuard<'a, RawInner<R>>,
+}
+
+impl<'a, R: Resources, T: 'a + Copy> Deref for RWer<'a, R, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] { &*self.slice }
+}
+
+impl<'a, R: Resources, T: Copy> DerefMut for RWer<'a, R, T> {
+    fn deref_mut(&mut self) -> &mut [T] { self.slice }
+}
+
+/// Readable mapping.
+pub struct Readable<R: Resources, T: Copy> {
+    raw: handle::RawMapping<R>,
+    len: usize,
+    phantom: PhantomData<T>,
+}
+
+impl<R: Resources, T: Copy> Readable<R, T> {
+    /// Acquire a mapping Reader
+    pub fn read(&mut self) -> Reader<R, T> {
+        unsafe { self.raw.read::<T>(self.len) }
     }
 }
 
-impl<'a, T: Copy, R: Resources, F: Factory<R>> Drop for RW<'a, T, R, F> where
-    F::Mapper: 'a
-{
-    fn drop(&mut self) {
-        self.factory.unmap_buffer_raw(self.raw.clone())
+/// Writable mapping.
+pub struct Writable<R: Resources, T: Copy> {
+    raw: handle::RawMapping<R>,
+    len: usize,
+    phantom: PhantomData<T>,
+}
+
+impl<R: Resources, T: Copy> Writable<R, T> {
+    /// Acquire a mapping Writer
+    pub fn write(&mut self) -> Writer<R, T> {
+        unsafe { self.raw.write::<T>(self.len) }
+    }
+}
+
+/// Readable & writable mapping.
+pub struct RWable<R: Resources, T: Copy> {
+    raw: handle::RawMapping<R>,
+    len: usize,
+    phantom: PhantomData<T>
+}
+
+impl<R: Resources, T: Copy> RWable<R, T> {
+    /// Acquire a mapping Reader
+    pub fn read(&mut self) -> Reader<R, T> {
+        unsafe { self.raw.read::<T>(self.len) }
+    }
+
+    /// Acquire a mapping Writer
+    pub fn write(&mut self) -> Writer<R, T> {
+        unsafe { self.raw.write::<T>(self.len) }
+    }
+
+    /// Acquire a mapping reader & writer
+    pub fn read_write(&mut self) -> RWer<R, T> {
+        unsafe { self.raw.read_write::<T>(self.len) }
     }
 }
 
 /// A service trait with methods for mapping already implemented.
 /// To be used by device back ends.
 #[allow(missing_docs)]
-pub trait Builder<'a, R: Resources> {
-    type RawMapping: Raw;
-
-    fn map_readable<T: Copy>(&'a mut self, Self::RawMapping, usize) -> Readable<T, R, Self> where
-        Self: Sized + Factory<R>;
-    fn map_writable<T: Copy>(&'a mut self, Self::RawMapping, usize) -> Writable<T, R, Self> where
-        Self: Sized + Factory<R>;
-    fn map_read_write<T: Copy>(&'a mut self, Self::RawMapping, usize) -> RW<T, R, Self> where
-        Self: Sized + Factory<R>;
+pub trait Builder<R: Resources>: Factory<R> {
+    fn map_readable<T: Copy>(&mut self, handle::RawMapping<R>, usize) -> Readable<R, T>;
+    fn map_writable<T: Copy>(&mut self, handle::RawMapping<R>, usize) -> Writable<R, T>;
+    fn map_read_write<T: Copy>(&mut self, handle::RawMapping<R>, usize) -> RWable<R, T>;
 }
 
-
-impl<'a, R: Resources, F: Factory<R>> Builder<'a, R> for F where
-    F::Mapper: 'a
-{
-    type RawMapping = F::Mapper;
-
-    fn map_readable<T: Copy>(&'a mut self, map: F::Mapper,
-                    length: usize) -> Readable<T, R, Self> {
+impl<R: Resources, F: Factory<R>> Builder<R> for F {
+    fn map_readable<T: Copy>(&mut self, raw: handle::RawMapping<R>, len: usize) -> Readable<R, T> {
         Readable {
-            raw: map,
-            len: length,
-            factory: self,
-            phantom_t: PhantomData,
+            raw: raw,
+            len: len,
+            phantom: PhantomData,
         }
     }
 
-    fn map_writable<T: Copy>(&'a mut self, map: F::Mapper,
-                    length: usize) -> Writable<T, R, Self> {
+    fn map_writable<T: Copy>(&mut self, raw: handle::RawMapping<R>, len: usize) -> Writable<R, T> {
         Writable {
-            raw: map,
-            len: length,
-            factory: self,
-            phantom_t: PhantomData,
+            raw: raw,
+            len: len,
+            phantom: PhantomData,
         }
     }
 
-    fn map_read_write<T: Copy>(&'a mut self, map: F::Mapper,
-                      length: usize) -> RW<T, R, Self> {
-        RW {
-            raw: map,
-            len: length,
-            factory: self,
-            phantom_t: PhantomData,
+    fn map_read_write<T: Copy>(&mut self, raw: handle::RawMapping<R>, len: usize) -> RWable<R, T> {
+        RWable {
+            raw: raw,
+            len: len,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -109,9 +109,7 @@ impl<R: Resources, C: draw::CommandBuffer<R>> Encoder<R, C> {
         D: Device<Resources=R, CommandBuffer=C>
     {
         device.pin_submitted_resources(&self.handles);
-        device.submit(&mut self.command_buffer,
-                      &self.access_info.mapped_reads[..],
-                      &self.access_info.mapped_writes[..]);
+        device.submit(&mut self.command_buffer, &self.access_info);
         self.command_buffer.reset();
         self.access_info.clear();
         self.handles.clear();

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -140,17 +140,16 @@ impl<R: Resources, C: draw::CommandBuffer<R>> Encoder<R, C> {
     }
 
     /// Update a buffer with a single structure.
-    pub fn update_constant_buffer<T: Copy>(&mut self, buf: &handle::Buffer<R, T>, data: &T) -> Result<(), UpdateError<usize>> {
+    pub fn update_constant_buffer<T: Copy>(&mut self, buf: &handle::Buffer<R, T>, data: &T) {
         use std::slice;
 
-        if buf.raw().mapping().is_some() { return Err(UpdateError::IsMapped); }
+        if buf.raw().mapping().is_some() { panic!("{}", UpdateError::IsMapped::<usize>); }
 
         let slice = unsafe {
             slice::from_raw_parts(data as *const T as *const u8, mem::size_of::<T>())
         };
         self.command_buffer.update_buffer(
             self.handles.ref_buffer(buf.raw()).clone(), slice, 0);
-        Ok(())
     }
 
     /// Update the contents of a texture.

--- a/src/render/src/factory.rs
+++ b/src/render/src/factory.rs
@@ -18,7 +18,7 @@
 //! exposes extension functions and shortcuts to aid with creating and managing graphics resources.
 //! See the `FactoryExt` trait for more information.
 
-use gfx_core::{format, handle, tex, state, Pod};
+use gfx_core::{format, handle, mapping, tex, state, Pod};
 use gfx_core::{Primitive, Resources, ShaderSet};
 use gfx_core::factory::{Bind, BufferRole, Factory};
 use gfx_core::pso::{CreationError, Descriptor};
@@ -127,6 +127,48 @@ pub trait FactoryExt<R: Resources>: Factory<R> {
     fn create_constant_buffer<T>(&mut self, num: usize) -> handle::Buffer<R, T> {
         self.create_buffer_dynamic(num, BufferRole::Uniform, Bind::empty())
             .unwrap()
+    }
+
+    /// Creates and maps a readable persistent buffer.
+    fn create_buffer_persistent_readable<T>(&mut self,
+                                            num: usize,
+                                            role: BufferRole,
+                                            bind: Bind) -> (handle::Buffer<R, T>,
+                                                            mapping::Readable<R, T>)
+        where T: Copy
+    {
+        let buffer = self.create_buffer_persistent(num, role, bind, mapping::READABLE)
+            .unwrap();
+        let mapping = self.map_buffer_readable(&buffer).unwrap();
+        (buffer, mapping)
+    }
+
+    /// Creates and maps a writable persistent buffer.
+    fn create_buffer_persistent_writable<T>(&mut self,
+                                            num: usize,
+                                            role: BufferRole,
+                                            bind: Bind) -> (handle::Buffer<R, T>,
+                                                            mapping::Writable<R, T>)
+        where T: Copy
+    {
+        let buffer = self.create_buffer_persistent(num, role, bind, mapping::WRITABLE)
+            .unwrap();
+        let mapping = self.map_buffer_writable(&buffer).unwrap();
+        (buffer, mapping)
+    }
+
+    /// Creates and maps an rw persistent buffer.
+    fn create_buffer_persistent_rw<T>(&mut self,
+                                      num: usize,
+                                      role: BufferRole,
+                                      bind: Bind) -> (handle::Buffer<R, T>,
+                                                      mapping::RWable<R, T>)
+        where T: Copy
+    {
+        let buffer = self.create_buffer_persistent(num, role, bind, mapping::RW)
+            .unwrap();
+        let mapping = self.map_buffer_rw(&buffer).unwrap();
+        (buffer, mapping)
     }
 
     /// Creates a `ShaderSet` from the supplied vertex and pixel shader source code.

--- a/src/render/src/factory.rs
+++ b/src/render/src/factory.rs
@@ -96,7 +96,7 @@ pub trait FactoryExt<R: Resources>: Factory<R> {
                             T: Pod + pso::buffer::Structure<format::Format>
     {
         //debug_assert!(nv <= self.get_capabilities().max_vertex_count);
-        self.create_buffer_const(vertices, BufferRole::Vertex, Bind::empty()).unwrap()
+        self.create_buffer_immutable(vertices, BufferRole::Vertex, Bind::empty()).unwrap()
     }
     
     /// Shorthand for creating a new vertex buffer from the supplied vertices, together with a

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -37,7 +37,7 @@ pub use gfx_core::{Device, Resources, Primitive};
 pub use gfx_core::{VertexCount, InstanceCount};
 pub use gfx_core::{ShaderSet, VertexShader, HullShader, DomainShader,
                    GeometryShader, PixelShader};
-pub use gfx_core::{format, handle, tex};
+pub use gfx_core::{format, handle, tex, mapping};
 pub use gfx_core::factory::{Factory, Typed, Usage, Bind,
                             BufferRole, BufferInfo, BufferError, BufferUpdateError,
                             LayerError, ResourceViewError, TargetViewError,  CombinedError,

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -24,7 +24,7 @@ extern crate gfx_core;
 
 /// public re-exported traits
 pub mod traits {
-    pub use gfx_core::{Device, Factory, DeviceFence, Pod};
+    pub use gfx_core::{Device, Factory, Pod};
     pub use factory::FactoryExt;
 }
 
@@ -38,7 +38,7 @@ pub use gfx_core::{VertexCount, InstanceCount};
 pub use gfx_core::{ShaderSet, VertexShader, HullShader, DomainShader,
                    GeometryShader, PixelShader};
 pub use gfx_core::{format, handle, tex};
-pub use gfx_core::factory::{Factory, Typed, Usage, Bind, MapAccess,
+pub use gfx_core::factory::{Factory, Typed, Usage, Bind,
                             BufferRole, BufferInfo, BufferError, BufferUpdateError,
                             LayerError, ResourceViewError, TargetViewError,  CombinedError,
                             RENDER_TARGET, DEPTH_STENCIL, SHADER_RESOURCE, UNORDERED_ACCESS,

--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -19,7 +19,7 @@ macro_rules! gfx_pipeline_inner {
     {
         $( $field:ident: $ty:ty, )*
     } => {
-        use $crate::pso::{DataLink, DataBind, Descriptor, InitError, RawDataSet};
+        use $crate::pso::{DataLink, DataBind, Descriptor, InitError, RawDataSet, AccessInfo};
 
         #[derive(Clone, Debug)]
         pub struct Data<R: $crate::Resources> {
@@ -207,9 +207,13 @@ macro_rules! gfx_pipeline_inner {
 
         impl<R: $crate::Resources> $crate::pso::PipelineData<R> for Data<R> {
             type Meta = Meta;
-            fn bake_to(&self, out: &mut RawDataSet<R>, meta: &Self::Meta, man: &mut $crate::handle::Manager<R>) {
+            fn bake_to(&self,
+                       out: &mut RawDataSet<R>,
+                       meta: &Self::Meta,
+                       man: &mut $crate::handle::Manager<R>,
+                       access: &mut AccessInfo<R>) {
                 $(
-                    meta.$field.bind_to(out, &self.$field, man);
+                    meta.$field.bind_to(out, &self.$field, man, access);
                 )*
             }
         }

--- a/src/render/src/pso/buffer.rs
+++ b/src/render/src/pso/buffer.rs
@@ -147,7 +147,7 @@ impl<R: Resources> DataBind<R> for RawVertexBuffer {
                 out.vertex_buffers.0[i] = value;
             }
         }
-        access.buffer_read(data);
+        if self.1 != 0 { access.buffer_read(data); }
     }
 }
 
@@ -191,8 +191,8 @@ DataBind<R> for ConstantBuffer<T> {
         if let Some((usage, slot)) = self.0 {
             let buf = man.ref_buffer(data.raw()).clone();
             out.constant_buffers.push(pso::ConstantBufferParam(buf, usage, slot));
+            access.buffer_read(data.raw())
         }
-        access.buffer_read(data.raw())
     }
 }
 

--- a/src/render/src/pso/buffer.rs
+++ b/src/render/src/pso/buffer.rs
@@ -221,8 +221,8 @@ impl<R: Resources, T: ToUniform> DataBind<R> for Global<T> {
     fn bind_to(&self,
                out: &mut RawDataSet<R>,
                data: &Self::Data,
-               man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut handle::Manager<R>,
+               _: &mut AccessInfo<R>) {
         if let Some(loc) = self.0 {
             let value = data.convert();
             out.global_constants.push((loc, value));

--- a/src/render/src/pso/buffer.rs
+++ b/src/render/src/pso/buffer.rs
@@ -20,7 +20,7 @@ use gfx_core::{handle, pso, shade};
 use gfx_core::factory::Typed;
 use gfx_core::format::Format;
 use shade::{ToUniform, Usage};
-use super::{DataLink, DataBind, ElementError, RawDataSet};
+use super::{DataLink, DataBind, ElementError, RawDataSet, AccessInfo};
 
 pub use gfx_core::pso::{BufferIndex, Element, ElemOffset, ElemStride, InstanceRate};
 
@@ -90,8 +90,12 @@ impl<'a,
 
 impl<R: Resources, T, I> DataBind<R> for VertexBufferCommon<T, I> {
     type Data = handle::Buffer<R, T>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
-        self.0.bind_to(out, data.raw(), man)
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
+        self.0.bind_to(out, data.raw(), man, access)
     }
 }
 
@@ -132,13 +136,18 @@ impl<'a> DataLink<'a> for RawVertexBuffer {
 
 impl<R: Resources> DataBind<R> for RawVertexBuffer {
     type Data = handle::RawBuffer<R>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         let value = Some((man.ref_buffer(data).clone(), 0));
         for i in 0 .. MAX_VERTEX_ATTRIBUTES {
             if (self.1 & (1<<i)) != 0 {
                 out.vertex_buffers.0[i] = value;
             }
         }
+        access.buffer_read(data);
     }
 }
 
@@ -174,11 +183,16 @@ DataLink<'a> for ConstantBuffer<T> {
 impl<R: Resources, T: Structure<shade::ConstFormat>>
 DataBind<R> for ConstantBuffer<T> {
     type Data = handle::Buffer<R, T>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         if let Some((usage, slot)) = self.0 {
             let buf = man.ref_buffer(data.raw()).clone();
             out.constant_buffers.push(pso::ConstantBufferParam(buf, usage, slot));
         }
+        access.buffer_read(data.raw())
     }
 }
 
@@ -204,7 +218,11 @@ impl<'a, T: ToUniform> DataLink<'a> for Global<T> {
 
 impl<R: Resources, T: ToUniform> DataBind<R> for Global<T> {
     type Data = T;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, _: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         if let Some(loc) = self.0 {
             let value = data.convert();
             out.global_constants.push((loc, value));

--- a/src/render/src/pso/mod.rs
+++ b/src/render/src/pso/mod.rs
@@ -50,44 +50,8 @@ use std::fmt;
 use gfx_core as d;
 pub use gfx_core::pso::{Descriptor};
 
-/// Informations about what is accessed in the pipeline
-#[derive(Debug)]
-pub struct AccessInfo<R: d::Resources> {
-    /// The GPU will read from buffers with these mappings
-    pub mapped_reads: Vec<d::handle::RawMapping<R>>,
-    /// The GPU will write from buffers with these mappings
-    pub mapped_writes: Vec<d::handle::RawMapping<R>>,
-}
-
-impl<R: d::Resources> AccessInfo<R> {
-    /// Creates empty access informations
-    pub fn new() -> Self {
-        AccessInfo {
-            mapped_reads: Vec::new(),
-            mapped_writes: Vec::new(),
-        }
-    }
-
-    /// Clear access informations
-    pub fn clear(&mut self) {
-        self.mapped_reads.clear();
-        self.mapped_writes.clear();
-    }
-
-    /// Register a buffer read access
-    pub fn buffer_read(&mut self, buffer: &d::handle::RawBuffer<R>) {
-        if let Some(mapping) = buffer.mapping() {
-            self.mapped_reads.push(mapping);
-        }
-    }
-
-    /// Register a buffer write access
-    pub fn buffer_write(&mut self, buffer: &d::handle::RawBuffer<R>) {
-        if let Some(mapping) = buffer.mapping() {
-            self.mapped_writes.push(mapping);
-        }
-    }
-}
+/// Informations about what is accessed by the pipeline
+pub type AccessInfo<R> = ::gfx_core::pso::AccessInfo<R>;
 
 /// A complete set of raw data that needs to be specified at run-time
 /// whenever we draw something with a PSO. This is what "data" struct

--- a/src/render/src/pso/resource.rs
+++ b/src/render/src/pso/resource.rs
@@ -100,7 +100,7 @@ impl<R: Resources> DataBind<R> for RawShaderResource {
                out: &mut RawDataSet<R>,
                data: &Self::Data,
                man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut AccessInfo<R>) {
         // TODO: register buffer view source access
         if let Some((slot, usage)) = self.0 {
             let view = man.ref_srv(data).clone();
@@ -135,7 +135,7 @@ impl<R: Resources, T> DataBind<R> for UnorderedAccess<T> {
                out: &mut RawDataSet<R>,
                data: &Self::Data,
                man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut AccessInfo<R>) {
         // TODO: register buffer view source access
         if let Some((slot, usage)) = self.0 {
             let view =  man.ref_uav(data.raw()).clone();
@@ -170,7 +170,7 @@ impl<R: Resources> DataBind<R> for Sampler {
                out: &mut RawDataSet<R>,
                data: &Self::Data,
                man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut AccessInfo<R>) {
         if let Some((slot, usage)) = self.0 {
             let sm = man.ref_sampler(data).clone();
             out.samplers.push(pso::SamplerParam(sm, usage, slot));

--- a/src/render/src/pso/resource.rs
+++ b/src/render/src/pso/resource.rs
@@ -19,7 +19,7 @@ use gfx_core::{ResourceViewSlot, UnorderedViewSlot, SamplerSlot, Resources};
 use gfx_core::{handle, pso, shade};
 use gfx_core::factory::Typed;
 use gfx_core::format::Format;
-use super::{DataLink, DataBind, RawDataSet};
+use super::{DataLink, DataBind, RawDataSet, AccessInfo};
 
 /// Shader resource component (SRV). Typically is a view into some texture,
 /// but can also be a buffer.
@@ -65,8 +65,12 @@ impl<'a, T> DataLink<'a> for ShaderResource<T> {
 
 impl<R: Resources, T> DataBind<R> for ShaderResource<T> {
     type Data = handle::ShaderResourceView<R, T>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
-        self.0.bind_to(out, data.raw(), man)
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
+        self.0.bind_to(out, data.raw(), man, access)
     }
 }
 
@@ -92,7 +96,12 @@ impl<'a> DataLink<'a> for RawShaderResource {
 
 impl<R: Resources> DataBind<R> for RawShaderResource {
     type Data = handle::RawShaderResourceView<R>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
+        // TODO: register buffer view source access
         if let Some((slot, usage)) = self.0 {
             let view = man.ref_srv(data).clone();
             out.resource_views.push(pso::ResourceViewParam(view, usage, slot));
@@ -122,7 +131,12 @@ impl<'a, T> DataLink<'a> for UnorderedAccess<T> {
 
 impl<R: Resources, T> DataBind<R> for UnorderedAccess<T> {
     type Data = handle::UnorderedAccessView<R, T>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
+        // TODO: register buffer view source access
         if let Some((slot, usage)) = self.0 {
             let view =  man.ref_uav(data.raw()).clone();
             out.unordered_views.push(pso::UnorderedViewParam(view, usage, slot));
@@ -152,7 +166,11 @@ impl<'a> DataLink<'a> for Sampler {
 
 impl<R: Resources> DataBind<R> for Sampler {
     type Data = handle::Sampler<R>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         if let Some((slot, usage)) = self.0 {
             let sm = man.ref_sampler(data).clone();
             out.samplers.push(pso::SamplerParam(sm, usage, slot));
@@ -180,8 +198,12 @@ impl<'a, T> DataLink<'a> for TextureSampler<T> {
 
 impl<R: Resources, T> DataBind<R> for TextureSampler<T> {
     type Data = (handle::ShaderResourceView<R, T>, handle::Sampler<R>);
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
-        self.0.bind_to(out, &data.0, man);
-        self.1.bind_to(out, &data.1, man);
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
+        self.0.bind_to(out, &data.0, man, access);
+        self.1.bind_to(out, &data.1, man, access);
     }
 }

--- a/src/render/src/pso/target.rs
+++ b/src/render/src/pso/target.rs
@@ -19,7 +19,7 @@ use gfx_core::{ColorSlot, Resources};
 use gfx_core::{format, handle, pso, state, target};
 use gfx_core::factory::Typed;
 use gfx_core::shade::OutputVar;
-use super::{DataLink, DataBind, RawDataSet};
+use super::{DataLink, DataBind, RawDataSet, AccessInfo};
 
 /// Render target component. Typically points to a color-formatted texture.
 /// - init: `&str` = name of the target
@@ -77,7 +77,11 @@ impl<'a, T: format::RenderFormat> DataLink<'a> for RenderTarget<T> {
 
 impl<R: Resources, T> DataBind<R> for RenderTarget<T> {
     type Data = handle::RenderTargetView<R, T>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         if let Some(slot) = self.0 {
             out.pixel_targets.add_color(slot, man.ref_rtv(data.raw()), data.raw().get_dimensions());
         }
@@ -101,8 +105,12 @@ impl<'a, T: format::BlendFormat> DataLink<'a> for BlendTarget<T> {
 
 impl<R: Resources, T> DataBind<R> for BlendTarget<T> {
     type Data = handle::RenderTargetView<R, T>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
-        self.0.bind_to(out, data.raw(), man)
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
+        self.0.bind_to(out, data.raw(), man, access)
     }
 }
 
@@ -132,7 +140,11 @@ impl<'a> DataLink<'a> for RawRenderTarget {
 
 impl<R: Resources> DataBind<R> for RawRenderTarget {
     type Data = handle::RawRenderTargetView<R>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         if let Some(slot) = self.0 {
             out.pixel_targets.add_color(slot, man.ref_rtv(data), data.get_dimensions());
         }
@@ -151,7 +163,11 @@ impl<'a, T: format::DepthFormat> DataLink<'a> for DepthTarget<T> {
 
 impl<R: Resources, T> DataBind<R> for DepthTarget<T> {
     type Data = handle::DepthStencilView<R, T>;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         let dsv = data.raw();
         out.pixel_targets.add_depth_stencil(man.ref_dsv(dsv), true, false, dsv.get_dimensions());
     }
@@ -168,7 +184,11 @@ impl<'a, T: format::StencilFormat> DataLink<'a> for StencilTarget<T> {
 
 impl<R: Resources, T> DataBind<R> for StencilTarget<T> {
     type Data = (handle::DepthStencilView<R, T>, (target::Stencil, target::Stencil));
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         let dsv = data.0.raw();
         out.pixel_targets.add_depth_stencil(man.ref_dsv(dsv), false, true, dsv.get_dimensions());
         out.ref_values.stencil = data.1;
@@ -186,7 +206,11 @@ impl<'a, T: format::DepthStencilFormat> DataLink<'a> for DepthStencilTarget<T> {
 
 impl<R: Resources, T> DataBind<R> for DepthStencilTarget<T> {
     type Data = (handle::DepthStencilView<R, T>, (target::Stencil, target::Stencil));
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, man: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         let dsv = data.0.raw();
         out.pixel_targets.add_depth_stencil(man.ref_dsv(dsv), true, true, dsv.get_dimensions());
         out.ref_values.stencil = data.1;
@@ -203,7 +227,11 @@ impl<'a> DataLink<'a> for Scissor {
 
 impl<R: Resources> DataBind<R> for Scissor {
     type Data = target::Rect;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, _: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         out.scissor = *data;
     }
 }
@@ -216,7 +244,11 @@ impl<'a> DataLink<'a> for BlendRef {
 
 impl<R: Resources> DataBind<R> for BlendRef {
     type Data = target::ColorValue;
-    fn bind_to(&self, out: &mut RawDataSet<R>, data: &Self::Data, _: &mut handle::Manager<R>) {
+    fn bind_to(&self,
+               out: &mut RawDataSet<R>,
+               data: &Self::Data,
+               man: &mut handle::Manager<R>,
+               access: &mut AccessInfo<R>) {
         out.ref_values.blend = *data;
     }
 }

--- a/src/render/src/pso/target.rs
+++ b/src/render/src/pso/target.rs
@@ -81,7 +81,7 @@ impl<R: Resources, T> DataBind<R> for RenderTarget<T> {
                out: &mut RawDataSet<R>,
                data: &Self::Data,
                man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut AccessInfo<R>) {
         if let Some(slot) = self.0 {
             out.pixel_targets.add_color(slot, man.ref_rtv(data.raw()), data.raw().get_dimensions());
         }
@@ -144,7 +144,7 @@ impl<R: Resources> DataBind<R> for RawRenderTarget {
                out: &mut RawDataSet<R>,
                data: &Self::Data,
                man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut AccessInfo<R>) {
         if let Some(slot) = self.0 {
             out.pixel_targets.add_color(slot, man.ref_rtv(data), data.get_dimensions());
         }
@@ -167,7 +167,7 @@ impl<R: Resources, T> DataBind<R> for DepthTarget<T> {
                out: &mut RawDataSet<R>,
                data: &Self::Data,
                man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut AccessInfo<R>) {
         let dsv = data.raw();
         out.pixel_targets.add_depth_stencil(man.ref_dsv(dsv), true, false, dsv.get_dimensions());
     }
@@ -188,7 +188,7 @@ impl<R: Resources, T> DataBind<R> for StencilTarget<T> {
                out: &mut RawDataSet<R>,
                data: &Self::Data,
                man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut AccessInfo<R>) {
         let dsv = data.0.raw();
         out.pixel_targets.add_depth_stencil(man.ref_dsv(dsv), false, true, dsv.get_dimensions());
         out.ref_values.stencil = data.1;
@@ -210,7 +210,7 @@ impl<R: Resources, T> DataBind<R> for DepthStencilTarget<T> {
                out: &mut RawDataSet<R>,
                data: &Self::Data,
                man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut AccessInfo<R>) {
         let dsv = data.0.raw();
         out.pixel_targets.add_depth_stencil(man.ref_dsv(dsv), true, true, dsv.get_dimensions());
         out.ref_values.stencil = data.1;
@@ -230,8 +230,8 @@ impl<R: Resources> DataBind<R> for Scissor {
     fn bind_to(&self,
                out: &mut RawDataSet<R>,
                data: &Self::Data,
-               man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut handle::Manager<R>,
+               _: &mut AccessInfo<R>) {
         out.scissor = *data;
     }
 }
@@ -247,8 +247,8 @@ impl<R: Resources> DataBind<R> for BlendRef {
     fn bind_to(&self,
                out: &mut RawDataSet<R>,
                data: &Self::Data,
-               man: &mut handle::Manager<R>,
-               access: &mut AccessInfo<R>) {
+               _: &mut handle::Manager<R>,
+               _: &mut AccessInfo<R>) {
         out.ref_values.blend = *data;
     }
 }

--- a/src/render/src/slice.rs
+++ b/src/render/src/slice.rs
@@ -161,7 +161,7 @@ macro_rules! impl_index_buffer {
         
         impl<'s, R: Resources> IntoIndexBuffer<R> for &'s [$prim_ty] {
             fn into_index_buffer<F: Factory<R> + ?Sized>(self, factory: &mut F) -> IndexBuffer<R> {
-                factory.create_buffer_const(self, BufferRole::Index, Bind::empty())
+                factory.create_buffer_immutable(self, BufferRole::Index, Bind::empty())
                        .unwrap()
                        .into_index_buffer(factory)
             }

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -270,7 +270,7 @@ pub fn init<T: gfx_core::format::RenderFormat>(title: &str, width: u32, height: 
 
     {
         use gfx_core::Device;
-        device.submit(&mut cbuf);
+        device.submit(&mut cbuf, &gfx_core::pso::AccessInfo::new());
     }
 
     let win = Window {

--- a/tests/handle.rs
+++ b/tests/handle.rs
@@ -10,7 +10,7 @@ fn mock_buffer<T>(len: usize) -> Buffer<DummyResources, T> {
     let mut handler = Manager::new();
     let raw = handler.make_buffer((), BufferInfo {
         role: BufferRole::Vertex,
-        usage: Usage::Const,
+        usage: Usage::Immutable,
         size: mem::size_of::<T>() * len,
         stride: 0,
         bind: Bind::empty(),
@@ -46,7 +46,8 @@ fn test_cleanup() {
         |_,_| (),
         |_,_| (),
         |_,_| (),
-        |_,_| ()
+        |_,_| (),
+        |_,_| (),
         );
     assert_eq!(count, 1);
 }


### PR DESCRIPTION
Working on #1020, focusing on the OpenGL backend:
- [x] buffer and mapping creation
- [x] mapping API and status tracking
- [x] mapping synchronisation with memory barriers and fences
- [x] automatically detect gpu-side mapping access
- [x] mapping cleanup
- [ ] review it and document it

Issues to consider before merging:
- There is only one fence option per mapping that is overwritten by subsequent submits, can this lead to some issues ? The hypothesis here is that if a fence submitted after another one (from the CPU side) is signaled, the previous fence has to have been signaled and there is no need to check both of them.
- use the return value of `glClientWaitSync`.

Issues to consider after merging:
- `RW{able, er}` are bad names. Use a typed mapping `Mapping<R, T, A>` where A defines the mapping access instead of the current three structs ?
- keep the persistent mapping issue open since only the OpenGL backend is done
- gpu write -> cpu read synchronisation has not been tested at all
- the status mutex could be replaced by an atomic since only `try_lock` is actually used
- check capabilities for memory barrier (ARB_shader_image_load_store) and fences (ARB_sync) ?
- use explicit invalidation if available (ARB_invalidate_subdata) ?
- being able to flush / invalidate only parts of a buffer could improve performances and allow some additional uses (triple buffering).