### PR TITLE
[ll] Add semaphore and fence sync primitives

### DIFF
--- a/examples/trianglell/main.rs
+++ b/examples/trianglell/main.rs
@@ -25,7 +25,7 @@ extern crate image;
 use gfx_corell::{buffer, command, format, pass, pso, shade, state, target, 
     Device, CommandPool, GraphicsCommandPool,
     GraphicsCommandBuffer, ProcessingCommandBuffer, TransferCommandBuffer, PrimaryCommandBuffer,
-    Primitive, Instance, Adapter, Surface, SwapChain, QueueFamily, Factory, SubPass};
+    Primitive, Instance, Adapter, Surface, SwapChain, QueueFamily, QueueSubmit, Factory, SubPass};
 use gfx_corell::command::{RenderPassEncoder, RenderPassInlineEncoder};
 use gfx_corell::format::Formatted;
 use gfx_corell::memory::{self, ImageBarrier, ImageStateSrc, ImageStateDst, ImageLayout, ImageAccess};
@@ -353,7 +353,16 @@ fn main() {
             cmd_buffer.finish()
         };
 
-        general_queues[0].submit_graphics(&[submit]);
+        general_queues[0].submit_graphics(
+            &[
+                QueueSubmit {
+                    cmd_buffers: &[submit],
+                    wait_semaphores: &[],
+                    signal_semaphores: &[],
+                }
+            ],
+            None,
+        );
     }
     
     //
@@ -397,7 +406,16 @@ fn main() {
             cmd_buffer.finish()
         };
 
-        general_queues[0].submit_graphics(&[submit]);
+        general_queues[0].submit_graphics(
+            &[
+                QueueSubmit {
+                    cmd_buffers: &[submit],
+                    wait_semaphores: &[],
+                    signal_semaphores: &[],
+                }
+            ],
+            None,
+        );
 
         // present frame
         swap_chain.present();

--- a/src/backend/vulkanll/src/factory.rs
+++ b/src/backend/vulkanll/src/factory.rs
@@ -1094,6 +1094,40 @@ impl core::Factory<R> for Factory {
         Ok(unsafe { mapping::Writer::new(slice, mapping) })
     }
 
+    fn create_semaphore(&mut self) -> native::Semaphore {
+        let info = vk::SemaphoreCreateInfo {
+            s_type: vk::StructureType::SemaphoreCreateInfo,
+            p_next: ptr::null(),
+            flags: vk::SemaphoreCreateFlags::empty(),
+        };
+
+        let semaphore = unsafe {
+            self.inner.0.create_semaphore(&info, None)
+                        .expect("Error on semaphore creation") // TODO: error handling
+        };
+
+        native::Semaphore(semaphore)
+    }
+
+    fn create_fence(&mut self, signaled: bool) -> native::Fence {
+        let info = vk::FenceCreateInfo {
+            s_type: vk::StructureType::FenceCreateInfo,
+            p_next: ptr::null(),
+            flags: if signaled {
+                vk::FENCE_CREATE_SIGNALED_BIT
+            } else {
+                vk::FenceCreateFlags::empty()
+            },
+        };
+
+        let fence = unsafe {
+            self.inner.0.create_fence(&info, None)
+                        .expect("Error on fence creation") // TODO: error handling
+        };
+
+        native::Fence(fence)
+    }
+
     fn destroy_heap(&mut self, heap: native::Heap) {
         unsafe { self.inner.0.free_memory(heap.0, None); }
     }

--- a/src/backend/vulkanll/src/native.rs
+++ b/src/backend/vulkanll/src/native.rs
@@ -155,3 +155,9 @@ pub struct DescriptorSet {
 pub struct DescriptorSetLayout {
     pub inner: vk::DescriptorSetLayout,
 }
+
+#[derive(Debug)]
+pub struct Semaphore(pub vk::Semaphore);
+
+#[derive(Debug)]
+pub struct Fence(pub vk::Fence);

--- a/src/corell/src/factory.rs
+++ b/src/corell/src/factory.rs
@@ -215,6 +215,12 @@ pub trait Factory<R: Resources> {
         where T: Copy;
 
     ///
+    fn create_semaphore(&mut self) -> R::Semaphore;
+
+    ///
+    fn create_fence(&mut self, signaled: bool) -> R::Fence;
+
+    ///
     fn destroy_heap(&mut self, R::Heap);
 
     ///

--- a/src/corell/src/lib.rs
+++ b/src/corell/src/lib.rs
@@ -173,6 +173,12 @@ pub trait QueueFamily: 'static {
     fn num_queues(&self) -> u32;
 }
 
+pub struct QueueSubmit<'a, C: CommandBuffer + 'a, R: Resources> {
+    pub cmd_buffers: &'a [command::Submit<C>],
+    pub wait_semaphores: &'a [(&'a R::Semaphore, shade::StageFlags)],
+    pub signal_semaphores: &'a [&'a R::Semaphore],
+}
+
 /// `CommandBuffers` are submitted to a `CommandQueue` and executed in-order of submission.
 /// `CommandQueue`s may run in parallel and need to be explicitly synchronized.
 pub trait CommandQueue {
@@ -185,7 +191,7 @@ pub trait CommandQueue {
     type SubpassCommandBuffer: CommandBuffer<SubmitInfo = Self::SubmitInfo>; // + SubpassCommandBuffer<Self::R>;
 
     /// Submit command buffers to queue for execution.
-    unsafe fn submit<C>(&mut self, cmd_buffers: &[command::Submit<C>])
+    unsafe fn submit<'a, C>(&mut self, submit_infos: &[QueueSubmit<C, Self::R>], fence: Option<&'a <Self::R as Resources>::Fence>)
         where C: CommandBuffer<SubmitInfo = Self::SubmitInfo>;
 }
 

--- a/src/corell/src/queue.rs
+++ b/src/corell/src/queue.rs
@@ -17,7 +17,7 @@
 //! There are different types of queues, which can create and submit associated command buffers.
 
 use std::ops::{Deref, DerefMut};
-use {CommandQueue};
+use {CommandQueue, QueueSubmit, Resources};
 use command::Submit;
 
 /// General command queue, which can execute graphics, compute and transfer command buffers.
@@ -28,17 +28,17 @@ impl<Q: CommandQueue> GeneralQueue<Q> {
         GeneralQueue(queue)
     }
 
-    pub fn submit_general(&mut self, cmd_buffers: &[Submit<Q::GeneralCommandBuffer>]) {
-        unsafe { self.submit(cmd_buffers) }
+    pub fn submit_general(&mut self, submit: &[QueueSubmit<Q::GeneralCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+        unsafe { self.submit(submit, fence) }
     }
-    pub fn submit_graphics(&mut self, cmd_buffers: &[Submit<Q::GraphicsCommandBuffer>]) {
-        unsafe { self.submit(cmd_buffers) }
+    pub fn submit_graphics(&mut self, submit: &[QueueSubmit<Q::GraphicsCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+        unsafe { self.submit(submit, fence) }
     }
-    pub fn submit_compute(&mut self, cmd_buffers: &[Submit<Q::ComputeCommandBuffer>]) {
-        unsafe { self.submit(cmd_buffers) }
+    pub fn submit_compute(&mut self, submit: &[QueueSubmit<Q::ComputeCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+        unsafe { self.submit(submit, fence) }
     }
-    pub fn submit_tranfer(&mut self, cmd_buffers: &[Submit<Q::TransferCommandBuffer>]) {
-        unsafe { self.submit(cmd_buffers) }
+    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+        unsafe { self.submit(submit, fence) }
     }
 }
 
@@ -78,11 +78,11 @@ impl<Q: CommandQueue> GraphicsQueue<Q> {
         GraphicsQueue(queue)
     }
 
-    pub fn submit_graphics(&mut self, cmd_buffers: &[Submit<Q::GraphicsCommandBuffer>]) {
-        unsafe { self.submit(cmd_buffers) }
+    pub fn submit_graphics(&mut self, submit: &[QueueSubmit<Q::GraphicsCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+        unsafe { self.submit(submit, fence) }
     }
-    pub fn submit_tranfer(&mut self, cmd_buffers: &[Submit<Q::TransferCommandBuffer>]) {
-        unsafe { self.submit(cmd_buffers) }
+    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+        unsafe { self.submit(submit, fence) }
     }
 }
 
@@ -112,11 +112,11 @@ impl<Q: CommandQueue> ComputeQueue<Q> {
         ComputeQueue(queue)
     }
 
-    pub fn submit_compute(&mut self, cmd_buffers: &[Submit<Q::ComputeCommandBuffer>]) {
-        unsafe { self.submit(cmd_buffers) }
+    pub fn submit_compute(&mut self, submit: &[QueueSubmit<Q::ComputeCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+        unsafe { self.submit(submit, fence) }
     }
-    pub fn submit_tranfer(&mut self, cmd_buffers: &[Submit<Q::TransferCommandBuffer>]) {
-        unsafe { self.submit(cmd_buffers) }
+    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+        unsafe { self.submit(submit, fence) }
     }
 }
 
@@ -146,8 +146,8 @@ impl<Q: CommandQueue> TransferQueue<Q> {
         TransferQueue(queue)
     }
 
-    pub fn submit_tranfer(&mut self, cmd_buffers: &[Submit<Q::TransferCommandBuffer>]) {
-        unsafe { self.submit(cmd_buffers) }
+    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+        unsafe { self.submit(submit, fence) }
     }
 }
 


### PR DESCRIPTION
First steps regarding synchronization support based on the vulkan API.
It should be possible to emulate Semaphore and Fence in dx12 using ID3D12Fence.

Additionally, extended the queue submit to allow fence and semaphore control, and batch multiple submits.

Following PR will address destruction, reset and further control options for image frame acquisition. Aiming to remove all remaining validation errors left in the trianglell example.