### PR TITLE
Add missing lifetime bound in DerefMut impl for RWer

### DIFF
--- a/src/core/src/mapping.rs
+++ b/src/core/src/mapping.rs
@@ -202,7 +202,7 @@ impl<'a, R: Resources, T: 'a + Copy> Deref for RWer<'a, R, T> {
     fn deref(&self) -> &[T] { &*self.slice }
 }
 
-impl<'a, R: Resources, T: Copy> DerefMut for RWer<'a, R, T> {
+impl<'a, R: Resources, T: 'a + Copy> DerefMut for RWer<'a, R, T> {
     fn deref_mut(&mut self) -> &mut [T] { self.slice }
 }
 


### PR DESCRIPTION
This isn't caught by the current stable compiler, but to me it looks like it was always wrong (the impl has fewer bounds on T than the struct) and the current nightly compiler errors out without this change.