### PR TITLE
Update sdl2 dependency in gfk_window_sdl

### DIFF
--- a/src/window/sdl/Cargo.toml
+++ b/src/window/sdl/Cargo.toml
@@ -26,6 +26,6 @@ authors = ["The Gfx-rs Developers"]
 name = "gfx_window_sdl"
 
 [dependencies]
-sdl2 = "0.18"
+sdl2 = "0.23"
 gfx_core = { path = "../../core", version = "0.5" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.12" }


### PR DESCRIPTION
`cargo build` and `cargo clippy` still complete without warnings.