### PR TITLE
A few formatting fixes

### DIFF
--- a/src/render/src/macros/mod.rs
+++ b/src/render/src/macros/mod.rs
@@ -39,13 +39,13 @@ macro_rules! gfx_defines {
     }) => {
         gfx_vertex_struct!($name {$($field:$ty = $e,)+});
     };
-    
+
     (constant $name:ident {
             $( $field:ident : $ty:ty = $e:expr, )+
     }) => {
         gfx_constant_struct!($name {$($field:$ty = $e,)+});
     };
-    
+
     (pipeline $name:ident {
             $( $field:ident : $ty:ty = $e:expr, )+
     }) => {
@@ -60,7 +60,7 @@ macro_rules! gfx_defines {
         }
         gfx_defines!($($tail)+);
     };
-    
+
     ($keyword:ident $name:ident {
             $( $field:ident : $ty:ty = $e:expr ),*
     }) => {

--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -45,7 +45,7 @@ macro_rules! gfx_pipeline_inner {
                 // v#
                 let mut _num_vb = 0;
                 $(
-                     if let Some(d) = meta.$field.link_vertex_buffer(_num_vb, &self.$field) {
+                    if let Some(d) = meta.$field.link_vertex_buffer(_num_vb, &self.$field) {
                         assert!(meta.$field.is_active());
                         desc.vertex_buffers[_num_vb as usize] = Some(d);
                         _num_vb += 1;

--- a/src/render/src/pso/buffer.rs
+++ b/src/render/src/pso/buffer.rs
@@ -35,6 +35,7 @@ type AttributeSlotSet = usize;
 /// Service struct to simplify the implementations of `VertexBuffer` and `InstanceBuffer`.
 pub struct VertexBufferCommon<T, I>(RawVertexBuffer, PhantomData<(T, I)>);
 /// Vertex buffer component. Advanced per vertex.
+///
 /// - init: `()`
 /// - data: `Buffer<T>`
 pub type VertexBuffer<T> = VertexBufferCommon<T, [(); 0]>;
@@ -42,19 +43,23 @@ pub type VertexBuffer<T> = VertexBufferCommon<T, [(); 0]>;
 pub type InstanceBuffer<T> = VertexBufferCommon<T, [(); 1]>;
 /// Raw vertex/instance buffer component. Can be used when the formats of vertex attributes
 /// are not known at compile time.
+///
 /// - init: `(&[&str, element], stride, inst_rate)`
 /// - data: `RawBuffer`
 pub struct RawVertexBuffer(Option<BufferIndex>, AttributeSlotSet);
 /// Constant buffer component.
+///
 /// - init: `&str` = name of the buffer
 /// - data: `Buffer<T>`
 pub struct ConstantBuffer<T: Structure<shade::ConstFormat>>(RawConstantBuffer, PhantomData<T>);
 /// Raw constant buffer component.
+///
 /// - init: `&str` = name of the buffer
 /// - data: `RawBuffer`
 pub struct RawConstantBuffer(Option<(Usage, ConstantBufferSlot)>);
 /// Global (uniform) constant component. Describes a free-standing value passed into
 /// the shader, which is not enclosed into any constant buffer. Deprecated in DX10 and higher.
+///
 /// - init: `&str` = name of the constant
 /// - data: `T` = value
 pub struct Global<T: ToUniform>(Option<shade::Location>, PhantomData<T>);

--- a/src/render/src/pso/resource.rs
+++ b/src/render/src/pso/resource.rs
@@ -23,20 +23,24 @@ use super::{DataLink, DataBind, RawDataSet, AccessInfo};
 
 /// Shader resource component (SRV). Typically is a view into some texture,
 /// but can also be a buffer.
+///
 /// - init: `&str` = name of the resource
 /// - data: `ShaderResourceView<T>`
 pub struct ShaderResource<T>(RawShaderResource, PhantomData<T>);
 /// Raw (untyped) shader resource (SRV).
+///
 /// - init: `&str` = name of the resource. This may change in the future.
 /// - data: `RawShaderResourceView`
 pub struct RawShaderResource(Option<(ResourceViewSlot, shade::Usage)>);
 /// Unordered access component (UAV). A writable resource (texture/buffer)
 /// with no defined access order across simultaneously executing shaders.
 /// Supported on DX10 and higher.
+///
 /// - init: `&str` = name of the resource
 /// - data: `UnorderedAccessView<T>`
 pub struct UnorderedAccess<T>(Option<(UnorderedViewSlot, shade::Usage)>, PhantomData<T>);
 /// Sampler component.
+///
 /// - init: `&str` = name of the sampler
 /// - data: `Sampler`
 pub struct Sampler(Option<(SamplerSlot, shade::Usage)>);
@@ -44,6 +48,7 @@ pub struct Sampler(Option<(SamplerSlot, shade::Usage)>);
 /// It only makes sense for DX9 class hardware, where every texture by default
 /// is bundled with a sampler, hence they are represented by the same name.
 /// In DX10 and higher samplers are totally separated from the textures.
+///
 /// - init: `&str` = name of the sampler/texture (assuming they match)
 /// - data: (`ShaderResourceView<T>`, `Sampler`)
 pub struct TextureSampler<T>(ShaderResource<T>, Sampler);

--- a/src/render/src/pso/target.rs
+++ b/src/render/src/pso/target.rs
@@ -22,34 +22,42 @@ use core::shade::OutputVar;
 use super::{DataLink, DataBind, RawDataSet, AccessInfo};
 
 /// Render target component. Typically points to a color-formatted texture.
+///
 /// - init: `&str` = name of the target
 /// - data: `RenderTargetView<T>`
 pub struct RenderTarget<T>(Option<ColorSlot>, PhantomData<T>);
 /// Render target component with active blending mode.
+///
 /// - init: (`&str`, `ColorMask`, `Blend` = blending state)
 /// - data: `RenderTargetView<T>`
 pub struct BlendTarget<T>(RawRenderTarget, PhantomData<T>);
 /// Raw (untyped) render target component with optional blending.
+///
 /// - init: (`&str`, `Format`, `ColorMask`, `Option<Blend>`)
 /// - data: `RawRenderTargetView`
 pub struct RawRenderTarget(Option<ColorSlot>);
 /// Depth target component.
+///
 /// - init: `Depth` = depth state
 /// - data: `DepthStencilView<T>`
 pub struct DepthTarget<T>(PhantomData<T>);
 /// Stencil target component.
+///
 /// - init: `Stencil` = stencil state
 /// - data: (`DepthStencilView<T>`, `(front, back)` = stencil reference values)
 pub struct StencilTarget<T>(PhantomData<T>);
 /// Depth + stencil target component.
+///
 /// - init: (`Depth` = depth state, `Stencil` = stencil state)
 /// - data: (`DepthStencilView<T>`, `(front, back)` = stencil reference values)
 pub struct DepthStencilTarget<T>(PhantomData<T>);
 /// Scissor component. Sets up the scissor test for rendering.
+///
 /// - init: `()`
 /// - data: `Rect` = target area
 pub struct Scissor(bool);
 /// Blend reference component. Sets up the reference color for blending.
+///
 /// - init: `()`
 /// - data: `ColorValue`
 pub struct BlendRef;


### PR DESCRIPTION
The more important thing here is the first commit, which fixes the documentation formatting. Before:

![bildschirmfoto am 2016-10-09 um 18 17 30](https://cloud.githubusercontent.com/assets/951129/19221905/b66319fa-8e4c-11e6-8952-7ce6d6919938.png)

After:

![bildschirmfoto am 2016-10-09 um 18 17 43](https://cloud.githubusercontent.com/assets/951129/19221907/bb129020-8e4c-11e6-8eb5-8deb2a8e36ce.png)
