### PR TITLE
[ll] Add explicit resource destruction

### DIFF
--- a/examples/trianglell/main.rs
+++ b/examples/trianglell/main.rs
@@ -308,6 +308,28 @@ fn main() {
         // present frame
         swap_chain.present();
     }
+
+    // cleanup!
+    factory.destroy_shader_lib(shader_lib);
+    factory.destroy_pipeline_layout(pipeline_layout);
+    factory.destroy_renderpass(render_pass);
+    factory.destroy_heap(heap);
+    factory.destroy_heap(image_heap);
+    factory.destroy_heap(image_upload_heap);
+    factory.destroy_buffer(vertex_buffer);
+    factory.destroy_buffer(image_upload_buffer);
+    factory.destroy_image(image_logo);
+    for pipeline in pipelines {
+        if let Ok(pipeline) = pipeline {
+            factory.destroy_graphics_pipeline(pipeline);
+        }
+    }
+    for framebuffer in framebuffers {
+        factory.destroy_framebuffer(framebuffer);
+    }
+    for rtv in frame_rtvs {
+        factory.destroy_render_target_view(rtv);
+    }
 }
 
 #[cfg(not(any(feature = "vulkan", target_os = "windows")))]

--- a/src/backend/vulkanll/src/factory.rs
+++ b/src/backend/vulkanll/src/factory.rs
@@ -845,4 +845,46 @@ impl core::Factory<R> for Factory {
 
         Ok(unsafe { mapping::Writer::new(slice, mapping) })
     }
+
+    fn destroy_heap(&mut self, heap: native::Heap) {
+        unsafe { self.inner.0.free_memory(heap.0, None); }
+    }
+
+    fn destroy_shader_lib(&mut self, shader_lib: native::ShaderLib) {
+        for shader in shader_lib.shaders.into_iter() {
+            unsafe { self.inner.0.destroy_shader_module(shader.1, None); }
+        }
+    }
+
+    fn destroy_renderpass(&mut self, rp: native::RenderPass) {
+        unsafe { self.inner.0.destroy_render_pass(rp.inner, None); }
+    }
+
+    fn destroy_pipeline_layout(&mut self, pl: native::PipelineLayout) {
+        unsafe { self.inner.0.destroy_pipeline_layout(pl.layout, None); }
+    }
+
+    fn destroy_graphics_pipeline(&mut self, pipeline: native::GraphicsPipeline) {
+        unsafe { self.inner.0.destroy_pipeline(pipeline.pipeline, None); }
+    }
+
+    fn destroy_compute_pipeline(&mut self, pipeline: native::ComputePipeline) {
+        unsafe { self.inner.0.destroy_pipeline(pipeline.pipeline, None); }
+    }
+
+    fn destroy_framebuffer(&mut self, fb: native::FrameBuffer) {
+        unsafe { self.inner.0.destroy_framebuffer(fb.inner, None); }
+    }
+
+    fn destroy_buffer(&mut self, buffer: native::Buffer) {
+        unsafe { self.inner.0.destroy_buffer(buffer.inner, None); }
+    }
+
+    fn destroy_image(&mut self, image: native::Image) {
+        unsafe { self.inner.0.destroy_image(image.0, None); }
+    }
+
+    fn destroy_render_target_view(&mut self, rtv: native::RenderTargetView) {
+        unsafe { self.inner.0.destroy_image_view(rtv.view, None); }
+    }
 }

--- a/src/corell/src/factory.rs
+++ b/src/corell/src/factory.rs
@@ -97,4 +97,24 @@ pub trait Factory<R: Resources> {
                                 -> Result<mapping::Writer<'a, R, T>,
                                           mapping::Error>
         where T: Copy;
+
+    fn destroy_heap(&mut self, R::Heap);
+
+    fn destroy_shader_lib(&mut self, R::ShaderLib);
+
+    fn destroy_renderpass(&mut self, R::RenderPass);
+
+    fn destroy_pipeline_layout(&mut self, R::PipelineLayout);
+
+    fn destroy_graphics_pipeline(&mut self, R::GraphicsPipeline);
+
+    fn destroy_compute_pipeline(&mut self, R::ComputePipeline);
+
+    fn destroy_framebuffer(&mut self, R::FrameBuffer);
+
+    fn destroy_buffer(&mut self, R::Buffer);
+
+    fn destroy_image(&mut self, R::Image);
+
+    fn destroy_render_target_view(&mut self, R::RenderTargetView);
 }


### PR DESCRIPTION
Add explicit resource destruction as proposed in #1216.
Implemented the new factory methods for the vulkan backend.

I went with a resource consuming interface (takes ownership of the resource) as I liked the concept of the factory giving ownership to the resource on creationg and taking it away on destruction.
```Rust
fn destroy_*(&mut self, R::Resource);
``` 