### PR TITLE
bump image dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ gfx_gl = "0.3"
 rand = "0.3"
 genmesh = "0.4"
 noise = "0.1"
-image = "0.6"
+image = "0.12.3"
 winit = "0.5"
 
 [target.x86_64-unknown-linux-gnu.dev_dependencies]


### PR DESCRIPTION
Existing dependency is on 0.6, which spews a bunch of warnings. This is annoying, so let's bump the dependecy to the latest version. 

Tested: examples.