### PR TITLE
Work around nonconforming OpenGL drivers returning the length of a uniform name without the trailing null byte.

### DIFF
--- a/src/backend/gl/src/shade.rs
+++ b/src/backend/gl/src/shade.rs
@@ -227,7 +227,9 @@ fn query_blocks(gl: &gl::Gl, caps: &c::Capabilities, prog: super::Program,
     // `layout(binding = n)`
     let explicit_binding = bindings.iter().any(|&i| i > 0);
 
-    let max_len = get_program_iv(gl, prog, gl::ACTIVE_UNIFORM_MAX_LENGTH);
+    // Some implementations seem to return the length of the uniform name without
+    // null termination. Therefore we allocate an extra byte here.
+    let max_len = get_program_iv(gl, prog, gl::ACTIVE_UNIFORM_MAX_LENGTH) + 1;
     let mut el_name = String::with_capacity(max_len as usize);
     el_name.extend(repeat('\0').take(max_len as usize));
 


### PR DESCRIPTION
This fixes shader reflection on some OpenGL drivers when long
uniform names or nested structs are used in a shader. On conforming
drivers it has no effect.