### PR TITLE
Derive convenience traits for PSO components and a few other types

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -30,6 +30,7 @@ path = "src/lib.rs"
 [dependencies]
 bitflags = "0.8"
 cgmath = { version = "0.14", optional = true }
+derivative = "1.0"
 draw_state = "0.7"
 log = "0.3"
 serde = { version = "1.0", optional = true }

--- a/src/core/src/command.rs
+++ b/src/core/src/command.rs
@@ -136,7 +136,7 @@ impl From<u32> for ClearColor {
 }
 
 /// Informations about what is accessed by a bunch of commands.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AccessInfo<R: Resources> {
     mapped_reads: HashSet<handle::RawBuffer<R>>,
     mapped_writes: HashSet<handle::RawBuffer<R>>,

--- a/src/core/src/handle.rs
+++ b/src/core/src/handle.rs
@@ -16,8 +16,8 @@
 
 //! Resource handles
 
-use std::{ops, cmp, hash};
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::sync::Arc;
 use {buffer, shade, texture, Resources};
 use memory::Typed;
@@ -26,24 +26,19 @@ use memory::Typed;
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RawBuffer<R: Resources>(Arc<buffer::Raw<R>>);
 
-impl<R: Resources> ops::Deref for RawBuffer<R> {
+impl<R: Resources> Deref for RawBuffer<R> {
     type Target = buffer::Raw<R>;
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
 /// Type-safe buffer handle
-#[derive(Clone, Debug)]
-pub struct Buffer<R: Resources, T>(RawBuffer<R>, PhantomData<T>);
-
-impl<R: Resources, T> cmp::PartialEq for Buffer<R, T> {
-    fn eq(&self, other: &Self) -> bool { self.0.eq(&other.0) }
-}
-
-impl<R: Resources, T> cmp::Eq for Buffer<R, T> {}
-
-impl<R: Resources, T> hash::Hash for Buffer<R, T> {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) { self.0.hash(state) }
-}
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Buffer<R: Resources, T>(
+    RawBuffer<R>,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
 
 impl<R: Resources, T> Typed for Buffer<R, T> {
     type Raw = RawBuffer<R>;
@@ -74,28 +69,32 @@ pub struct Shader<R: Resources>(Arc<R::Shader>);
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Program<R: Resources>(Arc<shade::Program<R>>);
 
-impl<R: Resources> ops::Deref for Program<R> {
+impl<R: Resources> Deref for Program<R> {
     type Target = shade::Program<R>;
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
 /// Raw Pipeline State Handle
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RawPipelineState<R: Resources>(Arc<R::PipelineStateObject>, Program<R>);
 
 /// Raw texture handle
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RawTexture<R: Resources>(Arc<texture::Raw<R>>);
 
-impl<R: Resources> ops::Deref for RawTexture<R> {
+impl<R: Resources> Deref for RawTexture<R> {
     type Target = texture::Raw<R>;
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
 /// Typed texture object
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-// TODO: manual Eq & Hash impl because PhantomData
-pub struct Texture<R: Resources, S>(RawTexture<R>, PhantomData<S>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Texture<R: Resources, S>(
+    RawTexture<R>,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<S>
+);
 
 impl<R: Resources, S> Typed for Texture<R, S> {
     type Raw = RawTexture<R>;
@@ -122,9 +121,13 @@ enum ViewSource<R: Resources> {
 pub struct RawShaderResourceView<R: Resources>(Arc<R::ShaderResourceView>, ViewSource<R>);
 
 /// Type-safe Shader Resource View Handle
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-// TODO: manual Eq & Hash impl because PhantomData
-pub struct ShaderResourceView<R: Resources, T>(RawShaderResourceView<R>, PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ShaderResourceView<R: Resources, T>(
+    RawShaderResourceView<R>,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
 
 impl<R: Resources, T> Typed for ShaderResourceView<R, T> {
     type Raw = RawShaderResourceView<R>;
@@ -140,9 +143,13 @@ impl<R: Resources, T> Typed for ShaderResourceView<R, T> {
 pub struct RawUnorderedAccessView<R: Resources>(Arc<R::UnorderedAccessView>, ViewSource<R>);
 
 /// Type-safe Unordered Access View Handle
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-// TODO: manual Eq & Hash impl because PhantomData
-pub struct UnorderedAccessView<R: Resources, T>(RawUnorderedAccessView<R>, PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct UnorderedAccessView<R: Resources, T>(
+    RawUnorderedAccessView<R>,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
 
 impl<R: Resources, T> Typed for UnorderedAccessView<R, T> {
     type Raw = RawUnorderedAccessView<R>;
@@ -180,9 +187,13 @@ impl<R: Resources> RawDepthStencilView<R> {
 }
 
 /// Typed RTV
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-// TODO: manual Eq & Hash impl because PhantomData
-pub struct RenderTargetView<R: Resources, T>(RawRenderTargetView<R>, PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct RenderTargetView<R: Resources, T>(
+    RawRenderTargetView<R>,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
 
 impl<R: Resources, T> RenderTargetView<R, T> {
     /// Get target dimensions
@@ -199,13 +210,19 @@ impl<R: Resources, T> Typed for RenderTargetView<R, T> {
 }
 
 /// Typed DSV
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-// TODO: manual Eq & Hash impl because PhantomData
-pub struct DepthStencilView<R: Resources, T>(RawDepthStencilView<R>, PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct DepthStencilView<R: Resources, T>(
+    RawDepthStencilView<R>,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
 
 impl<R: Resources, T> DepthStencilView<R, T> {
     /// Get target dimensions
-    pub fn get_dimensions(&self) -> texture::Dimensions { self.raw().get_dimensions() }
+    pub fn get_dimensions(&self) -> texture::Dimensions {
+        self.raw().get_dimensions()
+    }
 }
 
 impl<R: Resources, T> Typed for DepthStencilView<R, T> {
@@ -219,7 +236,7 @@ impl<R: Resources, T> Typed for DepthStencilView<R, T> {
 
 /// Sampler Handle
 // TODO: Arc it all
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Sampler<R: Resources>(Arc<R::Sampler>, texture::SamplerInfo);
 
 impl<R: Resources> Sampler<R> {
@@ -228,7 +245,7 @@ impl<R: Resources> Sampler<R> {
 }
 
 /// Fence Handle
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Fence<R: Resources>(Arc<R::Fence>);
 
 /// Stores reference-counted resources used in a command buffer.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -19,6 +19,8 @@
 
 #[macro_use]
 extern crate bitflags;
+#[macro_use]
+extern crate derivative;
 extern crate draw_state;
 extern crate log;
 
@@ -85,10 +87,12 @@ pub type ColorSlot = u8;
 pub type SamplerSlot = u8;
 
 macro_rules! define_shaders {
-    ($($name:ident),+) => {$(
+    ( $($name:ident),+ ) => {
+        $(
         #[allow(missing_docs)]
         #[derive(Clone, Debug, Eq, Hash, PartialEq)]
         pub struct $name<R: Resources>(handle::Shader<R>);
+
         impl<R: Resources> $name<R> {
             #[allow(missing_docs)]
             pub fn reference(&self, man: &mut handle::Manager<R>) -> &R::Shader {
@@ -100,7 +104,8 @@ macro_rules! define_shaders {
                 $name(shader)
             }
         }
-    )+}
+        )+
+    }
 }
 
 define_shaders!(VertexShader, HullShader, DomainShader, GeometryShader, PixelShader);
@@ -114,7 +119,6 @@ pub enum ShaderSet<R: Resources> {
     Geometry(VertexShader<R>, GeometryShader<R>, PixelShader<R>),
     /// Tessellated TODO: Tessellated, TessellatedGeometry, TransformFeedback
     Tessellated(VertexShader<R>, HullShader<R>, DomainShader<R>, PixelShader<R>),
-
 }
 
 impl<R: Resources> ShaderSet<R> {
@@ -131,7 +135,7 @@ impl<R: Resources> ShaderSet<R> {
 //TODO: use the appropriate units for max vertex count, etc
 /// Features that the device supports.
 #[allow(missing_docs)] // pretty self-explanatory fields!
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Capabilities {
     pub max_vertex_count: usize,
@@ -309,7 +313,7 @@ pub trait Adapter: Sized {
 }
 
 /// Information about a backend adapater.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct AdapterInfo {
     /// Adapter name

--- a/src/core/src/pso.rs
+++ b/src/core/src/pso.rs
@@ -28,7 +28,6 @@ use shade::Usage;
 use std::error::Error;
 use std::fmt;
 
-
 /// Maximum number of vertex buffers used in a PSO definition.
 pub const MAX_VERTEX_BUFFERS: usize = 4;
 
@@ -36,7 +35,7 @@ pub const MAX_VERTEX_BUFFERS: usize = 4;
 pub type BufferOffset = usize;
 
 /// Error types happening upon PSO creation on the device side.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CreationError;
 
 impl fmt::Display for CreationError {
@@ -213,7 +212,7 @@ impl Descriptor {
 }
 
 /// A complete set of vertex buffers to be used for vertex import in PSO.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct VertexBufferSet<R: Resources>(
     /// Array of buffer handles with offsets in them
     pub [Option<(R::Buffer, BufferOffset)>; MAX_VERTEX_ATTRIBUTES]
@@ -227,19 +226,19 @@ impl<R: Resources> VertexBufferSet<R> {
 }
 
 /// A constant buffer run-time parameter for PSO.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ConstantBufferParam<R: Resources>(pub R::Buffer, pub Usage, pub ConstantBufferSlot);
 
 /// A shader resource view (SRV) run-time parameter for PSO.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ResourceViewParam<R: Resources>(pub R::ShaderResourceView, pub Usage, pub ResourceViewSlot);
 
 /// An unordered access view (UAV) run-time parameter for PSO.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct UnorderedViewParam<R: Resources>(pub R::UnorderedAccessView, pub Usage, pub UnorderedViewSlot);
 
 /// A sampler run-time parameter for PSO.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct SamplerParam<R: Resources>(pub R::Sampler, pub Usage, pub SamplerSlot);
 
 /// A complete set of render targets to be used for pixel export in PSO.

--- a/src/core/src/shade.rs
+++ b/src/core/src/shade.rs
@@ -87,7 +87,7 @@ impl TextureType {
 }
 
 /// A type of the sampler variable.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct SamplerType(pub IsComparison, pub IsRect);
 
@@ -348,7 +348,7 @@ impl From<Stage> for Usage {
 }
 
 /// Vertex information that a shader takes as input.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct AttributeVar {
     /// Name of this attribute.
@@ -363,7 +363,7 @@ pub struct AttributeVar {
 
 /// A constant in the shader - a bit of data that doesn't vary
 // between the shader execution units (vertices/pixels/etc).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ConstVar {
     /// Name of this constant.
@@ -380,7 +380,7 @@ pub struct ConstVar {
 }
 
 /// A constant buffer.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ConstantBufferVar {
     /// Name of this constant buffer.
@@ -396,7 +396,7 @@ pub struct ConstantBufferVar {
 }
 
 /// Texture shader parameter.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct TextureVar {
     /// Name of this texture variable.
@@ -412,7 +412,7 @@ pub struct TextureVar {
 }
 
 /// Unordered access shader parameter.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct UnorderedVar {
     /// Name of this unordered variable.
@@ -424,7 +424,7 @@ pub struct UnorderedVar {
 }
 
 /// Sampler shader parameter.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct SamplerVar {
     /// Name of this sampler variable.
@@ -438,7 +438,7 @@ pub struct SamplerVar {
 }
 
 /// Target output variable.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct OutputVar {
     /// Name of this output variable.
@@ -452,7 +452,7 @@ pub struct OutputVar {
 }
 
 /// Metadata about a program.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct ProgramInfo {
     /// Attributes in the program
@@ -514,7 +514,7 @@ impl<R: Resources + hash::Hash> hash::Hash for Program<R> {
 }
 
 /// Error type for trying to store a UniformValue in a ConstVar.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CompatibilityError {
     /// Array sizes differ between the value and the var (trying to upload a vec2 as a vec4, etc)
     ErrorArraySize,

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -36,6 +36,7 @@ unstable = []
 
 [dependencies]
 cgmath = { version = "0.14", optional = true }
+derivative = "1.0"
 draw_state = "0.7"
 gfx_core = { path = "../core", version = "0.7" }
 log = "0.3"

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -21,6 +21,8 @@
 extern crate cgmath;
 
 extern crate log;
+#[macro_use]
+extern crate derivative;
 extern crate draw_state;
 extern crate gfx_core as core;
 

--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -21,15 +21,17 @@ macro_rules! gfx_pipeline_inner {
     } => {
         use $crate::pso::{DataLink, DataBind, Descriptor, InitError, RawDataSet, AccessInfo};
 
-        #[derive(Clone, Debug)]
+        #[derive(Clone, Debug, PartialEq)]
         pub struct Data<R: $crate::Resources> {
             $( pub $field: <$ty as DataBind<R>>::Data, )*
         }
 
+        #[derive(Clone, Debug, PartialEq)]
         pub struct Meta {
             $( $field: $ty, )*
         }
 
+        #[derive(Clone, Debug, PartialEq)]
         pub struct Init<'a> {
             $( pub $field: <$ty as DataLink<'a>>::Init, )*
         }

--- a/src/render/src/macros/structure.rs
+++ b/src/render/src/macros/structure.rs
@@ -31,7 +31,7 @@ macro_rules! gfx_impl_struct_meta {
         $( $field:ident: $ty:ty = $name:expr, )*
     }) => {
         #[allow(missing_docs)]
-        #[derive(Clone, Copy, Debug)]
+        #[derive(Clone, Copy, Debug, PartialEq)]
         $(#[$attr])*
         pub struct $root {
             $( pub $field: $ty, )*

--- a/src/render/src/pso/buffer.rs
+++ b/src/render/src/pso/buffer.rs
@@ -32,38 +32,64 @@ pub trait Structure<F> {
 }
 
 type AttributeSlotSet = usize;
+
 /// Service struct to simplify the implementations of `VertexBuffer` and `InstanceBuffer`.
-pub struct VertexBufferCommon<T, I>(RawVertexBuffer, PhantomData<(T, I)>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct VertexBufferCommon<T, I>(
+    RawVertexBuffer,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<(T, I)>
+);
+
 /// Vertex buffer component. Advanced per vertex.
 ///
 /// - init: `()`
 /// - data: `Buffer<T>`
 pub type VertexBuffer<T> = VertexBufferCommon<T, [(); 0]>;
+
 /// Instance buffer component. Same as the vertex buffer but advances per instance.
 pub type InstanceBuffer<T> = VertexBufferCommon<T, [(); 1]>;
+
 /// Raw vertex/instance buffer component. Can be used when the formats of vertex attributes
 /// are not known at compile time.
 ///
 /// - init: `(&[&str, element], stride, inst_rate)`
 /// - data: `RawBuffer`
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RawVertexBuffer(Option<BufferIndex>, AttributeSlotSet);
+
 /// Constant buffer component.
 ///
 /// - init: `&str` = name of the buffer
 /// - data: `Buffer<T>`
-pub struct ConstantBuffer<T: Structure<shade::ConstFormat>>(RawConstantBuffer, PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ConstantBuffer<T: Structure<shade::ConstFormat>>(
+    RawConstantBuffer,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
+
 /// Raw constant buffer component.
 ///
 /// - init: `&str` = name of the buffer
 /// - data: `RawBuffer`
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RawConstantBuffer(Option<(Usage, ConstantBufferSlot)>);
+
 /// Global (uniform) constant component. Describes a free-standing value passed into
 /// the shader, which is not enclosed into any constant buffer. Deprecated in DX10 and higher.
 ///
 /// - init: `&str` = name of the constant
 /// - data: `T` = value
-pub struct Global<T: ToUniform>(Option<shade::Location>, PhantomData<T>);
-
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Global<T: ToUniform>(
+    Option<shade::Location>,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
 
 fn match_attribute(_: &shade::AttributeVar, _: Format) -> bool {
     true //TODO

--- a/src/render/src/pso/mod.rs
+++ b/src/render/src/pso/mod.rs
@@ -57,7 +57,7 @@ pub use core::command::AccessInfo;
 /// It doesn't have any typing information, since PSO knows what
 /// format and layout to expect from each resource.
 #[allow(missing_docs)]
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RawDataSet<R: c::Resources>{
     pub vertex_buffers: c::pso::VertexBufferSet<R>,
     pub constant_buffers: Vec<c::pso::ConstantBufferParam<R>>,
@@ -166,7 +166,7 @@ impl<'a> From<ElementError<&'a str>> for ElementError<String> {
 }
 
 /// Failure to initilize the link between the shader and the data.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum InitError<S> {
     /// Vertex attribute mismatch.
     VertexImport(S, Option<c::format::Format>),
@@ -271,8 +271,9 @@ pub trait PipelineData<R: c::Resources> {
 }
 
 /// A strongly typed Pipleline State Object. See the module documentation for more information.
-pub struct PipelineState<R: c::Resources, M>(
-    c::handle::RawPipelineState<R>, c::Primitive, M);
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct PipelineState<R: c::Resources, M>(c::handle::RawPipelineState<R>,
+                                             c::Primitive, M);
 
 impl<R: c::Resources, M> PipelineState<R, M> {
     /// Create a new PSO from a raw handle and the "meta" instance.

--- a/src/render/src/pso/resource.rs
+++ b/src/render/src/pso/resource.rs
@@ -26,24 +26,42 @@ use super::{DataLink, DataBind, RawDataSet, AccessInfo};
 ///
 /// - init: `&str` = name of the resource
 /// - data: `ShaderResourceView<T>`
-pub struct ShaderResource<T>(RawShaderResource, PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ShaderResource<T>(
+    RawShaderResource,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
+
 /// Raw (untyped) shader resource (SRV).
 ///
 /// - init: `&str` = name of the resource. This may change in the future.
 /// - data: `RawShaderResourceView`
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RawShaderResource(Option<(ResourceViewSlot, shade::Usage)>);
+
 /// Unordered access component (UAV). A writable resource (texture/buffer)
 /// with no defined access order across simultaneously executing shaders.
 /// Supported on DX10 and higher.
 ///
 /// - init: `&str` = name of the resource
 /// - data: `UnorderedAccessView<T>`
-pub struct UnorderedAccess<T>(Option<(UnorderedViewSlot, shade::Usage)>, PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct UnorderedAccess<T>(
+    Option<(UnorderedViewSlot, shade::Usage)>,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
+
 /// Sampler component.
 ///
 /// - init: `&str` = name of the sampler
 /// - data: `Sampler`
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Sampler(Option<(SamplerSlot, shade::Usage)>);
+
 /// A convenience type for a texture paired with a sampler.
 /// It only makes sense for DX9 class hardware, where every texture by default
 /// is bundled with a sampler, hence they are represented by the same name.
@@ -51,8 +69,8 @@ pub struct Sampler(Option<(SamplerSlot, shade::Usage)>);
 ///
 /// - init: `&str` = name of the sampler/texture (assuming they match)
 /// - data: (`ShaderResourceView<T>`, `Sampler`)
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct TextureSampler<T>(ShaderResource<T>, Sampler);
-
 
 impl<'a, T> DataLink<'a> for ShaderResource<T> {
     type Init = &'a str;
@@ -78,7 +96,6 @@ impl<R: Resources, T> DataBind<R> for ShaderResource<T> {
         self.0.bind_to(out, data.raw(), man, access)
     }
 }
-
 
 impl<'a> DataLink<'a> for RawShaderResource {
     type Init = &'a str;
@@ -114,7 +131,6 @@ impl<R: Resources> DataBind<R> for RawShaderResource {
     }
 }
 
-
 impl<'a, T> DataLink<'a> for UnorderedAccess<T> {
     type Init = &'a str;
     fn new() -> Self {
@@ -149,7 +165,6 @@ impl<R: Resources, T> DataBind<R> for UnorderedAccess<T> {
     }
 }
 
-
 impl<'a> DataLink<'a> for Sampler {
     type Init = &'a str;
     fn new() -> Self {
@@ -182,7 +197,6 @@ impl<R: Resources> DataBind<R> for Sampler {
         }
     }
 }
-
 
 impl<'a, T> DataLink<'a> for TextureSampler<T> {
     type Init = &'a str;

--- a/src/render/src/pso/target.rs
+++ b/src/render/src/pso/target.rs
@@ -14,6 +14,7 @@
 
 //! Render target components for a PSO.
 
+use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use core::{ColorSlot, Resources};
 use core::{format, handle, pso, state, target};
@@ -25,43 +26,79 @@ use super::{DataLink, DataBind, RawDataSet, AccessInfo};
 ///
 /// - init: `&str` = name of the target
 /// - data: `RenderTargetView<T>`
-pub struct RenderTarget<T>(Option<ColorSlot>, PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct RenderTarget<T>(
+    Option<ColorSlot>,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
+
 /// Render target component with active blending mode.
 ///
 /// - init: (`&str`, `ColorMask`, `Blend` = blending state)
 /// - data: `RenderTargetView<T>`
-pub struct BlendTarget<T>(RawRenderTarget, PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BlendTarget<T>(
+    RawRenderTarget,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
+
 /// Raw (untyped) render target component with optional blending.
 ///
 /// - init: (`&str`, `Format`, `ColorMask`, `Option<Blend>`)
 /// - data: `RawRenderTargetView`
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct RawRenderTarget(Option<ColorSlot>);
+
 /// Depth target component.
 ///
 /// - init: `Depth` = depth state
 /// - data: `DepthStencilView<T>`
-pub struct DepthTarget<T>(PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct DepthTarget<T>(
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
+
 /// Stencil target component.
 ///
 /// - init: `Stencil` = stencil state
 /// - data: (`DepthStencilView<T>`, `(front, back)` = stencil reference values)
-pub struct StencilTarget<T>(PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct StencilTarget<T>(
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
+
 /// Depth + stencil target component.
 ///
 /// - init: (`Depth` = depth state, `Stencil` = stencil state)
 /// - data: (`DepthStencilView<T>`, `(front, back)` = stencil reference values)
-pub struct DepthStencilTarget<T>(PhantomData<T>);
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct DepthStencilTarget<T>(
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    PhantomData<T>
+);
+
 /// Scissor component. Sets up the scissor test for rendering.
 ///
 /// - init: `()`
 /// - data: `Rect` = target area
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Scissor(bool);
+
 /// Blend reference component. Sets up the reference color for blending.
 ///
 /// - init: `()`
 /// - data: `ColorValue`
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct BlendRef;
-
 
 impl<'a, T: format::RenderFormat> DataLink<'a> for RenderTarget<T> {
     type Init = &'a str;

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -2,12 +2,11 @@
 extern crate gfx;
 pub use gfx::format as fm;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Rg16;
 gfx_format!(Rg16: R16_G16 = Vec2<Float>);
 
 gfx_defines!{
-    #[derive(PartialEq)]
     vertex Vertex {
         _x: i8 = "x",
         _y: f32 = "y",
@@ -21,7 +20,7 @@ gfx_defines!{
     constant Local {
         pos: [u32; 4] = "pos",
     }
-    #[derive(PartialEq)] #[derive(PartialOrd)]
+
     constant LocalMeta {
         pos: [u32; 4] = "pos_meta",
     }


### PR DESCRIPTION
### Changed

* Derived `Clone`, `Copy`, `Debug`, `Eq`, `Hash`, and/or `PartialEq` for a bunch of structs, mostly within the `gfx::pso::*` module.
* Updated the `gfx_pipeline!` macro to automatically derive `Clone`, `Debug`, and `PartialEq` for the resulting `Data`, `Meta`, and `Init` structs.
* Updated the `gfx_impl_struct_meta!` macro to automatically derive `Clone`, `Copy`, `Debug`, and `PartialEq` for the resulting struct.
* Minor reformatting.

### Fixed

* Eliminated TODOs for manually implementing `Eq`, `Hash`, and `PartialEq` on several structs which contain `PhantomData<T>` as data members.

CC @kvark @msiglreith 