### PR TITLE
Allow missing docs for all macro-generated structs

### DIFF
--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -225,6 +225,7 @@ macro_rules! gfx_pipeline_base {
     ($module:ident {
         $( $field:ident: $ty:ty, )*
     }) => {
+        #[allow(missing_docs)]
         pub mod $module {
             #[allow(unused_imports)]
             use super::*;
@@ -241,6 +242,7 @@ macro_rules! gfx_pipeline {
     ($module:ident {
         $( $field:ident: $ty:ty = $value:expr, )*
     }) => {
+        #[allow(missing_docs)]
         pub mod $module {
             #[allow(unused_imports)]
             use super::*;

--- a/src/render/src/macros/structure.rs
+++ b/src/render/src/macros/structure.rs
@@ -30,6 +30,7 @@ macro_rules! gfx_impl_struct_meta {
     ($(#[$attr:meta])* impl_struct_meta $runtime_format:ty : $compile_format:path = $root:ident {
         $( $field:ident: $ty:ty = $name:expr, )*
     }) => {
+        #[allow(missing_docs)]
         #[derive(Clone, Copy, Debug)]
         $(#[$attr])*
         pub struct $root {


### PR DESCRIPTION
This pull request fixes issue #1176. Tested it successfully with a dummy crate on my machine.