### PR TITLE
Implement gfx::pso::buffer::RawGlobal

### DIFF
--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -54,7 +54,7 @@ pub use factory::PipelineStateError;
 pub use slice::{Slice, IntoIndexBuffer, IndexBuffer};
 pub use pso::{PipelineState};
 pub use pso::buffer::{VertexBuffer, InstanceBuffer, RawVertexBuffer,
-                      ConstantBuffer, RawConstantBuffer, Global};
+                      ConstantBuffer, RawConstantBuffer, Global, RawGlobal};
 pub use pso::resource::{ShaderResource, RawShaderResource, UnorderedAccess,
                         Sampler, TextureSampler};
 pub use pso::target::{DepthStencilTarget, DepthTarget, StencilTarget,

--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -94,8 +94,8 @@ macro_rules! gfx_pipeline_inner {
                                 assert!(meta.$field.is_active());
                                 continue;
                             },
-                            Some(Err(_)) => return Err(
-                                InitError::GlobalConstant(&gc.name, Some(()))
+                            Some(Err(e)) => return Err(
+                                InitError::GlobalConstant(&gc.name, Some(e))
                             ),
                             None => (),
                         }

--- a/src/render/src/pso/mod.rs
+++ b/src/render/src/pso/mod.rs
@@ -173,7 +173,7 @@ pub enum InitError<S> {
     /// Constant buffer mismatch.
     ConstantBuffer(S, Option<ElementError<S>>),
     /// Global constant mismatch.
-    GlobalConstant(S, Option<()>),
+    GlobalConstant(S, Option<c::shade::CompatibilityError>),
     /// Shader resource view mismatch.
     ResourceView(S, Option<()>),
     /// Unordered access view mismatch.
@@ -312,7 +312,7 @@ pub trait DataLink<'a>: Sized {
                             Option<Result<c::pso::ConstantBufferDesc, ElementError<&'b str>>> { None }
     /// Attempt to link with a global constant.
     fn link_global_constant(&mut self, _: &c::shade::ConstVar, _: &Self::Init) ->
-                            Option<Result<(), c::shade::UniformValue>> { None }
+                            Option<Result<(), c::shade::CompatibilityError>> { None }
     /// Attempt to link with an output render target (RTV).
     fn link_output(&mut self, _: &c::shade::OutputVar, _: &Self::Init) ->
                    Option<Result<c::pso::ColorTargetDesc, c::format::Format>> { None }


### PR DESCRIPTION
### Added

* Implement `gfx::pso::buffer::RawGlobal`.
* Add global link compatibility error into `gfx::pso::InitError` instead of `()`.

### Fixed

* Perform format compatibility checking for typed `Global`s.
* Initial implementation of `TODO` described in `match_attribute()` function.

CC @kvark @msiglreith 