### PR TITLE
Run-time specified instance rate

### DIFF
--- a/src/render/src/pso/target.rs
+++ b/src/render/src/pso/target.rs
@@ -14,7 +14,6 @@
 
 //! Render target components for a PSO.
 
-use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use core::{ColorSlot, Resources};
 use core::{format, handle, pso, state, target};


### PR DESCRIPTION
The new `ToInstanceRate` trait allows the same PSO declaration and shader to be used with both instanced and non-instanced attribute. There appears to be a real use case for it - sometimes we know the color (for example) on a per-object basis, sometimes it's per-vertex.