### PR TITLE
App launcher upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ addons:
 script:
   - export RUST_BACKTRACE=1
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo build --features vulkan; else cargo build; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cargo build --features metal; else cargo build; fi
   - cargo test -p gfx_core
   - cargo test -p gfx
   - cargo test -p gfx_device_gl
@@ -48,3 +49,4 @@ script:
   - cargo test -p gfx_window_glfw
   #- cargo test -p gfx_window_sdl
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --features vulkan; cargo test -p gfx_device_vulkan --features vulkan; cargo test -p gfx_window_vulkan --features vulkan; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --features metal; cargo test -p gfx_device_metal --features metal; cargo test -p gfx_window_metal --features metal; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ script:
   - cargo test -p gfx_window_glfw
   #- cargo test -p gfx_window_sdl
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --features vulkan; cargo test -p gfx_device_vulkan --features vulkan; cargo test -p gfx_window_vulkan --features vulkan; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --features metal; cargo test -p gfx_device_metal --features metal; cargo test -p gfx_window_metal --features metal; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cargo test --features metal; cargo test -p gfx_device_metal --features metal; cargo test -p gfx_window_metal --features metal; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_app"
-version = "0.3.0"
+version = "0.4.0"
 description = "GFX example application framework"
 homepage = "https://github.com/gfx-rs/gfx"
 keywords = ["graphics", "gamedev"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ gfx_window_glfw = { path = "src/window/glfw", version = "0.12" }
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.4" }
-gfx_window_dxgi = { path = "src/window/dxgi", version = "0.5" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.6" }
 
 [[example]]
 name = "blend"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "gfx_app"
 
 [dependencies]
 env_logger = "0.3"
-glutin = "0.7"
+glutin = "0.7.1"
 winit = "0.5.1"
 gfx_core = { path = "src/core", version = "0.5" }
 gfx = { path = "src/render", version = "0.13" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ env_logger = "0.3"
 glutin = "0.7.1"
 winit = "0.5.1"
 gfx_core = { path = "src/core", version = "0.5" }
-gfx = { path = "src/render", version = "0.13" }
+gfx = { path = "src/render", version = "0.13.1" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.12" }
 gfx_window_glutin = { path = "src/window/glutin", version = "0.13" }
 

--- a/examples/blend/main.rs
+++ b/examples/blend/main.rs
@@ -16,6 +16,7 @@
 extern crate gfx;
 extern crate gfx_app;
 extern crate image;
+extern crate winit;
 
 pub use gfx_app::ColorFormat;
 pub use gfx::format::{Rgba8, DepthStencil};
@@ -141,24 +142,33 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
         }
     }
 
-    //fn update() {
-    // glutin::Event::KeyboardInput(glutin::ElementState::Pressed, _, Some(glutin::VirtualKeyCode::B)) => {
-    //                let blend_func = blends_cycle.next().unwrap();
-    //                println!("Using '{}' blend equation", blend_func.1);
-    //                data.blend = blend_func.0;
-    //            },
-    //
-    //}
-
     fn render<C: gfx::CommandBuffer<R>>(&mut self, encoder: &mut gfx::Encoder<R, C>) {
+        self.bundle.data.blend = (self.id as i32).into();
         let locals = Locals { blend: self.id as i32 };
         encoder.update_constant_buffer(&self.bundle.data.locals, &locals);
         encoder.clear(&self.bundle.data.out, [0.0; 4]);
         self.bundle.encode(encoder);
     }
+
+    fn on(&mut self, event: winit::Event) -> bool {
+        match event {
+            winit::Event::KeyboardInput(_, _, Some(winit::VirtualKeyCode::Escape)) |
+            winit::Event::Closed => false,
+            winit::Event::KeyboardInput(winit::ElementState::Pressed, _, Some(winit::VirtualKeyCode::B)) => {
+                self.id += 1;
+                if self.id as usize >= BLENDS.len() {
+                    self.id = 0;
+                }
+                println!("Using '{}' blend equation", BLENDS[self.id as usize]);
+                true
+            },
+            _ => true
+        }
+    }
 }
 
 pub fn main() {
     use gfx_app::Application;
-    App::launch_default("Blending example");
+    let wb = winit::WindowBuilder::new().with_title("Blending example");
+    App::launch_default(wb);
 }

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -176,5 +176,5 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
 pub fn main() {
     use gfx_app::Application;
-    App::launch_default("Cube example");
+    App::launch_simple("Cube example");
 }

--- a/examples/flowmap/main.rs
+++ b/examples/flowmap/main.rs
@@ -161,5 +161,5 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
 pub fn main() {
     use gfx_app::Application;
-    App::launch_default("Flowmap example");
+    App::launch_simple("Flowmap example");
 }

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -152,7 +152,5 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
 pub fn main() {
     use gfx_app::Application;
-    //use gfx_app::ApplicationGL2;
-    //gfx_app::WrapGL2::<App<_>>::launch("Instancing example", gfx_app::DEFAULT_CONFIG);
-    App::launch_default("Instancing example");
+    App::launch_simple("Instancing example");
 }

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -127,5 +127,5 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
 pub fn main() {
     use gfx_app::Application;
-    App::launch_default("Mipmap example");
+    App::launch_simple("Mipmap example");
 }

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -186,8 +186,6 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 }
 
 pub fn main() {
-    //use gfx_app::{Application, ApplicationGL, DEFAULT_CONFIG, WrapGL2};
-    //WrapGL2::<App<_>>::launch("Particle example", DEFAULT_CONFIG);
     use gfx_app::Application;
-    App::launch_default("Particle example");
+    App::launch_simple("Particle example");
 }

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -16,6 +16,7 @@ extern crate cgmath;
 #[macro_use]
 extern crate gfx;
 extern crate gfx_app;
+extern crate winit;
 
 use std::sync::{Arc, RwLock};
 pub use gfx::format::{DepthStencil};
@@ -613,13 +614,21 @@ impl<R, C> gfx_app::ApplicationBase<R, C> for App<R, C> where
 
         self.encoder.flush(device);
     }
+
+    fn on(&mut self, event: winit::Event) -> bool {
+        match event {
+            winit::Event::KeyboardInput(_, _, Some(winit::VirtualKeyCode::Escape)) |
+            winit::Event::Closed => false,
+            _ => true
+        }
+    }
 }
 
 //----------------------------------------
 // Section-6: main entry point
 
 pub fn main() {
-    <App<_, _> as gfx_app::ApplicationGL>::launch(
-        "Multi-threaded shadow rendering example with gfx-rs",
-        gfx_app::DEFAULT_CONFIG);
+    let wb = winit::WindowBuilder::new().with_title(
+        "Multi-threaded shadow rendering example with gfx-rs");
+    gfx_app::launch_gl3::<App<_, _>>(wb);
 }

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -170,5 +170,5 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
 pub fn main() {
     use gfx_app::Application;
-    App::launch_default("Skybox example");
+    App::launch_simple("Skybox example");
 }

--- a/examples/terrain/main.rs
+++ b/examples/terrain/main.rs
@@ -165,5 +165,5 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
 pub fn main() {
     use gfx_app::Application;
-    App::launch_default(winit::WindowBuilder::new().with_title("Terrain example"));
+    App::launch_simple("Terrain example");
 }

--- a/examples/terrain/main.rs
+++ b/examples/terrain/main.rs
@@ -19,6 +19,7 @@ extern crate gfx_app;
 extern crate rand;
 extern crate genmesh;
 extern crate noise;
+extern crate winit;
 
 use rand::Rng;
 use cgmath::{SquareMatrix, Matrix4, Point3, Vector3};
@@ -164,5 +165,5 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
 pub fn main() {
     use gfx_app::Application;
-    App::launch_default("Terrain example");
+    App::launch_default(winit::WindowBuilder::new().with_title("Terrain example"));
 }

--- a/examples/terrain_tessellated/main.rs
+++ b/examples/terrain_tessellated/main.rs
@@ -180,5 +180,5 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
 
 pub fn main() {
     use gfx_app::Application;
-    App::launch_default("Terrain example");
+    App::launch_simple("Terrain tessellation example");
 }

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -28,7 +28,7 @@ name = "gfx_device_metal"
 [dependencies]
 log = "0.3"
 gfx_core = { path = "../../core", version = "0.5" }
-cocoa = "0.5.0"
+cocoa = "0.2.5"
 libc = "0.2"
 objc = "0.1.8"
 objc-foundation = "0.1"

--- a/src/backend/metal/src/factory.rs
+++ b/src/backend/metal/src/factory.rs
@@ -39,6 +39,9 @@ pub struct RawMapping {
     pointer: *mut c_void,
 }
 
+unsafe impl Send for RawMapping {}
+unsafe impl Sync for RawMapping {}
+
 impl mapping::Gate<Resources> for RawMapping {
     unsafe fn set<T>(&self, index: usize, val: T) {
         *(self.pointer as *mut T).offset(index as isize) = val;

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -217,7 +217,7 @@ impl core::Device for Device {
         unimplemented!()
     }
 
-    fn wait_fence(&mut self, fence: &h::Fence<Self::Resources>) {
+    fn wait_fence(&mut self, fence: &handle::Fence<Self::Resources>) {
         unimplemented!()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,12 +180,9 @@ Wrap<gfx_device_gl::Resources, gfx_device_gl::CommandBuffer, A> {
 
         let mut harness = Harness::new();
         'main: loop {
-            // quit when Esc is pressed.
             for event in window.poll_events() {
-                match event {
-                    glutin::Event::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape)) |
-                    glutin::Event::Closed => break 'main,
-                    _ => {}
+                if !app.on(event) {
+                    break 'main
                 }
             }
             // draw a frame

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,15 +91,206 @@ pub trait Factory<R: gfx::Resources>: gfx::Factory<R> {
     fn create_encoder(&mut self) -> gfx::Encoder<R, Self::CommandBuffer>;
 }
 
-
 pub trait ApplicationBase<R: gfx::Resources, C: gfx::CommandBuffer<R>> {
     fn new<F>(F, Init<R>) -> Self where F: Factory<R, CommandBuffer = C>;
     fn render<D>(&mut self, &mut D) where D: gfx::Device<Resources = R, CommandBuffer = C>;
     fn on(&mut self, winit::Event) -> bool;
 }
 
+
+impl Factory<gfx_device_gl::Resources> for gfx_device_gl::Factory {
+    type CommandBuffer = gfx_device_gl::CommandBuffer;
+    fn create_encoder(&mut self) -> gfx::Encoder<gfx_device_gl::Resources, Self::CommandBuffer> {
+        self.create_command_buffer().into()
+    }
+}
+
+pub fn launch_gl3<A>(wb: winit::WindowBuilder) where
+A: Sized + ApplicationBase<gfx_device_gl::Resources, gfx_device_gl::CommandBuffer>
+{
+    use gfx::traits::Device;
+
+    env_logger::init().unwrap();
+    let gl_version = glutin::GlRequest::GlThenGles {
+        opengl_version: (3, 2), // TODO: try more versions
+        opengles_version: (2, 0),
+    };
+    let builder = glutin::WindowBuilder::from_winit_builder(wb)
+                                        .with_gl(gl_version)
+                                        .with_vsync();
+    let (window, mut device, factory, main_color, main_depth) =
+        gfx_window_glutin::init::<ColorFormat, DepthFormat>(builder);
+    let (width, height) = window.get_inner_size().unwrap();
+    let shade_lang = device.get_info().shading_language;
+
+    let init = Init {
+        backend: if shade_lang.is_embedded {
+            shade::Backend::GlslEs(shade_lang)
+        } else {
+            shade::Backend::Glsl(shade_lang)
+        },
+        color: main_color,
+        depth: main_depth,
+        aspect_ratio: width as f32 / height as f32,
+    };
+    let mut app = A::new(factory, init);
+
+    let mut harness = Harness::new();
+    loop {
+        for event in window.poll_events() {
+            if !app.on(event) {
+                return
+            }
+        }
+        // draw a frame
+        app.render(&mut device);
+        window.swap_buffers().unwrap();
+        device.cleanup();
+        harness.bump();
+    }
+}
+
+
+#[cfg(target_os = "windows")]
+pub type D3D11CommandBuffer = gfx_device_dx11::CommandBuffer<gfx_device_dx11::DeferredContext>;
+#[cfg(target_os = "windows")]
+pub type D3D11CommandBufferFake = gfx_device_dx11::CommandBuffer<gfx_device_dx11::CommandList>;
+
+#[cfg(target_os = "windows")]
+impl Factory<gfx_device_dx11::Resources> for gfx_device_dx11::Factory {
+    type CommandBuffer = D3D11CommandBuffer;
+    fn create_encoder(&mut self) -> gfx::Encoder<gfx_device_dx11::Resources, Self::CommandBuffer> {
+        self.create_command_buffer_native().into()
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub fn launch_d3d11<A>(wb: winit::WindowBuilder) where
+A: Sized + ApplicationBase<gfx_device_dx11::Resources, D3D11CommandBuffer>
+{
+    use gfx::traits::{Device, Factory};
+
+    env_logger::init().unwrap();
+    let (window, device, mut factory, main_color) =
+        gfx_window_dxgi::init::<ColorFormat>(wb).unwrap();
+    let main_depth = factory.create_depth_stencil_view_only(window.size.0, window.size.1)
+                            .unwrap();
+
+    let mut app = Self::new(factory,
+                            Init {
+                                backend: shade::Backend::Hlsl(device.get_shader_model()),
+                                color: main_color,
+                                depth: main_depth,
+                                aspect_ratio: window.size.0 as f32 / window.size.1 as f32,
+                            });
+    let mut device = gfx_device_dx11::Deferred::from(device);
+
+    let mut harness = Harness::new();
+    loop {
+        for event in window.poll_events() {
+            if !app.on(event) {
+                return
+            }
+        }
+        app.render(&mut device);
+        window.swap_buffers(1);
+        device.cleanup();
+        harness.bump();
+    }
+}
+
+
+#[cfg(feature = "metal")]
+impl Factory<gfx_device_metal::Resources> for gfx_device_metal::Factory {
+    type CommandBuffer = gfx_device_metal::CommandBuffer;
+    fn create_encoder(&mut self) -> gfx::Encoder<gfx_device_metal::Resources, Self::CommandBuffer> {
+        self.create_command_buffer().into()
+    }
+}
+
+#[cfg(feature = "metal")]
+pub fn launch_metal<A>(wb: winit::WindowBuilder) where
+A: Sized + ApplicationBase<gfx_device_metal::Resources, gfx_device_metal::CommandBuffer>
+{
+    use gfx::traits::{Device, Factory};
+
+    env_logger::init().unwrap();
+    let (window, mut device, mut factory, main_color) = gfx_window_metal::init::<ColorFormat>(wb)
+                                                                                .unwrap();
+    let (width, height) = window.get_inner_size().unwrap();
+    let main_depth = factory.create_depth_stencil_view_only(width as u16, height as u16).unwrap();
+
+    let mut app = Self::new(factory, Init {
+        backend: shade::Backend::Msl(device.get_shader_model()),
+        color: main_color,
+        depth: main_depth,
+        aspect_ratio: width as f32 / height as f32
+    });
+
+    let mut harness = Harness::new();
+    loop {
+        for event in window.poll_events() {
+            if !app.on(event) {
+                return
+            }
+        }
+        app.render(&mut device);
+        window.swap_buffers().unwrap();
+        device.cleanup();
+        harness.bump();
+    }
+}
+
+
+#[cfg(feature = "vulkan")]
+impl Factory<gfx_device_vulkan::Resources> for gfx_device_vulkan::Factory {
+    type CommandBuffer = gfx_device_vulkan::CommandBuffer;
+    fn create_encoder(&mut self) -> gfx::Encoder<gfx_device_vulkan::Resources, Self::CommandBuffer> {
+        self.create_command_buffer().into()
+    }
+}
+
+#[cfg(feature = "vulkan")]
+pub fn launch_vulkan<A>(wb: winit::WindowBuilder) where
+A: Sized + ApplicationBase<gfx_device_vulkan::Resources, gfx_device_vulkan::CommandBuffer>
+{
+    use gfx::traits::{Device, Factory};
+
+    env_logger::init().unwrap();
+    let (mut win, mut factory) = gfx_window_vulkan::init::<ColorFormat>(wb);
+    let (width, height) = win.get_size();
+    let main_depth = factory.create_depth_stencil::<DepthFormat>(width, height).unwrap();
+
+    let mut app = Self::new(factory, Init {
+        backend: shade::Backend::Vulkan,
+        color: win.get_any_target(),
+        depth: main_depth.2,
+        aspect_ratio: width as f32 / height as f32, //TODO
+    });
+
+    let mut harness = Harness::new();
+    loop {
+        for event in window.poll_events() {
+            if !app.on(event) {
+                return
+            }
+        }
+        let mut frame = win.start_frame();
+        app.render(frame.get_queue());
+        frame.get_queue().cleanup();
+        harness.bump();
+    }
+}
+
+
 #[cfg(all(not(target_os = "windows"), not(feature = "vulkan"), not(feature = "metal")))]
 pub type DefaultResources = gfx_device_gl::Resources;
+#[cfg(all(target_os = "windows", not(feature = "vulkan")))]
+pub type DefaultResources = gfx_device_dx11::Resources;
+#[cfg(feature = "metal")]
+pub type DefaultResources = gfx_device_metal::Resources;
+#[cfg(feature = "vulkan")]
+pub type DefaultResources = gfx_device_vulkan::Resources;
 
 pub trait Application<R: gfx::Resources>: Sized {
     fn new<F: gfx::Factory<R>>(F, Init<R>) -> Self;
@@ -116,21 +307,21 @@ pub trait Application<R: gfx::Resources>: Sized {
         let wb = winit::WindowBuilder::new().with_title(name);
         <Self as Application<DefaultResources>>::launch_default(wb)
     }
-    #[cfg(all(target_os = "windows", not(feature = "vulkan")))]
-    fn launch_default(wb: winit::WindowBuilder) where WrapD3D11<Self>: ApplicationD3D11 {
-        WrapD3D11::<Self>::launch_d3d11(wb);
-    }
     #[cfg(all(not(target_os = "windows"), not(feature = "vulkan"), not(feature = "metal")))]
-    fn launch_default(wb: winit::WindowBuilder) where Self: Application<gfx_device_gl::Resources> {
-        Wrap::<_, _, Self>::launch_gl3(wb);
+    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultResources> {
+        launch_gl3::<Wrap<_, _, Self>>(wb);
+    }
+    #[cfg(all(target_os = "windows", not(feature = "vulkan")))]
+    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultResources> {
+        launch_d3d11::<Wrap<_, _, Self>>(wb);
     }
     #[cfg(feature = "metal")]
-    fn launch_default(wb: winit::WindowBuilder) where WrapMetal<Self>: ApplicationMetal {
-        WrapMetal::<Self>::launch_metal(wb)
+    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultResources> {
+        launch_metal::<Wrap<_, _, Self>>(wb);
     }
     #[cfg(feature = "vulkan")]
-    fn launch_default(wb: winit::WindowBuilder) where WrapVulkan<Self>: ApplicationVulkan {
-        WrapVulkan::<Self>::launch_vulkan(wb);
+    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultResources> {
+        launch_vulkan::<Wrap<_, _, Self>>(wb);
     }
 }
 
@@ -138,64 +329,6 @@ pub struct Wrap<R: gfx::Resources, C, A> {
     encoder: gfx::Encoder<R, C>,
     app: A,
 }
-
-#[cfg(feature = "metal")]
-pub type WrapMetal<A> = Wrap<gfx_device_metal::Resources, gfx_device_metal::CommandBuffer, A>;
-#[cfg(target_os = "windows")]
-pub type D3D11CommandBuffer = gfx_device_dx11::CommandBuffer<gfx_device_dx11::DeferredContext>;
-#[cfg(target_os = "windows")]
-pub type D3D11CommandBufferFake = gfx_device_dx11::CommandBuffer<gfx_device_dx11::CommandList>;
-#[cfg(target_os = "windows")]
-pub type WrapD3D11<A> = Wrap<gfx_device_dx11::Resources, D3D11CommandBuffer, A>;
-
-impl<A: Application<gfx_device_gl::Resources>>
-Wrap<gfx_device_gl::Resources, gfx_device_gl::CommandBuffer, A> {
-    pub fn launch_gl3(wb: winit::WindowBuilder) {
-        use gfx::traits::Device;
-
-        env_logger::init().unwrap();
-        let gl_version = glutin::GlRequest::GlThenGles {
-            opengl_version: (3, 2), // TODO: try more versions
-            opengles_version: (2, 0),
-        };
-        let builder = glutin::WindowBuilder::from_winit_builder(wb)
-                                            .with_gl(gl_version)
-                                            .with_vsync();
-        let (window, mut device, factory, main_color, main_depth) =
-            gfx_window_glutin::init::<ColorFormat, DepthFormat>(builder);
-        let (width, height) = window.get_inner_size().unwrap();
-        let shade_lang = device.get_info().shading_language;
-
-        let init = Init {
-            backend: if shade_lang.is_embedded {
-                shade::Backend::GlslEs(shade_lang)
-            } else {
-                shade::Backend::Glsl(shade_lang)
-            },
-            color: main_color,
-            depth: main_depth,
-            aspect_ratio: width as f32 / height as f32,
-        };
-        let mut app = Self::new(factory, init);
-
-        let mut harness = Harness::new();
-        'main: loop {
-            for event in window.poll_events() {
-                if !app.on(event) {
-                    break 'main
-                }
-            }
-            // draw a frame
-            app.render(&mut device);
-            window.swap_buffers().unwrap();
-            device.cleanup();
-            harness.bump();
-        }
-    }
-}
-
-#[cfg(feature = "vulkan")]
-pub type WrapVulkan<A> = Wrap<gfx_device_vulkan::Resources, gfx_device_vulkan::CommandBuffer, A>;
 
 impl<R, C, A> ApplicationBase<R, C> for Wrap<R, C, A>
     where R: gfx::Resources,
@@ -220,169 +353,5 @@ impl<R, C, A> ApplicationBase<R, C> for Wrap<R, C, A>
 
     fn on(&mut self, event: winit::Event) -> bool {
         self.app.on(event)
-    }
-}
-
-impl Factory<gfx_device_gl::Resources> for gfx_device_gl::Factory {
-    type CommandBuffer = gfx_device_gl::CommandBuffer;
-    fn create_encoder(&mut self) -> gfx::Encoder<gfx_device_gl::Resources, Self::CommandBuffer> {
-        self.create_command_buffer().into()
-    }
-}
-
-#[cfg(target_os = "windows")]
-pub trait ApplicationD3D11 {
-    fn launch_d3d11(winit::WindowBuilder);
-}
-
-#[cfg(target_os = "windows")]
-impl Factory<gfx_device_dx11::Resources> for gfx_device_dx11::Factory {
-    type CommandBuffer = D3D11CommandBuffer;
-    fn create_encoder(&mut self) -> gfx::Encoder<gfx_device_dx11::Resources, Self::CommandBuffer> {
-        self.create_command_buffer_native().into()
-    }
-}
-
-#[cfg(target_os = "windows")]
-impl<A: ApplicationBase<gfx_device_dx11::Resources, D3D11CommandBuffer>> ApplicationD3D11 for A {
-    fn launch_d3d11(wb: winit::WindowBuilder) {
-        use gfx::traits::{Device, Factory};
-
-        env_logger::init().unwrap();
-        let (window, device, mut factory, main_color) =
-            gfx_window_dxgi::init::<ColorFormat>(wb).unwrap();
-        let main_depth = factory.create_depth_stencil_view_only(window.size.0, window.size.1)
-            .unwrap();
-
-        let mut app = Self::new(factory,
-                                Init {
-                                    backend: shade::Backend::Hlsl(device.get_shader_model()),
-                                    color: main_color,
-                                    depth: main_depth,
-                                    aspect_ratio: window.size.0 as f32 / window.size.1 as f32,
-                                });
-        let mut device: gfx_device_dx11::Deferred = device.into();
-
-        let mut harness = Harness::new();
-        'main: loop {
-            // quit when Esc is pressed.
-            for event in window.poll_events() {
-                match event {
-                    winit::Event::KeyboardInput(_, _, Some(winit::VirtualKeyCode::Escape)) |
-                    winit::Event::Closed => break 'main,
-                    _ => {}
-                }
-            }
-            // draw a frame
-            app.render(&mut device);
-            window.swap_buffers(1);
-            device.cleanup();
-            harness.bump();
-        }
-    }
-}
-
-
-#[cfg(feature = "metal")]
-pub trait ApplicationMetal {
-    fn launch_metal(winit::WindowBuilder);
-}
-
-#[cfg(feature = "metal")]
-impl Factory<gfx_device_metal::Resources> for gfx_device_metal::Factory {
-    type CommandBuffer = gfx_device_metal::CommandBuffer;
-    fn create_encoder(&mut self) -> gfx::Encoder<gfx_device_metal::Resources, Self::CommandBuffer> {
-        self.create_command_buffer().into()
-    }
-}
-
-#[cfg(feature = "metal")]
-impl<
-    A: ApplicationBase<gfx_device_metal::Resources, gfx_device_metal::CommandBuffer>
-> ApplicationMetal for A {
-    fn launch_metal(wb: winit::WindowBuilder) {
-        use gfx::traits::{Device, Factory};
-
-        env_logger::init().unwrap();
-        let (window, mut device, mut factory, main_color) = gfx_window_metal::init::<ColorFormat>(wb)
-                                                                                   .unwrap();
-
-        let (width, height) = window.get_inner_size().unwrap();
-
-        let main_depth = factory.create_depth_stencil_view_only(width as u16, height as u16).unwrap();
-
-        let mut app = Self::new(factory, Init {
-            backend: shade::Backend::Msl(device.get_shader_model()),
-            color: main_color,
-            depth: main_depth,
-            aspect_ratio: width as f32 / height as f32
-        });
-
-        let mut harness = Harness::new();
-        'main: loop {
-            for event in window.poll_events() {
-                match event {
-                    winit::Event::KeyboardInput(_, _, Some(winit::VirtualKeyCode::Escape)) |
-                    winit::Event::Closed => break 'main,
-                    _ => {},
-                }
-            }
-
-            app.render(&mut device);
-            window.swap_buffers().unwrap();
-            device.cleanup();
-            harness.bump();
-        }
-    }
-}
-
-
-#[cfg(feature = "vulkan")]
-pub trait ApplicationVulkan {
-    fn launch_vulkan(winit::WindowBuilder);
-}
-
-#[cfg(feature = "vulkan")]
-impl Factory<gfx_device_vulkan::Resources> for gfx_device_vulkan::Factory {
-    type CommandBuffer = gfx_device_vulkan::CommandBuffer;
-    fn create_encoder(&mut self) -> gfx::Encoder<gfx_device_vulkan::Resources, Self::CommandBuffer> {
-        self.create_command_buffer().into()
-    }
-}
-
-#[cfg(feature = "vulkan")]
-impl<
-    A: ApplicationBase<gfx_device_vulkan::Resources, gfx_device_vulkan::CommandBuffer>
-> ApplicationVulkan for A {
-    fn launch(wb: winit::WindowBuilder) {
-        use gfx::traits::{Device, Factory};
-
-        env_logger::init().unwrap();
-        let (mut win, mut factory) = gfx_window_vulkan::init::<ColorFormat>(wb);
-        let (width, height) = win.get_size();
-        let main_depth = factory.create_depth_stencil::<DepthFormat>(width, height).unwrap();
-
-        let mut app = Self::new(factory, Init {
-            backend: shade::Backend::Vulkan,
-            color: win.get_any_target(),
-            depth: main_depth.2,
-            aspect_ratio: width as f32 / height as f32, //TODO
-        });
-
-        let mut harness = Harness::new();
-        'main: loop {
-            for event in win.get_window().poll_events() {
-                match event {
-                    winit::Event::KeyboardInput(_, _, Some(winit::VirtualKeyCode::Escape)) |
-                    winit::Event::Closed => break 'main,
-                    _ => {},
-                }
-            }
-
-            let mut frame = win.start_frame();
-            app.render(frame.get_queue());
-            frame.get_queue().cleanup();
-            harness.bump();
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ A: Sized + ApplicationBase<gfx_device_gl::Resources, gfx_device_gl::CommandBuffe
     let (width, height) = window.get_inner_size_points().unwrap();
     let shade_lang = device.get_info().shading_language;
 
-    let init = Init {
+    let mut app = A::new(factory, Init {
         backend: if shade_lang.is_embedded {
             shade::Backend::GlslEs(shade_lang)
         } else {
@@ -132,8 +132,7 @@ A: Sized + ApplicationBase<gfx_device_gl::Resources, gfx_device_gl::CommandBuffe
         color: main_color,
         depth: main_depth,
         aspect_ratio: width as f32 / height as f32,
-    };
-    let mut app = A::new(factory, init);
+    });
 
     let mut harness = Harness::new();
     loop {
@@ -176,13 +175,12 @@ A: Sized + ApplicationBase<gfx_device_dx11::Resources, D3D11CommandBuffer>
     let main_depth = factory.create_depth_stencil_view_only(window.size.0, window.size.1)
                             .unwrap();
 
-    let mut app = Self::new(factory,
-                            Init {
-                                backend: shade::Backend::Hlsl(device.get_shader_model()),
-                                color: main_color,
-                                depth: main_depth,
-                                aspect_ratio: window.size.0 as f32 / window.size.1 as f32,
-                            });
+    let mut app = A::new(factory, Init {
+        backend: shade::Backend::Hlsl(device.get_shader_model()),
+        color: main_color,
+        depth: main_depth,
+        aspect_ratio: window.size.0 as f32 / window.size.1 as f32,
+    });
     let mut device = gfx_device_dx11::Deferred::from(device);
 
     let mut harness = Harness::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ A: Sized + ApplicationBase<gfx_device_gl::Resources, gfx_device_gl::CommandBuffe
                                         .with_vsync();
     let (window, mut device, factory, main_color, main_depth) =
         gfx_window_glutin::init::<ColorFormat, DepthFormat>(builder);
-    let (width, height) = window.get_inner_size().unwrap();
+    let (width, height) = window.get_inner_size_points().unwrap();
     let shade_lang = device.get_info().shading_language;
 
     let init = Init {
@@ -213,14 +213,15 @@ pub fn launch_metal<A>(wb: winit::WindowBuilder) where
 A: Sized + ApplicationBase<gfx_device_metal::Resources, gfx_device_metal::CommandBuffer>
 {
     use gfx::traits::{Device, Factory};
+    use gfx::texture::Size;
 
     env_logger::init().unwrap();
     let (window, mut device, mut factory, main_color) = gfx_window_metal::init::<ColorFormat>(wb)
                                                                                 .unwrap();
-    let (width, height) = window.get_inner_size().unwrap();
-    let main_depth = factory.create_depth_stencil_view_only(width as u16, height as u16).unwrap();
+    let (width, height) = window.get_inner_size_points().unwrap();
+    let main_depth = factory.create_depth_stencil_view_only(width as Size, height as Size).unwrap();
 
-    let mut app = Self::new(factory, Init {
+    let mut app = A::new(factory, Init {
         backend: shade::Backend::Msl(device.get_shader_model()),
         color: main_color,
         depth: main_depth,
@@ -255,13 +256,14 @@ pub fn launch_vulkan<A>(wb: winit::WindowBuilder) where
 A: Sized + ApplicationBase<gfx_device_vulkan::Resources, gfx_device_vulkan::CommandBuffer>
 {
     use gfx::traits::{Device, Factory};
+    use gfx::texture::Size;
 
     env_logger::init().unwrap();
     let (mut win, mut factory) = gfx_window_vulkan::init::<ColorFormat>(wb);
     let (width, height) = win.get_size();
-    let main_depth = factory.create_depth_stencil::<DepthFormat>(width, height).unwrap();
+    let main_depth = factory.create_depth_stencil::<DepthFormat>(width as Size, height as Size).unwrap();
 
-    let mut app = Self::new(factory, Init {
+    let mut app = A::new(factory, Init {
         backend: shade::Backend::Vulkan,
         color: win.get_any_target(),
         depth: main_depth.2,
@@ -270,7 +272,7 @@ A: Sized + ApplicationBase<gfx_device_vulkan::Resources, gfx_device_vulkan::Comm
 
     let mut harness = Harness::new();
     loop {
-        for event in window.poll_events() {
+        for event in win.get_window().poll_events() {
             if !app.on(event) {
                 return
             }

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.13.0"
+version = "0.13.1"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -79,14 +79,14 @@ impl<T: Any + fmt::Debug + fmt::Display> Error for UpdateError<T> {
 ///
 /// The encoder exposes multiple functions that add commands to its internal `CommandBuffer`. To 
 /// submit these commands to the GPU so they can be rendered, call `flush`. 
-pub struct Encoder<R: Resources, C: command::Buffer<R>> {
+pub struct Encoder<R: Resources, C> {
     command_buffer: C,
     raw_pso_data: pso::RawDataSet<R>,
     access_info: pso::AccessInfo<R>,
     handles: handle::Manager<R>,
 }
 
-impl<R: Resources, C: command::Buffer<R>> From<C> for Encoder<R, C> {
+impl<R: Resources, C> From<C> for Encoder<R, C> {
     fn from(combuf: C) -> Encoder<R, C> {
         Encoder {
             command_buffer: combuf,

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.5.0"
+version = "0.6.0"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -60,24 +60,18 @@ pub enum InitError {
 }
 
 /// Initialize with a given size. Typed format version.
-pub fn init<Cf>(title: &str, requested_width: u16, requested_height: u16)
+pub fn init<Cf>(wb: winit::WindowBuilder)
            -> Result<(Window, Device, Factory, core::handle::RenderTargetView<Resources, Cf>), InitError>
 where Cf: format::RenderFormat
 {
-    init_raw(title, requested_width as winapi::INT, requested_height as winapi::INT, Cf::get_format())
+    init_raw(wb, Cf::get_format())
         .map(|(window, device, factory, color)| (window, device, factory, Typed::new(color)))
 }
 
 /// Initialize with a given size. Raw format version.
-pub fn init_raw(title: &str, requested_width: winapi::INT, requested_height: winapi::INT, color_format: format::Format)
+pub fn init_raw(wb: winit::WindowBuilder, color_format: format::Format)
                 -> Result<(Window, Device, Factory, core::handle::RawRenderTargetView<Resources>), InitError> {
-    let inner = match winit::WindowBuilder::new()
-        .with_title(title.to_owned())
-        .with_dimensions(requested_width as u32, requested_height as u32)
-        .with_min_dimensions(requested_width as u32, requested_height as u32)
-        .with_max_dimensions(requested_width as u32, requested_height as u32)
-        .build()
-    {
+    let inner = match wb.build() {
         Ok(w) => w,
         Err(_) => return Err(InitError::Window),
     };

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -29,7 +29,7 @@ name = "gfx_window_metal"
 log = "0.3"
 cocoa = "0.5.0"
 objc = "0.1.8"
-winit = "0.5.1"
+winit = "0.5"
 metal-rs = "0.1"
 gfx_core = { path = "../../core", version = "0.5" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.1" }

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -27,7 +27,7 @@ name = "gfx_window_metal"
 
 [dependencies]
 log = "0.3"
-cocoa = "0.5.0"
+cocoa = "0.2.5"
 objc = "0.1.8"
 winit = "0.5"
 metal-rs = "0.1"

--- a/src/window/metal/src/lib.rs
+++ b/src/window/metal/src/lib.rs
@@ -95,22 +95,20 @@ pub enum InitError {
     DriverType,
 }
 
-pub fn init<C: RenderFormat>(title: &str, requested_width: u32, requested_height: u32)
+pub fn init<C: RenderFormat>(wb: winit::WindowBuilder)
         -> Result<(MetalWindow, Device, Factory, RenderTargetView<Resources, C>), InitError>
 {
-    init_raw(title, requested_width, requested_height, C::get_format())
+    init_raw(wb, C::get_format())
         .map(|(window, device, factory, color)| (window, device, factory, Typed::new(color)))
 }
 
 /// Initialize with a given size. Raw format version.
-pub fn init_raw(title: &str, requested_width: u32, requested_height: u32, color_format: Format)
+pub fn init_raw(wb: winit::WindowBuilder, color_format: Format)
         -> Result<(MetalWindow, Device, Factory, RawRenderTargetView<Resources>), InitError>
 {
     use device_metal::map_format;
 
-    let winit_window = winit::WindowBuilder::new()
-        .with_dimensions(requested_width, requested_height)
-        .with_title(title.to_string()).build().unwrap();
+    let winit_window = wb.build().unwrap();
 
     unsafe {
         let wnd: cocoa_id = mem::transmute(winit_window.get_nswindow());

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -104,6 +104,10 @@ impl<T: Clone> Window<T> {
     pub fn get_window(&mut self) -> &mut winit::Window {
         &mut self.window
     }
+
+    pub fn get_size(&self) -> (u32, u32) {
+        self.window.get_inner_size_points().unwrap()
+    }
 }
 
 const LAYERS: &'static [&'static str] = &[
@@ -133,14 +137,13 @@ extern "system" fn callback(flags: vk::DebugReportFlagsEXT,
     vk::FALSE
 }
 
-pub fn init<T: core::format::RenderFormat>(title: &str, width: u32, height: u32)
+pub fn init<T: core::format::RenderFormat>(wb: winit::WindowBuilder)
                 -> (Window<T>, device_vulkan::Factory) {
-    let window = winit::WindowBuilder::new()
-        .with_dimensions(width, height)
-        .with_title(title.to_string()).build().unwrap();
+    let title = wb.window.title.clone();
+    let window = wb.build().unwrap();
 
     let debug = false;
-    let (mut device, mut factory, backend) = device_vulkan::create(title, 1,
+    let (mut device, mut factory, backend) = device_vulkan::create(&title, 1,
         if debug {LAYERS_DEBUG} else {LAYERS},
         if debug {EXTENSIONS_DEBUG} else {EXTENSIONS},
         DEV_EXTENSIONS);
@@ -222,6 +225,8 @@ pub fn init<T: core::format::RenderFormat>(title: &str, width: u32, height: u32)
         unsafe { modes.set_len(num as usize); }
         modes
     };
+
+    let (width, height) = window.get_inner_size_points().unwrap();
 
     // TODO: Use the queried information to check if our values are supported before creating the swapchain
     let swapchain_info = vk::SwapchainCreateInfoKHR {


### PR DESCRIPTION
Fixes #907

This PR simplifies the internals of gfx_app a bit, removing `Wrap*` typedefs as well as `Application*` traits.
It also properly routes the events to the application, making the whole API useful now.
The examples are not only updated, but also the controls are re-implemented for the `deferred`, `ubo_tilemap`, and `blend`.
A follow-up task #1104 has been created to make it even better.

Example of default backend with auto window:
```rust
    use gfx_app::Application;
    App::launch_simple("MyTitle");
```
Example of default backend with manual window:
```rust
    use gfx_app::Application;
    let wb = winit::WindowBuilder::new().with_title("MyTitle");
    App::launch_default(wb);
```
Example of forced GL3 backend:
```rust
    let wb = winit::WindowBuilder::new().with_title("MyTitle");
    gfx_app::launch_gl3::<App<_, _>>(wb);
```
