### PR TITLE
Add optional serialization support, version bumps, formatting fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo build --features vulkan; else cargo build; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cargo build --features metal; else cargo build; fi
   - cargo test --all
+  - cargo test -p gfx -p gfx_core --features serialize
   - cargo test -p gfx_window_sdl
   - cargo test -p gfx_device_gl
   - cargo test -p gfx_window_glutin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### v0.15 (2017-04-21)
+  - Add optional serialization support and fixed bugs ([#1234](https://github.com/gfx-rs/gfx/pull/1234))
+
 ### v0.14 (2017-01-16)
   - fixed `Fence` and `Sync` bounds ([#1095](https://github.com/gfx-rs/gfx/pull/1095))
   - dx11 buffer mapping support ([#1099](https://github.com/gfx-rs/gfx/pull/1099), [#1105](https://github.com/gfx-rs/gfx/pull/1105))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_app"
-version = "0.4.0"
+version = "0.5.0"
 description = "GFX example application framework"
 homepage = "https://github.com/gfx-rs/gfx"
 keywords = ["graphics", "gamedev"]
@@ -13,27 +13,27 @@ default = []
 sdl = ["gfx_window_sdl"]
 vulkan = ["gfx_device_vulkan", "gfx_device_vulkanll", "gfx_window_vulkan"]
 metal = ["gfx_device_metal", "gfx_window_metal"]
+serialize = ["gfx/serialize", "gfx_core/serialize"]
 unstable = []
-
 
 [lib]
 name = "gfx_app"
 
 [dependencies]
 log = "0.3"
-env_logger = "0.3"
+env_logger = "0.4"
 glutin = "0.7.1"
 winit = "0.5.1"
-gfx_core = { path = "src/core", version = "0.6" }
+gfx_core = { path = "src/core", version = "0.7" }
 gfx_corell = { path = "src/corell", version = "0.1" }
-gfx = { path = "src/render", version = "0.14" }
+gfx = { path = "src/render", version = "0.15" }
 gfx_macros = { path = "src/macros", version = "0.2" }
-gfx_device_gl = { path = "src/backend/gl", version = "0.13" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.14" }
+gfx_device_gl = { path = "src/backend/gl", version = "0.14" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.15" }
 
 [dependencies.gfx_device_vulkan]
 path = "src/backend/vulkan"
-version = "0.1"
+version = "0.2"
 optional = true
 
 [dependencies.gfx_device_vulkanll]
@@ -43,32 +43,32 @@ optional = true
 
 [dependencies.gfx_window_vulkan]
 path = "src/window/vulkan"
-version = "0.1"
+version = "0.2"
 optional = true
 
 [dependencies.gfx_device_metal]
 path = "src/backend/metal"
-version = "0.1"
+version = "0.2"
 optional = true
 
 [dependencies.gfx_window_metal]
 path = "src/window/metal"
-version = "0.1"
+version = "0.2"
 optional = true
 
 [dependencies.gfx_window_sdl]
 path = "src/window/sdl"
-version = "0.5"
+version = "0.6"
 optional = true
 
 [target.'cfg(unix)'.dependencies]
-gfx_window_glfw = { path = "src/window/glfw", version = "0.13" }
-gfx_window_sdl = { path = "src/window/sdl", version = "0.5" }
+gfx_window_glfw = { path = "src/window/glfw", version = "0.14" }
+gfx_window_sdl = { path = "src/window/sdl", version = "0.6" }
 
 [target.'cfg(windows)'.dependencies]
-gfx_device_dx11 = { path = "src/backend/dx11", version = "0.5" }
+gfx_device_dx11 = { path = "src/backend/dx11", version = "0.6" }
 # gfx_device_dx12ll = { path = "src/backend/dx12ll", version = "0.1" }
-gfx_window_dxgi = { path = "src/window/dxgi", version = "0.6" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.7" }
 
 [[example]]
 name = "blend"
@@ -133,7 +133,6 @@ path = "examples/particle/main.rs"
 [[example]]
 name = "trianglell"
 path = "examples/trianglell/main.rs"
-
 
 [dev-dependencies]
 cgmath = "0.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-    - TARGET: 1.15.1-x86_64-pc-windows
+    - TARGET: 1.16.0-x86_64-pc-windows
       COMPILER: gnu
-    - TARGET: 1.15.1-x86_64-pc-windows
+    - TARGET: 1.16.0-x86_64-pc-windows
       COMPILER: msvc
     - TARGET: nightly-x86_64-pc-windows
       COMPILER: msvc
@@ -18,3 +18,4 @@ build_script:
   - cargo build --features vulkan
 test_script:
   - cargo test --all --features vulkan
+  - cargo test -p gfx -p gfx_core --features serialize

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_dx11"
-version = "0.5.0"
+version = "0.6.0"
 description = "DirectX-11 backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,8 +29,8 @@ name = "gfx_device_dx11"
 
 [dependencies]
 log = "0.3"
-gfx_core = { path = "../../core", version = "0.6" }
+gfx_core = { path = "../../core", version = "0.7" }
 d3d11-sys = "0.2"
 d3dcompiler-sys = "0.2"
 dxguid-sys = "0.2"
-winapi = "0.2.7"
+winapi = "0.2.8"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_gl"
-version = "0.13.0"
+version = "0.14.0"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -30,4 +30,4 @@ name = "gfx_device_gl"
 [dependencies]
 log = "0.3"
 gfx_gl = "0.3.1"
-gfx_core = { path = "../../core", version = "0.6" }
+gfx_core = { path = "../../core", version = "0.7" }

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_metal"
-version = "0.1.0"
+version = "0.2.0"
 description = "Metal backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,7 +29,7 @@ name = "gfx_device_metal"
 
 [dependencies]
 log = "0.3"
-gfx_core = { path = "../../core", version = "0.6" }
+gfx_core = { path = "../../core", version = "0.7" }
 cocoa = "0.5"
 libc = "0.2"
 objc = "0.2"

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_device_vulkan"
-version = "0.1.0"
+version = "0.2.0"
 description = "Vulkan API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -19,5 +19,5 @@ vk = "0.0"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 shared_library = "0.1"
 winit = "0.5"
-gfx_core = { path = "../../core", version = "0.6" }
+gfx_core = { path = "../../core", version = "0.7" }
 spirv-utils = { git = "https://github.com/msiglreith/spirv-utils.git", branch = "gfx" }

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_core"
-version = "0.6.0"
+version = "0.7.0"
 description = "Core library of Gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,9 +28,12 @@ name = "gfx_core"
 path = "src/lib.rs"
 
 [dependencies]
-draw_state = "0.6"
-bitflags = "0.7"
+bitflags = "0.8"
+draw_state = "0.7"
 log = "0.3"
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
 
 [features]
+serialize = ["serde", "serde_derive", "draw_state/serialize"]
 unstable = []

--- a/src/core/src/buffer.rs
+++ b/src/core/src/buffer.rs
@@ -80,7 +80,8 @@ impl<R: Resources + hash::Hash> hash::Hash for Raw<R> {
 }
 
 /// Role of the memory buffer.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum Role {
     /// Generic vertex buffer
@@ -95,6 +96,7 @@ pub enum Role {
 
 /// An information block that is immutable and associated to each buffer.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Info {
     /// Role
     pub role: Role,

--- a/src/core/src/command.rs
+++ b/src/core/src/command.rs
@@ -22,7 +22,8 @@ use {state, target, pso, shade, texture, handle};
 
 /// A universal clear color supporting integet formats
 /// as well as the standard floating-point.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum ClearColor {
     /// Standard floating-point vec4 color
     Float([f32; 4]),
@@ -207,6 +208,7 @@ impl<R: Resources> AccessInfo<R> {
 pub type AccessInfoBuffers<'a, R> = hash_set::Iter<'a, handle::RawBuffer<R>>;
 
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct AccessGuard<'a, R: Resources> {
     inner: &'a AccessInfo<R>,
 }
@@ -255,6 +257,7 @@ impl<'a, R: Resources> Drop for AccessGuard<'a, R> {
 }
 
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct AccessGuardBuffers<'a, R: Resources> {
     buffers: AccessInfoBuffers<'a, R>
 }
@@ -270,6 +273,7 @@ impl<'a, R: Resources> Iterator for AccessGuardBuffers<'a, R> {
 }
 
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct AccessGuardBuffersChain<'a, R: Resources> {
     fst: AccessInfoBuffers<'a, R>,
     snd: AccessInfoBuffers<'a, R>

--- a/src/core/src/dummy.rs
+++ b/src/core/src/dummy.rs
@@ -26,7 +26,7 @@ pub struct DummyDevice {
 }
 
 /// Dummy resources phantom type
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum DummyResources {}
 
 impl Resources for DummyResources {
@@ -45,11 +45,11 @@ impl Resources for DummyResources {
 }
 
 /// Dummy fence that does nothing.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DummyFence;
 
 /// Dummy mapping which will crash on use.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DummyMapping;
 
 impl mapping::Gate<DummyResources> for DummyMapping {

--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -26,7 +26,7 @@ use memory::{Usage, Typed, Pod, cast_slice};
 use memory::{Bind, RENDER_TARGET, DEPTH_STENCIL, SHADER_RESOURCE, UNORDERED_ACCESS};
 
 /// Error creating either a ShaderResourceView, or UnorderedAccessView.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ResourceViewError {
     /// The corresponding bind flag is not present in the texture.
     NoBindFlag,
@@ -68,7 +68,7 @@ impl Error for ResourceViewError {
 }
 
 /// Error creating either a RenderTargetView, or DepthStencilView.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TargetViewError {
     /// The `RENDER_TARGET`/`DEPTH_STENCIL` flag is not present in the texture.
     NoBindFlag,
@@ -124,7 +124,7 @@ impl Error for TargetViewError {
 }
 
 /// An error from creating textures with views at the same time.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum CombinedError {
     /// Failed to create the raw texture.
     Texture(texture::CreationError),

--- a/src/core/src/format.rs
+++ b/src/core/src/format.rs
@@ -28,13 +28,15 @@ macro_rules! impl_channel_type {
         /// storage allocated with `SurfaceType`.
         #[allow(missing_docs)]
         #[repr(u8)]
-        #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
         pub enum ChannelType {
             $( $name, )*
         }
         $(
             #[allow(missing_docs)]
-            #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+            #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+            #[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
             pub enum $name {}
             impl ChannelTyped for $name {
                 type ShaderType = $shader_type;
@@ -66,7 +68,8 @@ macro_rules! impl_formats {
         /// The actual components are up to the swizzle to define.
         #[repr(u8)]
         #[allow(missing_docs, non_camel_case_types)]
-        #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
         pub enum SurfaceType {
             $( $name, )*
         }
@@ -87,7 +90,8 @@ macro_rules! impl_formats {
         }
         $(
             #[allow(missing_docs, non_camel_case_types)]
-            #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+            #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+            #[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
             pub enum $name {}
             impl SurfaceTyped for $name {
                 type DataType = $data_type;
@@ -155,7 +159,8 @@ impl_formats! {
 /// different physical channels, some may be hardcoded to 0 or 1.
 #[allow(missing_docs)]
 #[repr(u8)]
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
 pub enum ChannelSource {
     Zero,
     One,
@@ -168,7 +173,8 @@ pub enum ChannelSource {
 /// Channel swizzle configuration for the resource views.
 /// Note: It's not currently mirrored at compile-time,
 /// thus providing less safety and convenience.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
 pub struct Swizzle(pub ChannelSource, pub ChannelSource, pub ChannelSource, pub ChannelSource);
 
 impl Swizzle {
@@ -179,9 +185,9 @@ impl Swizzle {
 }
 
 /// Complete run-time surface format.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
 pub struct Format(pub SurfaceType, pub ChannelType);
-
 
 /// Compile-time surface type trait.
 pub trait SurfaceTyped {
@@ -284,7 +290,8 @@ macro_rules! alias {
     { $( $name:ident = $ty:ty, )* } => {
         $(
             #[allow(missing_docs)]
-            #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+            #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+            #[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
             pub struct $name(pub $ty);
             impl From<$ty> for $name {
                 fn from(v: $ty) -> $name {
@@ -334,7 +341,6 @@ pub type Vec3<T> = [T; 3];
 /// Abstracted 4-element container for macro internal use
 pub type Vec4<T> = [T; 4];
 
-
 /// Standard 8bits RGBA format.
 pub type Rgba8 = (R8_G8_B8_A8, Unorm);
 /// Standard 8bit gamma transforming RGB format.
@@ -354,7 +360,6 @@ pub type Depth = (D24, Unorm);
 pub type DepthStencil = (D24_S8, Unorm);
 /// Standard 32-bit floating-point depth format.
 pub type Depth32F = (D32, Float);
-
 
 macro_rules! impl_simple_formats {
     { $( $container:ident< $ty:ty > = $channel:ident $surface:ident, )* } => {

--- a/src/core/src/handle.rs
+++ b/src/core/src/handle.rs
@@ -23,7 +23,7 @@ use {buffer, shade, texture, Resources};
 use memory::Typed;
 
 /// Untyped buffer handle
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RawBuffer<R: Resources>(Arc<buffer::Raw<R>>);
 
 impl<R: Resources> ops::Deref for RawBuffer<R> {
@@ -84,7 +84,7 @@ impl<R: Resources> ops::Deref for Program<R> {
 pub struct RawPipelineState<R: Resources>(Arc<R::PipelineStateObject>, Program<R>);
 
 /// Raw texture handle
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RawTexture<R: Resources>(Arc<texture::Raw<R>>);
 
 impl<R: Resources> ops::Deref for RawTexture<R> {
@@ -236,6 +236,7 @@ pub struct Fence<R: Resources>(Arc<R::Fence>);
 /// referencing them both by the Factory on resource creation
 /// and the Renderer during CommandBuffer population.
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct Manager<R: Resources> {
     buffers:       Vec<Arc<buffer::Raw<R>>>,
     shaders:       Vec<Arc<R::Shader>>,

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -19,10 +19,14 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate log;
 extern crate draw_state;
-//extern crate num;
+extern crate log;
+
+#[cfg(feature = "serialize")]
+extern crate serde;
+#[cfg(feature = "serialize")]
+#[macro_use]
+extern crate serde_derive;
 
 use std::fmt::{self, Debug};
 use std::error::Error;
@@ -123,8 +127,9 @@ impl<R: Resources> ShaderSet<R> {
 
 //TODO: use the appropriate units for max vertex count, etc
 /// Features that the device supports.
-#[derive(Copy, Clone, Debug)]
 #[allow(missing_docs)] // pretty self-explanatory fields!
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Capabilities {
     pub max_vertex_count: usize,
     pub max_index_count: usize,
@@ -143,7 +148,8 @@ pub struct Capabilities {
 }
 
 /// Describes what geometric primitives are created from vertex data.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum Primitive {
     /// Each vertex represents a single point.
@@ -187,8 +193,9 @@ pub enum Primitive {
 }
 
 /// A type of each index value in the slice's index buffer
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
 #[allow(missing_docs)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum IndexType {
     U16,
@@ -212,8 +219,9 @@ pub trait Resources:          Clone + Hash + Debug + Eq + PartialEq + Any {
     type Mapping:             Hash + Debug + Eq + PartialEq + Any + Send + Sync + mapping::Gate<Self>;
 }
 
-#[derive(Clone, Debug, PartialEq)]
 #[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum SubmissionError {
     AccessOverlap,
 }
@@ -299,6 +307,7 @@ pub trait Adapter: Sized {
 
 /// Information about a backend adapater.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct AdapterInfo {
     /// Adapter name
     pub name: String,
@@ -346,6 +355,8 @@ pub trait Surface {
 }
 
 /// Handle to a backbuffer of the swapchain.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Frame(usize);
 
 impl Frame {

--- a/src/core/src/mapping.rs
+++ b/src/core/src/mapping.rs
@@ -36,7 +36,7 @@ pub trait Gate<R: Resources> {
 }
 
 /// Error accessing a mapping.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Error {
     /// The requested mapping access did not match the expected usage.
     InvalidAccess(memory::Access, memory::Usage),
@@ -101,6 +101,7 @@ impl<R: Resources> Raw<R> {
 
 unsafe impl<R: Resources> Sync for Raw<R> {}
 
+#[derive(Debug)]
 struct Guard<'a, R: Resources> {
     raw: &'a Raw<R>,
 }
@@ -180,6 +181,7 @@ pub unsafe fn write<R, T, S>(buffer: &buffer::Raw<R>, sync: S)
 }
 
 /// Mapping reader
+#[derive(Debug)]
 pub struct Reader<'a, R: Resources, T: 'a + Copy> {
     slice: &'a [T],
     #[allow(dead_code)] mapping: Guard<'a, R>,
@@ -194,6 +196,7 @@ impl<'a, R: Resources, T: 'a + Copy> Deref for Reader<'a, R, T> {
 /// Mapping writer.
 /// Currently is not possible to make write-only slice so while it is technically possible
 /// to read from Writer, it will lead to an undefined behavior. Please do not read from it.
+#[derive(Debug)]
 pub struct Writer<'a, R: Resources, T: 'a + Copy> {
     slice: &'a mut [T],
     #[allow(dead_code)] mapping: Guard<'a, R>,
@@ -209,9 +212,9 @@ impl<'a, R: Resources, T: 'a + Copy> DerefMut for Writer<'a, R, T> {
     fn deref_mut(&mut self) -> &mut [T] { self.slice }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
-#[doc(hidden)]
 /// A service struct that can be used by backends to track the mapping status
+#[derive(Debug, Eq, Hash, PartialEq)]
+#[doc(hidden)]
 pub struct Status<R: Resources> {
     cpu_wrote: bool,
     gpu_access: Option<handle::Fence<R>>,

--- a/src/core/src/memory.rs
+++ b/src/core/src/memory.rs
@@ -17,7 +17,8 @@
 use std::mem;
 
 /// How this memory will be used.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum Usage {
     /// Full speed GPU access.
@@ -36,6 +37,7 @@ pub enum Usage {
 
 bitflags!(
     /// Memory access
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub flags Access: u8 {
         /// Read access
         const READ  = 0x1,
@@ -48,6 +50,7 @@ bitflags!(
 
 bitflags!(
     /// Bind flags
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub flags Bind: u8 {
         /// Can be rendered into.
         const RENDER_TARGET    = 0x1,

--- a/src/core/src/pso.rs
+++ b/src/core/src/pso.rs
@@ -53,6 +53,7 @@ impl Error for CreationError {
 
 /// Color output configuration of the PSO.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ColorInfo {
     /// Color channel mask
     pub mask: s::ColorMask,
@@ -82,6 +83,7 @@ impl From<s::Blend> for ColorInfo {
 
 /// Depth and stencil state of the PSO.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct DepthStencilInfo {
     /// Optional depth test configuration
     pub depth: Option<s::Depth>,
@@ -129,6 +131,7 @@ pub type InstanceRate = u8;
 
 /// A struct element descriptor.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Element<F> {
     /// Element format
     pub format: F,
@@ -138,6 +141,7 @@ pub struct Element<F> {
 
 /// Vertex buffer descriptor
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct VertexBufferDesc {
     /// Total container size, in bytes
     pub stride: ElemStride,
@@ -163,6 +167,7 @@ pub type DepthStencilDesc = (format::Format, DepthStencilInfo);
 /// All the information surrounding a shader program that is required
 /// for PSO creation, including the formats of vertex buffers and pixel targets;
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Descriptor {
     /// Type of the primitive
     pub primitive: Primitive,
@@ -208,7 +213,7 @@ impl Descriptor {
 }
 
 /// A complete set of vertex buffers to be used for vertex import in PSO.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct VertexBufferSet<R: Resources>(
     /// Array of buffer handles with offsets in them
     pub [Option<(R::Buffer, BufferOffset)>; MAX_VERTEX_ATTRIBUTES]
@@ -222,23 +227,23 @@ impl<R: Resources> VertexBufferSet<R> {
 }
 
 /// A constant buffer run-time parameter for PSO.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ConstantBufferParam<R: Resources>(pub R::Buffer, pub Usage, pub ConstantBufferSlot);
 
 /// A shader resource view (SRV) run-time parameter for PSO.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ResourceViewParam<R: Resources>(pub R::ShaderResourceView, pub Usage, pub ResourceViewSlot);
 
 /// An unordered access view (UAV) run-time parameter for PSO.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct UnorderedViewParam<R: Resources>(pub R::UnorderedAccessView, pub Usage, pub UnorderedViewSlot);
 
 /// A sampler run-time parameter for PSO.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct SamplerParam<R: Resources>(pub R::Sampler, pub Usage, pub SamplerSlot);
 
 /// A complete set of render targets to be used for pixel export in PSO.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct PixelTargetSet<R: Resources> {
     /// Array of color target views
     pub colors: [Option<R::RenderTargetView>; MAX_COLOR_TARGETS],

--- a/src/core/src/shade.rs
+++ b/src/core/src/shade.rs
@@ -25,31 +25,37 @@ use {AttributeSlot, ColorSlot, ConstantBufferSlot, ResourceViewSlot, SamplerSlot
 pub type Dimension = u8;
 
 /// Whether the sampler samples an array texture.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum IsArray { Array, NoArray }
 
 /// Whether the sampler compares the depth value upon sampling.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum IsComparison { Compare, NoCompare }
 
 /// Whether the sampler samples a multisample texture.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum IsMultiSample { MultiSample, NoMultiSample }
 
 /// Whether the sampler samples a rectangle texture.
 ///
 /// Rectangle textures are the same as 2D textures, but accessed with absolute texture coordinates
 /// (as opposed to the usual, normalized to [0, 1]).
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum IsRect { Rect, NoRect }
 
 /// Whether the matrix is column or row major.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum MatrixFormat { ColumnMajor, RowMajor }
 
 /// A type of the texture variable.
 /// This has to match the actual data we bind to the shader.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum TextureType {
     /// Sample from a buffer.
     Buffer,
@@ -78,12 +84,14 @@ impl TextureType {
 }
 
 /// A type of the sampler variable.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct SamplerType(pub IsComparison, pub IsRect);
 
 /// Base type of this shader parameter.
 #[allow(missing_docs)]
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum BaseType {
     I32,
     U32,
@@ -93,7 +101,8 @@ pub enum BaseType {
 }
 
 /// Number of components this parameter represents.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum ContainerType {
     /// Scalar value
     Single,
@@ -107,7 +116,8 @@ pub enum ContainerType {
 
 /// Which program stage this shader represents.
 #[allow(missing_docs)]
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum Stage {
     Vertex,
@@ -128,7 +138,8 @@ pub type Location = usize;
 // unable to derive anything for fixed arrays
 /// A value that can be uploaded to the device as a uniform.
 #[allow(missing_docs)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum UniformValue {
     I32(i32),
     F32(f32),
@@ -255,6 +266,7 @@ impl_const_matrix!([2,2], [3,3], [4,4], [4,3]);
 
 bitflags!(
     /// Parameter usage flags.
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub flags Usage: u8 {
         /// Used by the vertex shader
         const VERTEX   = 0x1,
@@ -283,7 +295,8 @@ impl From<Stage> for Usage {
 }
 
 /// Vertex information that a shader takes as input.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct AttributeVar {
     /// Name of this attribute.
     pub name: String,
@@ -297,7 +310,8 @@ pub struct AttributeVar {
 
 /// A constant in the shader - a bit of data that doesn't vary
 // between the shader execution units (vertices/pixels/etc).
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ConstVar {
     /// Name of this constant.
     pub name: String,
@@ -313,7 +327,8 @@ pub struct ConstVar {
 }
 
 /// A constant buffer.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ConstantBufferVar {
     /// Name of this constant buffer.
     pub name: String,
@@ -328,7 +343,8 @@ pub struct ConstantBufferVar {
 }
 
 /// Texture shader parameter.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct TextureVar {
     /// Name of this texture variable.
     pub name: String,
@@ -343,7 +359,8 @@ pub struct TextureVar {
 }
 
 /// Unordered access shader parameter.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct UnorderedVar {
     /// Name of this unordered variable.
     pub name: String,
@@ -354,7 +371,8 @@ pub struct UnorderedVar {
 }
 
 /// Sampler shader parameter.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct SamplerVar {
     /// Name of this sampler variable.
     pub name: String,
@@ -367,7 +385,8 @@ pub struct SamplerVar {
 }
 
 /// Target output variable.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct OutputVar {
     /// Name of this output variable.
     pub name: String,
@@ -380,7 +399,8 @@ pub struct OutputVar {
 }
 
 /// Metadata about a program.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ProgramInfo {
     /// Attributes in the program
     pub vertex_attributes: Vec<AttributeVar>,
@@ -503,7 +523,7 @@ impl ConstVar {
 }
 
 /// An error type for creating shaders.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum CreateShaderError {
     /// The device does not support the requested shader model.
     ModelNotSupported,

--- a/src/core/src/texture.rs
+++ b/src/core/src/texture.rs
@@ -68,7 +68,7 @@ impl<R: Resources + hash::Hash> hash::Hash for Raw<R> {
 }
 
 /// Pure texture object creation error.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CreationError {
     /// Failed to map a given format to the device.
     Format(format::SurfaceType, Option<format::ChannelType>),
@@ -151,7 +151,8 @@ pub type NumFragments = u8;
 pub type Dimensions = (Size, Size, Size, AaMode);
 
 /// Describes the configuration of samples inside each texel.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum AaMode {
     /// No additional sample information
     Single,
@@ -197,7 +198,8 @@ impl AaMode {
 /// textures. Similarly for trilinear, it is really Quadralinear(?) for 3D
 /// textures. Alas, these names are simple, and match certain intuitions
 /// ingrained by many years of public use of inaccurate terminology.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum FilterMethod {
     /// The dumbest filtering possible, nearest-neighbor interpolation.
     Scale,
@@ -214,8 +216,9 @@ pub enum FilterMethod {
 }
 
 /// The face of a cube texture to do an operation on.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
 #[allow(missing_docs)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum CubeFace {
     PosX,
@@ -234,7 +237,8 @@ pub const CUBE_FACES: [CubeFace; 6] = [
 ];
 
 /// Specifies the kind of a texture storage to be allocated.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Kind {
     /// A single row of texels.
     D1(Size),
@@ -308,7 +312,8 @@ impl Kind {
 
 /// Describes a subvolume of a texture, which image data can be uploaded into.
 #[allow(missing_docs)]
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ImageInfoCommon<F> {
     pub xoffset: Size,
     pub yoffset: Size,
@@ -370,7 +375,8 @@ impl RawImageInfo {
 }
 
 /// Specifies how texture coordinates outside the range `[0, 1]` are handled.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum WrapMode {
     /// Tile the texture. That is, sample the coordinate modulo `1.0`. This is
     /// the default.
@@ -385,6 +391,7 @@ pub enum WrapMode {
 
 /// A wrapper for the LOD level of a texture.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Lod(i16);
 
 impl From<f32> for Lod {
@@ -401,6 +408,7 @@ impl Into<f32> for Lod {
 
 /// A wrapper for the 8bpp RGBA color, encoded as u32.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct PackedColor(pub u32);
 
 impl From<[f32; 4]> for PackedColor {
@@ -425,6 +433,7 @@ impl Into<[f32; 4]> for PackedColor {
 /// Specifies how to sample from a texture.
 // TODO: document the details of sampling.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct SamplerInfo {
     /// Filter method to use.
     pub filter: FilterMethod,
@@ -460,7 +469,8 @@ impl SamplerInfo {
 
 /// Texture storage descriptor.
 #[allow(missing_docs)]
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Info {
     pub kind: Kind,
     pub levels: Level,
@@ -494,7 +504,8 @@ impl Info {
 
 /// Texture resource view descriptor.
 #[allow(missing_docs)]
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ResourceDesc {
     pub channel: format::ChannelType,
     pub layer: Option<Layer>,
@@ -505,7 +516,8 @@ pub struct ResourceDesc {
 
 /// Texture render view descriptor.
 #[allow(missing_docs)]
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct RenderDesc {
     pub channel: format::ChannelType,
     pub level: Level,
@@ -514,6 +526,7 @@ pub struct RenderDesc {
 
 bitflags!(
     /// Depth-stencil read-only flags
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub flags DepthStencilFlags: u8 {
         /// Depth is read-only in the view.
         const RO_DEPTH    = 0x1,
@@ -526,7 +539,8 @@ bitflags!(
 
 /// Texture depth-stencil view descriptor.
 #[allow(missing_docs)]
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct DepthStencilDesc {
     pub level: Level,
     pub layer: Option<Layer>,

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.14.0"
+version = "0.15.0"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -30,9 +30,10 @@ name = "gfx"
 path = "src/lib.rs"
 
 [features]
+serialize = ["gfx_core/serialize", "draw_state/serialize"]
 unstable = []
 
 [dependencies]
-draw_state = "0.6"
+draw_state = "0.7"
+gfx_core = { path = "../core", version = "0.7" }
 log = "0.3"
-gfx_core = { path = "../core", version = "0.6" }

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -48,8 +48,13 @@ pub enum CopyError<S, D> {
     NoDstBindFlag,
 }
 
+/// Result type returned when copying a buffer into another buffer.
 pub type CopyBufferResult = Result<(), CopyError<usize, usize>>;
+
+/// Result type returned when copying buffer data into a texture.
 pub type CopyBufferTextureResult = Result<(), CopyError<usize, [texture::Size; 3]>>;
+
+/// Result type returned when copying texture data into a buffer.
 pub type CopyTextureBufferResult = Result<(), CopyError<[texture::Size; 3], usize>>;
 
 impl<S, D> fmt::Display for CopyError<S, D>
@@ -147,6 +152,7 @@ impl<T: Any + fmt::Debug + fmt::Display> Error for UpdateError<T> {
 ///
 /// The encoder exposes multiple functions that add commands to its internal `CommandBuffer`. To 
 /// submit these commands to the GPU so they can be rendered, call `flush`. 
+#[derive(Debug)]
 pub struct Encoder<R: Resources, C> {
     command_buffer: C,
     raw_pso_data: pso::RawDataSet<R>,

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -17,7 +17,6 @@
 //! An efficient, low-level, bindless graphics API for Rust. See [the
 //! blog](http://gfx-rs.github.io/) for explanations and annotated examples.
 
-#[macro_use]
 extern crate log;
 extern crate draw_state;
 extern crate gfx_core as core;
@@ -44,7 +43,8 @@ pub use core::memory::{self, Bind, TRANSFER_SRC, TRANSFER_DST, RENDER_TARGET,
 pub use core::command::{Buffer as CommandBuffer, InstanceParams};
 pub use core::shade::{ProgramInfo, UniformValue};
 
-pub use encoder::{Encoder, UpdateError};
+pub use encoder::{CopyBufferResult, CopyBufferTextureResult, CopyError,
+                  CopyTextureBufferResult, Encoder, UpdateError};
 pub use factory::PipelineStateError;
 pub use slice::{Slice, IntoIndexBuffer, IndexBuffer};
 pub use pso::{PipelineState};

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.6.0"
+version = "0.7.0"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,9 +29,9 @@ name = "gfx_window_dxgi"
 [dependencies]
 log = "0.3"
 kernel32-sys = "0.2"
-user32-sys = "0.1"
+user32-sys = "0.2"
 dxguid-sys = "0.2"
 winapi = "0.2"
 winit = "0.5.2"
-gfx_core = { path = "../../core", version = "0.6" }
-gfx_device_dx11 = { path = "../../backend/dx11", version = "0.5" }
+gfx_core = { path = "../../core", version = "0.7" }
+gfx_device_dx11 = { path = "../../backend/dx11", version = "0.6" }

--- a/src/window/glfw/Cargo.toml
+++ b/src/window/glfw/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glfw"
-version = "0.13.0"
+version = "0.14.0"
 description = "GLFW window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,6 +28,6 @@ documentation = "https://docs.rs/gfx_window_glfw"
 name = "gfx_window_glfw"
 
 [dependencies]
-glfw = "0.12"
-gfx_core = { path = "../../core", version = "0.6" }
-gfx_device_gl = { path = "../../backend/gl", version = "0.13" }
+glfw = "0.13"
+gfx_core = { path = "../../core", version = "0.7" }
+gfx_device_gl = { path = "../../backend/gl", version = "0.14" }

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.14.0"
+version = "0.15.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,5 +29,5 @@ name = "gfx_window_glutin"
 
 [dependencies]
 glutin = "0.7"
-gfx_core = { path = "../../core", version = "0.6" }
-gfx_device_gl = { path = "../../backend/gl", version = "0.13" }
+gfx_core = { path = "../../core", version = "0.7" }
+gfx_device_gl = { path = "../../backend/gl", version = "0.14" }

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_metal"
-version = "0.1.0"
+version = "0.2.0"
 description = "Metal window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -32,5 +32,5 @@ cocoa = "0.5"
 objc = "0.2"
 winit = "0.5"
 metal-rs = "0.3"
-gfx_core = { path = "../../core", version = "0.6" }
-gfx_device_metal = { path = "../../backend/metal", version = "0.1" }
+gfx_core = { path = "../../core", version = "0.7" }
+gfx_device_metal = { path = "../../backend/metal", version = "0.2" }

--- a/src/window/sdl/Cargo.toml
+++ b/src/window/sdl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_sdl"
-version = "0.5.0"
+version = "0.6.0"
 description = "SDL2 window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,6 +28,6 @@ name = "gfx_window_sdl"
 
 [dependencies]
 log = "0.3"
-sdl2 = "0.28"
-gfx_core = { path = "../../core", version = "0.6" }
-gfx_device_gl = { path = "../../backend/gl", version = "0.13" }
+sdl2 = "0.29"
+gfx_core = { path = "../../core", version = "0.7" }
+gfx_device_gl = { path = "../../backend/gl", version = "0.14" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_window_vulkan"
-version = "0.1.0"
+version = "0.2.0"
 description = "Vulkan window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -15,8 +15,8 @@ name = "gfx_window_vulkan"
 [dependencies]
 winit = "0.5"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
-gfx_core = { path = "../../core", version = "0.6" }
-gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.1" }
+gfx_core = { path = "../../core", version = "0.7" }
+gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.2" }
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.2"


### PR DESCRIPTION
> Note: This is the season finale for our two-part series. Prepare for `gfx` 0.15! :tada:

### Added
* Add `serialize` feature to `gfx_app` and `gfx_core`, courtesy of `draw_state` 0.7.0 (fixes #1229)
* Added API docs to `Copy{Buffer,BufferTexture,TextureBuffer}Result` types

### Changed
* Minor reformatting and alphabetical ordering of `#[derive]` statements
* Switch one manual `Eq` implementation to `#[derive]` instead
* Encoder now uses `#[derive(Debug)]`
* Bumped minor version numbers of affected crates (`gfx` is now up to 0.15.0)
* Updated several third-party dependencies
* Build against Rust 1.16.0 on AppVeyor

### Fixed
* Expose `CopyError` and `Copy{Buffer,BufferTexture,TextureBuffer}Result` types from `gfx`

CC @kvark