### PR TITLE
[WIP] Implement texture staging

### DIFF
--- a/src/backend/dx11/src/command.rs
+++ b/src/backend/dx11/src/command.rs
@@ -322,6 +322,25 @@ impl<P: Parser> command::Buffer<Resources> for CommandBuffer<P> {
                                               size_bytes as UINT));
     }
 
+    #[allow(unused_variables)]
+    fn copy_buffer_to_texture(&mut self, src: Buffer, src_offset_bytes: usize,
+                              dst: Texture,
+                              kind: tex::Kind,
+                              face: Option<tex::CubeFace>,
+                              img: tex::RawImageInfo) {
+        unimplemented!()
+    }
+
+    #[allow(unused_variables)]
+    fn copy_texture_to_buffer(&mut self,
+                              src: Texture,
+                              kind: tex::Kind,
+                              face: Option<tex::CubeFace>,
+                              img: tex::RawImageInfo,
+                              dst: Buffer, dst_offset_bytes: usize) {
+        unimplemented!()
+    }
+
     fn update_buffer(&mut self, buf: Buffer, data: &[u8], offset: usize) {
         self.parser.update_buffer(buf, data, offset);
     }

--- a/src/backend/dx11/src/execute.rs
+++ b/src/backend/dx11/src/execute.rs
@@ -59,20 +59,7 @@ pub fn update_buffer(context: *mut winapi::ID3D11DeviceContext, buffer: &Buffer,
 
 pub fn update_texture(context: *mut winapi::ID3D11DeviceContext, texture: &Texture, kind: tex::Kind,
                       face: Option<tex::CubeFace>, data: &[u8], image: &tex::RawImageInfo) {
-    use core::texture::CubeFace::*;
-    use winapi::UINT;
-
-    let array_slice = match face {
-        Some(PosX) => 0,
-        Some(NegX) => 1,
-        Some(PosY) => 2,
-        Some(NegY) => 3,
-        Some(PosZ) => 4,
-        Some(NegZ) => 5,
-        None => 0,
-    };
-    let num_mipmap_levels = 1; //TODO
-    let subres = array_slice * num_mipmap_levels + (image.mipmap as UINT);
+    let subres = texture_subres(face, image);
     let dst_resource = texture.as_resource();
     let (width, height, _, _) = kind.get_level_dimensions(image.mipmap);
     let stride = image.format.0.get_total_bits() as usize;
@@ -97,6 +84,21 @@ pub fn update_texture(context: *mut winapi::ID3D11DeviceContext, texture: &Textu
     }
 }
 
+fn texture_subres(face: Option<tex::CubeFace>, image: &tex::RawImageInfo) -> winapi::UINT {
+    use core::texture::CubeFace::*;
+
+    let array_slice = match face {
+        Some(PosX) => 0,
+        Some(NegX) => 1,
+        Some(PosY) => 2,
+        Some(NegY) => 3,
+        Some(PosZ) => 4,
+        Some(NegZ) => 5,
+        None => 0,
+    };
+    let num_mipmap_levels = 1; //TODO
+    array_slice * num_mipmap_levels + (image.mipmap as UINT)
+}
 
 pub fn process(ctx: *mut winapi::ID3D11DeviceContext, command: &command::Command, data_buf: &command::DataBuffer) {
     use winapi::UINT;

--- a/src/backend/gl/src/factory.rs
+++ b/src/backend/gl/src/factory.rs
@@ -177,9 +177,11 @@ impl Factory {
 
         mapping_access.map(|access| {
             let (kind, ptr) = if self.share.private_caps.buffer_storage_supported {
-                let gl_access = access_to_map_bits(access) |
-                                gl::MAP_PERSISTENT_BIT |
-                                gl::MAP_FLUSH_EXPLICIT_BIT;
+                let mut gl_access = access_to_map_bits(access) |
+                                    gl::MAP_PERSISTENT_BIT;
+                if access.contains(memory::WRITE) {
+                    gl_access |= gl::MAP_FLUSH_EXPLICIT_BIT;
+                }
                 let size = info.size as isize;
                 let ptr = unsafe {
                     gl.BindBuffer(target, buffer);

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -317,10 +317,29 @@ impl command::Buffer<Resources> for CommandBuffer {
         // TODO: blend/stencil
     }
 
-    #[allow(dead_code)]
+    #[allow(unused_variables)]
     fn copy_buffer(&mut self, src: Buffer, dst: Buffer,
                    src_offset_bytes: usize, dst_offset_bytes: usize,
                    size_bytes: usize) {
+        unimplemented!()
+    }
+
+    #[allow(unused_variables)]
+    fn copy_buffer_to_texture(&mut self, src: Buffer, src_offset_bytes: usize,
+                              dst: Texture,
+                              kind: texture::Kind,
+                              face: Option<texture::CubeFace>,
+                              img: texture::RawImageInfo) {
+        unimplemented!()
+    }
+
+    #[allow(unused_variables)]
+    fn copy_texture_to_buffer(&mut self,
+                              src: Texture,
+                              kind: texture::Kind,
+                              face: Option<texture::CubeFace>,
+                              img: texture::RawImageInfo,
+                              dst: Buffer, dst_offset_bytes: usize) {
         unimplemented!()
     }
 

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -242,6 +242,25 @@ impl command::Buffer<Resources> for Buffer {
         unimplemented!(); // TODO: synchronisation
     }
 
+    #[allow(unused_variables)]
+    fn copy_buffer_to_texture(&mut self, src: native::Buffer, src_offset_bytes: usize,
+                              dst: native::Texture,
+                              kind: tex::Kind,
+                              face: Option<tex::CubeFace>,
+                              img: tex::RawImageInfo) {
+        unimplemented!()
+    }
+
+    #[allow(unused_variables)]
+    fn copy_texture_to_buffer(&mut self,
+                              src: native::Texture,
+                              kind: tex::Kind,
+                              face: Option<tex::CubeFace>,
+                              img: tex::RawImageInfo,
+                              dst: native::Buffer, dst_offset_bytes: usize) {
+        unimplemented!()
+    }
+
     fn update_buffer(&mut self, _: native::Buffer, _: &[u8], _: usize) {}
     fn update_texture(&mut self, _: native::Texture, _: tex::Kind, _: Option<tex::CubeFace>,
                       _: &[u8], _: tex::RawImageInfo) {}

--- a/src/core/src/command.rs
+++ b/src/core/src/command.rs
@@ -68,6 +68,16 @@ pub trait Buffer<R: Resources>: Send {
     fn copy_buffer(&mut self, src: R::Buffer, dst: R::Buffer,
                    src_offset_bytes: usize, dst_offset_bytes: usize,
                    size_bytes: usize);
+    /// Copy part of a buffer to a texture
+    fn copy_buffer_to_texture(&mut self,
+                              src: R::Buffer, src_offset_bytes: usize,
+                              dst: R::Texture, texture::Kind,
+                              Option<texture::CubeFace>, texture::RawImageInfo);
+    /// Copy part of a texture to a buffer
+    fn copy_texture_to_buffer(&mut self,
+                              src: R::Texture, texture::Kind,
+                              Option<texture::CubeFace>, texture::RawImageInfo,
+                              dst: R::Buffer, dst_offset_bytes: usize);
     /// Update a vertex/index/uniform buffer
     fn update_buffer(&mut self, R::Buffer, data: &[u8], offset: usize);
     /// Update a texture

--- a/src/core/src/dummy.rs
+++ b/src/core/src/dummy.rs
@@ -100,6 +100,14 @@ impl command::Buffer<DummyResources> for DummyCommandBuffer {
     fn copy_buffer(&mut self, _: (), _: (),
                    _: usize, _: usize,
                    _: usize) {}
+    fn copy_buffer_to_texture(&mut self,
+                              _: (), _: usize,
+                              _: (), _: texture::Kind,
+                              _: Option<texture::CubeFace>, _: texture::RawImageInfo) {}
+    fn copy_texture_to_buffer(&mut self,
+                              _: (), _: texture::Kind,
+                              _: Option<texture::CubeFace>, _: texture::RawImageInfo,
+                              _: (), _: usize) {}
     fn update_buffer(&mut self, _: (), _: &[u8], _: usize) {}
     fn update_texture(&mut self, _: (), _: texture::Kind, _: Option<texture::CubeFace>,
                       _: &[u8], _: texture::RawImageInfo) {}

--- a/src/core/src/handle.rs
+++ b/src/core/src/handle.rs
@@ -161,6 +161,9 @@ pub struct RawRenderTargetView<R: Resources>(Arc<R::RenderTargetView>, RawTextur
 impl<R: Resources> RawRenderTargetView<R> {
     /// Get target dimensions
     pub fn get_dimensions(&self) -> texture::Dimensions { self.2 }
+
+    /// Get the associated texture
+    pub fn get_texture(&self) -> &RawTexture<R> { &self.1 }
 }
 
 /// Raw DSV
@@ -171,6 +174,9 @@ pub struct RawDepthStencilView<R: Resources>(Arc<R::DepthStencilView>, RawTextur
 impl<R: Resources> RawDepthStencilView<R> {
     /// Get target dimensions
     pub fn get_dimensions(&self) -> texture::Dimensions { self.2 }
+
+    /// Get the associated texture
+    pub fn get_texture(&self) -> &RawTexture<R> { &self.1 }
 }
 
 /// Typed RTV

--- a/src/core/src/texture.rs
+++ b/src/core/src/texture.rs
@@ -361,6 +361,14 @@ impl<F> ImageInfoCommon<F> {
     }
 }
 
+impl RawImageInfo {
+    /// Get the total number of bytes.
+    pub fn get_byte_count(&self) -> usize {
+        let texel_bytes = self.format.0.get_total_bits() / 8;
+        self.get_texel_count() * (texel_bytes as usize)
+    }
+}
+
 /// Specifies how texture coordinates outside the range `[0, 1]` are handled.
 #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
 pub enum WrapMode {


### PR DESCRIPTION
Implements texture staging by providing `copy_buffer_to_texture` and `copy_texture_to_buffer` methods.
Would close #1181 

@kvark: @Androcas and me will move on to the D3D11 implementation if you like the OpenGL one, I'm not sure if we want to add another example for staging or modify an existing one?