### PR TITLE
 Initial groundwork for a low level api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,11 @@ env_logger = "0.3"
 glutin = "0.7.1"
 winit = "0.5.1"
 gfx_core = { path = "src/core", version = "0.6" }
-gfx_corell = { path = "src/corell", version = "0.1" }gfx = { path = "src/render", version = "0.14" }gfx_device_gl = { path = "src/backend/gl", version = "0.13" }gfx_window_glutin = { path = "src/window/glutin", version = "0.14" }
+gfx_corell = { path = "src/corell", version = "0.1" }
+gfx = { path = "src/render", version = "0.14" }
+gfx_device_gl = { path = "src/backend/gl", version = "0.13" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.14" }
+
 [dependencies.gfx_device_vulkan]
 path = "src/backend/vulkan"
 version = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/gfx"
 [features]
 default = []
 sdl = ["gfx_window_sdl"]
-vulkan = ["gfx_device_vulkan", "gfx_window_vulkan"]
+vulkan = ["gfx_device_vulkan", "gfx_device_vulkanll", "gfx_window_vulkan"]
 metal = ["gfx_device_metal", "gfx_window_metal"]
 unstable = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,14 @@ env_logger = "0.3"
 glutin = "0.7.1"
 winit = "0.5.1"
 gfx_core = { path = "src/core", version = "0.6" }
-gfx = { path = "src/render", version = "0.14" }
-gfx_device_gl = { path = "src/backend/gl", version = "0.13" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.14" }
-
+gfx_corell = { path = "src/corell", version = "0.1" }gfx = { path = "src/render", version = "0.14" }gfx_device_gl = { path = "src/backend/gl", version = "0.13" }gfx_window_glutin = { path = "src/window/glutin", version = "0.14" }
 [dependencies.gfx_device_vulkan]
 path = "src/backend/vulkan"
+version = "0.1"
+optional = true
+
+[dependencies.gfx_device_vulkanll]
+path = "src/backend/vulkanll"
 version = "0.1"
 optional = true
 
@@ -59,6 +61,7 @@ gfx_window_glfw = { path = "src/window/glfw", version = "0.13" }
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.5" }
+gfx_device_dx12ll = { path = "src/backend/dx12ll", version = "0.1" }
 gfx_window_dxgi = { path = "src/window/dxgi", version = "0.6" }
 
 [[example]]
@@ -120,6 +123,11 @@ path = "examples/mipmap/main.rs"
 [[example]]
 name = "particle"
 path = "examples/particle/main.rs"
+
+[[example]]
+name = "trianglell"
+path = "examples/trianglell/main.rs"
+
 
 [dev_dependencies]
 cgmath = "0.7"

--- a/examples/trianglell/main.rs
+++ b/examples/trianglell/main.rs
@@ -1,0 +1,42 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate gfx_corell;
+
+#[cfg(target_os = "windows")]
+extern crate gfx_device_dx12ll;
+#[cfg(feature = "vulkanll")]
+extern crate gfx_device_vulkanll;
+
+extern crate winit;
+
+fn main() {
+    let window = winit::WindowBuilder::new()
+        .with_dimensions(1024, 768)
+        .with_title("triangle (Low Level)".to_string())
+        .build()
+        .unwrap();
+
+    'main: loop {
+        for event in window.poll_events() {
+            match event {
+                winit::Event::KeyboardInput(_, _, Some(winit::VirtualKeyCode::Escape)) |
+                winit::Event::Closed => break 'main,
+                _ => {},
+            }
+        }
+
+        // swap_chain.present();
+    }
+}

--- a/examples/trianglell/main.rs
+++ b/examples/trianglell/main.rs
@@ -21,7 +21,7 @@ extern crate gfx_device_vulkanll as back;
 
 extern crate winit;
 
-use gfx_corell::{Instance, PhysicalDevice, Surface, SwapChain};
+use gfx_corell::{Instance, PhysicalDevice, Surface, SwapChain, QueueFamily};
 
 pub type ColorFormat = gfx_corell::format::Rgba8;
 
@@ -36,12 +36,14 @@ fn main() {
     // instantiate backend
     let instance = back::Instance::create();
     let physical_devices = instance.enumerate_physical_devices();
+    let queue_descs = physical_devices[0].get_queue_families().iter().map(|family| { (family, family.num_queues()) }).collect();
+    
     for device in &physical_devices {
         println!("{:?}", device.get_info());
     }
 
     // build a new device and associated command queues
-    let (device, queues) = physical_devices[0].open();
+    let (device, queues) = physical_devices[0].open(queue_descs);
 
     let surface = back::Surface::from_window(&window, &instance);
     let mut swap_chain = surface.build_swapchain::<ColorFormat>(1024, 768, &queues[0]);
@@ -55,6 +57,11 @@ fn main() {
             }
         }
 
+        let frame = swap_chain.acquire_frame();
+
+        // rendering
+
+        // present frame
         swap_chain.present();
     }
 }

--- a/examples/trianglell/main.rs
+++ b/examples/trianglell/main.rs
@@ -15,11 +15,13 @@
 extern crate gfx_corell;
 
 #[cfg(target_os = "windows")]
-extern crate gfx_device_dx12ll;
+extern crate gfx_device_dx12ll as dx12;
 #[cfg(feature = "vulkanll")]
-extern crate gfx_device_vulkanll;
+extern crate gfx_device_vulkanll as vulkan;
 
 extern crate winit;
+
+use gfx_corell::{Instance, PhysicalDevice};
 
 fn main() {
     let window = winit::WindowBuilder::new()
@@ -27,6 +29,11 @@ fn main() {
         .with_title("triangle (Low Level)".to_string())
         .build()
         .unwrap();
+
+    let instance = dx12::Instance::create();
+    for device in instance.enumerate_physical_devices() {
+        println!("{:?}", device.get_info());
+    }
 
     'main: loop {
         for event in window.poll_events() {

--- a/examples/trianglell/main.rs
+++ b/examples/trianglell/main.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate env_logger;
 extern crate gfx_corell;
-
 #[cfg(all(target_os = "windows", not(feature = "vulkan")))]
 extern crate gfx_device_dx12ll as back;
 #[cfg(feature = "vulkan")]
@@ -21,9 +21,12 @@ extern crate gfx_device_vulkanll as back;
 
 extern crate winit;
 
-use gfx_corell::{Instance, PhysicalDevice};
+use gfx_corell::{Instance, PhysicalDevice, Surface, SwapChain};
+
+pub type ColorFormat = gfx_corell::format::Rgba8;
 
 fn main() {
+    env_logger::init().unwrap();
     let window = winit::WindowBuilder::new()
         .with_dimensions(1024, 768)
         .with_title("triangle (Low Level)".to_string())
@@ -40,6 +43,9 @@ fn main() {
     // build a new device and associated command queues
     let (device, queues) = physical_devices[0].open();
 
+    let surface = back::Surface::from_window(&window, &instance);
+    let mut swap_chain = surface.build_swapchain::<ColorFormat>(1024, 768, &queues[0]);
+
     'main: loop {
         for event in window.poll_events() {
             match event {
@@ -49,6 +55,6 @@ fn main() {
             }
         }
 
-        // swap_chain.present();
+        swap_chain.present();
     }
 }

--- a/examples/trianglell/main.rs
+++ b/examples/trianglell/main.rs
@@ -16,7 +16,7 @@ extern crate gfx_corell;
 
 #[cfg(target_os = "windows")]
 extern crate gfx_device_dx12ll as dx12;
-#[cfg(feature = "vulkanll")]
+#[cfg(feature = "vulkan")]
 extern crate gfx_device_vulkanll as vulkan;
 
 extern crate winit;

--- a/examples/trianglell/main.rs
+++ b/examples/trianglell/main.rs
@@ -21,7 +21,7 @@ extern crate gfx_device_vulkanll as back;
 
 extern crate winit;
 
-use gfx_corell::{Instance, PhysicalDevice, Surface, SwapChain, QueueFamily};
+use gfx_corell::{Instance, Adapter, Surface, SwapChain, QueueFamily};
 
 pub type ColorFormat = gfx_corell::format::Rgba8;
 
@@ -35,8 +35,10 @@ fn main() {
 
     // instantiate backend
     let instance = back::Instance::create();
-    let physical_devices = instance.enumerate_physical_devices();
-    let queue_descs = physical_devices[0].get_queue_families().iter().map(|family| { (family, family.num_queues()) }).collect();
+    let physical_devices = instance.enumerate_adapters();
+    let surface = instance.create_surface(&window);
+
+    let queue_descs = physical_devices[0].get_queue_families().map(|family| { (family, family.num_queues()) });
     
     for device in &physical_devices {
         println!("{:?}", device.get_info());
@@ -45,8 +47,7 @@ fn main() {
     // build a new device and associated command queues
     let (device, queues) = physical_devices[0].open(queue_descs);
 
-    let surface = back::Surface::from_window(&window, &instance);
-    let mut swap_chain = surface.build_swapchain::<ColorFormat>(1024, 768, &queues[0]);
+    let mut swap_chain = surface.build_swapchain::<ColorFormat>(&queues[0]);
 
     'main: loop {
         for event in window.poll_events() {

--- a/examples/trianglell/main.rs
+++ b/examples/trianglell/main.rs
@@ -14,10 +14,10 @@
 
 extern crate gfx_corell;
 
-#[cfg(target_os = "windows")]
-extern crate gfx_device_dx12ll as dx12;
+#[cfg(all(target_os = "windows", not(feature = "vulkan")))]
+extern crate gfx_device_dx12ll as back;
 #[cfg(feature = "vulkan")]
-extern crate gfx_device_vulkanll as vulkan;
+extern crate gfx_device_vulkanll as back;
 
 extern crate winit;
 
@@ -30,10 +30,15 @@ fn main() {
         .build()
         .unwrap();
 
-    let instance = dx12::Instance::create();
-    for device in instance.enumerate_physical_devices() {
+    // instantiate backend
+    let instance = back::Instance::create();
+    let physical_devices = instance.enumerate_physical_devices();
+    for device in &physical_devices {
         println!("{:?}", device.get_info());
     }
+
+    // build a new device and associated command queues
+    let (device, queues) = physical_devices[0].open();
 
     'main: loop {
         for event in window.poll_events() {

--- a/src/backend/dx12ll/Cargo.toml
+++ b/src/backend/dx12ll/Cargo.toml
@@ -34,3 +34,4 @@ dxgi-sys = "0.2"
 dxguid-sys = "0.2"
 comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
 winapi = "0.2"
+winit = "0.5"

--- a/src/backend/dx12ll/Cargo.toml
+++ b/src/backend/dx12ll/Cargo.toml
@@ -1,0 +1,32 @@
+
+# Copyright 2016 The Gfx-rs Developers.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "gfx_device_dx12ll"
+version = "0.1.0"
+description = "DirectX-12 (Low Level) backend for gfx-rs"
+homepage = "https://github.com/gfx-rs/gfx"
+repository = "https://github.com/gfx-rs/gfx"
+keywords = ["graphics", "gamedev"]
+license = "Apache-2.0"
+authors = ["The Gfx-rs Developers"]
+
+[lib]
+name = "gfx_device_dx12ll"
+
+[dependencies]
+log = "0.3"
+gfx_corell = { path = "../../corell", version = "0.1.0" }
+d3d12-sys = "0.2"

--- a/src/backend/dx12ll/Cargo.toml
+++ b/src/backend/dx12ll/Cargo.toml
@@ -30,3 +30,7 @@ name = "gfx_device_dx12ll"
 log = "0.3"
 gfx_corell = { path = "../../corell", version = "0.1.0" }
 d3d12-sys = "0.2"
+dxgi-sys = "0.2"
+dxguid-sys = "0.2"
+comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
+winapi = "0.2"

--- a/src/backend/dx12ll/src/data.rs
+++ b/src/backend/dx12ll/src/data.rs
@@ -1,0 +1,129 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::format::Format;
+use winapi::*;
+
+pub fn map_format(format: Format, is_target: bool) -> Option<DXGI_FORMAT> {
+    use core::format::SurfaceType::*;
+    use core::format::ChannelType::*;
+    Some(match format.0 {
+        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 => return None,
+        R8 => match format.1 {
+            Int   => DXGI_FORMAT_R8_SINT,
+            Uint  => DXGI_FORMAT_R8_UINT,
+            Inorm => DXGI_FORMAT_R8_SNORM,
+            Unorm => DXGI_FORMAT_R8_UNORM,
+            _ => return None,
+        },
+        R8_G8 => match format.1 {
+            Int   => DXGI_FORMAT_R8G8_SINT,
+            Uint  => DXGI_FORMAT_R8G8_UINT,
+            Inorm => DXGI_FORMAT_R8G8_SNORM,
+            Unorm => DXGI_FORMAT_R8G8_UNORM,
+            _ => return None,
+        },
+        R8_G8_B8_A8 => match format.1 {
+            Int   => DXGI_FORMAT_R8G8B8A8_SINT,
+            Uint  => DXGI_FORMAT_R8G8B8A8_UINT,
+            Inorm => DXGI_FORMAT_R8G8B8A8_SNORM,
+            Unorm => DXGI_FORMAT_R8G8B8A8_UNORM,
+            Srgb  => DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,
+            _ => return None,
+        },
+        R10_G10_B10_A2 => match format.1 {
+            Uint  => DXGI_FORMAT_R10G10B10A2_UINT,
+            Unorm => DXGI_FORMAT_R10G10B10A2_UNORM,
+            _ => return None,
+        },
+        R11_G11_B10 => match format.1 {
+            Float => DXGI_FORMAT_R11G11B10_FLOAT,
+            _ => return None,
+        },
+        R16 => match format.1 {
+            Int   => DXGI_FORMAT_R16_SINT,
+            Uint  => DXGI_FORMAT_R16_UINT,
+            Inorm => DXGI_FORMAT_R16_SNORM,
+            Unorm => DXGI_FORMAT_R16_UNORM,
+            Float => DXGI_FORMAT_R16_FLOAT,
+            _ => return None,
+        },
+        R16_G16 => match format.1 {
+            Int   => DXGI_FORMAT_R16G16_SINT,
+            Uint  => DXGI_FORMAT_R16G16_UINT,
+            Inorm => DXGI_FORMAT_R16G16_SNORM,
+            Unorm => DXGI_FORMAT_R16G16_UNORM,
+            Float => DXGI_FORMAT_R16G16_FLOAT,
+            _ => return None,
+        },
+        R16_G16_B16 => return None,
+        R16_G16_B16_A16 => match format.1 {
+            Int   => DXGI_FORMAT_R16G16B16A16_SINT,
+            Uint  => DXGI_FORMAT_R16G16B16A16_UINT,
+            Inorm => DXGI_FORMAT_R16G16B16A16_SNORM,
+            Unorm => DXGI_FORMAT_R16G16B16A16_UNORM,
+            Float => DXGI_FORMAT_R16G16B16A16_FLOAT,
+            _ => return None,
+        },
+        R32 => match format.1 {
+            Int   => DXGI_FORMAT_R32_SINT,
+            Uint  => DXGI_FORMAT_R32_UINT,
+            Float => DXGI_FORMAT_R32_FLOAT,
+            _ => return None,
+        },
+        R32_G32 => match format.1 {
+            Int   => DXGI_FORMAT_R32G32_SINT,
+            Uint  => DXGI_FORMAT_R32G32_UINT,
+            Float => DXGI_FORMAT_R32G32_FLOAT,
+            _ => return None,
+        },
+        R32_G32_B32 => match format.1 {
+            Int   => DXGI_FORMAT_R32G32B32_SINT,
+            Uint  => DXGI_FORMAT_R32G32B32_UINT,
+            Float => DXGI_FORMAT_R32G32B32_FLOAT,
+            _ => return None,
+        },
+        R32_G32_B32_A32 => match format.1 {
+            Int   => DXGI_FORMAT_R32G32B32A32_SINT,
+            Uint  => DXGI_FORMAT_R32G32B32A32_UINT,
+            Float => DXGI_FORMAT_R32G32B32A32_FLOAT,
+            _ => return None,
+        },
+        B8_G8_R8_A8 => match format.1 {
+            Unorm => DXGI_FORMAT_B8G8R8A8_UNORM,
+            _ => return None,
+        },
+        D16 => match (is_target, format.1) {
+            (true, _)      => DXGI_FORMAT_D16_UNORM,
+            (false, Unorm) => DXGI_FORMAT_R16_UNORM,
+            _ => return None,
+        },
+        D24 => match (is_target, format.1) {
+            (true, _)      => DXGI_FORMAT_D24_UNORM_S8_UINT,
+            (false, Unorm) => DXGI_FORMAT_R24_UNORM_X8_TYPELESS,
+            _ => return None,
+        },
+        D24_S8 => match (is_target, format.1) {
+            (true, _)      => DXGI_FORMAT_D24_UNORM_S8_UINT,
+            (false, Unorm) => DXGI_FORMAT_R24_UNORM_X8_TYPELESS,
+            (false, Uint)  => DXGI_FORMAT_X24_TYPELESS_G8_UINT,
+            _ => return None,
+        },
+        D32 => match (is_target, format.1) {
+            (true, _)      => DXGI_FORMAT_D32_FLOAT,
+            (false, Float) => DXGI_FORMAT_R32_FLOAT,
+            _ => return None,
+        },
+    })
+}

--- a/src/backend/dx12ll/src/lib.rs
+++ b/src/backend/dx12ll/src/lib.rs
@@ -12,4 +12,196 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[macro_use]
+extern crate log;
+extern crate comptr;
+extern crate d3d12;
+extern crate dxgi;
+extern crate dxguid;
 extern crate gfx_corell as core;
+extern crate winapi;
+
+use comptr::ComPtr;
+use std::ptr;
+use std::os::raw::c_void;
+use std::os::windows::ffi::OsStringExt;
+use std::ffi::OsString;
+
+#[derive(Clone)]
+pub struct PhysicalDevice {
+    adapter: ComPtr<winapi::IDXGIAdapter2>,
+    info: core::PhysicalDeviceInfo,
+}
+
+impl core::PhysicalDevice for PhysicalDevice {
+    type B = Backend;
+
+    fn open(&self) -> (Device, Vec<CommandQueue>) {
+        unimplemented!()
+    }
+
+    fn get_info(&self) -> core::PhysicalDeviceInfo {
+        self.info.clone()
+    }
+}
+
+pub struct Device {
+
+}
+
+impl core::Device for Device {
+
+}
+
+pub struct CommandQueue {
+
+}
+
+impl core::CommandQueue for CommandQueue {
+    type B = Backend;
+
+    fn submit(&mut self, cmd_buffer: &()) {
+        unimplemented!()
+    }
+}
+
+pub struct SwapChain {
+
+}
+
+impl core::SwapChain for SwapChain {
+    type B = Backend;
+
+    fn present(&mut self) {
+        unimplemented!()
+    }
+}
+
+pub struct Instance {
+    inner: ComPtr<winapi::IDXGIFactory4>,
+    physical_devices: Vec<PhysicalDevice>,
+}
+
+impl core::Instance for Instance {
+    type B = Backend;
+
+    fn create() -> Instance {
+        // Enable debug layer
+        let mut debug_controller = ComPtr::<winapi::ID3D12Debug>::new(ptr::null_mut());
+        let hr = unsafe {
+            d3d12::D3D12GetDebugInterface(
+                &dxguid::IID_ID3D12Debug,
+                debug_controller.as_mut() as *mut *mut _ as *mut *mut c_void)
+        };
+
+        if winapi::SUCCEEDED(hr) {
+            unsafe { debug_controller.EnableDebugLayer() };
+        }
+
+        // Create DXGI factory
+        let mut dxgi_factory = ComPtr::<winapi::IDXGIFactory4>::new(ptr::null_mut());
+
+        let hr = unsafe {
+            dxgi::CreateDXGIFactory2(
+                winapi::DXGI_CREATE_FACTORY_DEBUG,
+                &dxguid::IID_IDXGIFactory4,
+                dxgi_factory.as_mut() as *mut *mut _ as *mut *mut c_void)
+        };
+
+        if !winapi::SUCCEEDED(hr) {
+            error!("Failed on dxgi factory creation: {:?}", hr);
+        }
+
+        // Enumerate adapters
+        let mut cur_index = 0;
+        let mut devices = Vec::new();
+        loop {
+            let mut adapter = ComPtr::<winapi::IDXGIAdapter2>::new(ptr::null_mut());
+            let hr = unsafe {
+                dxgi_factory.EnumAdapters1(
+                    cur_index,
+                    adapter.as_mut() as *mut *mut _ as *mut *mut winapi::IDXGIAdapter1)
+            };
+
+            if hr == winapi::DXGI_ERROR_NOT_FOUND {
+                break;
+            }
+
+            // Check for D3D12 support
+            let hr = unsafe {
+                d3d12::D3D12CreateDevice(
+                    adapter.as_mut_ptr() as *mut _ as *mut winapi::IUnknown,
+                    winapi::D3D_FEATURE_LEVEL_11_0, // TODO: correct feature level?
+                    &dxguid::IID_ID3D12Device,
+                    ptr::null_mut(),
+                )
+            };
+
+            if winapi::SUCCEEDED(hr) {
+                // We have found a possible adapter
+                // acquire the device information
+                let mut desc: winapi::DXGI_ADAPTER_DESC2 = unsafe { std::mem::uninitialized() };
+                unsafe { adapter.GetDesc2(&mut desc); }
+
+                let device_name = {
+                    let len = desc.Description.iter().take_while(|&&c| c != 0).count();
+                    let name = <OsString as OsStringExt>::from_wide(&desc.Description[..len]);
+                    name.to_string_lossy().into_owned()
+                };
+
+                let info = core::PhysicalDeviceInfo {
+                    name: device_name,
+                    vendor: desc.VendorId as usize,
+                    device: desc.DeviceId as usize,
+                    software_rendering: false, // TODO: check for WARP adapter (software rasterizer)?
+                };
+
+                devices.push(
+                    PhysicalDevice {
+                        adapter: adapter,
+                        info: info,
+                    });
+            }
+
+            cur_index += 1;
+        }
+
+        Instance {
+            inner: dxgi_factory,
+            physical_devices: devices,
+        }
+    }
+
+    fn enumerate_physical_devices(&self) -> Vec<PhysicalDevice> {
+        self.physical_devices.clone()
+    }
+}
+
+pub enum Backend { }
+
+impl core::Backend for Backend {
+    type CommandBuffer = ();
+    type CommandQueue = CommandQueue;
+    type Device = Device;
+    type Instance = Instance;
+    type PhysicalDevice = PhysicalDevice;
+    type Resources = Resources;
+    type SwapChain = SwapChain;
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Resources { }
+
+impl core::Resources for Resources {
+    type Buffer = ();
+    type Shader = ();
+    type RenderPass = ();
+    type PipelineLayout = ();
+    type PipelineStateObject = ();
+    type Image = ();
+    type ShaderResourceView = ();
+    type UnorderedAccessView = ();
+    type RenderTargetView = ();
+    type DepthStencilView = ();
+    type Sampler = ();
+}

--- a/src/backend/dx12ll/src/lib.rs
+++ b/src/backend/dx12ll/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate gfx_corell as core;

--- a/src/backend/vulkanll/Cargo.toml
+++ b/src/backend/vulkanll/Cargo.toml
@@ -1,0 +1,33 @@
+# Copyright 2016 The Gfx-rs Developers.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "gfx_device_vulkanll"
+version = "0.1.0"
+description = "Vulkan (Low Level) backend for gfx-rs"
+homepage = "https://github.com/gfx-rs/gfx"
+repository = "https://github.com/gfx-rs/gfx"
+keywords = ["graphics", "gamedev"]
+license = "Apache-2.0"
+authors = ["The Gfx-rs Developers"]
+
+[lib]
+name = "gfx_device_vulkanll"
+
+[dependencies]
+log = "0.3"
+shared_library = "0.1"
+gfx_corell = { path = "../../corell", version = "0.1.0" }
+ash = "0.14.0"
+spirv-utils = { git = "https://github.com/msiglreith/spirv-utils.git", branch = "gfx" }

--- a/src/backend/vulkanll/Cargo.toml
+++ b/src/backend/vulkanll/Cargo.toml
@@ -27,8 +27,12 @@ name = "gfx_device_vulkanll"
 
 [dependencies]
 log = "0.3"
+lazy_static = "0.2"
 shared_library = "0.1"
 gfx_corell = { path = "../../corell", version = "0.1.0" }
-ash = "0.14.0"
+ash = { path = "../../../../../ash-master" } #"0.14.0"
 spirv-utils = { git = "https://github.com/msiglreith/spirv-utils.git", branch = "gfx" }
 winit = "0.5"
+
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "0.2.2"

--- a/src/backend/vulkanll/Cargo.toml
+++ b/src/backend/vulkanll/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.3"
 lazy_static = "0.2"
 shared_library = "0.1"
 gfx_corell = { path = "../../corell", version = "0.1.0" }
-ash = { path = "../../../../../ash-master" } #"0.14.0"
+ash = { git = "https://github.com/msiglreith/ash.git", branch = "ll" }
 spirv-utils = { git = "https://github.com/msiglreith/spirv-utils.git", branch = "gfx" }
 winit = "0.5"
 

--- a/src/backend/vulkanll/Cargo.toml
+++ b/src/backend/vulkanll/Cargo.toml
@@ -31,3 +31,4 @@ shared_library = "0.1"
 gfx_corell = { path = "../../corell", version = "0.1.0" }
 ash = "0.14.0"
 spirv-utils = { git = "https://github.com/msiglreith/spirv-utils.git", branch = "gfx" }
+winit = "0.5"

--- a/src/backend/vulkanll/src/data.rs
+++ b/src/backend/vulkanll/src/data.rs
@@ -1,0 +1,151 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ash::vk;
+use core::format::{SurfaceType, ChannelType};
+
+pub fn map_format(surface: SurfaceType, chan: ChannelType) -> Option<vk::Format> {
+    use core::format::SurfaceType::*;
+    use core::format::ChannelType::*;
+    Some(match surface {
+        R4_G4 => match chan {
+            Unorm => vk::Format::R4g4UnormPack8,
+            _ => return None,
+        },
+        R4_G4_B4_A4 => match chan {
+            Unorm => vk::Format::R4g4b4a4UnormPack16,
+            _ => return None,
+        },
+        R5_G5_B5_A1 => match chan {
+            Unorm => vk::Format::R5g5b5a1UnormPack16,
+             _ => return None,
+        },
+        R5_G6_B5 => match chan {
+            Unorm => vk::Format::R5g6b5UnormPack16,
+             _ => return None,
+        },
+        R8 => match chan {
+            Int   => vk::Format::R8Sint,
+            Uint  => vk::Format::R8Uint,
+            Inorm => vk::Format::R8Snorm,
+            Unorm => vk::Format::R8Unorm,
+            Srgb  => vk::Format::R8Srgb,
+            _ => return None,
+        },
+        R8_G8 => match chan {
+            Int   => vk::Format::R8g8Sint,
+            Uint  => vk::Format::R8g8Uint,
+            Inorm => vk::Format::R8g8Snorm,
+            Unorm => vk::Format::R8g8Unorm,
+            Srgb  => vk::Format::R8g8Srgb,
+            _ => return None,
+        },
+        R8_G8_B8_A8 => match chan {
+            Int   => vk::Format::R8g8b8a8Sint,
+            Uint  => vk::Format::R8g8b8a8Uint,
+            Inorm => vk::Format::R8g8b8a8Snorm,
+            Unorm => vk::Format::R8g8b8a8Unorm,
+            Srgb  => vk::Format::R8g8b8a8Srgb,
+            _ => return None,
+        },
+        R10_G10_B10_A2 => match chan {
+            Int   => vk::Format::A2r10g10b10SintPack32,
+            Uint  => vk::Format::A2r10g10b10UintPack32,
+            Inorm => vk::Format::A2r10g10b10SnormPack32,
+            Unorm => vk::Format::A2r10g10b10UnormPack32,
+            _ => return None,
+        },
+        R11_G11_B10 => match chan {
+            Float => vk::Format::B10g11r11UfloatPack32,
+            _ => return None,
+        },
+        R16 => match chan {
+            Int   => vk::Format::R16Sint,
+            Uint  => vk::Format::R16Uint,
+            Inorm => vk::Format::R16Snorm,
+            Unorm => vk::Format::R16Unorm,
+            Float => vk::Format::R16Sfloat,
+            _ => return None,
+        },
+        R16_G16 => match chan {
+            Int   => vk::Format::R16g16Sint,
+            Uint  => vk::Format::R16g16Uint,
+            Inorm => vk::Format::R16g16Snorm,
+            Unorm => vk::Format::R16g16Unorm,
+            Float => vk::Format::R16g16Sfloat,
+            _ => return None,
+        },
+        R16_G16_B16 => match chan {
+            Int   => vk::Format::R16g16b16Sint,
+            Uint  => vk::Format::R16g16b16Uint,
+            Inorm => vk::Format::R16g16b16Snorm,
+            Unorm => vk::Format::R16g16b16Unorm,
+            Float => vk::Format::R16g16b16Sfloat,
+            _ => return None,
+        },
+        R16_G16_B16_A16 => match chan {
+            Int   => vk::Format::R16g16b16a16Sint,
+            Uint  => vk::Format::R16g16b16a16Uint,
+            Inorm => vk::Format::R16g16b16a16Snorm,
+            Unorm => vk::Format::R16g16b16a16Unorm,
+            Float => vk::Format::R16g16b16a16Sfloat,
+            _ => return None,
+        },
+        R32 => match chan {
+            Int   => vk::Format::R32Sint,
+            Uint  => vk::Format::R32Uint,
+            Float => vk::Format::R32Sfloat,
+            _ => return None,
+        },
+        R32_G32 => match chan {
+            Int   => vk::Format::R32g32Sint,
+            Uint  => vk::Format::R32g32Uint,
+            Float => vk::Format::R32g32Sfloat,
+            _ => return None,
+        },
+        R32_G32_B32 => match chan {
+            Int   => vk::Format::R32g32b32Sint,
+            Uint  => vk::Format::R32g32b32Uint,
+            Float => vk::Format::R32g32b32Sfloat,
+            _ => return None,
+        },
+        R32_G32_B32_A32 => match chan {
+            Int   => vk::Format::R32g32b32a32Sint,
+            Uint  => vk::Format::R32g32b32a32Uint,
+            Float => vk::Format::R32g32b32a32Sfloat,
+            _ => return None,
+        },
+        B8_G8_R8_A8 => match chan {
+            Unorm => vk::Format::B8g8r8a8Unorm,
+            _ => return None,
+        },
+        D16 => match chan {
+            Unorm  => vk::Format::D16Unorm,
+            _ => return None,
+        },
+        D24 => match chan {
+            Unorm => vk::Format::X8D24UnormPack32,
+            _ => return None,
+        },
+        D24_S8 => match chan {
+            Unorm => vk::Format::D24UnormS8Uint,
+            _ => return None,
+        },
+        D32 => match chan {
+            Float => vk::Format::D32Sfloat,
+            _ => return None,
+        },
+    })
+}
+

--- a/src/backend/vulkanll/src/lib.rs
+++ b/src/backend/vulkanll/src/lib.rs
@@ -15,3 +15,71 @@
 extern crate gfx_corell as core;
 extern crate ash;
 
+pub struct PhysicalDevice {
+
+}
+
+impl core::PhysicalDevice for PhysicalDevice {
+    type B = Backend;
+}
+
+pub struct Device {
+
+}
+
+impl core::Device for Device {
+
+}
+
+pub struct CommandQueue {
+
+}
+
+impl core::CommandQueue for CommandQueue {
+    type B = Backend;
+}
+
+pub struct SwapChain {
+
+}
+
+impl core::SwapChain for SwapChain {
+    type B = Backend;
+}
+
+pub struct Instance {
+
+}
+
+impl core::Instance for Instance {
+    type B = Backend;
+}
+
+pub enum Backend { }
+
+impl core::Backend for Backend {
+    type CommandBuffer = ();
+    type CommandQueue = CommandQueue;
+    type Device = Device;
+    type Instance = Instance;
+    type PhysicalDevice = PhysicalDevice;
+    type Resources = Resources;
+    type SwapChain = SwapChain;
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Resources { }
+
+impl core::Resources for Resources {
+    type Buffer = ();
+    type Shader = ();
+    type RenderPass = ();
+    type PipelineLayout = ();
+    type PipelineStateObject = ();
+    type Image = ();
+    type ShaderResourceView = ();
+    type UnorderedAccessView = ();
+    type RenderTargetView = ();
+    type DepthStencilView = ();
+    type Sampler = ();
+}

--- a/src/backend/vulkanll/src/lib.rs
+++ b/src/backend/vulkanll/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2016 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate gfx_corell as core;
+extern crate ash;
+

--- a/src/backend/vulkanll/src/lib.rs
+++ b/src/backend/vulkanll/src/lib.rs
@@ -35,8 +35,8 @@ impl core::PhysicalDevice for PhysicalDevice {
         unimplemented!()
     }
 
-    fn get_info(&self) -> core::PhysicalDeviceInfo {
-        self.info.clone()
+    fn get_info(&self) -> &core::PhysicalDeviceInfo {
+        &self.info
     }
 }
 
@@ -58,6 +58,14 @@ impl core::CommandQueue for CommandQueue {
     fn submit(&mut self, cmd_buffer: &()) {
         unimplemented!()
     }
+}
+
+pub struct Surface {
+
+}
+
+impl core::Surface for Surface {
+    
 }
 
 pub struct SwapChain {
@@ -188,6 +196,7 @@ impl core::Backend for Backend {
     type Instance = Instance;
     type PhysicalDevice = PhysicalDevice;
     type Resources = Resources;
+    type Surface = Surface;
     type SwapChain = SwapChain;
 }
 

--- a/src/backend/vulkanll/src/lib.rs
+++ b/src/backend/vulkanll/src/lib.rs
@@ -15,12 +15,29 @@
 extern crate gfx_corell as core;
 extern crate ash;
 
-pub struct PhysicalDevice {
+use ash::version::{EntryV1_0, InstanceV1_0, V1_0};
+use ash::vk;
 
+use std::ffi::{CStr, CString};
+use std::iter;
+use std::mem;
+use std::ptr;
+use std::sync::Arc;
+
+pub struct PhysicalDevice {
+    info: core::PhysicalDeviceInfo,
 }
 
 impl core::PhysicalDevice for PhysicalDevice {
     type B = Backend;
+
+    fn open(&self) -> (Device, Vec<CommandQueue>) {
+        unimplemented!()
+    }
+
+    fn get_info(&self) -> core::PhysicalDeviceInfo {
+        self.info.clone()
+    }
 }
 
 pub struct Device {
@@ -37,6 +54,10 @@ pub struct CommandQueue {
 
 impl core::CommandQueue for CommandQueue {
     type B = Backend;
+
+    fn submit(&mut self, cmd_buffer: &()) {
+        unimplemented!()
+    }
 }
 
 pub struct SwapChain {
@@ -45,14 +66,117 @@ pub struct SwapChain {
 
 impl core::SwapChain for SwapChain {
     type B = Backend;
+
+    fn present(&mut self) {
+        unimplemented!()
+    }
 }
 
-pub struct Instance {
+struct InstanceInner(pub ash::Instance<V1_0>);
+impl Drop for InstanceInner {
+    fn drop(&mut self) {
+        unsafe { self.0.destroy_instance(None); }
+    }
+}
 
+const SURFACE_EXTENSIONS: &'static [&'static str] = &[
+    "VK_KHR_surface",
+
+    // Platform-specific WSI extensions
+    "VK_KHR_xlib_surface",
+    "VK_KHR_xcb_surface",
+    "VK_KHR_wayland_surface",
+    "VK_KHR_mir_surface",
+    "VK_KHR_android_surface",
+    "VK_KHR_win32_surface",
+];
+
+pub struct Instance {
+    // Vk specs [2.5 Threading Behavior]
+    // Externally Synchronized Parameters: The `instance` parameter in `vkDestroyInstance`
+    // `Arc` ensures that we only call drop once
+    inner: Arc<InstanceInner>,
 }
 
 impl core::Instance for Instance {
     type B = Backend;
+
+    fn create() -> Instance {
+        // TODO: return errors instead of panic
+        let entry = ash::Entry::new().expect("Unable to load vulkan entry points");
+
+        let app_info = vk::ApplicationInfo {
+            s_type: vk::StructureType::ApplicationInfo,
+            p_next: ptr::null(),
+            p_application_name: "vulkan_ll".as_ptr() as *const _, // TODO:
+            application_version: 0,
+            p_engine_name: "gfx-rs".as_ptr() as *const _,
+            engine_version: 0, //TODO
+            api_version: 0, //TODO
+        };
+
+        let instance_extensions = entry.enumerate_instance_extension_properties()
+                                       .expect("Unable to enumerate instance extensions");
+        // Check our surface extensions against the available extensions
+        let surface_extensions = SURFACE_EXTENSIONS.iter().filter_map(|ext| {
+            instance_extensions.iter().find(|inst_ext| {
+                unsafe { CStr::from_ptr(inst_ext.extension_name.as_ptr()) == CStr::from_ptr(ext.as_ptr() as *const i8) }
+            }).and_then(|_| Some(*ext))
+        }).collect::<Vec<&str>>();
+
+        let instance = {
+            let cstrings = surface_extensions.iter()
+                                    .map(|&s| CString::new(s).unwrap())
+                                    .collect::<Vec<_>>();
+
+            let str_pointers = cstrings.iter()
+                                    .map(|s| s.as_ptr())
+                                    .collect::<Vec<_>>();
+
+            let create_info = vk::InstanceCreateInfo {
+                s_type: vk::StructureType::InstanceCreateInfo,
+                p_next: ptr::null(),
+                flags: vk::InstanceCreateFlags::empty(),
+                p_application_info: &app_info,
+                enabled_layer_count: 0,
+                pp_enabled_layer_names: ptr::null(),
+                enabled_extension_count: str_pointers.len() as u32,
+                pp_enabled_extension_names: str_pointers.as_ptr(),
+            };
+
+            entry.create_instance(&create_info, None).expect("Unable to create vulkan instance")
+        };
+
+        Instance {
+            inner: Arc::new(InstanceInner(instance)),
+        }
+    }
+
+    fn enumerate_physical_devices(&self) -> Vec<PhysicalDevice> {
+        self.inner.0.enumerate_physical_devices()
+            .expect("Unable to enumerate physical devices")
+            .iter()
+            .map(|&device| {
+                // TODO: add an ash function for this
+                let properties = unsafe {
+                    let mut out = mem::zeroed();
+                    self.inner.0.fp_v1_0().get_physical_device_properties(device, &mut out);
+                    out
+                };
+
+                let info = core::PhysicalDeviceInfo {
+                    name: String::new(), // TODO: retrieve name
+                    vendor: properties.vendor_id as usize,
+                    device: properties.device_id as usize,
+                    software_rendering: properties.device_type == vk::PhysicalDeviceType::Cpu,
+                };
+
+                PhysicalDevice {
+                    info: info,
+                }
+            })
+            .collect()
+    }
 }
 
 pub enum Backend { }

--- a/src/corell/Cargo.toml
+++ b/src/corell/Cargo.toml
@@ -1,0 +1,30 @@
+# Copyright 2016 The Gfx-rs Developers.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "gfx_corell"
+version = "0.1.1"
+description = "Core (Low Level) library of Gfx-rs"
+homepage = "https://github.com/gfx-rs/gfx"
+repository = "https://github.com/gfx-rs/gfx"
+keywords = ["graphics"]
+license = "Apache-2.0"
+authors = ["The Gfx-rs Developers"]
+
+[lib]
+name = "gfx_corell"
+path = "src/lib.rs"
+
+[dependencies]
+log = "0.3"

--- a/src/corell/src/command.rs
+++ b/src/corell/src/command.rs
@@ -1,0 +1,19 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Command Buffer device interface
+
+pub trait CommandBuffer {
+
+}

--- a/src/corell/src/factory.rs
+++ b/src/corell/src/factory.rs
@@ -1,0 +1,35 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use Resources;
+
+/// A `Factory` is responsible for creating and managing resources for the backend it was created
+/// with. 
+///
+/// # Construction and Handling
+/// A `Factory` is typically created along with other objects using a helper function of the
+/// appropriate gfx_window module (e.g. gfx_window_glutin::init()).
+///
+/// This factory structure can then be used to create and manage different resources, like buffers,
+/// shader programs and textures. See the individual methods for more information.
+///
+/// Also see the `FactoryExt` trait inside the `gfx` module for additional methods.
+#[allow(missing_docs)]
+pub trait Factory<R: Resources> {
+    /// 
+    fn allocate_memory(&mut self);
+
+    ///
+    fn create_shader(&mut self, code: &[u8]);
+}

--- a/src/corell/src/format.rs
+++ b/src/corell/src/format.rs
@@ -1,0 +1,422 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Universal format specification.
+//! Applicable to textures, views, and vertex buffers.
+
+//TODO:
+//  DXT 1-5, BC7
+//  ETC2_RGB, // Use the EXT2 algorithm on 3 components.
+//  ETC2_SRGB, // Use the EXT2 algorithm on 4 components (RGBA) in the sRGB color space.
+//  ETC2_EAC_RGBA8, // Use the EXT2 EAC algorithm on 4 components.
+use memory::Pod;
+
+macro_rules! impl_channel_type {
+    { $($name:ident = $shader_type:ident [ $($imp_trait:ident),* ] ,)* } => {
+        /// Type of a surface channel. This is how we interpret the
+        /// storage allocated with `SurfaceType`.
+        #[allow(missing_docs)]
+        #[repr(u8)]
+        #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+        pub enum ChannelType {
+            $( $name, )*
+        }
+        $(
+            #[allow(missing_docs)]
+            #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+            pub enum $name {}
+            impl ChannelTyped for $name {
+                type ShaderType = $shader_type;
+                fn get_channel_type() -> ChannelType {
+                    ChannelType::$name
+                }
+            }
+            $(
+                impl $imp_trait for $name {}
+            )*
+        )*
+    }
+}
+
+impl_channel_type! {
+    Int     = i32 [TextureChannel, RenderChannel],
+    Uint    = u32 [TextureChannel, RenderChannel],
+    Inorm   = f32 [TextureChannel, RenderChannel, BlendChannel],
+    Unorm   = f32 [TextureChannel, RenderChannel, BlendChannel],
+    Float   = f32 [TextureChannel, RenderChannel, BlendChannel],
+    Srgb    = f32 [TextureChannel, RenderChannel, BlendChannel],
+}
+
+macro_rules! impl_formats {
+    { $($name:ident : $container:ident < $($channel:ident),* > = $data_type:ty {$alpha_bits:expr} [ $($imp_trait:ident),* ] ,)* } => {
+        /// Type of the allocated texture surface. It is supposed to only
+        /// carry information about the number of bits per each channel.
+        /// The actual types are up to the views to decide and interpret.
+        /// The actual components are up to the swizzle to define.
+        #[repr(u8)]
+        #[allow(missing_docs, non_camel_case_types)]
+        #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+        pub enum SurfaceType {
+            $( $name, )*
+        }
+        impl SurfaceType {
+            /// Return the total number of bits for this format.
+            pub fn get_total_bits(&self) -> u8 {
+                use std::mem::size_of;
+                match *self {
+                    $( SurfaceType::$name => (size_of::<$data_type>() * 8) as u8, )*
+                }
+            }
+            /// Return the number of bits allocated for alpha and stencil.
+            pub fn get_alpha_stencil_bits(&self) -> u8  {
+                match *self {
+                    $( SurfaceType::$name => $alpha_bits, )*
+                }
+            }
+        }
+        $(
+            #[allow(missing_docs, non_camel_case_types)]
+            #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+            pub enum $name {}
+            impl SurfaceTyped for $name {
+                type DataType = $data_type;
+                fn get_surface_type() -> SurfaceType {
+                    SurfaceType::$name
+                }
+            }
+            $(
+                impl $imp_trait for $name {}
+            )*
+            $(
+                impl Formatted for ($name, $channel) {
+                    type Surface = $name;
+                    type Channel = $channel;
+                    type View = $container< <$channel as ChannelTyped>::ShaderType >;
+                }
+            )*
+        )*
+    }
+}
+
+
+impl_formats! {
+    R4_G4           : Vec2<Unorm> = u8 {0}  [TextureSurface, RenderSurface],
+    R4_G4_B4_A4     : Vec4<Unorm> = u16 {4} [TextureSurface, RenderSurface],
+    R5_G5_B5_A1     : Vec4<Unorm> = u16 {1} [TextureSurface, RenderSurface],
+    R5_G6_B5        : Vec3<Unorm> = u16 {0} [TextureSurface, RenderSurface],
+    R8              : Vec1<Int, Uint, Inorm, Unorm> = u8 {0}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R8_G8           : Vec2<Int, Uint, Inorm, Unorm> = [u8; 2] {0}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R8_G8_B8_A8     : Vec4<Int, Uint, Inorm, Unorm, Srgb> = [u8; 4] {8}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R10_G10_B10_A2  : Vec4<Uint, Unorm> = u32 {2}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R11_G11_B10     : Vec4<Unorm, Float> = u32 {0}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R16             : Vec1<Int, Uint, Inorm, Unorm, Float> = u16 {0}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R16_G16         : Vec2<Int, Uint, Inorm, Unorm, Float> = [u16; 2] {0}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R16_G16_B16     : Vec3<Int, Uint, Inorm, Unorm, Float> = [u16; 3] {0}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R16_G16_B16_A16 : Vec4<Int, Uint, Inorm, Unorm, Float> = [u16; 4] {16}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R32             : Vec1<Int, Uint, Float> = u32 {0}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R32_G32         : Vec2<Int, Uint, Float> = [u32; 2] {0}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R32_G32_B32     : Vec3<Int, Uint, Float> = [u32; 3] {0}
+        [BufferSurface, TextureSurface, RenderSurface],
+    R32_G32_B32_A32 : Vec4<Int, Uint, Float> = [u32; 4] {32}
+        [BufferSurface, TextureSurface, RenderSurface],
+    B8_G8_R8_A8     : Vec4<Unorm> = [u8; 4] {32}
+        [BufferSurface, TextureSurface, RenderSurface],
+    D16             : Vec1<Unorm> = F16 {0} [TextureSurface, DepthSurface],
+    D24             : Vec1<Unorm> = f32 {8} [TextureSurface, DepthSurface], //hacky stencil bits
+    D24_S8          : Vec1<Unorm, Uint> = u32 {8} [TextureSurface, DepthSurface, StencilSurface],
+    D32             : Vec1<Float> = f32 {0} [TextureSurface, DepthSurface],
+    //D32_S8          : Vec1<Unorm, Float, Uint> = (f32, u32) {32} [TextureSurface, DepthSurface, StencilSurface],
+}
+
+
+/// Source channel in a swizzle configuration. Some may redirect onto
+/// different physical channels, some may be hardcoded to 0 or 1.
+#[allow(missing_docs)]
+#[repr(u8)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+pub enum ChannelSource {
+    Zero,
+    One,
+    X,
+    Y,
+    Z,
+    W,
+}
+
+/// Channel swizzle configuration for the resource views.
+/// Note: It's not currently mirrored at compile-time,
+/// thus providing less safety and convenience.
+#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+pub struct Swizzle(pub ChannelSource, pub ChannelSource, pub ChannelSource, pub ChannelSource);
+
+impl Swizzle {
+    /// Create a new swizzle where each channel is unmapped.
+    pub fn new() -> Swizzle {
+        Swizzle(ChannelSource::X, ChannelSource::Y, ChannelSource::Z, ChannelSource::W)
+    }
+}
+
+/// Complete run-time surface format.
+#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+pub struct Format(pub SurfaceType, pub ChannelType);
+
+
+/// Compile-time surface type trait.
+pub trait SurfaceTyped {
+    /// The corresponding data type to be passed from CPU.
+    type DataType: Pod;
+    /// Return the run-time value of the type.
+    fn get_surface_type() -> SurfaceType;
+}
+/// An ability of a surface type to be used for vertex buffers.
+pub trait BufferSurface: SurfaceTyped {}
+/// An ability of a surface type to be used for textures.
+pub trait TextureSurface: SurfaceTyped {}
+/// An ability of a surface type to be used for render targets.
+pub trait RenderSurface: SurfaceTyped {}
+/// An ability of a surface type to be used for depth targets.
+pub trait DepthSurface: SurfaceTyped {}
+/// An ability of a surface type to be used for stencil targets.
+pub trait StencilSurface: SurfaceTyped {}
+
+/// Compile-time channel type trait.
+pub trait ChannelTyped {
+    /// Shader-visible type that corresponds to this channel.
+    /// For example, normalized integers are visible as floats.
+    type ShaderType;
+    /// Return the run-time value of the type.
+    fn get_channel_type() -> ChannelType;
+}
+/// An ability of a channel type to be used for textures.
+pub trait TextureChannel: ChannelTyped {}
+/// An ability of a channel type to be used for render targets.
+pub trait RenderChannel: ChannelTyped {}
+/// An ability of a channel type to be used for blended render targets.
+pub trait BlendChannel: RenderChannel {}
+
+/// Compile-time full format trait.
+pub trait Formatted {
+    /// Associated surface type.
+    type Surface: SurfaceTyped;
+    /// Associated channel type.
+    type Channel: ChannelTyped;
+    /// Shader view type of this format.
+    type View;
+    /// Return the run-time value of the type.
+    fn get_format() -> Format {
+        Format(
+            Self::Surface::get_surface_type(),
+            Self::Channel::get_channel_type())
+    }
+}
+/// Ability to be used for vertex buffers.
+pub trait BufferFormat: Formatted {}
+/// Ability to be used for depth targets.
+pub trait DepthFormat: Formatted {}
+/// Ability to be used for vertex buffers.
+pub trait StencilFormat: Formatted {}
+/// Ability to be used for depth+stencil targets.
+pub trait DepthStencilFormat: DepthFormat + StencilFormat {}
+/// Ability to be used for textures.
+pub trait TextureFormat: Formatted {}
+/// Ability to be used for render targets.
+pub trait RenderFormat: Formatted {}
+/// Ability to be used for blended render targets.
+pub trait BlendFormat: RenderFormat {}
+
+impl<F> BufferFormat for F where
+    F: Formatted,
+    F::Surface: BufferSurface,
+    F::Channel: ChannelTyped,
+{}
+impl<F> DepthFormat for F where
+    F: Formatted,
+    F::Surface: DepthSurface,
+    F::Channel: RenderChannel,
+{}
+impl<F> StencilFormat for F where
+    F: Formatted,
+    F::Surface: StencilSurface,
+    F::Channel: RenderChannel,
+{}
+impl<F> DepthStencilFormat for F where
+    F: DepthFormat + StencilFormat
+{}
+impl<F> TextureFormat for F where
+    F: Formatted,
+    F::Surface: TextureSurface,
+    F::Channel: TextureChannel,
+{}
+impl<F> RenderFormat for F where
+    F: Formatted,
+    F::Surface: RenderSurface,
+    F::Channel: RenderChannel,
+{}
+impl<F> BlendFormat for F where
+    F: Formatted,
+    F::Surface: RenderSurface,
+    F::Channel: BlendChannel,
+{}
+
+macro_rules! alias {
+    { $( $name:ident = $ty:ty, )* } => {
+        $(
+            #[allow(missing_docs)]
+            #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+            pub struct $name(pub $ty);
+            impl From<$ty> for $name {
+                fn from(v: $ty) -> $name {
+                    $name(v)
+                }
+            }
+
+            unsafe impl Pod for $name {}
+
+            impl $name {
+                /// Convert a 2-element slice.
+                pub fn cast2(v: [$ty; 2]) -> [$name; 2] {
+                    [$name(v[0]), $name(v[1])]
+                }
+                /// Convert a 3-element slice.
+                pub fn cast3(v: [$ty; 3]) -> [$name; 3] {
+                    [$name(v[0]), $name(v[1]), $name(v[2])]
+                }
+                /// Convert a 4-element slice.
+                pub fn cast4(v: [$ty; 4]) -> [$name; 4] {
+                    [$name(v[0]), $name(v[1]), $name(v[2]), $name(v[3])]
+                }
+                /// Convert a generic slice by transmutation.
+                pub fn cast_slice(slice: &[$ty]) -> &[$name] {
+                    use std::mem::transmute;
+                    unsafe { transmute(slice) }
+                }
+            }
+        )*
+    }
+}
+
+alias! {
+    U8Norm = u8,
+    I8Norm = i8,
+    U16Norm = u16,
+    I16Norm = i16,
+    F16 = u16, // half-float
+}
+
+/// Abstracted 1-element container for macro internal use
+pub type Vec1<T> = T;
+/// Abstracted 2-element container for macro internal use
+pub type Vec2<T> = [T; 2];
+/// Abstracted 3-element container for macro internal use
+pub type Vec3<T> = [T; 3];
+/// Abstracted 4-element container for macro internal use
+pub type Vec4<T> = [T; 4];
+
+
+/// Standard 8bits RGBA format.
+pub type Rgba8 = (R8_G8_B8_A8, Unorm);
+/// Standard 8bit gamma transforming RGB format.
+pub type Srgba8 = (R8_G8_B8_A8, Srgb);
+/// Standard HDR floating-point format with 10 bits for RGB components
+/// and 2 bits for the alpha.
+pub type Rgb10a2F = (R10_G10_B10_A2, Float);
+/// Standard 16-bit floating-point RGBA format.
+pub type Rgba16F = (R16_G16_B16_A16, Float);
+/// Standard 32-bit floating-point RGBA format.
+pub type Rgba32F = (R32_G32_B32_A32, Float);
+/// Standard 8bits BGRA format.
+pub type Bgra8 = (B8_G8_R8_A8, Unorm);
+/// Standard 24-bit depth format.
+pub type Depth = (D24, Unorm);
+/// Standard 24-bit depth format with 8-bit stencil.
+pub type DepthStencil = (D24_S8, Unorm);
+/// Standard 32-bit floating-point depth format.
+pub type Depth32F = (D32, Float);
+
+
+macro_rules! impl_simple_formats {
+    { $( $container:ident< $ty:ty > = $channel:ident $surface:ident, )* } => {
+        $(
+            impl Formatted for $container<$ty> {
+                type Surface = $surface;
+                type Channel = $channel;
+                type View = $container<<$channel as ChannelTyped>::ShaderType>;
+            }
+        )*
+    }
+}
+
+macro_rules! impl_formats_8bit {
+    { $( $ty:ty = $channel:ident, )* } => {
+        impl_simple_formats! {$(
+            Vec1<$ty> = $channel R8,
+            Vec2<$ty> = $channel R8_G8,
+            Vec4<$ty> = $channel R8_G8_B8_A8,
+        )*}
+    }
+}
+
+macro_rules! impl_formats_16bit {
+    { $( $ty:ty = $channel:ident, )* } => {
+        impl_simple_formats! {$(
+            Vec1<$ty> = $channel R16,
+            Vec2<$ty> = $channel R16_G16,
+            Vec3<$ty> = $channel R16_G16_B16,
+            Vec4<$ty> = $channel R16_G16_B16_A16,
+        )*}
+    }
+}
+
+macro_rules! impl_formats_32bit {
+    { $( $ty:ty = $channel:ident, )* } => {
+        impl_simple_formats! {$(
+            Vec1<$ty> = $channel R32,
+            Vec2<$ty> = $channel R32_G32,
+            Vec3<$ty> = $channel R32_G32_B32,
+            Vec4<$ty> = $channel R32_G32_B32_A32,
+        )*}
+    }
+}
+
+impl_formats_8bit! {
+    u8 = Uint,
+    i8 = Int,
+    U8Norm = Unorm,
+    I8Norm = Inorm,
+}
+
+impl_formats_16bit! {
+    u16 = Uint,
+    i16 = Int,
+    U16Norm = Unorm,
+    I16Norm = Inorm,
+    F16 = Float,
+}
+
+impl_formats_32bit! {
+    u32 = Uint,
+    i32 = Int,
+    f32 = Float,
+}

--- a/src/corell/src/lib.rs
+++ b/src/corell/src/lib.rs
@@ -1,0 +1,121 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate log;
+
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::any::Any;
+
+pub mod command;
+pub mod factory;
+pub mod format;
+pub mod memory;
+
+/// Draw vertex count.
+pub type VertexCount = u32;
+/// Draw number of instances
+pub type InstanceCount = u32;
+/// Number of vertices in a patch
+pub type PatchSize = u8;
+
+/// Describes what geometric primitives are created from vertex data.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Primitive {
+    /// Each vertex represents a single point.
+    PointList,
+    /// Each pair of vertices represent a single line segment. For example, with `[a, b, c, d,
+    /// e]`, `a` and `b` form a line, `c` and `d` form a line, and `e` is discarded.
+    LineList,
+    /// Every two consecutive vertices represent a single line segment. Visually forms a "path" of
+    /// lines, as they are all connected. For example, with `[a, b, c]`, `a` and `b` form a line
+    /// line, and `b` and `c` form a line.
+    LineStrip,
+    /// Each triplet of vertices represent a single triangle. For example, with `[a, b, c, d, e]`,
+    /// `a`, `b`, and `c` form a triangle, `d` and `e` are discarded.
+    TriangleList,
+    /// Every three consecutive vertices represent a single triangle. For example, with `[a, b, c,
+    /// d]`, `a`, `b`, and `c` form a triangle, and `b`, `c`, and `d` form a triangle.
+    TriangleStrip,
+    /// Patch list,
+    /// used with shaders capable of producing primitives on their own (tessellation)
+    PatchList(PatchSize),
+}
+
+/// A type of each index value in the slice's index buffer
+#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[allow(missing_docs)]
+#[repr(u8)]
+pub enum IndexType {
+    U16,
+    U32,
+}
+
+pub trait Instance {
+    type B: Backend;
+
+    // TODO: Use an iterator instead of Vec?
+    fn enumerate_physical_devices(&self) -> Vec<<<Self as Instance>::B as Backend>::PhysicalDevice>;
+}
+
+pub trait PhysicalDevice {
+    type B: Backend;
+
+    fn open(&self) -> (<<Self as PhysicalDevice>::B as Backend>::Device, Vec<<<Self as PhysicalDevice>::B as Backend>::CommandQueue>);
+}
+
+pub trait Device {
+    
+}
+
+pub trait CommandQueue {
+    type B: Backend;
+
+    /// Submits a `CommandBuffer` to the GPU queue for execution.
+    fn submit(&mut self, &mut <<Self as CommandQueue>::B as Backend>::CommandBuffer);
+}
+
+pub trait SwapChain {
+    type B: Backend;
+
+    fn present(&mut self);
+}
+
+/// Different resource types of a specific API. 
+pub trait Resources:          Clone + Hash + Debug + Eq + PartialEq + Any {
+    type Buffer:              Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync + Copy;
+    type Shader:              Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync;
+    type RenderPass:          Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync;
+    type PipelineLayout:      Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync;
+    type PipelineStateObject: Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync;
+    type Image:               Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync;
+    type ShaderResourceView:  Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync + Copy;
+    type UnorderedAccessView: Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync + Copy;
+    type RenderTargetView:    Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync + Copy;
+    type DepthStencilView:    Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync;
+    type Sampler:             Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync + Copy;
+}
+
+/// Different types of a specific API.
+pub trait Backend {
+    type CommandBuffer;
+    type CommandQueue: CommandQueue;
+    type Device: Device;
+    type Instance: Instance;
+    type PhysicalDevice: PhysicalDevice;
+    type Resources: Resources;
+    type SwapChain: SwapChain;
+}

--- a/src/corell/src/lib.rs
+++ b/src/corell/src/lib.rs
@@ -113,7 +113,14 @@ pub trait CommandQueue {
 
 /// A `Surface` abstracts the surface of a native window, which will be presented
 pub trait Surface {
+    type B: Backend;
+    type Window;
 
+    fn from_window(window: &Self::Window, instance: &<<Self as Surface>::B as Backend>::Instance) -> Self;
+
+    fn build_swapchain<T: format::RenderFormat>(&self,
+        width: u32, height: u32,
+        present_queue: &<<Self as Surface>::B as Backend>::CommandQueue) -> <<Self as Surface>::B as Backend>::SwapChain;
 }
 
 /// The `SwapChain` is the backend representation of the surface.

--- a/src/corell/src/lib.rs
+++ b/src/corell/src/lib.rs
@@ -74,38 +74,45 @@ pub trait Instance {
     /// Instantiate a new `Instance`, this is our entry point for applications
     fn create() -> Self;
 
-    /// Enumerate all available devices supporting this backend 
+    /// Enumerate all available adapters supporting this backend 
     fn enumerate_adapters(&self) -> Vec<Self::Adapter>;
 
     /// Create a new surface from a native window.
     fn create_surface(&self, window: &Self::Window) -> Self::Surface;
 }
 
+/// Represents a physical or virtual device, which is capable of running the backend.
 pub trait Adapter {
     type CommandQueue: CommandQueue;
     type Device: Device;
     type QueueFamily: QueueFamily;
 
+    /// Create a new device and command queues.
     fn open<'a, I>(&self, queue_descs: I) -> (Self::Device, Vec<Self::CommandQueue>)
         where I: Iterator<Item=(&'a Self::QueueFamily, u32)>;
 
+    /// Get the `AdapterInfo` for this adapater.
     fn get_info(&self) -> &AdapterInfo;
 
+    /// Return the supported queue families for this adapter.
     fn get_queue_families(&self) -> Iter<Self::QueueFamily>;
 }
 
+/// Information about a backend adapater.
 #[derive(Clone, Debug)]
 pub struct AdapterInfo {
     /// Adapter name
     pub name: String,
-    /// Vendor PCI id of the physical device
+    /// Vendor PCI id of the adapter
     pub vendor: usize,
-    /// PCI id of the physical device
+    /// PCI id of the adapter
     pub device: usize,
     /// The device is based on a software rasterizer
     pub software_rendering: bool,
 }
 
+/// `QueueFamily` denotes a group of command queues provided by the backend
+/// with the same properties/type.
 pub trait QueueFamily: 'static {
     type Surface: Surface;
 
@@ -139,6 +146,13 @@ pub trait Surface {
 
 /// Handle to a backbuffer of the swapchain.
 pub struct Frame(usize);
+
+impl Frame {
+    #[doc(hidden)]
+    pub fn new(id: usize) -> Self {
+        Frame(id)
+    }
+}
 
 /// The `SwapChain` is the backend representation of the surface.
 /// It consists of multiple buffers, which will be presented on the surface.

--- a/src/corell/src/lib.rs
+++ b/src/corell/src/lib.rs
@@ -67,6 +67,8 @@ pub enum IndexType {
 pub trait Instance {
     type B: Backend;
 
+    fn create() -> Self;
+
     // TODO: Use an iterator instead of Vec?
     fn enumerate_physical_devices(&self) -> Vec<<<Self as Instance>::B as Backend>::PhysicalDevice>;
 }
@@ -75,6 +77,19 @@ pub trait PhysicalDevice {
     type B: Backend;
 
     fn open(&self) -> (<<Self as PhysicalDevice>::B as Backend>::Device, Vec<<<Self as PhysicalDevice>::B as Backend>::CommandQueue>);
+    fn get_info(&self) -> PhysicalDeviceInfo;
+}
+
+#[derive(Clone, Debug)]
+pub struct PhysicalDeviceInfo {
+    /// Phyiscal device name
+    pub name: String,
+    /// Vendor PCI id of the physical device
+    pub vendor: usize,
+    /// PCI id of the physical device
+    pub device: usize,
+    /// The device is based on a software rasterizer
+    pub software_rendering: bool,
 }
 
 pub trait Device {
@@ -85,7 +100,7 @@ pub trait CommandQueue {
     type B: Backend;
 
     /// Submits a `CommandBuffer` to the GPU queue for execution.
-    fn submit(&mut self, &mut <<Self as CommandQueue>::B as Backend>::CommandBuffer);
+    fn submit(&mut self, cmd_buffer: &<<Self as CommandQueue>::B as Backend>::CommandBuffer);
 }
 
 pub trait SwapChain {

--- a/src/corell/src/memory.rs
+++ b/src/corell/src/memory.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Gfx-rs Developers.
+// Copyright 2017 The Gfx-rs Developers.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/corell/src/memory.rs
+++ b/src/corell/src/memory.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Memory stuff
+
+/// A trait for plain-old-data types.
+///
+/// A POD type does not have invalid bit patterns and can be safely
+/// created from arbitrary bit pattern.
+pub unsafe trait Pod {}
+
+macro_rules! impl_pod {
+    ( ty = $($ty:ty)* ) => { $( unsafe impl Pod for $ty {} )* };
+    ( ar = $($tt:expr)* ) => { $( unsafe impl<T: Pod> Pod for [T; $tt] {} )* };
+}
+
+impl_pod! { ty = isize usize i8 u8 i16 u16 i32 u32 i64 u64 f32 f64 }
+impl_pod! { ar =
+    0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
+}


### PR DESCRIPTION
## Motivation
The next gen APIs (Vulkan and D3D12) offer an low level interface of the GPU in comparison to older APIs like OpenGL or D3D11. To avoid overhead due to high level abstraction we want to investigate the implementation of a thin wrapper above the mentioned low level APIs to address https://github.com/gfx-rs/gfx/issues/1102.

## Goals
This PR creates a new low level core API `corell` and two backend implementations for the low level core. corell is heavily based on the vulkan API and shares a lot of concepts like `Instance`, `Surface`, etc., but tries to also take d3d12 into account. In future steps further abstractions could be considered to reduce the amount of setup code.

Planned coverage for this PR:
- [x] Instance/Context
- [x] Surface
- [x] Swapchain
- [x] PhysicalDevice

Note: Also includes some dummy types for other objects.
`format` and `memory` are mainly copied from `core`.

Hoping for early feedback if this is the intended way to go with regards to #1102.


cc @MaikKlein for quick checking ash based vulkan implementation if you have time 😄 