### PR TITLE
Add the rendering::graphics-api category

### DIFF
--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -21,6 +21,7 @@ repository = "https://github.com/gfx-rs/gfx"
 keywords = ["graphics", "gamedev"]
 license = "Apache-2.0"
 authors = ["The Gfx-rs Developers"]
+categories = ["rendering::graphics-api"]
 
 [lib]
 name = "gfx"


### PR DESCRIPTION
That way gfx will show up here: https://crates.io/categories/rendering::graphics-api.