### PR TITLE
Bump version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If you compile the example for the first time, it may take some while since all 
 If you want to build your own stand-alone gfx program, add the following to your new `Cargo.toml`:
 
 	[dependencies]
-	gfx = "0.12"
+	gfx = "0.13"
 
 
 For gfx to work, it needs access to the graphics system of the OS. This is typically provided through some window initialization API.


### PR DESCRIPTION
The version number in the installation instructions in the README is outdated, as described in #1111. 