### PR TITLE
Fix Metal backend's color handling

### DIFF
--- a/src/backend/metal/src/map.rs
+++ b/src/backend/metal/src/map.rs
@@ -237,16 +237,13 @@ pub fn map_format(format: Format, is_target: bool) -> Option<MTLPixelFormat> {
             Int   => RGBA8Sint,
             Uint  => RGBA8Uint,
             Inorm => RGBA8Snorm,
-            Unorm => if is_target {
-                         BGRA8Unorm
-                     } else {
-                         RGBA8Unorm
-                     },
-            Srgb  => if is_target {
-                         BGRA8Unorm_sRGB
-                     } else {
-                         RGBA8Unorm_sRGB
-                     },
+            Unorm => RGBA8Unorm,
+            Srgb  => RGBA8Unorm_sRGB,
+            _ => return None,
+        },
+        B8_G8_R8_A8 => match format.1 {
+            Unorm => BGRA8Unorm,
+            Srgb  => BGRA8Unorm_sRGB,
             _ => return None,
         },
         R10_G10_B10_A2 => match format.1 {

--- a/src/core/src/format.rs
+++ b/src/core/src/format.rs
@@ -145,7 +145,7 @@ impl_formats! {
         [BufferSurface, TextureSurface, RenderSurface],
     R32_G32_B32_A32 : Vec4<Int, Uint, Float> = [u32; 4] {32}
         [BufferSurface, TextureSurface, RenderSurface],
-    B8_G8_R8_A8     : Vec4<Unorm> = [u8; 4] {32}
+    B8_G8_R8_A8     : Vec4<Unorm, Srgb> = [u8; 4] {32}
         [BufferSurface, TextureSurface, RenderSurface],
     D16             : Vec1<Unorm> = F16 {0} [TextureSurface, DepthSurface],
     D24             : Vec1<Unorm> = f32 {8} [TextureSurface, DepthSurface], //hacky stencil bits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,12 @@ extern crate gfx_window_vulkan;
 
 pub mod shade;
 
-#[cfg(not(feature = "vulkan"))]
+#[cfg(not(any(feature = "vulkan", feature = "metal")))]
 pub type ColorFormat = gfx::format::Rgba8;
 #[cfg(feature = "vulkan")]
 pub type ColorFormat = gfx::format::Bgra8;
+#[cfg(feature = "metal")]
+pub type ColorFormat = (gfx::format::B8_G8_R8_A8, gfx::format::Srgb);
 
 #[cfg(feature = "metal")]
 pub type DepthFormat = gfx::format::Depth32F;


### PR DESCRIPTION
Two issues were causing distored colors when using the Metal backend:

1. RGBA8 was mapped to BGRA8 when rendering, to accomodate CAMetalLayer's requirement that it only use BGRA ordering for 8-bit backbuffer formats. This however created issues when handling textures, so instead we expose this difference to the user. It should only require them to choose a backbuffer format based on the backend used, which is already needed for Vulkan.

2. CAMetalLayer appears to interpret the buffer as sRGB whether you want it to or not. To accomodate this we use the backbuffer color format (B8_G8_R8_A8, Srgb) in gfx_app when using Metal, so writes to the backbuffer are transformed properly. This may actually be an error on our side, because we do some hacky things with regards to backbuffer management, but until those are fixed this will at least produce correct results.

Addresses issue #1204