### PR TITLE
gfx_device_gl: Add a new field allowing to use an externally managed framebuffer object as the display target.

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -186,6 +186,7 @@ pub struct CommandBuffer {
     pub buf: Vec<Command>,
     pub data: DataBuffer,
     fbo: FrameBuffer,
+    pub display_fb: FrameBuffer,
     cache: Cache,
     active_attribs: usize,
 }
@@ -196,6 +197,7 @@ impl CommandBuffer {
             buf: Vec::new(),
             data: DataBuffer::new(),
             fbo: fbo,
+            display_fb: 0 as FrameBuffer,
             cache: Cache::new(),
             active_attribs: 0,
         }
@@ -298,7 +300,7 @@ impl command::Buffer<Resources> for CommandBuffer {
             self.is_main_target(pts.depth) &&
             self.is_main_target(pts.stencil);
         if is_main {
-            self.buf.push(Command::BindFrameBuffer(gl::DRAW_FRAMEBUFFER, 0));
+            self.buf.push(Command::BindFrameBuffer(gl::DRAW_FRAMEBUFFER, self.display_fb));
         } else {
             let num = pts.colors.iter().position(|c| c.is_none())
                          .unwrap_or(pts.colors.len()) as c::ColorSlot;

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -182,10 +182,26 @@ impl Cache {
     }
 }
 
+/// A command buffer abstraction for OpenGL.
+///
+/// Manages a list of commands that will be executed when submitted to a `Device`. Usually it is
+/// best to use a `Encoder` to manage the command buffer which implements `From<CommandBuffer>`.
+///
+/// If you want to display your rendered results to a framebuffer created externally, see the
+/// `display_fb` field.
 pub struct CommandBuffer {
     pub buf: Vec<Command>,
     pub data: DataBuffer,
     fbo: FrameBuffer,
+    /// The framebuffer to use for rendering to the main targets (0 by default).
+    ///
+    /// Use this to set the framebuffer that will be used for the screen display targets created
+    /// with `create_main_targets_raw`. Usually you don't need to set this field directly unless
+    /// your OS doesn't provide a default framebuffer with name 0 and you have to render to a
+    /// different framebuffer object that can be made visible on the screen (iOS/tvOS need this).
+    ///
+    /// This framebuffer must exist and be configured correctly (with renderbuffer attachments,
+    /// etc.) so that rendering to it can occur immediately.
     pub display_fb: FrameBuffer,
     cache: Cache,
     active_attribs: usize,


### PR DESCRIPTION
Adds a new public field `display_fb` to the `CommandBuffer` structure in the `gfx_device_gl` backend. If not changed by the user it will have the value 0. This allows to use an existing framebuffer object as the drawing destination instead of the Framebuffer with name 0. Useful on iOS/tvOS where no default frame buffer exists and drawing can only occur on system provided renderbuffers.

I expect this be used with the `create_main_targets_raw` function to create the default color and depth targets. These will automatically use the framebuffer object given in the `display_fb` field.

If you are happy with this I would like to do more pull requests for better iOS support (e.g. only use supported OpenGL ES 3.0 features).