### PR TITLE
[ll] vulkan: Update to latest ash and fix graphics pipeline creation

### DIFF
--- a/src/backend/vulkanll/Cargo.toml
+++ b/src/backend/vulkanll/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.3"
 lazy_static = "0.2"
 shared_library = "0.1"
 gfx_corell = { path = "../../corell", version = "0.1.0" }
-ash = { git = "https://github.com/msiglreith/ash.git", branch = "ll" }
+ash = "0.15"
 spirv-utils = { git = "https://github.com/msiglreith/spirv-utils.git", branch = "gfx" }
 winit = "0.5"
 

--- a/src/backend/vulkanll/src/command.rs
+++ b/src/backend/vulkanll/src/command.rs
@@ -122,13 +122,12 @@ impl CommandBuffer {
         };
 
         unsafe {
-            self.device.0.fp_v1_0().cmd_clear_color_image(
+            self.device.0.cmd_clear_color_image(
                 self.inner,
                 rtv.image,
                 vk::ImageLayout::TransferDstOptimal,
                 &clear_value,
-                1,
-                &base_range, // TODO: ranges
+                &[base_range],
             )
         };
     }
@@ -214,7 +213,7 @@ impl CommandBuffer {
 
     fn dispatch(&mut self, x: u32, y: u32, z: u32) {
         unsafe {
-            self.device.0.fp_v1_0().cmd_dispatch(
+            self.device.0.cmd_dispatch(
                 self.inner, // commandBuffer
                 x,          // groupCountX
                 y,          // groupCountY
@@ -243,12 +242,11 @@ impl CommandBuffer {
         let offsets = vbs.0.iter().map(|&(_, offset)| offset as u64).collect::<Vec<_>>();
 
         unsafe {
-            self.device.0.fp_v1_0().cmd_bind_vertex_buffers(
+            self.device.0.cmd_bind_vertex_buffers(
                 self.inner,
                 0,
-                buffers.len() as u32,
-                buffers.as_ptr(),
-                offsets.as_ptr(),
+                &buffers,
+                &offsets,
             );
         }
     }


### PR DESCRIPTION
Once a error occurs during pipeline creation we now recover all piplines, which were sucessfully built, instead of returning an error for all of them.