### PR TITLE
Rename `to_resource` to `as_resource`

### DIFF
--- a/src/backend/dx11/src/execute.rs
+++ b/src/backend/dx11/src/execute.rs
@@ -73,7 +73,7 @@ pub fn update_texture(context: *mut winapi::ID3D11DeviceContext, texture: &Textu
     };
     let num_mipmap_levels = 1; //TODO
     let subres = array_slice * num_mipmap_levels + (image.mipmap as UINT);
-    let dst_resource = texture.to_resource();
+    let dst_resource = texture.as_resource();
     let (width, height, _, _) = kind.get_level_dimensions(image.mipmap);
     let stride = image.format.0.get_total_bits() as usize;
     let row_pitch = width as usize * stride;

--- a/src/backend/dx11/src/execute.rs
+++ b/src/backend/dx11/src/execute.rs
@@ -22,8 +22,8 @@ fn copy_buffer(context: *mut winapi::ID3D11DeviceContext,
                src: &Buffer, dst: &Buffer,
                src_offset: UINT, dst_offset: UINT,
                size: UINT) {
-    let src_resource = src.to_resource();
-    let dst_resource = dst.to_resource();
+    let src_resource = src.as_resource();
+    let dst_resource = dst.as_resource();
     let src_box = winapi::D3D11_BOX {
         left: src_offset,
         right: src_offset + size,

--- a/src/backend/dx11/src/factory.rs
+++ b/src/backend/dx11/src/factory.rs
@@ -722,7 +722,7 @@ impl core::Factory<R> for Factory {
         };
 
         let mut raw_view = ptr::null_mut();
-        let raw_tex = self.frame_handles.ref_texture(htex).to_resource();
+        let raw_tex = self.frame_handles.ref_texture(htex).as_resource();
         let hr = unsafe {
             (*self.device).CreateShaderResourceView(raw_tex, &native_desc, &mut raw_view)
         };
@@ -790,7 +790,7 @@ impl core::Factory<R> for Factory {
             u: extra,
         };
         let mut raw_view = ptr::null_mut();
-        let raw_tex = self.frame_handles.ref_texture(htex).to_resource();
+        let raw_tex = self.frame_handles.ref_texture(htex).as_resource();
         let hr = unsafe {
             (*self.device).CreateRenderTargetView(raw_tex, &native_desc, &mut raw_view)
         };
@@ -855,7 +855,7 @@ impl core::Factory<R> for Factory {
         };
 
         let mut raw_view = ptr::null_mut();
-        let raw_tex = self.frame_handles.ref_texture(htex).to_resource();
+        let raw_tex = self.frame_handles.ref_texture(htex).as_resource();
         let hr = unsafe {
             (*self.device).CreateDepthStencilView(raw_tex, &native_desc, &mut raw_view)
         };
@@ -944,7 +944,7 @@ pub fn ensure_mapped(mapping: &mut MappingGate,
             DepthPitch: 0,
         };
             
-        let dst = raw_handle.to_resource() as *mut winapi::d3d11::ID3D11Resource;
+        let dst = raw_handle.as_resource() as *mut winapi::d3d11::ID3D11Resource;
         let hr = unsafe {
             (*ctx).Map(dst, 0, map_type, 0, &mut sres)
         };
@@ -963,7 +963,7 @@ pub fn ensure_unmapped(mapping: &mut MappingGate,
     if !mapping.pointer.is_null() {
         let raw_handle = *buffer.resource();
         unsafe {
-            (*context).Unmap(raw_handle.to_resource() as *mut winapi::d3d11::ID3D11Resource, 0);
+            (*context).Unmap(raw_handle.as_resource() as *mut winapi::d3d11::ID3D11Resource, 0);
         }
 
         mapping.pointer = ptr::null_mut();

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -395,7 +395,7 @@ impl core::Device for Device {
                 (*(v.depth_stencil as Child)).Release();
                 (*(v.blend as Child)).Release();
             },
-            |_, texture| unsafe { (*texture.resource().to_resource()).Release(); },
+            |_, texture| unsafe { (*texture.resource().as_resource()).Release(); },
             |_, v| unsafe { (*v.0).Release(); }, //SRV
             |_, _| {}, //UAV
             |_, v| unsafe { (*v.0).Release(); }, //RTV

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -82,8 +82,7 @@ use core::command::{AccessInfo, AccessGuard};
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Buffer(native::Buffer);
 impl Buffer {
-    // TODO: 'as_resource' would be better ?
-    pub fn to_resource(&self) -> *mut winapi::ID3D11Resource {
+    pub fn as_resource(&self) -> *mut winapi::ID3D11Resource {
         type Res = *mut winapi::ID3D11Resource;
         match self.0 {
             native::Buffer(t) => t as Res,
@@ -94,8 +93,7 @@ impl Buffer {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Texture(native::Texture);
 impl Texture {
-    // TODO: 'as_resource' would be better ?
-    pub fn to_resource(&self) -> *mut winapi::ID3D11Resource {
+    pub fn as_resource(&self) -> *mut winapi::ID3D11Resource {
         type Res = *mut winapi::ID3D11Resource;
         match self.0 {
             native::Texture::D1(t) => t as Res,

--- a/src/backend/metal/src/factory.rs
+++ b/src/backend/metal/src/factory.rs
@@ -677,7 +677,7 @@ impl core::Factory<Resources> for Factory {
         // };
         //
         // let mut raw_view = ptr::null_mut();
-        // let raw_tex = self.frame_handles.ref_texture(htex).to_resource();
+        // let raw_tex = self.frame_handles.ref_texture(htex).as_resource();
         // let hr = unsafe {
         // (*self.device).CreateShaderResourceView(raw_tex, &native_desc, &mut raw_view)
         // };
@@ -763,7 +763,7 @@ impl core::Factory<Resources> for Factory {
         // };
         //
         // let mut raw_view = ptr::null_mut();
-        // let raw_tex = self.frame_handles.ref_texture(htex).to_resource();
+        // let raw_tex = self.frame_handles.ref_texture(htex).as_resource();
         // let hr = unsafe {
         // (*self.device).CreateDepthStencilView(raw_tex, &native_desc, &mut raw_view)
         // };


### PR DESCRIPTION
For #1130 (tiny little potential contribution).

I lack the capacity to test this as I don't have a Windows environment.