### PR TITLE
Fix for the PSO error bounds

### DIFF
--- a/src/render/src/factory.rs
+++ b/src/render/src/factory.rs
@@ -40,7 +40,17 @@ pub enum PipelineStateError<S> {
     DeviceCreate(CreationError),
 }
 
-impl<S: Error> fmt::Display for PipelineStateError<S> {
+impl<'a> From<PipelineStateError<&'a str>> for PipelineStateError<String> {
+    fn from(pse: PipelineStateError<&'a str>) -> PipelineStateError<String> {
+        match pse {
+            PipelineStateError::Program(e) => PipelineStateError::Program(e),
+            PipelineStateError::DescriptorInit(e) => PipelineStateError::DescriptorInit(e.into()),
+            PipelineStateError::DeviceCreate(e) => PipelineStateError::DeviceCreate(e),
+        }
+    }
+}
+
+impl<S: fmt::Debug + fmt::Display> fmt::Display for PipelineStateError<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             PipelineStateError::Program(ref e) => write!(f, "{}: {}", self.description(), e),
@@ -50,7 +60,7 @@ impl<S: Error> fmt::Display for PipelineStateError<S> {
     }
 }
 
-impl<S: Error> Error for PipelineStateError<S> {
+impl<S: fmt::Debug + fmt::Display> Error for PipelineStateError<S> {
     fn description(&self) -> &str {
         match *self {
             PipelineStateError::Program(_) => "Shader program failed to link",

--- a/src/render/src/pso/mod.rs
+++ b/src/render/src/pso/mod.rs
@@ -158,7 +158,7 @@ impl<'a> From<InitError<&'a str>> for InitError<String> {
     }
 }
 
-impl<S: Error> fmt::Display for InitError<S> {
+impl<S: fmt::Debug + fmt::Display> fmt::Display for InitError<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::InitError::*;
         let desc = self.description();
@@ -174,7 +174,7 @@ impl<S: Error> fmt::Display for InitError<S> {
     }
 }
 
-impl<S: Error> Error for InitError<S> {
+impl<S: fmt::Debug + fmt::Display> Error for InitError<S> {
     fn description(&self) -> &str {
         use self::InitError::*;
         match *self {


### PR DESCRIPTION
We used to `impl<S: Error> Error for PipelineStateError` while actually using `S = String` and `S = &str`, which don't satisfy the `Error` bound, making the whole thing a bit useless. This PR fixes that.