### PR TITLE
[ll] More on sync and minimize errors

### DIFF
--- a/src/backend/vulkanll/src/factory.rs
+++ b/src/backend/vulkanll/src/factory.rs
@@ -1128,6 +1128,13 @@ impl core::Factory<R> for Factory {
         native::Fence(fence)
     }
 
+    fn reset_fences(&mut self, fences: &[&native::Fence]) {
+        let fences = fences.iter().map(|fence| fence.0).collect::<Vec<_>>();
+        unsafe {
+            self.inner.0.reset_fences(&fences);
+        }
+    }
+
     fn destroy_heap(&mut self, heap: native::Heap) {
         unsafe { self.inner.0.free_memory(heap.0, None); }
     }
@@ -1200,5 +1207,13 @@ impl core::Factory<R> for Factory {
 
     fn destroy_descriptor_set_layout(&mut self, layout: native::DescriptorSetLayout) {
         unsafe { self.inner.0.destroy_descriptor_set_layout(layout.inner, None); }
+    }
+
+    fn destroy_fence(&mut self, fence: native::Fence) {
+        unsafe { self.inner.0.destroy_fence(fence.0, None); }
+    }
+
+    fn destroy_semaphore(&mut self, semaphore: native::Semaphore) {
+        unsafe { self.inner.0.destroy_semaphore(semaphore.0, None); }
     }
 }

--- a/src/backend/vulkanll/src/lib.rs
+++ b/src/backend/vulkanll/src/lib.rs
@@ -94,16 +94,20 @@ impl core::Adapter for Adapter {
     type QueueFamily = QueueFamily;
 
     fn open<'a, I>(&self, queue_descs: I) -> core::Device<Resources, Factory, CommandQueue>
-        where I: Iterator<Item=(&'a QueueFamily, u32)>
+        where I: ExactSizeIterator<Item=(&'a QueueFamily, u32)>
     {
+        let mut queue_priorities = Vec::with_capacity(queue_descs.len());
+
         let queue_infos = queue_descs.map(|(family, queue_count)| {
+                queue_priorities.push(vec![0.0f32; queue_count as usize]);
+
                 vk::DeviceQueueCreateInfo {
                     s_type: vk::StructureType::DeviceQueueCreateInfo,
                     p_next: ptr::null(),
                     flags: vk::DeviceQueueCreateFlags::empty(),
                     queue_family_index: family.family_index,
                     queue_count: queue_count,
-                    p_queue_priorities: vec![0.0f32; queue_count as usize].as_ptr(),
+                    p_queue_priorities: queue_priorities.last().unwrap().as_ptr(),
                 }
             }).collect::<Vec<_>>();
 

--- a/src/corell/src/factory.rs
+++ b/src/corell/src/factory.rs
@@ -221,6 +221,9 @@ pub trait Factory<R: Resources> {
     fn create_fence(&mut self, signaled: bool) -> R::Fence;
 
     ///
+    fn reset_fences(&mut self, fences: &[&R::Fence]);
+
+    ///
     fn destroy_heap(&mut self, R::Heap);
 
     ///
@@ -282,4 +285,10 @@ pub trait Factory<R: Resources> {
 
     ///
     fn destroy_descriptor_set_layout(&mut self, R::DescriptorSetLayout);
+
+    ///
+    fn destroy_fence(&mut self, R::Fence);
+
+    ///
+    fn destroy_semaphore(&mut self, R::Semaphore);
 }

--- a/src/corell/src/lib.rs
+++ b/src/corell/src/lib.rs
@@ -138,7 +138,7 @@ pub trait Adapter {
 
     /// Create a new device and command queues.
     fn open<'a, I>(&self, queue_descs: I) -> Device<Self::Resources, Self::Factory, Self::CommandQueue>
-        where I: Iterator<Item=(&'a Self::QueueFamily, u32)>;
+        where I: ExactSizeIterator<Item=(&'a Self::QueueFamily, u32)>;
 
     /// Get the `AdapterInfo` for this adapater.
     fn get_info(&self) -> &AdapterInfo;

--- a/src/corell/src/lib.rs
+++ b/src/corell/src/lib.rs
@@ -175,8 +175,8 @@ pub trait QueueFamily: 'static {
 
 pub struct QueueSubmit<'a, C: CommandBuffer + 'a, R: Resources> {
     pub cmd_buffers: &'a [command::Submit<C>],
-    pub wait_semaphores: &'a [(&'a R::Semaphore, shade::StageFlags)],
-    pub signal_semaphores: &'a [&'a R::Semaphore],
+    pub wait_semaphores: &'a [(&'a mut R::Semaphore, pso::PipelineStage)],
+    pub signal_semaphores: &'a [&'a mut R::Semaphore],
 }
 
 /// `CommandBuffers` are submitted to a `CommandQueue` and executed in-order of submission.
@@ -191,8 +191,11 @@ pub trait CommandQueue {
     type SubpassCommandBuffer: CommandBuffer<SubmitInfo = Self::SubmitInfo>; // + SubpassCommandBuffer<Self::R>;
 
     /// Submit command buffers to queue for execution.
-    unsafe fn submit<'a, C>(&mut self, submit_infos: &[QueueSubmit<C, Self::R>], fence: Option<&'a <Self::R as Resources>::Fence>)
+    unsafe fn submit<'a, C>(&mut self, submit_infos: &[QueueSubmit<C, Self::R>], fence: Option<&'a mut <Self::R as Resources>::Fence>)
         where C: CommandBuffer<SubmitInfo = Self::SubmitInfo>;
+
+    ///
+    fn wait_idle(&mut self);
 }
 
 /// `CommandPool` can allocate command buffers of a specific type only.
@@ -237,13 +240,22 @@ impl Frame {
     pub fn id(&self) -> usize { self.0 }
 }
 
+/// Synchronization primitives which will be signaled once a frame got retrieved.
+///
+/// The semaphore or fence _must_ be unsignaled.
+pub enum FrameSync<'a, R: Resources> {
+    Semaphore(&'a R::Semaphore),
+    Fence(&'a R::Fence)
+}
+
 /// The `SwapChain` is the backend representation of the surface.
 /// It consists of multiple buffers, which will be presented on the surface.
 pub trait SwapChain {
     type Image;
+    type R: Resources;
 
     fn get_images(&mut self) -> &[Self::Image];
-    fn acquire_frame(&mut self) -> Frame;
+    fn acquire_frame(&mut self, sync: FrameSync<Self::R>) -> Frame;
     fn present(&mut self);
 }
 

--- a/src/corell/src/queue.rs
+++ b/src/corell/src/queue.rs
@@ -28,16 +28,16 @@ impl<Q: CommandQueue> GeneralQueue<Q> {
         GeneralQueue(queue)
     }
 
-    pub fn submit_general(&mut self, submit: &[QueueSubmit<Q::GeneralCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+    pub fn submit_general(&mut self, submit: &[QueueSubmit<Q::GeneralCommandBuffer, Q::R>], fence: Option<&mut <Q::R as Resources>::Fence>) {
         unsafe { self.submit(submit, fence) }
     }
-    pub fn submit_graphics(&mut self, submit: &[QueueSubmit<Q::GraphicsCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+    pub fn submit_graphics(&mut self, submit: &[QueueSubmit<Q::GraphicsCommandBuffer, Q::R>], fence: Option<&mut <Q::R as Resources>::Fence>) {
         unsafe { self.submit(submit, fence) }
     }
-    pub fn submit_compute(&mut self, submit: &[QueueSubmit<Q::ComputeCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+    pub fn submit_compute(&mut self, submit: &[QueueSubmit<Q::ComputeCommandBuffer, Q::R>], fence: Option<&mut <Q::R as Resources>::Fence>) {
         unsafe { self.submit(submit, fence) }
     }
-    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&mut <Q::R as Resources>::Fence>) {
         unsafe { self.submit(submit, fence) }
     }
 }
@@ -78,10 +78,10 @@ impl<Q: CommandQueue> GraphicsQueue<Q> {
         GraphicsQueue(queue)
     }
 
-    pub fn submit_graphics(&mut self, submit: &[QueueSubmit<Q::GraphicsCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+    pub fn submit_graphics(&mut self, submit: &[QueueSubmit<Q::GraphicsCommandBuffer, Q::R>], fence: Option<&mut <Q::R as Resources>::Fence>) {
         unsafe { self.submit(submit, fence) }
     }
-    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&mut <Q::R as Resources>::Fence>) {
         unsafe { self.submit(submit, fence) }
     }
 }
@@ -112,10 +112,10 @@ impl<Q: CommandQueue> ComputeQueue<Q> {
         ComputeQueue(queue)
     }
 
-    pub fn submit_compute(&mut self, submit: &[QueueSubmit<Q::ComputeCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+    pub fn submit_compute(&mut self, submit: &[QueueSubmit<Q::ComputeCommandBuffer, Q::R>], fence: Option<&mut <Q::R as Resources>::Fence>) {
         unsafe { self.submit(submit, fence) }
     }
-    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&mut <Q::R as Resources>::Fence>) {
         unsafe { self.submit(submit, fence) }
     }
 }
@@ -146,7 +146,7 @@ impl<Q: CommandQueue> TransferQueue<Q> {
         TransferQueue(queue)
     }
 
-    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&<Q::R as Resources>::Fence>) {
+    pub fn submit_tranfer(&mut self, submit: &[QueueSubmit<Q::TransferCommandBuffer, Q::R>], fence: Option<&mut <Q::R as Resources>::Fence>) {
         unsafe { self.submit(submit, fence) }
     }
 }


### PR DESCRIPTION
Improve synchronization for submission and frame acquisition.
Fix issue on vulkan backend that queue priority vec only lifes on the stack and can get overwritten.

Current synchronization strategy in the example is pretty bad as it blocks forces a pipeline flush each frame.

Compute shaders next!