### PR TITLE
Use full namespaces in macro-generated fns which return ::std types

### DIFF
--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -37,7 +37,7 @@ macro_rules! gfx_pipeline_inner {
         impl<'a> $crate::pso::PipelineInit for Init<'a> {
             type Meta = Meta;
             fn link_to<'s>(&self, desc: &mut Descriptor, info: &'s $crate::ProgramInfo)
-                       -> Result<Self::Meta, InitError<&'s str>>
+                       -> ::std::result::Result<Self::Meta, InitError<&'s str>>
             {
                 let mut meta = Meta {
                     $( $field: <$ty as DataLink<'a>>::new(), )*

--- a/src/render/src/macros/structure.rs
+++ b/src/render/src/macros/structure.rs
@@ -40,7 +40,7 @@ macro_rules! gfx_impl_struct_meta {
         unsafe impl $crate::traits::Pod for $root {}
 
         impl $crate::pso::buffer::Structure<$runtime_format> for $root {
-            fn query(name: &str) -> Option<$crate::pso::buffer::Element<$runtime_format>> {
+            fn query(name: &str) -> ::std::option::Option<$crate::pso::buffer::Element<$runtime_format>> {
                 use std::mem::{size_of, transmute};
                 use $crate::pso::buffer::{Element, ElemOffset};
                 // using "1" here as a simple non-zero pointer addres


### PR DESCRIPTION
This avoids clash when you define your own `Result` type. e.g.

```rust
gfx_defines! {
     vertex Vertex { /* ... */ }
     pipeline pipe { /* ... */ }
}

pub type Result<T> = ::std::result::Result<T, MyError>;
```

Will cause a compile failure:

```
error[E0244]: wrong number of type arguments: expected 1, found 2
  --> src/file.rs:12:1
   |
12 | gfx_defines! {
   | ^ expected 1 type argument
   |
   = note: this error originates in a macro outside of the current crate

error: aborting due to previous error
```