### PR TITLE
Change changelog order into new to old and add links for mentioned issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,50 +1,50 @@
 ## Change Log
 
 ### v0.14 (2017-01-16)
-  - fixed `Fence` and `Sync` bounds (#1095)
-  - dx11 buffer mapping support (#1099, #1105)
-  - redesigned resource usage model for next-gen compatibility (#1123)
-  - buffer copy support (#1129)
-  - fixed and improved some errors (#1137, #1138)
-  - application launcher revamp and resize support (#1121)
+  - fixed `Fence` and `Sync` bounds ([#1095](https://github.com/gfx-rs/gfx/pull/1095))
+  - dx11 buffer mapping support ([#1099](https://github.com/gfx-rs/gfx/pull/1099), [#1105](https://github.com/gfx-rs/gfx/pull/1105))
+  - redesigned resource usage model for next-gen compatibility ([#1123](https://github.com/gfx-rs/gfx/pull/1123))
+  - buffer copy support ([#1129](https://github.com/gfx-rs/gfx/pull/1129))
+  - fixed and improved some errors ([#1137](https://github.com/gfx-rs/gfx/pull/1137), [#1138](https://github.com/gfx-rs/gfx/pull/1138))
+  - application launcher revamp and resize support ([#1121](https://github.com/gfx-rs/gfx/pull/1121))
 
 ### v0.13 (2016-12-18)
-  - experimental Metal backend (#969, #1049, #1050)
-  - persistent mapping (#1026)
-  - tessellation support (#1027, #1088)
+  - experimental Metal backend ([#969](https://github.com/gfx-rs/gfx/pull/969), [#1049](https://github.com/gfx-rs/gfx/pull/1049), [#1050](https://github.com/gfx-rs/gfx/pull/1050))
+  - persistent mapping ([#1026](https://github.com/gfx-rs/gfx/pull/1026))
+  - tessellation support ([#1027](https://github.com/gfx-rs/gfx/pull/1027), [#1088](https://github.com/gfx-rs/gfx/pull/1088))
   - new examples: gamma, particle, terrain_tessellated
-  - better PSO error messages, constant offset checks (#1004)
-  - unified scissor: now Y-reversed on GL (#1092)
-  - "const" resources are now called "immutable"
-  - faster handle clones and cleaner core  API (#1031)
+  - better PSO error messages, constant offset checks ([#1004](https://github.com/gfx-rs/gfx/pull/1004))
+  - unified scissor: now Y-reversed on GL ([#1092](https://github.com/gfx-rs/gfx/pull/1092))
+  - `const` resources are now called `immutable`
+  - faster handle clones and cleaner core  API ([#1031](https://github.com/gfx-rs/gfx/pull/1031))
 
 ### v0.12 (2016-06-23)
-  - Android / GLES support (#993)
-  - GL unsigned int samplers (#991)
-  - better errors (#976)
+  - Android / GLES support ([#993](https://github.com/gfx-rs/gfx/pull/993))
+  - GL unsigned int samplers ([#991](https://github.com/gfx-rs/gfx/pull/991))
+  - better errors ([#976](https://github.com/gfx-rs/gfx/pull/976))
   - better GLSL pre core reflection
 
 ### v0.11 (2016-04-30)
-  - modified `Slice` API (#955)
-  - fixed GL blending where it's not in the core (#953)
+  - modified `Slice` API ([#955](https://github.com/gfx-rs/gfx/pull/955))
+  - fixed GL blending where it's not in the core ([#953](https://github.com/gfx-rs/gfx/pull/953))
   - raw PSO components for vertex buffers and render targets
 
 ### v0.10.2 (2016-04-15)
-  - fixed get_texel_count (#937)
+  - fixed get_texel_count ([#937](https://github.com/gfx-rs/gfx/pull/937))
 
 ### v0.10.1 (2016-03-26)
-  - fixed update_texture (#912)
+  - fixed update_texture ([#912](https://github.com/gfx-rs/gfx/pull/912))
 
 ### v0.10 (2016-03-21)
-  - Direct3D 11 backend (#861)
+  - Direct3D 11 backend ([#861](https://github.com/gfx-rs/gfx/pull/861))
 
 ### v0.9.2 (2016-02-24)
-  - fixed universal format views (#886)
-  - fixed constant buffer binding (#828)
+  - fixed universal format views ([#886](https://github.com/gfx-rs/gfx/pull/886))
+  - fixed constant buffer binding ([#828](https://github.com/gfx-rs/gfx/pull/828))
 
 ### v0.9.1 (2016-02-19)
-  - window resize support (#879)
-  - deriving windows attributes from target formats (#874)
+  - window resize support ([#879](https://github.com/gfx-rs/gfx/pull/879))
+  - deriving windows attributes from target formats ([#874](https://github.com/gfx-rs/gfx/pull/874))
 
 ### v0.9 (2016-01-22)
-  - Pipepeline State Object revolution (#828)
+  - Pipepeline State Object revolution ([#828](https://github.com/gfx-rs/gfx/pull/828))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,14 @@
 ## Change Log
 
-### Version 0.9 (2016-01-22)
-  - Pipepeline State Object revolution (#828)
-- v0.9.1 (2016-02-19)
-  - window resize support (#879)
-  - deriving windows attributes from target formats (#874)
-- v0.9.2 (2016-02-24)
-  - fixed universal format views (#886)
-  - fixed constant buffer binding (#828)
+### v0.14 (2017-01-16)
+  - fixed `Fence` and `Sync` bounds (#1095)
+  - dx11 buffer mapping support (#1099, #1105)
+  - redesigned resource usage model for next-gen compatibility (#1123)
+  - buffer copy support (#1129)
+  - fixed and improved some errors (#1137, #1138)
+  - application launcher revamp and resize support (#1121)
 
-### Version 0.10 (2016-03-21)
-  - Direct3D 11 backend (#861)
-- v0.10.1 (2016-03-26)
-  - fixed update_texture (#912)
-- v0.10.2 (2016-04-15)
-  - fixed get_texel_count (#937)
-
-### Version 0.11 (2016-04-30)
-  - modified `Slice` API (#955)
-  - fixed GL blending where it's not in the core (#953)
-  - raw PSO components for vertex buffers and render targets
-
-### Version 0.12 (2016-06-23)
-  - Android / GLES support (#993)
-  - GL unsigned int samplers (#991)
-  - better errors (#976)
-  - better GLSL pre core reflection
-
-### Version 0.13 (2016-12-18)
+### v0.13 (2016-12-18)
   - experimental Metal backend (#969, #1049, #1050)
   - persistent mapping (#1026)
   - tessellation support (#1027, #1088)
@@ -37,10 +18,33 @@
   - "const" resources are now called "immutable"
   - faster handle clones and cleaner core  API (#1031)
 
-### Version 0.14 (2017-01-16)
-  - fixed `Fence` and `Sync` bounds (#1095) 
-  - dx11 buffer mapping support (#1099, #1105)
-  - redesigned resource usage model for next-gen compatibility (#1123)
-  - buffer copy support (#1129)
-  - fixed and improved some errors (#1137, #1138)
-  - application launcher revamp and resize support (#1121)
+### v0.12 (2016-06-23)
+  - Android / GLES support (#993)
+  - GL unsigned int samplers (#991)
+  - better errors (#976)
+  - better GLSL pre core reflection
+
+### v0.11 (2016-04-30)
+  - modified `Slice` API (#955)
+  - fixed GL blending where it's not in the core (#953)
+  - raw PSO components for vertex buffers and render targets
+
+### v0.10.2 (2016-04-15)
+  - fixed get_texel_count (#937)
+
+### v0.10.1 (2016-03-26)
+  - fixed update_texture (#912)
+
+### v0.10 (2016-03-21)
+  - Direct3D 11 backend (#861)
+
+### v0.9.2 (2016-02-24)
+  - fixed universal format views (#886)
+  - fixed constant buffer binding (#828)
+
+### v0.9.1 (2016-02-19)
+  - window resize support (#879)
+  - deriving windows attributes from target formats (#874)
+
+### v0.9 (2016-01-22)
+  - Pipepeline State Object revolution (#828)


### PR DESCRIPTION
Since all changelogs go new to old and it's common to link the issues, I thought why not :)
And @kvark mentioned on reddit he would welcome a PR in this regard.