### PR TITLE
Fix pipeline definition macro

### DIFF
--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -226,9 +226,9 @@ macro_rules! gfx_pipeline_base {
         $( $field:ident: $ty:ty, )*
     }) => {
         pub mod $module {
-            use $crate;
             #[allow(unused_imports)]
             use super::*;
+            use super::gfx;
             gfx_pipeline_inner!{ $(
                 $field: $ty,
             )*}
@@ -242,9 +242,9 @@ macro_rules! gfx_pipeline {
         $( $field:ident: $ty:ty = $value:expr, )*
     }) => {
         pub mod $module {
-            use $crate;
             #[allow(unused_imports)]
             use super::*;
+            use super::gfx;
             gfx_pipeline_inner!{ $(
                 $field: $ty,
             )*}


### PR DESCRIPTION
`use $crate;` is not allowed due to recent restrictions and `use super::*;` won't import the gfx crate. (allowed in future but feature gated https://github.com/rust-lang/rfcs/pull/1560)

Closes #1070 