### PR TITLE
src/core/src/pso.rs: remove assert

### DIFF
--- a/src/core/src/pso.rs
+++ b/src/core/src/pso.rs
@@ -286,7 +286,6 @@ impl<R: Resources> PixelTargetSet<R> {
     }
 
     fn set_dimensions(&mut self, dim: texture::Dimensions) {
-        debug_assert!(self.dimensions.map(|d| d == dim).unwrap_or(true));
         self.dimensions = Some(dim);
     }
 


### PR DESCRIPTION
When running the Cube example in `piston-examples`, I noticed that resizing the window does not update the sizes of the buffers. I discovered that the pipeline data needs to be updated according to the window's dimensions, and it resulted in the following commit (not yet pushed to `piston-examples`), which has successfully solved the problem for me (along with the assert removal in this pull request):

https://github.com/da-x/piston-examples/commit/f88489145cf0d873ad2479285a5b0db9bee7ffbe

Is there a better way to fix window resizing in `piston-examples`, or can we have this assert removed?

@bvssvni , @sectopod , @Bastacyclop 