### PR TITLE
Add sdl window example, update to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,12 @@ optional = true
 
 [dependencies.gfx_window_sdl]
 path = "src/window/sdl"
-version = "0.6"
+version = "0.7"
 optional = true
 
 [target.'cfg(unix)'.dependencies]
 gfx_window_glfw = { path = "src/window/glfw", version = "0.15" }
-gfx_window_sdl = { path = "src/window/sdl", version = "0.6" }
+gfx_window_sdl = { path = "src/window/sdl", version = "0.7" }
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.6" }

--- a/src/window/sdl/Cargo.toml
+++ b/src/window/sdl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_sdl"
-version = "0.6.0"
+version = "0.7.0"
 description = "SDL2 window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,6 +28,14 @@ name = "gfx_window_sdl"
 
 [dependencies]
 log = "0.3"
-sdl2 = "0.29"
+sdl2 = "0.30"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.14" }
+# Currently there is an issue with cargo and dev-dependencies:
+# https://github.com/rust-lang/cargo/issues/860
+# TODO: move gfx to [dev-dependencies] once it gets resolved.
+gfx = { path = "../../render", version = "*" }
+
+[[example]]
+name = "window"
+path = "examples/window.rs"

--- a/src/window/sdl/examples/window.rs
+++ b/src/window/sdl/examples/window.rs
@@ -1,0 +1,59 @@
+// Copyright 2015 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+extern crate gfx;
+extern crate gfx_window_sdl;
+extern crate sdl2;
+
+use gfx::Device;
+use sdl2::event::Event;
+use sdl2::keyboard::Keycode;
+use gfx::format::{Rgba8, DepthStencil};
+
+const CLEAR_COLOR: [f32; 4] = [0.1, 0.2, 0.3, 1.0];
+
+pub fn main() {
+    let sdl_context = sdl2::init().unwrap();
+    let video = sdl_context.video().unwrap();
+    // Request opengl core 3.2 for example:
+    video.gl_attr().set_context_profile(sdl2::video::GLProfile::Core);
+    video.gl_attr().set_context_version(3, 2);
+    let builder = video.window("SDL Window", 1024, 768);
+    let (window, _gl_context, mut device, mut factory, main_color, _main_depth) =
+        gfx_window_sdl::init::<Rgba8, DepthStencil>(builder).unwrap();
+
+    let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
+
+    let mut events = sdl_context.event_pump().unwrap();
+
+    let mut running = true;
+    while running {
+        // handle events
+        for event in events.poll_iter() {
+            match event {
+                Event::Quit { .. } |
+                Event::KeyUp { keycode: Some(Keycode::Escape), .. } => {
+                    running = false;
+                }
+                _ => {}
+            }
+        }
+
+        // draw a frame
+        encoder.clear(&main_color, CLEAR_COLOR);
+        // <- draw actual stuff here
+        encoder.flush(&mut device);
+        window.gl_swap_window();
+        device.cleanup();
+    }
+}


### PR DESCRIPTION
*gfx_window_sdl* requires sdl2 = "0.29" stopping usage of later sdl2 versions or requiring gfx to be updated manually for each sdl2 minor release. 

Since this lib is used as a helper for sdl and isn't particularly likely to break with newer minor versions, it is more helpful to declare a minimum sdl2 version `sdl2 = ">= 0.29, < 1"`. This allows a top-level consumer to declare, for example, sdl2 = "0" and have it work properly (ie currently fetching v0.30.0).

In the case newer versions cause issues, it is still clear which version(s) can be tried by viewing the minimum declared.

I've also added an sdl version of the triangle example, this adds a little compile assurance to gfx_window_sdl when running `cargo test`. I added the gfx dev-depencency sdl version to be `sdl2 = "0"` meaning the example will always test the latest 0 minor version, but this could be changed to `sdl2 = "0.30"` if greater build consistency is required. (However, I think its better as 0, as it matches the >= 0.29 better)

What are this projects views on forward compatibility of this sort?