### PR TITLE
[GL] Make sure VAO is binded before calling VertexAttribPointer

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -109,8 +109,9 @@ pub const COLOR_DEFAULT: s::Color = s::Color {
     blend: None,
 };
 
-pub const RESET: [Command; 13] = [
+pub const RESET: [Command; 14] = [
     Command::BindProgram(0),
+    Command::BindVao,
     //Command::UnbindAttribute, //not needed, handled by the cache
     Command::BindIndex(0),
     Command::BindFrameBuffer(gl::FRAMEBUFFER, 0),
@@ -214,7 +215,6 @@ impl command::Buffer<Resources> for CommandBuffer {
     }
 
     fn bind_vertex_buffers(&mut self, vbs: c::pso::VertexBufferSet<Resources>) {
-        self.buf.push(Command::BindVao);
         for i in 0 .. c::MAX_VERTEX_ATTRIBUTES {
             match (vbs.0[i], self.cache.attributes[i]) {
                 (None, Some(fm)) => {

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -77,6 +77,7 @@ pub enum Command {
     BindUnorderedView(c::pso::UnorderedViewParam<Resources>),
     BindSampler(c::pso::SamplerParam<Resources>, Option<gl::types::GLenum>),
     BindPixelTargets(c::pso::PixelTargetSet<Resources>),
+    BindVao,
     BindAttribute(c::AttributeSlot, Buffer, BufferElement),
     UnbindAttribute(c::AttributeSlot),
     BindIndex(Buffer),
@@ -213,6 +214,7 @@ impl command::Buffer<Resources> for CommandBuffer {
     }
 
     fn bind_vertex_buffers(&mut self, vbs: c::pso::VertexBufferSet<Resources>) {
+        self.buf.push(Command::BindVao);
         for i in 0 .. c::MAX_VERTEX_ATTRIBUTES {
             match (vbs.0[i], self.cache.attributes[i]) {
                 (None, Some(fm)) => {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -264,7 +264,7 @@ pub struct Share {
 pub struct Device {
     info: Info,
     share: Rc<Share>,
-    _vao: ArrayBuffer,
+    vao: ArrayBuffer,
     frame_handles: handle::Manager<Resources>,
     max_resource_count: Option<usize>,
 }
@@ -315,7 +315,7 @@ impl Device {
                 private_caps: private,
                 handles: RefCell::new(handles),
             }),
-            _vao: vao,
+            vao: vao,
             frame_handles: handle::Manager::new(),
             max_resource_count: Some(999999),
         }
@@ -544,6 +544,12 @@ impl Device {
                 }
                 if let Some(ref stencil) = pts.stencil {
                     self.bind_target(point, gl::STENCIL_ATTACHMENT, stencil);
+                }
+            },
+            Command::BindVao => {
+                let gl = &self.share.context;
+                unsafe {
+                    gl.BindVertexArray(self.vao);
                 }
             },
             Command::BindAttribute(slot, buffer,  bel) => {


### PR DESCRIPTION
## Rationale:
gfx_device_gl uses single VAO, which is binded once during device initialization. This causes problems when gfx is used with other libraries and middlewares, which can use their own VAO.

## Changes:
This PR adds a command which binds VAO owned by gfx, before binding VBO and calling VertexAttribPointer.