### PR TITLE
[ll] Add Constant Buffer Views

### DIFF
--- a/src/backend/vulkanll/src/factory.rs
+++ b/src/backend/vulkanll/src/factory.rs
@@ -817,11 +817,11 @@ impl core::Factory<R> for Factory {
         Ok(image.0)
     }
 
-    fn view_buffer_as_constant(&mut self, buffer: &native::Buffer, range: Range<usize>) -> Result<native::ConstantBufferView, f::TargetViewError> {
+    fn view_buffer_as_constant(&mut self, buffer: &native::Buffer, offset: usize, size: usize) -> Result<native::ConstantBufferView, f::TargetViewError> {
         Ok(native::ConstantBufferView {
             buffer: buffer.inner,
-            offset: range.start,
-            size: range.end - range.start,   
+            offset: offset,
+            size: size,   
         })
     }
 
@@ -1201,6 +1201,8 @@ impl core::Factory<R> for Factory {
     fn destroy_render_target_view(&mut self, rtv: native::RenderTargetView) {
         unsafe { self.inner.0.destroy_image_view(rtv.view, None); }
     }
+
+    fn destroy_constant_buffer_view(&mut self, _: native::ConstantBufferView) { }
 
     fn destroy_shader_resource_view(&mut self, srv: native::ShaderResourceView) {
         match srv {

--- a/src/backend/vulkanll/src/lib.rs
+++ b/src/backend/vulkanll/src/lib.rs
@@ -730,6 +730,7 @@ impl core::Resources for Resources {
     type Buffer = native::Buffer;
     type UnboundImage = factory::UnboundImage;
     type Image = native::Image;
+    type ConstantBufferView = native::ConstantBufferView;
     type ShaderResourceView = native::ShaderResourceView;
     type UnorderedAccessView = native::UnorderedAccessView;
     type RenderTargetView = native::RenderTargetView;

--- a/src/backend/vulkanll/src/native.rs
+++ b/src/backend/vulkanll/src/native.rs
@@ -112,6 +112,13 @@ pub struct Image(pub vk::Image);
 pub struct Sampler(pub vk::Sampler);
 
 #[derive(Debug, Hash)]
+pub struct ConstantBufferView {
+    pub buffer: vk::Buffer,
+    pub offset: usize,
+    pub size: usize,
+}
+
+#[derive(Debug, Hash)]
 pub enum ShaderResourceView {
     Buffer,
     Image(vk::ImageView),

--- a/src/corell/src/factory.rs
+++ b/src/corell/src/factory.rs
@@ -93,7 +93,7 @@ pub enum DescriptorWrite<'a, R: Resources> {
     StorageImage(Vec<(&'a R::ShaderResourceView, memory::ImageLayout)>),
     UniformTexelBuffer,
     StorageTexelBuffer,
-    ConstantBuffer,
+    ConstantBuffer(Vec<&'a R::ConstantBufferView>),
     StorageBuffer,
     InputAttachment(Vec<(&'a R::ShaderResourceView, memory::ImageLayout)>),
 }
@@ -156,6 +156,9 @@ pub trait Factory<R: Resources> {
 
     ///
     fn bind_image_memory(&mut self, heap: &R::Heap, offset: u64, image: R::UnboundImage) -> Result<R::Image, image::CreationError>;
+
+    ///
+    fn view_buffer_as_constant(&mut self, buffer: &R::Buffer, range: Range<usize>) -> Result<R::ConstantBufferView, TargetViewError>;
 
     ///
     fn view_image_as_render_target(&mut self, image: &R::Image, format: format::Format) -> Result<R::RenderTargetView, TargetViewError>;

--- a/src/corell/src/factory.rs
+++ b/src/corell/src/factory.rs
@@ -158,7 +158,7 @@ pub trait Factory<R: Resources> {
     fn bind_image_memory(&mut self, heap: &R::Heap, offset: u64, image: R::UnboundImage) -> Result<R::Image, image::CreationError>;
 
     ///
-    fn view_buffer_as_constant(&mut self, buffer: &R::Buffer, range: Range<usize>) -> Result<R::ConstantBufferView, TargetViewError>;
+    fn view_buffer_as_constant(&mut self, buffer: &R::Buffer, offset: usize, size: usize) -> Result<R::ConstantBufferView, TargetViewError>;
 
     ///
     fn view_image_as_render_target(&mut self, image: &R::Image, format: format::Format) -> Result<R::RenderTargetView, TargetViewError>;
@@ -270,6 +270,9 @@ pub trait Factory<R: Resources> {
 
     ///
     fn destroy_render_target_view(&mut self, R::RenderTargetView);
+
+    ///
+    fn destroy_constant_buffer_view(&mut self, R::ConstantBufferView);
 
     ///
     fn destroy_shader_resource_view(&mut self, R::ShaderResourceView);

--- a/src/corell/src/lib.rs
+++ b/src/corell/src/lib.rs
@@ -270,6 +270,7 @@ pub trait Resources:          Clone + Hash + Debug + Any {
     type Buffer:              Debug + Any + Send + Sync;
     type UnboundImage:        Debug + Any + Send + Sync;
     type Image:               Debug + Any + Send + Sync;
+    type ConstantBufferView:  Debug + Any + Send + Sync;
     type ShaderResourceView:  Debug + Any + Send + Sync;
     type UnorderedAccessView: Debug + Any + Send + Sync;
     type RenderTargetView:    Debug + Any + Send + Sync;


### PR DESCRIPTION
Constant buffer views (Cbv) are a concept introduced by dx12, which uses views for everything now.
Cbvs needs to be explicitly created in contrast to e.g vertex buffer views.
In vulkan these are represented as the underlying buffer and a range.
