### PR TITLE
Enable PROGRAM_POINT_SIZE in OpenGL backend

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -295,6 +295,7 @@ impl Device {
         }
         unsafe {
             gl.PixelStorei(gl::UNPACK_ALIGNMENT, 1);
+            gl.Enable(gl::PROGRAM_POINT_SIZE);
         }
         // create main VAO and bind it
         let mut vao = 0;


### PR DESCRIPTION
This lets the vertex shader write to gl_PointSize, so that point primitives can be rendered as different sizes.

The flag is enabled during initialization of the OpenGL backend.