### PR TITLE
Add attributes to gfx_defines macros

### DIFF
--- a/src/render/src/macros/mod.rs
+++ b/src/render/src/macros/mod.rs
@@ -34,16 +34,16 @@ macro_rules! gfx_format {
 /// Defines vertex, constant and pipeline formats in one block
 #[macro_export]
 macro_rules! gfx_defines {
-    (vertex $name:ident {
+    ($(#[$attr:meta])* vertex $name:ident {
             $( $field:ident : $ty:ty = $e:expr, )+
     }) => {
-        gfx_vertex_struct!($name {$($field:$ty = $e,)+});
+        gfx_vertex_struct_meta!($(#[$attr])* vertex_struct_meta $name {$($field:$ty = $e,)+});
     };
 
-    (constant $name:ident {
+    ($(#[$attr:meta])* constant $name:ident {
             $( $field:ident : $ty:ty = $e:expr, )+
     }) => {
-        gfx_constant_struct!($name {$($field:$ty = $e,)+});
+        gfx_constant_struct_meta!($(#[$attr])* constant_struct_meta $name {$($field:$ty = $e,)+});
     };
 
     (pipeline $name:ident {
@@ -52,6 +52,29 @@ macro_rules! gfx_defines {
         gfx_pipeline!($name {$($field:$ty = $e,)+});
     };
 
+    // The recursive case for vertex structs
+    ($(#[$attr:meta])* vertex $name:ident {
+            $( $field:ident : $ty:ty = $e:expr, )+
+    } $($tail:tt)+) => {
+        gfx_defines! {
+            $(#[$attr])*
+            vertex $name { $($field : $ty = $e,)+ }
+        }
+        gfx_defines!($($tail)+);
+    };
+
+    // The recursive case for constant structs
+    ($(#[$attr:meta])* constant $name:ident {
+            $( $field:ident : $ty:ty = $e:expr, )+
+    } $($tail:tt)+) => {
+        gfx_defines! {
+            $(#[$attr])*
+            constant $name { $($field : $ty = $e,)+ }
+        }
+        gfx_defines!($($tail)+);
+    };
+
+    // The recursive case for the other keywords
     ($keyword:ident $name:ident {
             $( $field:ident : $ty:ty = $e:expr, )+
     } $($tail:tt)+) => {

--- a/src/render/src/macros/structure.rs
+++ b/src/render/src/macros/structure.rs
@@ -18,8 +18,20 @@
 macro_rules! gfx_impl_struct {
     ($runtime_format:ty : $compile_format:path = $root:ident {
         $( $field:ident: $ty:ty = $name:expr, )*
+    }) => (gfx_impl_struct_meta! {
+        impl_struct_meta $runtime_format : $compile_format = $root {
+            $( $field : $ty = $name, )*
+        }
+    })
+}
+
+#[macro_export]
+macro_rules! gfx_impl_struct_meta {
+    ($(#[$attr:meta])* impl_struct_meta $runtime_format:ty : $compile_format:path = $root:ident {
+        $( $field:ident: $ty:ty = $name:expr, )*
     }) => {
         #[derive(Clone, Copy, Debug)]
+        $(#[$attr])*
         pub struct $root {
             $( pub $field: $ty, )*
         }
@@ -66,7 +78,19 @@ macro_rules! gfx_impl_struct {
 macro_rules! gfx_vertex_struct {
     ($root:ident {
         $( $field:ident: $ty:ty = $name:expr, )*
-    }) => (gfx_impl_struct!{
+    }) => (gfx_vertex_struct_meta! {
+        vertex_struct_meta $root {
+            $( $field : $ty = $name, )*
+        }
+    })
+}
+
+#[macro_export]
+macro_rules! gfx_vertex_struct_meta {
+    ($(#[$attr:meta])* vertex_struct_meta $root:ident {
+        $( $field:ident: $ty:ty = $name:expr, )*
+    }) => (gfx_impl_struct_meta!{
+        $(#[$attr])* impl_struct_meta
         $crate::format::Format : $crate::format::Formatted =
         $root {
             $( $field: $ty = $name, )*
@@ -78,7 +102,19 @@ macro_rules! gfx_vertex_struct {
 macro_rules! gfx_constant_struct {
     ($root:ident {
         $( $field:ident: $ty:ty = $name:expr, )*
-    }) => (gfx_impl_struct!{
+    }) => (gfx_constant_struct_meta!{
+        constant_struct_meta $root {
+            $( $field : $ty = $name, )*
+        }
+    })
+}
+
+#[macro_export]
+macro_rules! gfx_constant_struct_meta {
+    ($(#[$attr:meta])* constant_struct_meta $root:ident {
+        $( $field:ident: $ty:ty = $name:expr, )*
+    }) => (gfx_impl_struct_meta!{
+        $(#[$attr])* impl_struct_meta
         $crate::shade::ConstFormat : $crate::shade::Formatted =
         $root {
             $( $field: $ty = $name, )*

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -7,6 +7,7 @@ pub struct Rg16;
 gfx_format!(Rg16: R16_G16 = Vec2<Float>);
 
 gfx_defines!{
+    #[derive(PartialEq)]
     vertex Vertex {
         _x: i8 = "x",
         _y: f32 = "y",
@@ -19,6 +20,10 @@ gfx_defines!{
     
     constant Local {
         pos: [u32; 4] = "pos",
+    }
+    #[derive(PartialEq)] #[derive(PartialOrd)]
+    constant LocalMeta {
+        pos: [u32; 4] = "pos_meta",
     }
     
     pipeline testpipe {


### PR DESCRIPTION
For this commit, it only works on the `vertex` and `constant` structs, and NOT any of their fields.