### PR TITLE
[ll] Core update (GL) [03/..]

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -52,6 +52,7 @@ pub struct DataPointer {
     size: u32,
 }
 
+#[derive(Clone)]
 pub struct DataBuffer(Vec<u8>);
 impl DataBuffer {
     /// Create a new empty data buffer.
@@ -637,7 +638,15 @@ impl command::Buffer<Resources> for CommandBuffer {
 impl c::CommandBuffer for CommandBuffer {
     type SubmitInfo = SubmitInfo;
     unsafe fn end(&mut self) -> SubmitInfo {
-        unimplemented!()
+        // TODO: Slow! Avoid cloning!
+        // Constraints:
+        //   cmd can only be written on one thread,
+        //   and send read-only submit to the queue.
+        //   In theory we could just share a pointer to the buffer.
+        SubmitInfo {
+            buf: self.buf.clone(),
+            data: self.data.clone(),
+        }
     }
 }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -17,6 +17,7 @@
 use gl;
 use core::{self as c, command, state as s};
 use core::target::{ColorValue, Depth, Mirror, Rect, Stencil};
+use native::{GeneralCommandBuffer, GraphicsCommandBuffer, ComputeCommandBuffer, TransferCommandBuffer, SubpassCommandBuffer};
 use {Buffer, BufferElement, Program, FrameBuffer, Texture,
      NewTexture, Resources, PipelineState, ResourceView, TargetView};
 
@@ -71,6 +72,10 @@ impl DataBuffer {
     }
 }
 
+pub struct SubmitInfo {
+    pub buf: Vec<Command>,
+    pub data: DataBuffer,
+}
 
 /// Serialized device command.
 #[derive(Clone, Copy, Debug)]
@@ -628,3 +633,29 @@ impl command::Buffer<Resources> for CommandBuffer {
                       instances));
     }
 }
+
+impl c::CommandBuffer for CommandBuffer {
+    type SubmitInfo = SubmitInfo;
+    unsafe fn end(&mut self) -> SubmitInfo {
+        unimplemented!()
+    }
+}
+
+// CommandBuffer trait implementation
+macro_rules! impl_cmd_buffer {
+    ($buffer:ident) => (
+        impl command::CommandBuffer for $buffer {
+            type SubmitInfo = SubmitInfo;
+            unsafe fn end(&mut self) -> SubmitInfo {
+                self.0.end()
+            }
+        }
+    )
+}
+
+impl_cmd_buffer!(GeneralCommandBuffer);
+impl_cmd_buffer!(GraphicsCommandBuffer);
+impl_cmd_buffer!(ComputeCommandBuffer);
+impl_cmd_buffer!(TransferCommandBuffer);
+impl_cmd_buffer!(SubpassCommandBuffer);
+

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -37,6 +37,7 @@ pub use self::info::{Info, PlatformName, Version};
 mod command;
 mod factory;
 mod info;
+mod native;
 mod shade;
 mod state;
 mod tex;
@@ -958,4 +959,56 @@ impl c::Device for Device {
             |gl, fence| unsafe { gl.DeleteSync(fence.0) },
         );
     }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct Adapter;
+
+impl c::Adapter for Adapter {
+    type CommandQueue = CommandQueue;
+    type Factory = Factory;
+    type QueueFamily = QueueFamily;
+    type Resources = Resources;
+
+    fn enumerate_adapters() -> Vec<Self> {
+        vec![Adapter]
+    }
+
+    fn open(&self, queue_descs: &[(&QueueFamily, u32)]) -> c::Device_<Resources, Factory, CommandQueue> {
+        unimplemented!()
+    }
+
+    fn get_info(&self) -> &c::AdapterInfo {
+        unimplemented!()
+    }
+
+    fn get_queue_families(&self) -> &[QueueFamily] {
+        unimplemented!()
+    }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct CommandQueue;
+
+impl c::CommandQueue for CommandQueue {
+    type Resources = Resources;
+    type SubmitInfo = command::SubmitInfo;
+    type GeneralCommandBuffer = native::GeneralCommandBuffer;
+    type GraphicsCommandBuffer = native::GraphicsCommandBuffer;
+    type ComputeCommandBuffer = native::ComputeCommandBuffer;
+    type TransferCommandBuffer = native::TransferCommandBuffer;
+    type SubpassCommandBuffer = native::SubpassCommandBuffer;
+
+    unsafe fn submit<'a, C>(&mut self, submit_infos: &[c::QueueSubmit<C, Resources>], fence: Option<&'a mut Fence>)
+        where C: c::CommandBuffer<SubmitInfo = command::SubmitInfo>
+    {
+        unimplemented!()
+    }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct QueueFamily;
+
+impl c::QueueFamily for QueueFamily {
+    fn num_queues(&self) -> u32 { 1 }
 }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -1042,22 +1042,3 @@ pub struct QueueFamily;
 impl c::QueueFamily for QueueFamily {
     fn num_queues(&self) -> u32 { 1 }
 }
-
-#[allow(missing_copy_implementations)]
-pub struct SwapChain;
-
-impl c::SwapChain for SwapChain {
-    type R = Resources;
-
-    fn get_images(&mut self) -> &[NewTexture] {
-        unimplemented!()
-    }
-
-    fn acquire_frame(&mut self, sync: c::FrameSync<Resources>) -> c::Frame {
-        unimplemented!()
-    }
-
-    fn present(&mut self) {
-        unimplemented!()
-    }
-}

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -970,10 +970,6 @@ impl c::Adapter for Adapter {
     type QueueFamily = QueueFamily;
     type Resources = Resources;
 
-    fn enumerate_adapters() -> Vec<Self> {
-        vec![Adapter]
-    }
-
     fn open(&self, queue_descs: &[(&QueueFamily, u32)]) -> c::Device_<Resources, Factory, CommandQueue> {
         unimplemented!()
     }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -1,0 +1,21 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use command::CommandBuffer;
+
+pub struct GeneralCommandBuffer(pub CommandBuffer);
+pub struct GraphicsCommandBuffer(pub CommandBuffer);
+pub struct ComputeCommandBuffer(pub CommandBuffer);
+pub struct TransferCommandBuffer(pub CommandBuffer);
+pub struct SubpassCommandBuffer(pub CommandBuffer);

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -363,9 +363,6 @@ pub trait Adapter: Sized {
     /// Associated `Resources` type.
     type Resources: Resources;
 
-    /// Enumerate all available adapters supporting this backend 
-    fn enumerate_adapters() -> Vec<Self>;
-
     /// Create a new device and command queues.
     fn open(&self, queue_descs: &[(&Self::QueueFamily, u32)]) -> Device_<Self::Resources, Self::Factory, Self::CommandQueue>;
 
@@ -435,15 +432,10 @@ pub trait CommandQueue {
 pub trait Surface {
     /// Associated `CommandQueue` type.
     type CommandQueue: CommandQueue;
-    /// Associated native `Window` type.
-    type Window;
     ///
     type SwapChain: SwapChain;
     ///
     type QueueFamily: QueueFamily;
-
-    /// Create a new surface from a native window.
-    fn from_window(window: &Self::Window) -> Self;
 
     /// Check if the queue family supports presentation for this surface.
     fn supports_queue(&self, queue_family: &Self::QueueFamily) -> bool;
@@ -494,4 +486,16 @@ pub trait SwapChain {
 
     /// Present one acquired frame in FIFO order.
     fn present(&mut self);
+}
+
+/// Extension for windows.
+/// Main entry point for backend initialization from a window.
+pub trait WindowExt {
+    /// Associated `Surface` type.
+    type Surface: Surface;
+    /// Associated `Adapter` type.
+    type Adapter: Adapter;
+
+    /// Create window surface and enumerate all available adapters.
+    fn get_surface_and_adapters(&mut self) -> (Self::Surface, Vec<Self::Adapter>);
 }

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -174,3 +174,32 @@ pub fn new_views<Cf, Df>(window: &glutin::Window)
         device_gl::create_main_targets_raw(dim, Cf::get_format().0, Df::get_format().0);
     (Typed::new(color_view_raw), Typed::new(depth_view_raw))
 }
+
+pub struct Surface;
+
+impl core::Surface for Surface {
+    type CommandQueue = device_gl::CommandQueue;
+    type SwapChain = device_gl::SwapChain;
+    type QueueFamily = device_gl::QueueFamily;
+
+    fn supports_queue(&self, queue_family: &device_gl::QueueFamily) -> bool { true }
+    fn build_swapchain<T: core::format::RenderFormat>(&self,
+                    present_queue: &device_gl::CommandQueue) -> device_gl::SwapChain
+    {
+        unimplemented!()
+    }
+}
+
+pub struct Window<'a>(&'a glutin::Window);
+
+impl<'a> core::WindowExt for Window<'a> {
+    type Surface = Surface;
+    type Adapter = device_gl::Adapter;
+
+    fn get_surface_and_adapters(&mut self) -> (Surface, Vec<device_gl::Adapter>) {
+        unsafe { self.0.make_current().unwrap() };
+        let adapter = device_gl::Adapter::new(|s| self.0.get_proc_address(s) as *const std::os::raw::c_void);
+
+        (Surface, vec![adapter])
+    }
+}

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -175,16 +175,35 @@ pub fn new_views<Cf, Df>(window: &glutin::Window)
     (Typed::new(color_view_raw), Typed::new(depth_view_raw))
 }
 
+#[allow(missing_copy_implementations)]
+pub struct SwapChain;
+
+impl core::SwapChain for SwapChain {
+    type R = device_gl::Resources;
+
+    fn get_images(&mut self) -> &[device_gl::NewTexture] {
+        unimplemented!()
+    }
+
+    fn acquire_frame(&mut self, sync: core::FrameSync<device_gl::Resources>) -> core::Frame {
+        unimplemented!()
+    }
+
+    fn present(&mut self) {
+        unimplemented!()
+    }
+}
+
 pub struct Surface;
 
 impl core::Surface for Surface {
     type CommandQueue = device_gl::CommandQueue;
-    type SwapChain = device_gl::SwapChain;
+    type SwapChain = SwapChain;
     type QueueFamily = device_gl::QueueFamily;
 
     fn supports_queue(&self, queue_family: &device_gl::QueueFamily) -> bool { true }
     fn build_swapchain<T: core::format::RenderFormat>(&self,
-                    present_queue: &device_gl::CommandQueue) -> device_gl::SwapChain
+                    present_queue: &device_gl::CommandQueue) -> SwapChain
     {
         unimplemented!()
     }

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -232,7 +232,6 @@ impl<'a> core::WindowExt for Window<'a> {
     type Surface = Surface;
     type Adapter = device_vulkan::Adapter;
 
-    /// Create window surface and enumerate all available adapters.
     fn get_surface_and_adapters(&mut self) -> (Surface, Vec<device_vulkan::Adapter>) {
         let surface = Surface::from_window(self.0);
         let adapters = INSTANCE.raw.enumerate_physical_devices()


### PR DESCRIPTION
- Implement device creation part for GL
- Move SwapChain to the window crate because OpenGL requires the glutin window for swapping the buffers on present

Command buffer submission on GL is not optimal atm due to cloning the internal data and cmd buffers.
I'll rebase the `ll` branch after the PR on the latest master to avoid conflicts for the future merge.

Next task would be the d3d11 and d3d12 backend, updating the `gfx_app` and some smaller changes to `render`. Hopefully we can reach an mergable state then.
Unfortunately I don't have access to an OS X machine so I can't take care of the Metal backend.