### PR TITLE
Use glBufferData instead of glBufferStorage for zero sized buffers

### DIFF
--- a/src/backend/gl/src/factory.rs
+++ b/src/backend/gl/src/factory.rs
@@ -125,7 +125,7 @@ impl Factory {
             0 as *const gl::types::GLvoid
         };
 
-        if self.share.private_caps.buffer_storage_supported {
+        if self.share.private_caps.buffer_storage_supported && info.size > 0 {
             let usage = match info.usage {
                 Data => 0,
                 // TODO: we could use mapping instead of glBufferSubData


### PR DESCRIPTION
Zero sized buffers are allowed in OpenGL. However, attempting to create one using glBufferStorage will result in an [invalid operation error](https://www.opengl.org/sdk/docs/man/html/glBufferStorage.xhtml#errors). The glBufferData function does not have this limitation (only negative sizes are considered invalid) and should be used instead for this case. 