### PR TITLE
Implement init_existing and init_existing_raw for gfx_window_glutin

### DIFF
--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.13.0"
+version = "0.13.1"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -54,6 +54,19 @@ where
     (window, device, factory, Typed::new(color_view), Typed::new(ds_view))
 }
 
+/// Initialize with an existing Glutin window.
+/// Generically parametrized version over the main framebuffer format.
+pub fn init_existing<Cf, Df>(window: &glutin::Window) ->
+            (device_gl::Device, device_gl::Factory,
+            handle::RenderTargetView<R, Cf>, handle::DepthStencilView<R, Df>)
+where
+    Cf: format::RenderFormat,
+    Df: format::DepthFormat,
+{
+    let (device, factory, color_view, ds_view) = init_existing_raw(window, Cf::get_format(), Df::get_format());
+    (device, factory, Typed::new(color_view), Typed::new(ds_view))
+}
+
 fn get_window_dimensions(window: &glutin::Window) -> texture::Dimensions {
     let (width, height) = window.get_inner_size().unwrap();
     let aa = window.get_pixel_format().multisampling
@@ -80,16 +93,27 @@ pub fn init_raw(builder: glutin::WindowBuilder,
             .build()
     }.unwrap();
 
+    let (device, factory, color_view, ds_view) = init_existing_raw(&window, color_format, ds_format);
+
+    (window, device, factory, color_view, ds_view)
+}
+
+/// Initialize with an existing Glutin window. Raw version.
+pub fn init_existing_raw(window: &glutin::Window,
+                color_format: format::Format, ds_format: format::Format) ->
+                (device_gl::Device, device_gl::Factory,
+                handle::RawRenderTargetView<R>, handle::RawDepthStencilView<R>)
+{
     unsafe { window.make_current().unwrap() };
     let (device, factory) = device_gl::create(|s|
         window.get_proc_address(s) as *const std::os::raw::c_void);
 
     // create the main color/depth targets
-    let dim = get_window_dimensions(&window);
+    let dim = get_window_dimensions(window);
     let (color_view, ds_view) = device_gl::create_main_targets_raw(dim, color_format.0, ds_format.0);
 
     // done
-    (window, device, factory, color_view, ds_view)
+    (device, factory, color_view, ds_view)
 }
 
 /// Update the internal dimensions of the main framebuffer targets. Generic version over the format.

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -56,6 +56,16 @@ where
 
 /// Initialize with an existing Glutin window.
 /// Generically parametrized version over the main framebuffer format.
+///
+/// # Example (using Piston to create the window)
+///
+/// let settings = piston::window::WindowSettings::new("Example", [800, 600]);
+/// let mut glutin_window = glutin_window::GlutinWindow::new(&settings).unwrap();
+///
+/// let (mut device, mut factory, main_color, main_depth) =
+///     gfx_window_glutin::init_existing::<ColorFormat, DepthFormat>(&glutin_window.window);
+///
+/// let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
 pub fn init_existing<Cf, Df>(window: &glutin::Window) ->
             (device_gl::Device, device_gl::Factory,
             handle::RenderTargetView<R, Cf>, handle::DepthStencilView<R, Df>)


### PR DESCRIPTION
## Rationale

I would like to be able to combine Piston and gfx in a more modular fashion. Currently, there are 2 options to create and initialise a Glutin window with gfx:

1. Use PistonWindow<GlutinWindow>. This creates the window and initialises gfx. The version of gfx is the same one that ships with Piston (potentially outdated).
2. Use gfx_window_glutin. This creates the window and initialises gfx. There is no way to wrap this window in a way Piston understands ([GlutinWindow](https://docs.rs/pistoncore-glutin_window/0.30.0/glutin_window/struct.GlutinWindow.html))

Each library is taking responsibility of creating the window from a builder. I would like to split the responsibility of creating the window, from initialising gfx.

## Implementation

This is a simple overloaded API. Instead of using a passed builder to construct the glutin::Window directly, the window is passed as a parameter. This can be borrowed as no ownership is needed, and therefore it is not returned.

## Safety

What will happen if you try and initialise an existing window multiple times? The existing API creates the window so this is not possible.

## Versioning

I have bumped the minor version in Cargo.toml to 0.13.1. The change should be 100% backwards compatible.