### PR TITLE
Remove gfx import in pipeline macro

### DIFF
--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -228,7 +228,6 @@ macro_rules! gfx_pipeline_base {
         pub mod $module {
             #[allow(unused_imports)]
             use super::*;
-            use super::gfx;
             gfx_pipeline_inner!{ $(
                 $field: $ty,
             )*}
@@ -244,7 +243,6 @@ macro_rules! gfx_pipeline {
         pub mod $module {
             #[allow(unused_imports)]
             use super::*;
-            use super::gfx;
             gfx_pipeline_inner!{ $(
                 $field: $ty,
             )*}


### PR DESCRIPTION
As RFC 1560 (https://github.com/rust-lang/rfcs/pull/1560) is now stabilized on nightly 1.14.0 `use super::*` will now import all occurences of `use gfx;` from the parent module. This allows to compile code like following:
``` Rust
#[macro_use]
extern crate gfx as gfx_temp;

mod foo {
    // Import `gfx` into this module.
    // The new pipeline module created in the macro has access
    // to this import via `use super::*;`
    use gfx_temp; 

    gfx_defines!{
        vertex Vertex {
            pos: [f32; 4] = "a_Pos",
            tex_coord: [f32; 2] = "a_TexCoord",
        }

        pipeline pipe {
            vbuf: gfx_temp::VertexBuffer<Vertex> = (),
        }
    }
}
```
So as long as the `gfx` module is imported in the module where you define the pipeline everything should work. Following this condition the regression https://github.com/gfx-rs/gfx/issues/1070 would be resolved.