### PR TITLE
Make the CreateProgramError a proper struct

### DIFF
--- a/src/backend/gl/src/shade.rs
+++ b/src/backend/gl/src/shade.rs
@@ -522,7 +522,7 @@ pub fn create_program(gl: &gl::Gl, caps: &c::Capabilities, private: &PrivateCaps
 
         Ok((name, info))
     } else {
-        Err(log)
+        Err(log.into())
     }
 }
 

--- a/src/core/src/shade.rs
+++ b/src/core/src/shade.rs
@@ -535,4 +535,23 @@ impl Error for CreateShaderError {
 }
 
 /// An error type for creating programs.
-pub type CreateProgramError = String;
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateProgramError(String);
+
+impl fmt::Display for CreateProgramError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad(&self.0)
+    }
+}
+
+impl Error for CreateProgramError {
+    fn description(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<S: Into<String>> From<S> for CreateProgramError {
+    fn from(s: S) -> CreateProgramError {
+        CreateProgramError(s.into())
+    }
+}

--- a/src/render/src/shade.rs
+++ b/src/render/src/shade.rs
@@ -93,7 +93,7 @@ impl Error for ProgramError {
             ProgramError::Hull(ref e) => Some(e),
             ProgramError::Domain(ref e) => Some(e),
             ProgramError::Pixel(ref e) => Some(e),
-            _ => None,
+            ProgramError::Link(ref e) => Some(e),
         }
     }
 }


### PR DESCRIPTION
 Makes the CreateProgramError type a proper struct which impls the `Error` trait. This means that you can now get the cause of a `ProgramError::Link` error.