### PR TITLE
[GL] bind output "Target{n}" to n if  isn't available

### DIFF
--- a/src/backend/gl/src/shade.rs
+++ b/src/backend/gl/src/shade.rs
@@ -478,6 +478,15 @@ pub fn create_program(gl: &gl::Gl, caps: &c::Capabilities, private: &PrivateCaps
         unsafe { gl.AttachShader(name, sh) };
     }
 
+    if !private.program_interface_supported {
+        for i in 0..c::MAX_COLOR_TARGETS {
+            let color_name = format!("Target{}\0", i);
+            unsafe {
+                gl.BindFragDataLocation(name, i as u32, (&color_name[..]).as_ptr() as *mut gl::types::GLchar);
+            }
+         }
+    }
+
     unsafe { gl.LinkProgram(name) };
     info!("\tLinked program {}", name);
 


### PR DESCRIPTION
Where `n` is in the range of `0..core::MAX_COLOR_TARGETS` (4). Done before linking, safe [even if outputs are not present](https://www.opengl.org/wiki/Fragment_Shader#Output_buffers):
> Note that it is perfectly legal to assign names to fragment colors that are not mentioned in the fragment shader. The linking process will only use the names that are actually mentioned in the fragment shader. Because of that, it is also perfectly legal to assign multiple names to the same number; this is only an error if you attempt to link a program that uses both names.