### PR TITLE
Add a gfx::Slice::split_at method.

### DIFF
--- a/src/render/src/slice.rs
+++ b/src/render/src/slice.rs
@@ -99,6 +99,19 @@ impl<R: Resources> Slice<R> {
             p::PatchList(num) => nv / (num as u32),
         }
     }
+
+    /// Divides one slice into two at an index.
+    ///
+    /// The first will contain the range in the index-buffer [self.start, mid) (excluding the index mid itself) and the
+    /// second will contain the range [mid, self.end).
+    pub fn split_at(&self, mid: VertexCount) -> (Self, Self) {
+        let mut first = self.clone();
+        let mut second = self.clone();
+        first.end = mid;
+        second.start = mid;
+
+        (first, second)
+    }
 }
 
 /// Type of index-buffer used in a Slice.


### PR DESCRIPTION
A simple method to split a slice in two in a similar way as [std::slice::split_at](https://doc.rust-lang.org/std/primitive.slice.html#method.split_at). This is useful when grouping the geometry for several draw calls in the same buffer.