### PR TITLE
Bump glutin version to from 0.6 to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "gfx_app"
 
 [dependencies]
 env_logger = "0.3"
-glutin = "0.6"
+glutin = "0.7"
 winit = "0.5.1"
 gfx_core = { path = "src/core", version = "0.5" }
 gfx = { path = "src/render", version = "0.13" }

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -26,6 +26,6 @@ authors = ["The Gfx-rs Developers"]
 name = "gfx_window_glutin"
 
 [dependencies]
-glutin = "0.6"
+glutin = "0.7"
 gfx_core = { path = "../../core", version = "0.5" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.12" }


### PR DESCRIPTION
Glutin 0.7 ported the library to Winit, but otherwise appeared to be a drop-in replacement for 0.6.