### PR TITLE
Delete `gfx_app::Backend`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,6 @@ pub struct WindowTargets<R: gfx::Resources> {
     pub aspect_ratio: f32,
 }
 
-pub enum Backend {
-    OpenGL2,
-    Direct3D11 { pix_mode: bool },
-    Metal,
-}
-
 struct Harness {
     start: std::time::Instant,
     num_frames: f64,


### PR DESCRIPTION
It has been completely succeeded by `gfx_app::shade::Backend`.