### PR TITLE
Metal fixes and additions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ authors = ["The Gfx-rs Developers"]
 documentation = "https://docs.rs/gfx"
 
 [features]
-default = []
+default = ["metal"]
 vulkan = ["gfx_device_vulkan", "gfx_window_vulkan"]
+metal = ["gfx_device_metal", "gfx_window_metal"]
 unstable = []
 
 
@@ -36,6 +37,16 @@ path = "src/window/vulkan"
 version = "0.1"
 optional = true
 
+[dependencies.gfx_device_metal]
+path = "src/backend/metal"
+version = "0.1"
+optional = true
+
+[dependencies.gfx_window_metal]
+path = "src/window/metal"
+version = "0.1"
+optional = true
+
 [target.'cfg(unix)'.dependencies]
 gfx_window_glfw = { path = "src/window/glfw", version = "0.12" }
 gfx_window_sdl = { path = "src/window/sdl", version = "0.4" }
@@ -43,10 +54,6 @@ gfx_window_sdl = { path = "src/window/sdl", version = "0.4" }
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.4" }
 gfx_window_dxgi = { path = "src/window/dxgi", version = "0.4" }
-
-[target.x86_64-apple-darwin.dependencies]
-gfx_device_metal = { path = "src/backend/metal", version = "0.1" }
-gfx_window_metal = { path = "src/window/metal", version = "0.1" }
 
 [[example]]
 name = "blend"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["The Gfx-rs Developers"]
 documentation = "https://docs.rs/gfx"
 
 [features]
-default = ["metal"]
+default = []
 vulkan = ["gfx_device_vulkan", "gfx_window_vulkan"]
 metal = ["gfx_device_metal", "gfx_window_metal"]
 unstable = []

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -92,7 +92,6 @@ gfx_defines!{
     constant CubeLocals {
         transform: [[f32; 4]; 4] = "u_Transform",
         radius: f32 = "u_Radius",
-        _padding: [f32; 3] = "",
     }
 
     pipeline light {
@@ -518,7 +517,6 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         let mut cube_locals = CubeLocals {
             transform: (proj * view.mat).into(),
             radius: LIGHT_RADIUS,
-            _padding: [0.0; 3]
         };
         encoder.update_constant_buffer(&self.light.data.locals_vs, &cube_locals);
         cube_locals.radius = EMITTER_RADIUS;

--- a/examples/deferred/shader/blit.glslv
+++ b/examples/deferred/shader/blit.glslv
@@ -1,10 +1,9 @@
 #version 150 core
 
-in ivec2 a_Pos;
-in ivec2 a_TexCoord;
+in ivec4 a_PosTexCoord;
 out vec2 v_TexCoord;
 
 void main() {
-	v_TexCoord = a_TexCoord;
-	gl_Position = vec4(a_Pos, 0.0, 1.0);
+	v_TexCoord = a_PosTexCoord.zw;
+	gl_Position = vec4(a_PosTexCoord.xy, 0.0, 1.0);
 }

--- a/examples/deferred/shader/blit_frag.metal
+++ b/examples/deferred/shader/blit_frag.metal
@@ -1,0 +1,23 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct VertexOut {
+    float4 pos [[ position ]];
+    float2 uv;
+};
+
+struct FragmentOut {
+    float4 main [[ color(0) ]];
+};
+
+fragment FragmentOut frag(VertexOut in [[ stage_in ]],
+                          texture2d<float, access::sample> t_BlitTex [[ texture(0) ]],
+                          sampler t_BlitTex_                         [[ sampler(0) ]])
+{
+    FragmentOut out;
+
+    out.main = t_BlitTex.sample(t_BlitTex_, in.uv);
+
+    return out;
+}

--- a/examples/deferred/shader/blit_vertex.metal
+++ b/examples/deferred/shader/blit_vertex.metal
@@ -1,0 +1,24 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct VertexInput {
+    int4 a_PosTexCoord [[ attribute(0) ]];
+};
+
+struct VertexOut {
+    float4 pos [[ position ]];
+    float2 uv;
+};
+
+vertex VertexOut vert(VertexInput in [[ stage_in ]])
+{
+    VertexOut out;
+
+    out.pos = float4(float2(in.a_PosTexCoord.xy), 0.0, 1.0);
+
+    out.uv = float2(in.a_PosTexCoord.zw);
+    out.uv.y = 1.0 - out.uv.y;
+
+    return out;
+}

--- a/examples/deferred/shader/deferred.hlsl
+++ b/examples/deferred/shader/deferred.hlsl
@@ -49,8 +49,8 @@ TerrainOutput TerrainPs(TerrainVarying In) {
 
 Texture2D<float4> t_BlitTex;
 
-float4 BlitVs(int2 pos: a_Pos): SV_Position {
-	return float4(pos, 0.0, 1.0);
+float4 BlitVs(int4 pos: a_PosTexCoord): SV_Position {
+	return float4(pos.xy, 0.0, 1.0);
 }
 
 float4 BlitPs(float4 pos: SV_Position): SV_Target {

--- a/examples/deferred/shader/emitter_frag.metal
+++ b/examples/deferred/shader/emitter_frag.metal
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct FragmentOut {
+    float4 main [[ color(0) ]];
+};
+
+fragment FragmentOut frag()
+{
+    FragmentOut out;
+
+    out.main = float4(1.0);
+
+    return out;
+};
+

--- a/examples/deferred/shader/emitter_vertex.metal
+++ b/examples/deferred/shader/emitter_vertex.metal
@@ -1,0 +1,26 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct VertexInput {
+    int3 a_Pos [[ attribute(0) ]];
+};
+
+constant const int NUM_LIGHTS = 250;
+
+struct Cube {
+    float4x4 transform;
+    float radius;
+};
+
+struct Lights {
+    float4 lights[NUM_LIGHTS];
+};
+
+vertex float4 vert(constant Cube&   CubeLocals    [[ buffer(1) ]],
+                   constant Lights& LightPosBlock [[ buffer(2) ]],
+                   VertexInput      in            [[ stage_in ]],
+                   uint             iid           [[ instance_id ]])
+{
+    return CubeLocals.transform * float4(CubeLocals.radius * float3(in.a_Pos) + LightPosBlock.lights[iid].xyz, 1.0);
+}

--- a/examples/deferred/shader/light_frag.metal
+++ b/examples/deferred/shader/light_frag.metal
@@ -1,0 +1,52 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct VertexOut {
+    float4 pos [[ position ]];
+    float3 light_pos;
+};
+
+struct FragmentOut {
+    float4 main [[ color(0) ]];
+};
+
+struct Light {
+    packed_float3 pos;
+    float radius;
+};
+
+fragment FragmentOut frag(constant Light&                LightLocals [[ buffer(0) ]],
+                          texture2d<float, access::read> t_Position  [[ texture(0) ]],
+                          //sampler   t_Position [[ sampler(0) ]],
+                          texture2d<float, access::read> t_Normal    [[ texture(1) ]],
+                          //sampler   t_Normal   [[ sampler(1) ]],
+                          texture2d<float, access::read> t_Diffuse   [[ texture(2) ]],
+                          //sampler   t_Diffuse  [[ sampler(2) ]],
+                          VertexOut                      in          [[ stage_in ]])
+{
+    FragmentOut out;
+
+    uint2 itc = uint2(in.pos.xy);
+
+    float3 pos =     t_Position.read(itc).xyz;
+    float3 normal =  t_Normal.read(itc).xyz;
+    float3 diffuse = t_Diffuse.read(itc).xyz;
+
+    float3 light = in.light_pos;
+    float3 to_light = normalize(light - pos);
+    float3 to_cam = normalize(LightLocals.pos - pos);
+
+    float3 n = normalize(normal);
+    float s = pow(max(0.0, dot(to_cam, reflect(-to_light, n))), 20.0);
+    float d = max(0.0, dot(n, to_light));
+
+    float dist_sq = dot(light - pos, light - pos);
+    float scale = max(0.0, 1.0 - dist_sq * LightLocals.radius);
+
+    float3 res_color = d * diffuse + float3(s);
+
+    out.main = float4(scale * res_color, 1.0);
+
+    return out;
+};

--- a/examples/deferred/shader/light_vertex.metal
+++ b/examples/deferred/shader/light_vertex.metal
@@ -1,0 +1,36 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct VertexInput {
+    int3 a_Pos [[ attribute(0) ]];
+};
+
+struct VertexOut {
+    float4 pos [[ position ]];
+    float3 light_pos;
+};
+
+constant const int NUM_LIGHTS = 250;
+
+struct Cube {
+    float4x4 transform;
+    float radius;
+};
+
+struct Lights {
+    float4 lights[NUM_LIGHTS];
+};
+
+vertex VertexOut vert(constant Cube&   CubeLocals    [[ buffer(1) ]],
+                      constant Lights& LightPosBlock [[ buffer(2) ]],
+                      VertexInput      in            [[ stage_in ]],
+                      uint             iid           [[ instance_id ]])
+{
+    VertexOut out;
+
+    out.light_pos = LightPosBlock.lights[iid].xyz;
+    out.pos = CubeLocals.transform * float4(CubeLocals.radius * float3(in.a_Pos) + out.light_pos, 1.0);
+
+    return out;
+}

--- a/examples/deferred/shader/terrain_frag.metal
+++ b/examples/deferred/shader/terrain_frag.metal
@@ -1,0 +1,29 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct VertexOut {
+    float4 pos [[ position ]];
+    float3 position;
+    float3 normal;
+    float3 color;
+};
+
+struct FragmentOut {
+    float4 pos    [[ color(0) ]];
+    float4 normal [[ color(1) ]];
+    float4 color  [[ color(2) ]];
+};
+
+fragment FragmentOut frag(VertexOut in [[ stage_in ]]) {
+    FragmentOut out;
+
+    float3 n = normalize(in.normal);
+
+    out.pos = float4(in.position, 0.0);
+    out.normal = float4(n, 0.0);
+    out.color = float4(in.color, 1.0);
+
+    return out;
+};
+

--- a/examples/deferred/shader/terrain_vertex.metal
+++ b/examples/deferred/shader/terrain_vertex.metal
@@ -1,0 +1,35 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct VertexInput {
+    float3 a_Pos    [[ attribute(0) ]];
+    float3 a_Normal [[ attribute(1) ]];
+    float3 a_Color  [[ attribute(2) ]];
+};
+
+struct VertexOut {
+    float4 pos [[ position ]];
+    float3 position;
+    float3 normal;
+    float3 color;
+};
+
+struct VsLocals {
+    float4x4 model;
+    float4x4 view;
+    float4x4 proj;
+};
+
+vertex VertexOut vert(constant VsLocals &TerrainLocals [[ buffer(1) ]],
+                      VertexInput in            [[ stage_in ]])
+{
+    VertexOut out;
+
+    out.pos = TerrainLocals.proj * TerrainLocals.view * TerrainLocals.model * float4(in.a_Pos, 1.0);
+    out.position = (TerrainLocals.model * float4(in.a_Pos, 1.0)).xyz;
+    out.normal = (TerrainLocals.model * float4(in.a_Normal, 1.0)).xyz;
+    out.color = in.a_Color;
+
+    return out;
+}

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -100,12 +100,14 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         let vs = gfx_app::shade::Source {
             glsl_120: include_bytes!("shader/instancing_120.glslv"),
             glsl_150: include_bytes!("shader/instancing_150.glslv"),
+            msl_11:   include_bytes!("shader/instancing_vertex.metal"),
             hlsl_40:  include_bytes!("data/vertex.fx"),
             .. gfx_app::shade::Source::empty()
         };
         let fs = gfx_app::shade::Source {
             glsl_120: include_bytes!("shader/instancing_120.glslf"),
             glsl_150: include_bytes!("shader/instancing_150.glslf"),
+            msl_11:   include_bytes!("shader/instancing_frag.metal"),
             hlsl_40:  include_bytes!("data/pixel.fx"),
             .. gfx_app::shade::Source::empty()
         };

--- a/examples/instancing/shader/instancing_frag.metal
+++ b/examples/instancing/shader/instancing_frag.metal
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+
+using namespace metal;
+
+struct VertexOut {
+    float4 pos [[ position ]];
+    float4 color;
+};
+
+struct FragmentOut {
+    float4 main [[ color(0) ]];
+};
+
+fragment FragmentOut frag(VertexOut in [[ stage_in ]])
+{
+    FragmentOut out;
+
+    out.main = in.color;
+
+    return out;
+};
+

--- a/examples/instancing/shader/instancing_vertex.metal
+++ b/examples/instancing/shader/instancing_vertex.metal
@@ -20,7 +20,10 @@ vertex VertexOut vert(VertexInput     in     [[ stage_in ]],
     VertexOut out;
 
     out.pos = float4((in.a_Position * Locals) + in.a_Translate, 0.0, 1.0);
-    out.color = unpack_unorm4x8_to_float(in.a_Color);
+    out.color = float4(in.a_Color >> 24,
+                      (in.a_Color >> 16) & 0x000000FF,
+                      (in.a_Color >> 8)  & 0x000000FF,
+                       in.a_Color        & 0x000000FF) / 255.0;
 
     return out;
 }

--- a/examples/instancing/shader/instancing_vertex.metal
+++ b/examples/instancing/shader/instancing_vertex.metal
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+#include <metal_pack>
+
+using namespace metal;
+
+struct VertexInput {
+    float2 a_Position   [[ attribute(0) ]];
+    float2 a_Translate  [[ attribute(1) ]];
+    uint   a_Color      [[ attribute(2) ]];
+};
+
+struct VertexOut {
+    float4 pos [[ position ]];
+    float4 color;
+};
+
+vertex VertexOut vert(VertexInput     in     [[ stage_in ]],
+                      constant float& Locals [[ buffer(2) ]])
+{
+    VertexOut out;
+
+    out.pos = float4((in.a_Position * Locals) + in.a_Translate, 0.0, 1.0);
+    out.color = unpack_unorm4x8_to_float(in.a_Color);
+
+    return out;
+}
+
+

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -622,7 +622,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
 // Section-6: main entry point
 
 pub fn main() {
-    <App<_, _> as gfx_app::ApplicationGL>::launch(
+    <App<_, _> as gfx_app::ApplicationMetal>::launch(
         "Multi-threaded shadow rendering example with gfx-rs",
         gfx_app::DEFAULT_CONFIG);
 }

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -21,9 +21,9 @@ use std::sync::{Arc, RwLock};
 pub use gfx::format::{DepthStencil};
 pub use gfx_app::{ColorFormat, DepthFormat};
 
-#[cfg(target_os="macos")]
+#[cfg(feature="metal")]
 pub use gfx::format::Depth32F as Depth;
-#[cfg(not(target_os="macos"))]
+#[cfg(not(feature="metal"))]
 pub use gfx::format::Depth;
 
 // Section-1: vertex formats and shader parameters
@@ -487,7 +487,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
                 gfx::Primitive::TriangleList,
                 gfx::state::Rasterizer::new_fill()
                                        .with_cull_back()
-                                       .with_offset(2.0, 1),
+                                       .with_offset(2.0, 2),
                 shadow::new()
                 ).unwrap()
         };
@@ -622,7 +622,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
 // Section-6: main entry point
 
 pub fn main() {
-    <App<_, _> as gfx_app::ApplicationGL>::launch(
+    <App<_, _> as gfx_app::ApplicationMetal>::launch(
         "Multi-threaded shadow rendering example with gfx-rs",
         gfx_app::DEFAULT_CONFIG);
 }

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -487,7 +487,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
                 gfx::Primitive::TriangleList,
                 gfx::state::Rasterizer::new_fill()
                                        .with_cull_back()
-                                       .with_offset(2.0, 2),
+                                       .with_offset(2.0, 1),
                 shadow::new()
                 ).unwrap()
         };
@@ -622,7 +622,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
 // Section-6: main entry point
 
 pub fn main() {
-    <App<_, _> as gfx_app::ApplicationMetal>::launch(
+    <App<_, _> as gfx_app::ApplicationGL>::launch(
         "Multi-threaded shadow rendering example with gfx-rs",
         gfx_app::DEFAULT_CONFIG);
 }

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -622,7 +622,7 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
 // Section-6: main entry point
 
 pub fn main() {
-    <App<_, _> as gfx_app::ApplicationMetal>::launch(
+    <App<_, _> as gfx_app::ApplicationGL>::launch(
         "Multi-threaded shadow rendering example with gfx-rs",
         gfx_app::DEFAULT_CONFIG);
 }

--- a/examples/shadow/shader/forward_150.glslf
+++ b/examples/shadow/shader/forward_150.glslf
@@ -45,7 +45,7 @@ void main() {
 		vec3 light_dir = normalize(light.pos.xyz - v_Position);
 		float diffuse = max(0.0, dot(normal, light_dir));
 		// add light contribution
-		color += shadow * diffuse * light.color.xyz;
+		color = light_local.xyw;//+= shadow * diffuse * light.color.xyz;
 	}
 	// multiply the light by material color
     Target0 = vec4(color, 1.0) * u_Color;

--- a/examples/shadow/shader/forward_150.glslf
+++ b/examples/shadow/shader/forward_150.glslf
@@ -45,7 +45,7 @@ void main() {
 		vec3 light_dir = normalize(light.pos.xyz - v_Position);
 		float diffuse = max(0.0, dot(normal, light_dir));
 		// add light contribution
-		color = light_local.xyw;//+= shadow * diffuse * light.color.xyz;
+		color += shadow * diffuse * light.color.xyz;
 	}
 	// multiply the light by material color
     Target0 = vec4(color, 1.0) * u_Color;

--- a/examples/shadow/shader/forward_frag.metal
+++ b/examples/shadow/shader/forward_frag.metal
@@ -46,14 +46,13 @@ fragment FragmentOut frag(constant Locals& PsLocals [[ buffer(2) ]],
 
         float4 light_local = light.proj * float4(in.position, 1.0);
         light_local.xyw = (light_local.xyz / light_local.w + 1.0) / 2.0;
-        light_local.y = light_local.y;
-        //light_local.z = i;
+        light_local.y = 1.0 - light_local.y;
 
         float shadow = t_Shadow.sample_compare(s, light_local.xy, i, light_local.w);
         float3 light_dir = normalize(light.pos.xyz - in.position);
         float diffuse = max(0.0, dot(normal, light_dir));
 
-        color += shadow *  b_Lights[i].color.xyz;
+        color += shadow * diffuse * b_Lights[i].color.xyz;
     }
 
     out.main = float4(color, 1.0) * PsLocals.u_Color;

--- a/examples/shadow/shader/forward_frag.metal
+++ b/examples/shadow/shader/forward_frag.metal
@@ -10,10 +10,6 @@ struct Light {
     float4x4 proj;
 };
 
-struct LightArray {
-    Light lights[MAX_LIGHTS];
-};
-
 struct Locals {
     float4 u_Color;
     int u_NumLights;
@@ -21,7 +17,6 @@ struct Locals {
 };
 
 struct FragmentIn {
-    float4 pos [[ position ]];
     float3 position;
     float3 normal;
 };
@@ -30,34 +25,38 @@ struct FragmentOut {
     float4 main [[ color(0) ]];
 };
 
-constexpr sampler shadow_sampler;
+constexpr sampler s(coord::normalized, address::clamp_to_edge, filter::linear, compare_func::less_equal);
 
-fragment FragmentOut frag(constant Locals& PsLocals     [[ buffer(2) ]],
-                          constant LightArray& b_Lights [[ buffer(3) ]],
+fragment FragmentOut frag(constant Locals& PsLocals [[ buffer(2) ]],
+                          constant Light* b_Lights  [[ buffer(3) ]],
+
                           depth2d_array<float, access::sample> t_Shadow [[ texture(0) ]],
-                          FragmentIn in                 [[ stage_in ]])
+                          sampler t_Shadow_                             [[ sampler(0) ]],
+
+                          FragmentIn in [[ stage_in ]])
 {
     FragmentOut out;
 
-    float3 normal = normalize(in.normal);
+    float3 normal = in.normal;
     float3 ambient = float3(0.05, 0.05, 0.05);
     float3 color = ambient;
 
-    for (int i = 0; i < min(PsLocals.u_NumLights, MAX_LIGHTS); ++i) {
-        Light light = b_Lights.lights[i];
+    for (int i = 0; i < PsLocals.u_NumLights && i < MAX_LIGHTS; ++i) {
+        Light light = b_Lights[i];
 
-        float4 light_local = b_Lights.lights[i].proj * float4(in.position, 1.0);
+        float4 light_local = light.proj * float4(in.position, 1.0);
         light_local.xyw = (light_local.xyz / light_local.w + 1.0) / 2.0;
-        light_local.z = i;
+        light_local.y = light_local.y;
+        //light_local.z = i;
 
-        float shadow = t_Shadow.sample(shadow_sampler, light_local.xy, light_local.z);
+        float shadow = t_Shadow.sample_compare(s, light_local.xy, i, light_local.w);
         float3 light_dir = normalize(light.pos.xyz - in.position);
         float diffuse = max(0.0, dot(normal, light_dir));
 
-        color += shadow; // * light.color.xyz;
+        color += shadow *  b_Lights[i].color.xyz;
     }
 
-    out.main = PsLocals.u_Color;//float4(color, 1.0) * PsLocals.u_Color;//float4(1.0, 0.5, 0.2, 1.0);//float4(color, 1.0) * PsLocals.u_Color;
+    out.main = float4(color, 1.0) * PsLocals.u_Color;
 
     return out;
 };

--- a/examples/shadow/shader/shadow_vertex.metal
+++ b/examples/shadow/shader/shadow_vertex.metal
@@ -9,6 +9,8 @@ struct VertexInput {
 vertex float4 vert(constant float4x4& Locals [[ buffer(1) ]],
                    VertexInput in            [[ stage_in ]])
 {
-    return Locals * float4(in.a_Pos);
+    float4 ndc = Locals * float4(in.a_Pos);
+    ndc.z = (ndc.z + ndc.w) * 0.5;
+    return ndc;
 }
 

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -32,4 +32,5 @@ cocoa = "0.3"
 libc = "0.2"
 objc = "0.1.8"
 objc-foundation = "0.1"
+bit-set = "0.4"
 metal = { git = "https://github.com/fkaa/metal-rs" }

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -33,4 +33,4 @@ libc = "0.2"
 objc = "0.1.8"
 objc-foundation = "0.1"
 bit-set = "0.4"
-metal = { git = "https://github.com/fkaa/metal-rs" }
+metal-rs = "0.1"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -28,7 +28,7 @@ name = "gfx_device_metal"
 [dependencies]
 log = "0.3"
 gfx_core = { path = "../../core", version = "0.5" }
-cocoa = "0.3"
+cocoa = "0.2"
 libc = "0.2"
 objc = "0.1.8"
 objc-foundation = "0.1"

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -169,7 +169,7 @@ impl command::Buffer<Resources> for CommandBuffer {
     fn bind_vertex_buffers(&mut self, vbs: pso::VertexBufferSet<Resources>) {
         for i in 0..MAX_VERTEX_ATTRIBUTES {
             if let Some((buffer, offset)) = vbs.0[i] {
-                self.encoder.set_vertex_buffer(i as u64, offset as u64, unsafe { *(buffer.0).0 });
+                self.encoder.set_vertex_buffer(30 - i as u64, offset as u64, unsafe { *(buffer.0).0 });
             }
         }
     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -14,7 +14,7 @@
 
 #![allow(missing_docs)]
 
-use cocoa::foundation::NSRange;
+//use cocoa::foundation::NSRange;
 
 use core::{pso, shade, state, target, texture, command};
 use core::{IndexType, VertexCount};
@@ -27,31 +27,27 @@ use {Resources, Buffer, Texture, Pipeline};
 
 use encoder::MetalEncoder;
 
-use native;
 use native::{Rtv, Srv, Dsv};
 
 use metal::*;
 
-use std::collections::HashSet;
 use std::ptr;
 
 pub struct CommandBuffer {
     queue: MTLCommandQueue,
     device: MTLDevice,
     encoder: MetalEncoder,
-    drawable: *mut CAMetalDrawable,
     should_restore: bool
 }
 
 unsafe impl Send for CommandBuffer {}
 
 impl CommandBuffer {
-    pub fn new(device: MTLDevice, queue: MTLCommandQueue, drawable: *mut CAMetalDrawable) -> Self {
+    pub fn new(device: MTLDevice, queue: MTLCommandQueue) -> Self {
         CommandBuffer {
             device: device,
             queue: queue,
             encoder: MetalEncoder::new(queue.new_command_buffer()),
-            drawable: drawable,
             should_restore: false
         }
     }
@@ -287,9 +283,6 @@ impl command::Buffer<Resources> for CommandBuffer {
 
                 // invalidate old buffer in cache
                 self.encoder.invalidate_buffer(b);
-
-                // and release so we don't leak and get kernel panic..
-                b.release();
             }
         } else {
             // TODO(fkaa): how do we (eventually) handle updating buffers when

--- a/src/backend/metal/src/encoder.rs
+++ b/src/backend/metal/src/encoder.rs
@@ -515,14 +515,16 @@ impl MetalEncoder {
         }
     }
 
-    pub fn draw_indexed_instanced(&self, index_count: u64, index_type: MTLIndexType, index_buffer: MTLBuffer, index_buffer_offset: u64, instance_count: u64) {
+    pub fn draw_indexed_instanced(&self, index_count: u64, index_buffer_offset: u64, instance_count: u64, base_vertex: i64, base_instance: u64) {
         if let Some((buf, ty)) = self.cache.index_buffer {
             self.render.draw_indexed_primitives_instanced(MTLPrimitiveType::Triangle,
                                                           index_count,
-                                                          index_type,
-                                                          index_buffer,
+                                                          ty,
+                                                          buf,
                                                           index_buffer_offset,
-                                                          instance_count);
+                                                          instance_count,
+                                                          base_vertex,
+                                                          base_instance);
         } else {
             error!("Cannot draw indexed primitives without a index buffer bound");
         }

--- a/src/backend/metal/src/encoder.rs
+++ b/src/backend/metal/src/encoder.rs
@@ -1,0 +1,531 @@
+// Copyright 2016 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(missing_docs)]
+
+use gfx_core::{draw, pso, shade, state, target, tex};
+use gfx_core::{IndexType, VertexCount};
+use gfx_core::{MAX_VERTEX_ATTRIBUTES, MAX_CONSTANT_BUFFERS,
+               MAX_RESOURCE_VIEWS,
+               MAX_SAMPLERS, MAX_COLOR_TARGETS};
+
+use gfx_core::shade::Stage;
+
+use {Resources, Buffer, Texture, Pipeline};
+
+use native;
+use native::{Rtv, Srv, Dsv};
+
+use metal::*;
+
+use std::mem;
+
+// Grabbed from https://developer.apple.com/metal/limits/
+const MTL_MAX_TEXTURE_BINDINGS: usize = 128;
+const MTL_MAX_BUFFER_BINDINGS: usize = 31;
+const MTL_MAX_SAMPLER_BINDINGS: usize = 16;
+
+const MTL_MAX_TEXTURE_BINDINGS_SZ: usize = MTL_MAX_TEXTURE_BINDINGS / 32;
+
+// TODO(fkaa): can we use associated constants and `Bindings` trait instead?
+const VS_IDX: usize = 0;
+const FS_IDX: usize = 1;
+const CS_IDX: usize = 2;
+
+// TODO(fkaa): handle retain/release for bindings
+pub struct MetalTextureBindings {
+    textures: [MTLTexture; MTL_MAX_TEXTURE_BINDINGS],
+
+    // TODO(fkaa): change to [[u32; 32]; 4] to avoid limitations of no
+    //             type-level integers
+    bound: [u32; MTL_MAX_TEXTURE_BINDINGS_SZ]
+}
+
+impl MetalTextureBindings {
+    pub fn new() -> Self {
+        MetalTextureBindings {
+            textures: [MTLTexture::nil(); MTL_MAX_TEXTURE_BINDINGS],
+            bound: [0; MTL_MAX_TEXTURE_BINDINGS_SZ]
+        }
+    }
+
+    pub fn insert(&mut self, index: usize, texture: MTLTexture) {
+        self.textures[index] = texture;
+        self.bound[index / 32] |= (1 << (index % 32));
+    }
+
+    pub fn reset(&mut self) {
+        self.textures = [MTLTexture::nil(); MTL_MAX_TEXTURE_BINDINGS];
+        self.bound = [0; MTL_MAX_TEXTURE_BINDINGS_SZ];
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct MetalBufferBindings {
+    buffers: [MTLBuffer; MTL_MAX_BUFFER_BINDINGS],
+    offsets: [u64; MTL_MAX_BUFFER_BINDINGS],
+    bound: u32
+}
+
+impl MetalBufferBindings {
+    pub fn new() -> Self {
+        MetalBufferBindings {
+            buffers: [MTLBuffer::nil(); MTL_MAX_BUFFER_BINDINGS],
+            offsets: [0u64; MTL_MAX_BUFFER_BINDINGS],
+            bound: 0u32
+        }
+    }
+
+    pub fn insert(&mut self, index: usize, offset: u64, buffer: MTLBuffer) {
+        self.buffers[index] = buffer;
+        self.offsets[index] = offset;
+        self.bound |= (1 << index);
+    }
+
+    pub fn is_bound(&self, buffer: MTLBuffer) -> bool {
+        match self.buffers.iter().position(|&b| b == buffer) {
+            Some(idx) => self.bound & (1 << idx) != 0,
+            None => false
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.buffers = [MTLBuffer::nil(); MTL_MAX_BUFFER_BINDINGS];
+        self.offsets = [0u64; MTL_MAX_BUFFER_BINDINGS];
+        self.bound = 0;
+    }
+
+}
+
+#[derive(Copy, Clone)]
+pub struct MetalSamplerBindings {
+    samplers: [MTLSamplerState; MTL_MAX_SAMPLER_BINDINGS],
+    min_lods: [f32; MTL_MAX_SAMPLER_BINDINGS],
+    max_lods: [f32; MTL_MAX_SAMPLER_BINDINGS],
+    bound: u16
+}
+
+impl MetalSamplerBindings {
+    pub fn new() -> Self {
+        MetalSamplerBindings {
+            samplers: [MTLSamplerState::nil(); MTL_MAX_SAMPLER_BINDINGS],
+            min_lods: [0f32; MTL_MAX_SAMPLER_BINDINGS],
+            max_lods: [0f32; MTL_MAX_SAMPLER_BINDINGS],
+            bound: 0u16
+        }
+    }
+
+    pub fn insert(&mut self, index: usize, lod_min: f32, lod_max: f32, sampler: MTLSamplerState) {
+        self.samplers[index] = sampler;
+        self.min_lods[index] = lod_min;
+        self.max_lods[index] = lod_max;
+        self.bound |= (1 << index);
+    }
+
+    pub fn reset(&mut self) {
+        self.samplers = [MTLSamplerState::nil(); MTL_MAX_SAMPLER_BINDINGS];
+        self.min_lods = [0f32; MTL_MAX_SAMPLER_BINDINGS];
+        self.max_lods = [0f32; MTL_MAX_SAMPLER_BINDINGS];
+        self.bound = 0;
+    }
+}
+
+pub struct MetalEncoderCache {
+    render: MTLRenderPipelineState,
+
+    scissor: Option<MTLScissorRect>,
+    viewport: Option<MTLViewport>,
+    front_face_winding: Option<MTLWinding>,
+    cull_mode: Option<MTLCullMode>,
+    fill_mode: Option<MTLTriangleFillMode>,
+    depth_clip_mode: Option<MTLDepthClipMode>,
+    depth_bias: Option<(f32, f32)>,
+    blend_color: Option<[f32; 4]>,
+    stencil_front_back_ref: Option<(u32, u32)>,
+
+    index_buffer: Option<(MTLBuffer, MTLIndexType)>,
+    depth_stencil: MTLDepthStencilState,
+
+    texture_bindings: [MetalTextureBindings; 3],
+    buffer_bindings: [MetalBufferBindings; 3],
+    sampler_bindings: [MetalSamplerBindings; 3],
+}
+
+impl MetalEncoderCache {
+    pub fn new() -> Self {
+        let tbs = {
+            let mut tbs: [MetalTextureBindings; 3] = unsafe { mem::uninitialized() };
+            for tb in &mut tbs {
+                *tb = MetalTextureBindings::new();
+            }
+            tbs
+        };
+
+        MetalEncoderCache {
+            render: MTLRenderPipelineState::nil(),
+
+            scissor: None,
+            viewport: None,
+            front_face_winding: None,
+            cull_mode: None,
+            fill_mode: None,
+            depth_clip_mode: None,
+            depth_bias: None,
+            blend_color: None,
+            stencil_front_back_ref: None,
+
+            index_buffer: None,
+            depth_stencil: MTLDepthStencilState::nil(),
+
+            texture_bindings: tbs,
+            buffer_bindings: [MetalBufferBindings::new(); 3],
+            sampler_bindings: [MetalSamplerBindings::new(); 3],
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.render = MTLRenderPipelineState::nil();
+
+        self.scissor = None;
+        self.viewport = None;
+        self.front_face_winding = None;
+        self.cull_mode = None;
+        self.fill_mode = None;
+        self.depth_clip_mode = None;
+        self.depth_bias = None;
+        self.blend_color = None;
+        self.stencil_front_back_ref = None;
+
+        // TODO(fkaa): retain/release? does encoder really have ownership?
+        self.index_buffer = None;
+        self.depth_stencil = MTLDepthStencilState::nil();
+
+        self.texture_bindings.iter_mut().map(|binds| binds.reset());
+        self.buffer_bindings.iter_mut().map(|binds| binds.reset());
+        self.sampler_bindings.iter_mut().map(|binds| binds.reset());
+    }
+}
+
+pub struct MetalEncoder {
+    command_buffer: MTLCommandBuffer,
+
+    render_desc:    MTLRenderPassDescriptor,
+    render:         MTLRenderCommandEncoder,
+    blit:           MTLBlitCommandEncoder,
+    compute:        MTLComputeCommandEncoder,
+
+    cache:          MetalEncoderCache
+}
+
+impl MetalEncoder {
+    pub fn new(cb: MTLCommandBuffer) -> Self {
+        MetalEncoder {
+            command_buffer: cb,
+
+            render_desc:    MTLRenderPassDescriptor::nil(),
+            render:         MTLRenderCommandEncoder::nil(),
+            blit:           MTLBlitCommandEncoder::nil(),
+            compute:        MTLComputeCommandEncoder::nil(),
+
+            cache:          MetalEncoderCache::new()
+
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.cache.reset();
+    }
+
+    pub fn restore_render_state(&mut self) {
+        debug_assert!(!self.render.is_null(), "Render encoder must be non-nil");
+
+        if let Some(viewport) = self.cache.viewport {
+            self.render.set_viewport(viewport);
+        }
+
+        if let Some(winding) = self.cache.front_face_winding {
+            self.render.set_front_facing_winding(winding);
+        }
+
+        if let Some(cull) = self.cache.cull_mode {
+            self.render.set_cull_mode(cull);
+        }
+
+        if let Some(fill) = self.cache.fill_mode {
+            self.render.set_triangle_fill_mode(fill);
+        }
+
+        if let Some(clip) = self.cache.depth_clip_mode {
+            self.render.set_depth_clip_mode(clip);
+        }
+
+        if let Some(blend) = self.cache.blend_color {
+            self.render.set_blend_color(blend[0], blend[1], blend[2], blend[3]);
+        }
+
+        if let Some((bias, slope)) = self.cache.depth_bias {
+            self.render.set_depth_bias(bias, slope, 16f32);
+        }
+
+        if let Some((front, back)) = self.cache.stencil_front_back_ref {
+            self.render.set_stencil_front_back_reference_value(front, back);
+        }
+
+        if !self.cache.render.is_null() {
+            self.render.set_render_pipeline_state(self.cache.render);
+        }
+
+        if !self.cache.depth_stencil.is_null() {
+            self.render.set_depth_stencil_state(self.cache.depth_stencil);
+        }
+
+        for stage in 0..3 {
+            for idx in 0..MTL_MAX_TEXTURE_BINDINGS {
+                let tex = self.cache.texture_bindings[stage].textures[idx];
+
+                if !tex.is_null() {
+                    if stage == VS_IDX {
+                        self.render.set_vertex_texture(idx as u64, tex);
+                    } else {
+                        self.render.set_fragment_texture(idx as u64, tex);
+                    }
+                }
+            }
+
+            for idx in 0..MTL_MAX_BUFFER_BINDINGS {
+                let buf = self.cache.buffer_bindings[stage].buffers[idx];
+                let offset = self.cache.buffer_bindings[stage].offsets[idx];
+
+                if !buf.is_null() {
+                    if stage == VS_IDX {
+                        self.render.set_vertex_buffer(idx as u64, offset, buf);
+                    } else {
+                        self.render.set_fragment_buffer(idx as u64, offset, buf);
+                    }
+                }
+            }
+
+            for idx in 0..MTL_MAX_SAMPLER_BINDINGS {
+                let sampler = self.cache.sampler_bindings[stage].samplers[idx];
+                let min = self.cache.sampler_bindings[stage].min_lods[idx];
+                let max = self.cache.sampler_bindings[stage].max_lods[idx];
+
+                if !sampler.is_null() {
+                    if stage == VS_IDX {
+                        self.render.set_vertex_sampler_state_with_lod(idx as u64, min, max, sampler);
+                    } else {
+                        self.render.set_fragment_sampler_state_with_lod(idx as u64, min, max, sampler);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn set_render_pass_descriptor(&mut self, desc: MTLRenderPassDescriptor) {
+        self.render_desc = desc;
+    }
+
+    pub fn begin_render_encoding(&mut self) -> MTLRenderCommandEncoder {
+        debug_assert!(!self.render_desc.is_null(), "Render description must be non-nil");
+        debug_assert!(!self.command_buffer.is_null(), "Command Buffer must be non-nil");
+        debug_assert!(self.blit.is_null() && self.compute.is_null(), "Remaining encoders must be ended");
+
+        self.render = self.command_buffer.new_render_command_encoder(self.render_desc);
+        self.render
+    }
+
+    pub fn is_render_encoding(&self) -> bool {
+        !self.render.is_null()
+    }
+
+    pub fn start_command_buffer(&mut self, buf: MTLCommandBuffer) {
+        debug_assert!(!buf.is_null(), "New Command Buffer must be non-nil");
+
+        unsafe {
+            buf.retain();
+            let old = self.command_buffer;
+            self.command_buffer = buf;
+            old.release();
+        }
+    }
+
+    pub fn commit_command_buffer(&mut self, drawable: CAMetalDrawable, wait: bool) {
+        debug_assert!(!self.command_buffer.is_null(), "Command Buffer must be non-nil");
+
+        // TODO(fkaa): commit
+        if !drawable.is_null() {
+            self.command_buffer.present_drawable(drawable);
+        }
+
+        self.command_buffer.commit();
+
+        if wait {
+            self.command_buffer.wait_until_completed();
+        }
+
+        unsafe {
+            self.command_buffer.release();
+        }
+        self.command_buffer = MTLCommandBuffer::nil();
+    }
+
+    pub fn sync(&mut self, resource: MTLResource) {
+        self.blit = self.command_buffer.new_blit_command_encoder();
+        self.blit.synchronize_resource(resource);
+        self.blit.end_encoding();
+        self.blit = MTLBlitCommandEncoder::nil();
+    }
+
+    pub fn end_encoding(&mut self) {
+        unsafe {
+            if !self.render.is_null() {
+                self.render.end_encoding();
+                self.render.release();
+                self.render = MTLRenderCommandEncoder::nil();
+            }
+
+            if !self.blit.is_null() {
+                self.blit.end_encoding();
+                self.blit.release();
+                self.blit = MTLBlitCommandEncoder::nil();
+
+            }
+
+            if !self.compute.is_null() {
+                self.compute.end_encoding();
+                self.compute.release();
+                self.compute = MTLComputeCommandEncoder::nil();
+            }
+        }
+    }
+
+    pub fn is_buffer_bound(&mut self, buf: MTLBuffer) -> bool {
+        self.cache.buffer_bindings.iter().any(|binds| binds.is_bound(buf))
+    }
+
+    pub fn set_render_pipeline_state(&mut self, pso: MTLRenderPipelineState) {
+        self.cache.render = pso;
+    }
+
+    pub fn set_viewport_cache(&mut self, viewport: MTLViewport) {
+        self.cache.viewport = Some(viewport);
+    }
+
+    pub fn set_viewport(&mut self, viewport: MTLViewport) {
+        self.cache.viewport = Some(viewport);
+    }
+
+    pub fn set_front_facing_winding(&mut self, winding: MTLWinding) {
+        self.cache.front_face_winding = Some(winding);
+    }
+
+    pub fn set_cull_mode(&mut self, mode: MTLCullMode) {
+        self.cache.cull_mode = Some(mode);
+    }
+
+    pub fn set_depth_clip_mode(&mut self, mode: MTLDepthClipMode) {
+        self.cache.depth_clip_mode = Some(mode);
+    }
+
+    pub fn set_scissor_rect(&mut self, rect: MTLScissorRect) {
+        self.cache.scissor = Some(rect);
+    }
+
+    pub fn set_triangle_fill_mode(&mut self, mode: MTLTriangleFillMode) {
+        self.cache.fill_mode = Some(mode);
+    }
+
+    pub fn set_blend_color(&mut self, color: [f32; 4]) {
+        self.cache.blend_color = Some(color);
+    }
+
+    pub fn set_depth_bias(&mut self, bias: f32, slope: f32, clamp: f32) {
+        self.cache.depth_bias = Some((bias, slope));
+    }
+
+    pub fn set_depth_stencil_state(&mut self, depth_stencil: MTLDepthStencilState) {
+        self.cache.depth_stencil = depth_stencil;
+    }
+
+    pub fn set_stencil_reference_value(&mut self, value: u32) {
+        self.cache.stencil_front_back_ref = Some((value, value));
+    }
+
+    pub fn set_stencil_front_back_reference_value(&mut self, front: u32, back: u32) {
+        self.cache.stencil_front_back_ref = Some((front, back));
+    }
+
+    // TODO(fkaa): cut down on unnecessary binds for shader resources
+    pub fn set_vertex_texture(&mut self, index: u64, texture: MTLTexture) {
+        self.cache.texture_bindings[VS_IDX].insert(index as usize, texture);
+    }
+
+    pub fn set_fragment_texture(&mut self, index: u64, texture: MTLTexture) {
+        self.cache.texture_bindings[FS_IDX].insert(index as usize, texture);
+    }
+
+    pub fn set_vertex_buffer(&mut self, index: u64, offset: u64, buffer: MTLBuffer) {
+        self.cache.buffer_bindings[VS_IDX].insert(index as usize, offset, buffer);
+    }
+
+    pub fn set_fragment_buffer(&mut self, index: u64, offset: u64, buffer: MTLBuffer) {
+        self.cache.buffer_bindings[FS_IDX].insert(index as usize, offset, buffer);
+    }
+
+    pub fn set_vertex_sampler_state(&mut self, index: u64, lod_min: f32, lod_max: f32, sampler: MTLSamplerState) {
+        self.cache.sampler_bindings[VS_IDX].insert(index as usize, lod_min, lod_max, sampler);
+    }
+
+    pub fn set_fragment_sampler_state(&mut self, index: u64, lod_min: f32, lod_max: f32, sampler: MTLSamplerState) {
+        self.cache.sampler_bindings[FS_IDX].insert(index as usize, lod_min, lod_max, sampler);
+    }
+
+    pub fn set_index_buffer(&mut self, buf: MTLBuffer, idx_type: MTLIndexType) {
+        self.cache.index_buffer = Some((buf, idx_type));
+    }
+
+    pub fn draw(&mut self, start: u64, count: u64) {
+        self.render.draw_primitives(MTLPrimitiveType::Triangle, start, count);
+    }
+
+    pub fn draw_instanced(&self, start: u64, count: u64, instance_count: u64) {
+        self.render.draw_primitives_instanced(MTLPrimitiveType::Triangle, start, count, instance_count);
+    }
+
+    pub fn draw_indexed(&self, index_count: u64, index_buffer_offset: u64) {
+        if let Some((buf, ty)) = self.cache.index_buffer {
+            self.render.draw_indexed_primitives(MTLPrimitiveType::Triangle,
+                                                index_count,
+                                                ty,
+                                                buf,
+                                                index_buffer_offset);
+        } else {
+            error!("Cannot draw indexed primitives without a index buffer bound");
+        }
+    }
+
+    pub fn draw_indexed_instanced(&self, index_count: u64, index_type: MTLIndexType, index_buffer: MTLBuffer, index_buffer_offset: u64, instance_count: u64) {
+        if let Some((buf, ty)) = self.cache.index_buffer {
+            self.render.draw_indexed_primitives_instanced(MTLPrimitiveType::Triangle,
+                                                          index_count,
+                                                          index_type,
+                                                          index_buffer,
+                                                          index_buffer_offset,
+                                                          instance_count);
+        } else {
+            error!("Cannot draw indexed primitives without a index buffer bound");
+        }
+    }
+
+}

--- a/src/backend/metal/src/encoder.rs
+++ b/src/backend/metal/src/encoder.rs
@@ -14,19 +14,6 @@
 
 #![allow(missing_docs)]
 
-use core::{pso, shade, state, target};
-use core::{IndexType, VertexCount};
-use core::{MAX_VERTEX_ATTRIBUTES, MAX_CONSTANT_BUFFERS,
-               MAX_RESOURCE_VIEWS,
-               MAX_SAMPLERS, MAX_COLOR_TARGETS};
-
-use core::shade::Stage;
-
-use {Resources, Buffer, Texture, Pipeline};
-
-use native;
-use native::{Rtv, Srv, Dsv};
-
 use metal::*;
 
 use std::mem;
@@ -62,7 +49,7 @@ impl MetalTextureBindings {
 
     pub fn insert(&mut self, index: usize, texture: MTLTexture) {
         self.textures[index] = texture;
-        self.bound[index / 32] |= (1 << (index % 32));
+        self.bound[index / 32] |= 1 << (index % 32);
     }
 
     pub fn reset(&mut self) {
@@ -90,7 +77,7 @@ impl MetalBufferBindings {
     pub fn insert(&mut self, index: usize, offset: u64, buffer: MTLBuffer) {
         self.buffers[index] = buffer;
         self.offsets[index] = offset;
-        self.bound |= (1 << index);
+        self.bound |= 1 << index;
     }
 
     pub fn is_bound(&self, buffer: MTLBuffer) -> bool {
@@ -134,7 +121,7 @@ impl MetalSamplerBindings {
         self.samplers[index] = sampler;
         self.min_lods[index] = lod_min;
         self.max_lods[index] = lod_max;
-        self.bound |= (1 << index);
+        self.bound |= 1 << index;
     }
 
     pub fn reset(&mut self) {
@@ -360,9 +347,7 @@ impl MetalEncoder {
     pub fn start_command_buffer(&mut self, buf: MTLCommandBuffer) {
         debug_assert!(!buf.is_null(), "New Command Buffer must be non-nil");
 
-        unsafe {
-            self.command_buffer = buf;
-        }
+        self.command_buffer = buf;
     }
 
     pub fn commit_command_buffer(&mut self, drawable: CAMetalDrawable, wait: bool) {
@@ -423,10 +408,6 @@ impl MetalEncoder {
 
     pub fn set_render_pipeline_state(&mut self, pso: MTLRenderPipelineState) {
         self.cache.render = pso;
-    }
-
-    pub fn set_viewport_cache(&mut self, viewport: MTLViewport) {
-        self.cache.viewport = Some(viewport);
     }
 
     pub fn set_viewport(&mut self, viewport: MTLViewport) {

--- a/src/backend/metal/src/factory.rs
+++ b/src/backend/metal/src/factory.rs
@@ -55,7 +55,6 @@ impl mapping::Gate<Resources> for RawMapping {
 
 
 pub struct Factory {
-    drawable: *mut CAMetalDrawable,
     device: MTLDevice,
     queue: MTLCommandQueue,
     share: Arc<Share>,
@@ -63,9 +62,8 @@ pub struct Factory {
 }
 
 impl Factory {
-    pub fn new(device: MTLDevice, share: Arc<Share>, drawable: *mut CAMetalDrawable) -> Factory {
+    pub fn new(device: MTLDevice, share: Arc<Share>) -> Factory {
         Factory {
-            drawable: drawable,
             device: device,
             queue: device.new_command_queue(),
             share: share,
@@ -74,7 +72,7 @@ impl Factory {
     }
 
     pub fn create_command_buffer(&self) -> CommandBuffer {
-        CommandBuffer::new(self.device, self.queue, self.drawable)
+        CommandBuffer::new(self.device, self.queue)
     }
 
     fn create_buffer_internal(&self,
@@ -89,7 +87,7 @@ impl Factory {
             return Err(buffer::CreationError::UnsupportedBind(info.bind));
         }
 
-        let mut raw_buf = if let Some(data) = raw_data {
+        let raw_buf = if let Some(data) = raw_data {
             self.device
                 .new_buffer_with_data(unsafe { mem::transmute(data) }, info.size as u64, usage)
         } else {

--- a/src/backend/metal/src/factory.rs
+++ b/src/backend/metal/src/factory.rs
@@ -378,12 +378,12 @@ impl core::Factory<Resources> for Factory {
             alpha_to_one: false,
             alpha_to_coverage: false,
             depth_bias: if let Some(ref offset) = desc.rasterizer.offset {
-                offset.0
+                offset.1
             } else {
                 0
             },
             slope_scaled_depth_bias: if let Some(ref offset) = desc.rasterizer.offset {
-                offset.1
+                offset.0
             } else {
                 0
             },

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -44,6 +44,11 @@ pub use self::command::CommandBuffer;
 pub use self::factory::Factory;
 pub use self::map::*;
 
+// Grabbed from https://developer.apple.com/metal/limits/
+const MTL_MAX_TEXTURE_BINDINGS: usize = 128;
+const MTL_MAX_BUFFER_BINDINGS: usize = 31;
+const MTL_MAX_SAMPLER_BINDINGS: usize = 16;
+
 /// Internal struct of shared data between the device and its factories.
 #[doc(hidden)]
 pub struct Share {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -345,7 +345,7 @@ pub fn create(format: core::format::Format,
                                                        });
 
 
-    let mut factory = Factory::new(mtl_device, device.share.clone(), d);
+    let mut factory = Factory::new(mtl_device, device.share.clone());
 
     let color_target = {
         use core::Factory;

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -19,7 +19,7 @@ extern crate objc;
 extern crate objc_foundation;
 extern crate cocoa;
 extern crate gfx_core as core;
-extern crate metal;
+extern crate metal_rs as metal;
 extern crate bit_set;
 
 // use cocoa::base::{selector, class};

--- a/src/backend/metal/src/map.rs
+++ b/src/backend/metal/src/map.rs
@@ -211,67 +211,61 @@ pub fn map_format(format: Format, is_target: bool) -> Option<MTLPixelFormat> {
 
     Some(match format.0 {
         R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 => return None,
-        R8 => {
-            match format.1 {
-                Int => R8Sint,
-                Uint => R8Uint,
-                Inorm => R8Snorm,
-                Unorm => R8Unorm,
-                _ => return None,
-            }
-        }
-        R8_G8 => {
-            match format.1 {
-                Int => RG8Sint,
-                Uint => RG8Uint,
-                Inorm => RG8Snorm,
-                Unorm => RG8Unorm,
-                _ => return None,
-            }
-        }
-        R8_G8_B8_A8 => {
-            match format.1 {
-                Int => RGBA8Sint,
-                Uint => RGBA8Uint,
-                Inorm => RGBA8Snorm,
-                Unorm => RGBA8Unorm,
-                Srgb => RGBA8Unorm_sRGB,
-                _ => return None,
-            }
-        }
-        R10_G10_B10_A2 => {
-            match format.1 {
-                Uint => RGB10A2Uint,
-                Unorm => RGB10A2Unorm,
-                _ => return None,
-            }
-        }
-        R11_G11_B10 => {
-            match format.1 {
-                Float => RG11B10Float,
-                _ => return None,
-            }
-        }
-        R16 => {
-            match format.1 {
-                Int => R16Sint,
-                Uint => R16Uint,
-                Inorm => R16Snorm,
-                Unorm => R16Unorm,
-                Float => R16Float,
-                _ => return None,
-            }
-        }
-        R16_G16 => {
-            match format.1 {
-                Int => RG16Sint,
-                Uint => RG16Uint,
-                Inorm => RG16Snorm,
-                Unorm => RG16Unorm,
-                Float => RG16Float,
-                _ => return None,
-            }
-        }
+        R8 => match format.1 {
+            Int   => R8Sint,
+            Uint  => R8Uint,
+            Inorm => R8Snorm,
+            Unorm => R8Unorm,
+            _ => return None,
+        },
+        R8_G8 => match format.1 {
+            Int   => RG8Sint,
+            Uint  => RG8Uint,
+            Inorm => RG8Snorm,
+            Unorm => RG8Unorm,
+            _ => return None,
+        },
+        R8_G8_B8_A8 => match format.1 {
+            Int   => RGBA8Sint,
+            Uint  => RGBA8Uint,
+            Inorm => RGBA8Snorm,
+            Unorm => if is_target {
+                         BGRA8Unorm
+                     } else {
+                         RGBA8Unorm
+                     },
+            Srgb  => if is_target {
+                         BGRA8Unorm_sRGB
+                     } else {
+                         RGBA8Unorm_sRGB
+                     },
+            _ => return None,
+        },
+        R10_G10_B10_A2 => match format.1 {
+            Uint  => RGB10A2Uint,
+            Unorm => RGB10A2Unorm,
+            _ => return None,
+        },
+        R11_G11_B10 => match format.1 {
+            Float => RG11B10Float,
+            _ => return None,
+        },
+        R16 => match format.1 {
+            Int   => R16Sint,
+            Uint  => R16Uint,
+            Inorm => R16Snorm,
+            Unorm => R16Unorm,
+            Float => R16Float,
+            _ => return None,
+        },
+        R16_G16 => match format.1 {
+            Int   => RG16Sint,
+            Uint  => RG16Uint,
+            Inorm => RG16Snorm,
+            Unorm => RG16Unorm,
+            Float => RG16Float,
+            _ => return None,
+        },
         R16_G16_B16 => return None,
         R16_G16_B16_A16 => {
             match format.1 {
@@ -563,5 +557,65 @@ pub fn map_wrap(wrap: WrapMode) -> MTLSamplerAddressMode {
         WrapMode::Mirror => MirrorRepeat, // TODO: MirrorClampToEdge?
         WrapMode::Clamp => ClampToEdge, // TODO: MirrorClampToEdge, ClampToZero?
         WrapMode::Border => ClampToZero, // TODO: what border?
+    }
+}
+
+pub fn map_write_mask(mask: state::ColorMask) -> MTLColorWriteMask {
+    let mut mtl_mask = MTLColorWriteMaskNone;
+
+    if mask.contains(state::RED) {
+        mtl_mask.insert(MTLColorWriteMaskRed);
+    }
+
+    if mask.contains(state::GREEN) {
+        mtl_mask.insert(MTLColorWriteMaskGreen);
+    }
+
+    if mask.contains(state::BLUE) {
+        mtl_mask.insert(MTLColorWriteMaskBlue);
+    }
+
+    if mask.contains(state::ALPHA) {
+        mtl_mask.insert(MTLColorWriteMaskAlpha);
+    }
+
+    mtl_mask
+}
+
+pub fn map_blend_factor(factor: state::Factor, scalar: bool) -> MTLBlendFactor {
+    use gfx_core::state::BlendValue::*;
+    use gfx_core::state::Factor::*;
+    match factor {
+        Zero => MTLBlendFactor::Zero,
+        One => MTLBlendFactor::One,
+        SourceAlphaSaturated => MTLBlendFactor::SourceAlphaSaturated,
+        ZeroPlus(SourceColor) if !scalar => MTLBlendFactor::SourceColor,
+        ZeroPlus(SourceAlpha) => MTLBlendFactor::SourceAlpha,
+        ZeroPlus(DestColor) if !scalar => MTLBlendFactor::DestinationColor,
+        ZeroPlus(DestAlpha) => MTLBlendFactor::DestinationAlpha,
+        ZeroPlus(ConstColor) if !scalar => MTLBlendFactor::BlendColor,
+        ZeroPlus(ConstAlpha) => MTLBlendFactor::BlendAlpha,
+        OneMinus(SourceColor) if !scalar => MTLBlendFactor::OneMinusSourceColor,
+        OneMinus(SourceAlpha) => MTLBlendFactor::OneMinusSourceAlpha,
+        OneMinus(DestColor) if !scalar => MTLBlendFactor::OneMinusDestinationColor,
+        OneMinus(DestAlpha) => MTLBlendFactor::OneMinusDestinationAlpha,
+        OneMinus(ConstColor) if !scalar => MTLBlendFactor::OneMinusBlendColor,
+        OneMinus(ConstAlpha) => MTLBlendFactor::OneMinusBlendAlpha,
+        _ => {
+            error!("Invalid blend factor requested for {}: {:?}",
+                if scalar {"alpha"} else {"color"}, factor);
+            MTLBlendFactor::Zero
+        }
+    }
+}
+
+pub fn map_blend_op(equation: state::Equation) -> MTLBlendOperation {
+    use gfx_core::state::Equation::*;
+    match equation {
+        Add => MTLBlendOperation::Add,
+        Sub => MTLBlendOperation::Subtract,
+        RevSub => MTLBlendOperation::ReverseSubtract,
+        Min => MTLBlendOperation::Min,
+        Max => MTLBlendOperation::Max,
     }
 }

--- a/src/backend/metal/src/map.rs
+++ b/src/backend/metal/src/map.rs
@@ -527,10 +527,10 @@ pub fn map_texture_usage(usage: Usage) -> (MTLResourceOptions, MTLStorageMode) {
 pub fn map_buffer_usage(usage: Usage) -> MTLResourceOptions {
     match usage {
         Usage::GpuOnly => MTLResourceStorageModePrivate,
-        Usage::Immutable => MTLResourceCPUCacheModeDefaultCache,
-        Usage::Dynamic => MTLResourceCPUCacheModeDefaultCache,
-        Usage::CpuOnly(access) => map_access(access),
-        Usage::Persistent(access) => map_access(access),
+        Usage::Immutable => MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeManaged,
+        Usage::Dynamic => MTLResourceCPUCacheModeDefaultCache | MTLResourceStorageModeManaged,
+        Usage::CpuOnly(access) => map_access(access) | MTLResourceStorageModeManaged,
+        Usage::Persistent(access) => map_access(access) | MTLResourceStorageModeManaged,
     }
 }
 
@@ -583,8 +583,9 @@ pub fn map_write_mask(mask: state::ColorMask) -> MTLColorWriteMask {
 }
 
 pub fn map_blend_factor(factor: state::Factor, scalar: bool) -> MTLBlendFactor {
-    use gfx_core::state::BlendValue::*;
-    use gfx_core::state::Factor::*;
+    use core::state::BlendValue::*;
+    use core::state::Factor::*;
+
     match factor {
         Zero => MTLBlendFactor::Zero,
         One => MTLBlendFactor::One,
@@ -610,7 +611,8 @@ pub fn map_blend_factor(factor: state::Factor, scalar: bool) -> MTLBlendFactor {
 }
 
 pub fn map_blend_op(equation: state::Equation) -> MTLBlendOperation {
-    use gfx_core::state::Equation::*;
+    use core::state::Equation::*;
+
     match equation {
         Add => MTLBlendOperation::Add,
         Sub => MTLBlendOperation::Subtract,

--- a/src/backend/metal/src/mirror.rs
+++ b/src/backend/metal/src/mirror.rs
@@ -17,7 +17,6 @@
 // use cocoa::foundation::{NSUInteger};
 
 use core::{self, shade};
-use factory::DUMMY_BUFFER_SLOT;
 
 use metal::*;
 
@@ -52,7 +51,6 @@ pub fn populate_vertex_attributes(info: &mut shade::ProgramInfo,
 pub fn populate_info(info: &mut shade::ProgramInfo,
                      stage: shade::Stage,
                      args: NSArray<MTLArgument>) {
-    //    use core::shade::Stage;
     use map::{map_base_type, map_texture_type};
 
     let usage = stage.into();
@@ -63,8 +61,7 @@ pub fn populate_info(info: &mut shade::ProgramInfo,
 
         match arg.type_() {
             MTLArgumentType::Buffer => {
-                // we skip the dummy buffer, which is used in our fake PSO
-                if arg.index() == DUMMY_BUFFER_SLOT {
+                if name.starts_with("vertexBuffer.") {
                     continue;
                 }
 

--- a/src/backend/metal/src/mirror.rs
+++ b/src/backend/metal/src/mirror.rs
@@ -23,7 +23,7 @@ use metal::*;
 
 pub fn map_base_type_to_format(ty: shade::BaseType) -> MTLVertexFormat {
     use metal::MTLVertexFormat::*;
-    use gfx_core::shade::BaseType::*;
+    use core::shade::BaseType::*;
 
     match ty {
         I32 => MTLVertexFormat::Int,

--- a/src/backend/metal/src/mirror.rs
+++ b/src/backend/metal/src/mirror.rs
@@ -21,13 +21,16 @@ use factory::DUMMY_BUFFER_SLOT;
 
 use metal::*;
 
-fn _map_base_type_from_component(ct: MTLDataType) -> shade::BaseType {
-    use metal::MTLDataType::*;
+pub fn map_base_type_to_format(ty: shade::BaseType) -> MTLVertexFormat {
+    use metal::MTLVertexFormat::*;
+    use gfx_core::shade::BaseType::*;
 
-    match ct {
-        Float | Float2 | Float3 | Float4 | Float2x2 | Float2x3 | Float2x4 | Float3x2 |
-        Float3x3 | Float3x4 | Float4x2 | Float4x3 | Float4x4 => shade::BaseType::F32,
-        _ => shade::BaseType::I32,
+    match ty {
+        I32 => MTLVertexFormat::Int,
+        U32 => MTLVertexFormat::UInt,
+        F32 => MTLVertexFormat::Float,
+        Bool => MTLVertexFormat::Char2,
+        F64 => { unimplemented!() }
     }
 }
 

--- a/src/backend/metal/src/mirror.rs
+++ b/src/backend/metal/src/mirror.rs
@@ -22,7 +22,6 @@ use factory::DUMMY_BUFFER_SLOT;
 use metal::*;
 
 pub fn map_base_type_to_format(ty: shade::BaseType) -> MTLVertexFormat {
-    use metal::MTLVertexFormat::*;
     use core::shade::BaseType::*;
 
     match ty {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,27 +116,18 @@ pub trait Application<R: gfx::Resources>: Sized {
     {
         WrapD3D11::<Self>::launch(name, DEFAULT_CONFIG);
     }
-<<<<<<< 7b084cfbb95e3e4d1ea51e91746fc75b2efb3be3
-    #[cfg(all(not(target_os = "windows"), not(feature = "vulkan")))]
+    #[cfg(all(not(target_os = "windows"), not(feature = "vulkan"), not(feature = "metal")))]
     fn launch_default(name: &str)
         where WrapGL2<Self>: ApplicationGL
     {
         WrapGL2::<Self>::launch(name, DEFAULT_CONFIG);
     }
-    // #[cfg(target_os = "macos")]
-    // fn launch_default(name: &str) where WrapMetal<Self>: ApplicationMetal {
-    // WrapMetal::<Self>::launch(name, DEFAULT_CONFIG)
-    // }
-=======
-    #[cfg(all(not(target_os = "windows"), not(feature = "vulkan"), not(feature = "metal")))]
-    fn launch_default(name: &str) where WrapGL2<Self>: ApplicationGL {
-        WrapGL2::<Self>::launch(name, DEFAULT_CONFIG);
-    }
     #[cfg(feature = "metal")]
-    fn launch_default(name: &str) where WrapMetal<Self>: ApplicationMetal {
+    fn launch_default(name: &str)
+        where WrapMetal<Self>: ApplicationMetal
+    {
         WrapMetal::<Self>::launch(name, DEFAULT_CONFIG)
     }
->>>>>>> MTL - rewrite encoder into something manageable
     #[cfg(feature = "vulkan")]
     fn launch_default(name: &str)
         where WrapVulkan<Self>: ApplicationVulkan

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,9 @@ extern crate gfx_device_dx11;
 #[cfg(target_os = "windows")]
 extern crate gfx_window_dxgi;
 
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 extern crate gfx_device_metal;
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 extern crate gfx_window_metal;
 
 #[cfg(feature = "vulkan")]
@@ -42,9 +42,9 @@ pub type ColorFormat = gfx::format::Rgba8;
 #[cfg(feature = "vulkan")]
 pub type ColorFormat = gfx::format::Bgra8;
 
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 pub type DepthFormat = gfx::format::Depth32F;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(feature = "metal"))]
 pub type DepthFormat = gfx::format::DepthStencil;
 
 pub struct Init<R: gfx::Resources> {
@@ -116,6 +116,7 @@ pub trait Application<R: gfx::Resources>: Sized {
     {
         WrapD3D11::<Self>::launch(name, DEFAULT_CONFIG);
     }
+<<<<<<< 7b084cfbb95e3e4d1ea51e91746fc75b2efb3be3
     #[cfg(all(not(target_os = "windows"), not(feature = "vulkan")))]
     fn launch_default(name: &str)
         where WrapGL2<Self>: ApplicationGL
@@ -126,6 +127,16 @@ pub trait Application<R: gfx::Resources>: Sized {
     // fn launch_default(name: &str) where WrapMetal<Self>: ApplicationMetal {
     // WrapMetal::<Self>::launch(name, DEFAULT_CONFIG)
     // }
+=======
+    #[cfg(all(not(target_os = "windows"), not(feature = "vulkan"), not(feature = "metal")))]
+    fn launch_default(name: &str) where WrapGL2<Self>: ApplicationGL {
+        WrapGL2::<Self>::launch(name, DEFAULT_CONFIG);
+    }
+    #[cfg(feature = "metal")]
+    fn launch_default(name: &str) where WrapMetal<Self>: ApplicationMetal {
+        WrapMetal::<Self>::launch(name, DEFAULT_CONFIG)
+    }
+>>>>>>> MTL - rewrite encoder into something manageable
     #[cfg(feature = "vulkan")]
     fn launch_default(name: &str)
         where WrapVulkan<Self>: ApplicationVulkan
@@ -139,7 +150,7 @@ pub struct Wrap<R: gfx::Resources, C: gfx::CommandBuffer<R>, A> {
     app: A,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 pub type WrapMetal<A> = Wrap<gfx_device_metal::Resources, gfx_device_metal::CommandBuffer, A>;
 #[cfg(target_os = "windows")]
 pub type D3D11CommandBuffer = gfx_device_dx11::CommandBuffer<gfx_device_dx11::DeferredContext>;
@@ -283,12 +294,12 @@ impl<A: ApplicationBase<gfx_device_dx11::Resources, D3D11CommandBuffer>> Applica
 }
 
 
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 pub trait ApplicationMetal {
     fn launch(&str, Config);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 impl Factory<gfx_device_metal::Resources> for gfx_device_metal::Factory {
     type CommandBuffer = gfx_device_metal::CommandBuffer;
     fn create_encoder(&mut self) -> gfx::Encoder<gfx_device_metal::Resources, Self::CommandBuffer> {
@@ -296,7 +307,7 @@ impl Factory<gfx_device_metal::Resources> for gfx_device_metal::Factory {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 impl<
     A: ApplicationBase<gfx_device_metal::Resources, gfx_device_metal::CommandBuffer>
 > ApplicationMetal for A {

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -236,12 +236,12 @@ impl<R: Resources, C: command::Buffer<R>> Encoder<R, C> {
                 pipeline: &pso::PipelineState<R, D::Meta>, user_data: &D)
     {
         let (pso, _) = self.handles.ref_pso(pipeline.get_handle());
-        self.command_buffer.bind_pipeline_state(pso.clone());
         //TODO: make `raw_data` a member to this struct, to re-use the heap allocation
         self.raw_pso_data.clear();
         user_data.bake_to(&mut self.raw_pso_data, pipeline.get_meta(), &mut self.handles, &mut self.access_info);
-        self.command_buffer.bind_vertex_buffers(self.raw_pso_data.vertex_buffers.clone());
         self.command_buffer.bind_pixel_targets(self.raw_pso_data.pixel_targets.clone());
+        self.command_buffer.bind_pipeline_state(pso.clone());
+        self.command_buffer.bind_vertex_buffers(self.raw_pso_data.vertex_buffers.clone());
         self.command_buffer.set_ref_values(self.raw_pso_data.ref_values);
         self.command_buffer.set_scissor(self.raw_pso_data.scissor);
         self.command_buffer.bind_constant_buffers(&self.raw_pso_data.constant_buffers);

--- a/src/shade.rs
+++ b/src/shade.rs
@@ -16,7 +16,7 @@
 pub use gfx_device_gl::Version as GlslVersion;
 #[cfg(target_os = "windows")]
 pub use gfx_device_dx11::ShaderModel as DxShaderModel;
-#[cfg(target_os = "macos")]
+#[cfg(feature = "metal")]
 pub use gfx_device_metal::ShaderModel as MetalShaderModel;
 /// Shader backend with version numbers.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -25,7 +25,7 @@ pub enum Backend {
     GlslEs(GlslVersion),
     #[cfg(target_os = "windows")]
     Hlsl(DxShaderModel),
-    #[cfg(target_os = "macos")]
+    #[cfg(feature = "metal")]
     Msl(MetalShaderModel),
     #[cfg(feature = "vulkan")]
     Vulkan,
@@ -112,7 +112,7 @@ impl<'a> Source<'a> {
                     _ => return Err(SelectError(backend)),
                 }
             }
-            #[cfg(target_os = "macos")]
+            #[cfg(feature = "metal")]
             Backend::Msl(revision) => {
                 match *self {
                     Source { msl_11: s, .. } if s != EMPTY && revision >= 11 => s,

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -30,6 +30,6 @@ log = "0.3"
 cocoa = "0.2.4"
 objc = "0.1.8"
 winit = "0.5.1"
-metal = { git = "https://github.com/fkaa/metal-rs" }
+metal-rs = "0.1"
 gfx_core = { path = "../../core", version = "0.5" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.1" }

--- a/src/window/metal/src/lib.rs
+++ b/src/window/metal/src/lib.rs
@@ -110,6 +110,8 @@ pub fn init<C: RenderFormat>(title: &str, requested_width: u32, requested_height
 pub fn init_raw(title: &str, requested_width: u32, requested_height: u32, color_format: Format)
         -> Result<(MetalWindow, Device, Factory, RawRenderTargetView<Resources>), InitError>
 {
+    use gfx_device_metal::map_format;
+
     let winit_window = winit::WindowBuilder::new()
         .with_dimensions(requested_width, requested_height)
         .with_title(title.to_string()).build().unwrap();
@@ -118,11 +120,10 @@ pub fn init_raw(title: &str, requested_width: u32, requested_height: u32, color_
         let wnd: cocoa_id = mem::transmute(winit_window.get_nswindow());
 
         let layer = CAMetalLayer::new();
-        layer.set_pixel_format(MTLPixelFormat::BGRA8Unorm_sRGB);
-        /*layer.set_pixel_format(match gfx_device_metal::map_format(color_format, true) {
+        layer.set_pixel_format(match gfx_device_metal::map_format(color_format, true) {
             Some(fm) => fm,
             None => return Err(InitError::Format(color_format)),
-        });*/
+        });
         let draw_size = winit_window.get_inner_size().unwrap();
         layer.set_edge_antialiasing_mask(0);
         layer.set_masks_to_bounds(true);

--- a/src/window/metal/src/lib.rs
+++ b/src/window/metal/src/lib.rs
@@ -117,13 +117,17 @@ pub fn init_raw(title: &str, requested_width: u32, requested_height: u32, color_
     unsafe {
         let wnd: cocoa_id = mem::transmute(winit_window.get_nswindow());
 
-        let layer = CAMetalLayer::layer();
-        layer.set_pixel_format(MTLPixelFormat::BGRA8Unorm);
+        let layer = CAMetalLayer::new();
+        layer.set_pixel_format(MTLPixelFormat::BGRA8Unorm_sRGB);
         /*layer.set_pixel_format(match gfx_device_metal::map_format(color_format, true) {
             Some(fm) => fm,
             None => return Err(InitError::Format(color_format)),
         });*/
         let draw_size = winit_window.get_inner_size().unwrap();
+        layer.set_edge_antialiasing_mask(0);
+        layer.set_masks_to_bounds(true);
+        //layer.set_magnification_filter(kCAFilterNearest);
+        //layer.set_minification_filter(kCAFilterNearest);
         layer.set_drawable_size(NSSize::new(draw_size.0 as f64, draw_size.1 as f64));
         layer.set_presents_with_transaction(false);
         layer.remove_all_animations();

--- a/src/window/metal/src/lib.rs
+++ b/src/window/metal/src/lib.rs
@@ -20,7 +20,7 @@ extern crate log;
 extern crate objc;
 extern crate cocoa;
 extern crate winit;
-extern crate metal;
+extern crate metal_rs as metal;
 extern crate gfx_core as core;
 extern crate gfx_device_metal as device_metal;
 


### PR DESCRIPTION
Lots of changes to the metal backend to make it actually useable:
* Memory leaks reduced by a lot (no more kernel panics! 🎉 )
* Now available as a feature rather than being awkwardly squished in between getting commented out and being default for OSX
* Lots more missing stuff implemented (Still missing buffer mapping, I have some ideas here though)
* Moved the metal bindings to crates.io, so we wont break previous published versions

Examples that were added:
* Instancing
* Deferred
* Shadow (*fixed*)

A few things that were changed to make room for Metal:
* Deferred example used two `[i8; 2]` types in one of the vertex attribute macros. Metal sees this as two elements with a stride of 2, and a minimum stride of 4 is required, so it got changed to a `[i8; 4]`. **NOTE**: Changed other shaders but haven't compiled DX
* The `Encoder::draw(...)` function previously bound the pipeline state & vertex buffers before render targets, which Metal requires before everything else. Changed so that order is now `Render targets -> PSO -> Rest`. Tested on GL and nothing was broken, haven't checked DX11, unsure about Vulkan.

Let me know if I missed something