### PR TITLE
Add ProgramError::Geometry enum variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ gfx_gl = "0.3"
 rand = "0.3"
 genmesh = "0.4"
 noise = "0.1"
-image = "0.12.3"
+image = "0.13"
 winit = "0.5"
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]

--- a/src/render/src/factory.rs
+++ b/src/render/src/factory.rs
@@ -189,7 +189,27 @@ pub trait FactoryExt<R: Resources>: Factory<R> {
         Ok(ShaderSet::Simple(vs, ps))
     }
 
-    /// Mainly for testing
+    /// Creates a `ShaderSet` from the supplied vertex, geometry, and pixel
+    /// shader source code. Mainly used for testing.
+    fn create_shader_set_geometry(&mut self, vs_code: &[u8], gs_code: &[u8], ps_code: &[u8])
+                         -> Result<ShaderSet<R>, ProgramError> {
+        let vs = match self.create_shader_vertex(vs_code) {
+            Ok(s) => s,
+            Err(e) => return Err(ProgramError::Vertex(e)),
+        };
+        let gs = match self.create_shader_geometry(gs_code) {
+            Ok(s) => s,
+            Err(e) => return Err(ProgramError::Geometry(e)),
+        };
+        let ps = match self.create_shader_pixel(ps_code) {
+            Ok(s) => s,
+            Err(e) => return Err(ProgramError::Pixel(e)),
+        };
+        Ok(ShaderSet::Geometry(vs, gs, ps))
+    }
+
+    /// Creates a `ShaderSet` from the supplied vertex, hull, domain, and pixel
+    /// shader source code. Mainly used for testing.
     fn create_shader_set_tessellation(&mut self, vs_code: &[u8], hs_code: &[u8], ds_code: &[u8], ps_code: &[u8])
                          -> Result<ShaderSet<R>, ProgramError> {
         let vs = match self.create_shader_vertex(vs_code) {

--- a/src/render/src/shade.rs
+++ b/src/render/src/shade.rs
@@ -79,14 +79,16 @@ impl_uniforms! {
 }
 
 /// Program linking error
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ProgramError {
     /// Unable to compile the vertex shader
     Vertex(core::CreateShaderError),
-    /// Unable to compile the pixel shader
+    /// Unable to compile the hull shader
     Hull(core::CreateShaderError),
-    /// Unable to compile the pixel shader
+    /// Unable to compile the domain shader
     Domain(core::CreateShaderError),
+    /// Unable to compile the geometry shader
+    Geometry(core::CreateShaderError),
     /// Unable to compile the pixel shader
     Pixel(core::CreateShaderError),
     /// Unable to link
@@ -99,6 +101,7 @@ impl fmt::Display for ProgramError {
             ProgramError::Vertex(ref e) => write!(f, "{}: {}", self.description(), e),
             ProgramError::Hull(ref e) => write!(f, "{}: {}", self.description(), e),
             ProgramError::Domain(ref e) => write!(f, "{}: {}", self.description(), e),
+            ProgramError::Geometry(ref e) => write!(f, "{}: {}", self.description(), e),
             ProgramError::Pixel(ref e) => write!(f, "{}: {}", self.description(), e),
             ProgramError::Link(ref e) => write!(f, "{}: {}", self.description(), e),
         }
@@ -111,6 +114,7 @@ impl Error for ProgramError {
             ProgramError::Vertex(_) => "Unable to compile the vertex shader",
             ProgramError::Hull(_) => "Unable to compile the hull shader",
             ProgramError::Domain(_) => "Unable to compile the domain shader",
+            ProgramError::Geometry(_) => "Unable to compile the geometry shader",
             ProgramError::Pixel(_) => "Unable to compile the pixel shader",
             ProgramError::Link(_) => "Unable to link",
         }
@@ -121,6 +125,7 @@ impl Error for ProgramError {
             ProgramError::Vertex(ref e) => Some(e),
             ProgramError::Hull(ref e) => Some(e),
             ProgramError::Domain(ref e) => Some(e),
+            ProgramError::Geometry(ref e) => Some(e),
             ProgramError::Pixel(ref e) => Some(e),
             ProgramError::Link(ref e) => Some(e),
         }


### PR DESCRIPTION
### Added
* Add `ProgramError::Geometry` enum variant.
* Add `create_shader_set_geometry` method to `FactoryExt`.

### Changed
* Clarified `create_shader_set_tessellation` doc comments.

### Fixed
* Corrected usage of "pixel shader" to the correct shader types in `ProgramError` doc comments.

CC @kvark @msiglreith 