### PR TITLE
#1106 CI test SDL window fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: rust
-cache: cargo
+cache:
+  cargo: true
+  directories:
+   - $HOME/deps
 rust:
   - stable
   - nightly
@@ -17,16 +20,20 @@ notifications:
 before_install:
   - "export DISPLAY=:99.0"
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
+  # Extract SDL2 .deb into a cached directory (see cache section above and LIBRARY_PATH exports below)
+  # Will no longer be needed when Trusty build environment goes out of beta at Travis CI
+  # (assuming it will have libsdl2-dev and Rust by then)
+  # see https://docs.travis-ci.com/user/trusty-ci-environment/
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then scripts/travis-install-sdl2.sh ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl2; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated cmake || brew upgrade cmake; fi
+
 addons:
   apt:
     sources:
       # install a newer cmake since at this time Travis only has version 2.8.7
       - george-edison55-precise-backports
-      # add a repository for libsdl2-dev (enable sudo before uncommenting this)
-      #- sourceline: 'ppa:zoogie/sdl2-snapshots'
     packages:
       - xdotool
       - cmake
@@ -36,12 +43,18 @@ addons:
       - libxinerama1
       - libxcursor-dev
       - libxcursor1
-      #- libsdl2-dev
       - libglfw-dev
 script:
   - export RUST_BACKTRACE=1
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$PATH:$HOME/deps/bin ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export LIBRARY_PATH=$HOME/deps/usr/lib/x86_64-linux-gnu ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export LD_LIBRARY_PATH=$LIBRARY_PATH ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo build --features vulkan; else cargo build; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cargo build --features metal; else cargo build; fi
   - cargo test --all
+  - cargo test -p gfx_window_sdl
+  - cargo test -p gfx_device_gl
+  - cargo test -p gfx_window_glutin
+  - cargo test -p gfx_window_glfw
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --all --features vulkan; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cargo test --all --features metal; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ optional = true
 
 [target.'cfg(unix)'.dependencies]
 gfx_window_glfw = { path = "src/window/glfw", version = "0.13" }
+gfx_window_sdl = { path = "src/window/sdl", version = "0.5" }
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.5" }

--- a/scripts/travis-install-sdl2.sh
+++ b/scripts/travis-install-sdl2.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -ev
+
+DEST=$HOME/deps
+
+-d $DEST/usr/bin/sdl2-config && exit
+
+mkdir -p $DEST
+cd $DEST
+
+test -f dev.deb || curl -sLo dev.deb http://ppa.launchpad.net/zoogie/sdl2-snapshots/ubuntu/pool/main/libs/libsdl2/libsdl2-dev_2.0.3+z4~20140315-8621-1ppa1precise1_amd64.deb
+test -f bin.deb || curl -sLo bin.deb http://ppa.launchpad.net/zoogie/sdl2-snapshots/ubuntu/pool/main/libs/libsdl2/libsdl2_2.0.3+z4~20140315-8621-1ppa1precise1_amd64.deb
+
+dpkg-deb -x bin.deb .
+dpkg-deb -x dev.deb .
+
+sed -e s,/usr,$DEST,g $DEST/usr/bin/sdl2-config > $DEST/usr/bin/sdl2-config.new
+mv $DEST/usr/bin/sdl2-config.new $DEST/usr/bin/sdl2-config
+chmod a+x $DEST/usr/bin/sdl2-config
+

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -79,15 +79,18 @@ pub type InitOk<Cf, Df> =
 /// # Example
 ///
 /// ```no_run
+/// extern crate gfx_core;
 /// extern crate gfx_window_sdl;
 /// extern crate sdl2;
+///
+/// use gfx_core::format::{DepthStencil, Rgba8};
 ///
 /// fn main() {
 ///     let sdl = sdl2::init().unwrap();
 ///
 ///     let builder = sdl.video().unwrap().window("Example", 800, 600);
 ///     let (window, glcontext, device, factory, color_view, depth_view) =
-///         gfx_window_sdl::init(builder).expect("gfx_window_sdl::init failed!");
+///         gfx_window_sdl::init::<Rgba8, DepthStencil>(builder).expect("gfx_window_sdl::init failed!");
 ///
 ///     // some code...
 /// }


### PR DESCRIPTION
Installs SDL2 from the formerly used PPA into $HOME/deps, then caches it.

Readds cargo test -p  since cargo test --all still does not test local dependencies.

Trivial fix in gfx_window_sdl doctest.
