### PR TITLE
[ll] Command Pools and application [05/..]

### DIFF
--- a/src/backend/dx11/src/factory.rs
+++ b/src/backend/dx11/src/factory.rs
@@ -900,6 +900,8 @@ impl core::Factory<R> for Factory {
         }
     }
 
+    fn create_semaphore(&mut self) -> () { unimplemented!() }
+
     fn read_mapping<'a, 'b, T>(&'a mut self, buf: &'b h::Buffer<R, T>)
                                -> Result<mapping::Reader<'b, R, T>,
                                          mapping::Error>

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -208,7 +208,7 @@ pub fn create(driver_type: winapi::D3D_DRIVER_TYPE, desc: &winapi::DXGI_SWAP_CHA
         return Err(hr)
     }
 
-    let factory = Factory::new(device, Arc::new(share));
+    let factory = Factory::new(device, feature_level, Arc::new(share));
     Ok((factory, swap_chain))
 }
 

--- a/src/backend/dx12/src/factory.rs
+++ b/src/backend/dx12/src/factory.rs
@@ -38,6 +38,8 @@ impl f::Factory<R> for Factory {
 
     fn create_sampler(&mut self, _: t::SamplerInfo) -> handle::Sampler<R> { unimplemented!() }
 
+    fn create_semaphore(&mut self) -> () { unimplemented!() }
+
     fn read_mapping<'a, 'b, T>(&'a mut self, buf: &'b handle::Buffer<R, T>)
                                -> Result<mapping::Reader<'b, R, T>,
                                          mapping::Error>

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -144,6 +144,10 @@ impl core::CommandQueue for CommandQueue {
     {
         unimplemented!()
     }
+
+    fn wait_idle(&mut self) {
+        unimplemented!()
+    }
 }
 
 pub struct Factory {

--- a/src/backend/gl/src/factory.rs
+++ b/src/backend/gl/src/factory.rs
@@ -510,6 +510,8 @@ impl f::Factory<R> for Factory {
         self.share.handles.borrow_mut().make_sampler(sam, info)
     }
 
+    fn create_semaphore(&mut self) -> () { unimplemented!() }
+
     fn read_mapping<'a, 'b, T>(&'a mut self, buf: &'b handle::Buffer<R, T>)
                                -> Result<mapping::Reader<'b, R, T>,
                                          mapping::Error>

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -867,6 +867,7 @@ impl Device {
     }
 }
 
+/*
 impl c::Device for Device {
     type Resources = Resources;
     type CommandBuffer = command::CommandBuffer;
@@ -960,6 +961,7 @@ impl c::Device for Device {
         );
     }
 }
+*/
 
 #[allow(missing_copy_implementations)]
 pub struct Adapter {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -1057,6 +1057,10 @@ impl c::CommandQueue for CommandQueue {
     {
         unimplemented!()
     }
+
+    fn wait_idle(&mut self) {
+        unimplemented!()
+    }
 }
 
 #[allow(missing_copy_implementations)]

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -14,9 +14,10 @@
 
 use ash::vk;
 use ash::version::DeviceV1_0;
-use core::command;
+use core::{command, pso, shade, state, target, texture as tex};
+use core::{IndexType, VertexCount};
 use native::{GeneralCommandBuffer, GraphicsCommandBuffer, ComputeCommandBuffer, TransferCommandBuffer, SubpassCommandBuffer};
-use RawDevice;
+use {RawDevice, Resources};
 use std::sync::Arc;
 
 pub struct SubmitInfo {
@@ -57,3 +58,110 @@ impl_cmd_buffer!(GraphicsCommandBuffer);
 impl_cmd_buffer!(ComputeCommandBuffer);
 impl_cmd_buffer!(TransferCommandBuffer);
 impl_cmd_buffer!(SubpassCommandBuffer);
+
+
+// TEMPORARY!
+impl command::Buffer<Resources> for GraphicsCommandBuffer {
+    fn reset(&mut self) {
+        unimplemented!()
+    }
+
+    fn bind_pipeline_state(&mut self, _: ()) {
+        unimplemented!()
+    }
+
+    fn bind_vertex_buffers(&mut self, _: pso::VertexBufferSet<Resources>) {
+        unimplemented!()
+    }
+
+    fn bind_constant_buffers(&mut self, _: &[pso::ConstantBufferParam<Resources>]) {
+        unimplemented!()
+    }
+
+    fn bind_global_constant(&mut self, _: shade::Location, _: shade::UniformValue) {
+        unimplemented!()
+    }
+
+    fn bind_resource_views(&mut self, _: &[pso::ResourceViewParam<Resources>]) {
+        unimplemented!()
+    }
+
+    fn bind_unordered_views(&mut self, _: &[pso::UnorderedViewParam<Resources>]) {
+        unimplemented!()
+    }
+
+    fn bind_samplers(&mut self, _: &[pso::SamplerParam<Resources>]) {
+        unimplemented!()
+    }
+
+    fn bind_pixel_targets(&mut self, _: pso::PixelTargetSet<Resources>) {
+        unimplemented!()
+    }
+
+    fn bind_index(&mut self, _: (), _: IndexType) {
+        unimplemented!()
+    }
+
+    fn set_scissor(&mut self, _: target::Rect) {
+        unimplemented!()
+    }
+
+    fn set_ref_values(&mut self, _: state::RefValues) {
+        unimplemented!()
+    }
+
+    fn copy_buffer(&mut self, src: (), dst: (),
+                   src_offset_bytes: usize, dst_offset_bytes: usize,
+                   size_bytes: usize) {
+        unimplemented!()
+    }
+
+    fn copy_buffer_to_texture(&mut self, src: (), src_offset_bytes: usize,
+                              dst: (),
+                              kind: tex::Kind,
+                              face: Option<tex::CubeFace>,
+                              img: tex::RawImageInfo) {
+        unimplemented!()
+    }
+
+    fn copy_texture_to_buffer(&mut self,
+                              src: (),
+                              kind: tex::Kind,
+                              face: Option<tex::CubeFace>,
+                              img: tex::RawImageInfo,
+                              dst: (), dst_offset_bytes: usize) {
+        unimplemented!()
+    }
+
+    fn update_buffer(&mut self, buf: (), data: &[u8], offset: usize) {
+        unimplemented!()
+    }
+
+    fn update_texture(&mut self, tex: (), kind: tex::Kind, face: Option<tex::CubeFace>,
+                      data: &[u8], image: tex::RawImageInfo) {
+        unimplemented!()
+    }
+
+    fn generate_mipmap(&mut self, srv: ()) {
+        unimplemented!()
+    }
+
+    fn clear_color(&mut self, target: (), value: command::ClearColor) {
+        unimplemented!()
+    }
+
+    fn clear_depth_stencil(&mut self, target: (), depth: Option<target::Depth>,
+                           stencil: Option<target::Stencil>) {
+        unimplemented!()
+    }
+
+    fn call_draw(&mut self, start: VertexCount, count: VertexCount, instances: Option<command::InstanceParams>) {
+        unimplemented!();
+    }
+
+    fn call_draw_indexed(&mut self, start: VertexCount, count: VertexCount,
+                         base: VertexCount, instances: Option<command::InstanceParams>) {
+        unimplemented!()
+    }
+
+}

--- a/src/backend/vulkan/src/factory.rs
+++ b/src/backend/vulkan/src/factory.rs
@@ -15,6 +15,7 @@
 use core::{self as c, factory as f, handle, texture as t, format, shade, pso, buffer, mapping};
 use core::memory::Bind;
 use core::ShaderSet;
+use native;
 use std::sync::Arc;
 use {Resources as R, Factory};
 
@@ -37,6 +38,8 @@ impl f::Factory<R> for Factory {
                      Result<handle::Shader<R>, shade::CreateShaderError> { unimplemented!() }
 
     fn create_sampler(&mut self, _: t::SamplerInfo) -> handle::Sampler<R> { unimplemented!() }
+
+    fn create_semaphore(&mut self) -> native::Semaphore { unimplemented!() }
 
     fn read_mapping<'a, 'b, T>(&'a mut self, buf: &'b handle::Buffer<R, T>)
                                -> Result<mapping::Reader<'b, R, T>,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -37,6 +37,10 @@ mod command;
 pub mod data;
 mod factory;
 pub mod native;
+mod pool;
+
+pub use pool::{GeneralCommandPool, GraphicsCommandPool,
+    ComputeCommandPool, TransferCommandPool, SubpassCommandPool};
 
 const SURFACE_EXTENSIONS: &'static [&'static str] = &[
     vk::VK_KHR_SURFACE_EXTENSION_NAME,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -397,6 +397,12 @@ impl core::CommandQueue for CommandQueue {
 
         unimplemented!()
     }
+
+    fn wait_idle(&mut self) {
+        unsafe {
+            self.device.0.queue_wait_idle(*self.raw.lock().unwrap());
+        }
+    }
 }
 
 pub struct Factory {

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::BorrowMut;
 use std::ops::DerefMut;
 use std::ptr;
 use std::sync::Arc;
@@ -77,9 +78,11 @@ macro_rules! impl_pool {
         }
 
         impl pool::$pool for $pool {
-            fn from_queue<Q>(queue: &mut Q, capacity: usize) -> $pool
-                where Q: Into<$queue<CommandQueue>> + DerefMut<Target=CommandQueue>
+            fn from_queue<Q>(mut queue: Q, capacity: usize) -> $pool
+                where Q: Into<$queue<CommandQueue>> + BorrowMut<CommandQueue>
             {
+                let queue = queue.borrow_mut();
+
                 // Create command pool
                 let info = vk::CommandPoolCreateInfo {
                     s_type: vk::StructureType::CommandPoolCreateInfo,
@@ -113,7 +116,7 @@ macro_rules! impl_pool {
                             device: queue.device.clone(),
                         }
                     )
-                }).collect::<Vec<_>>();
+                }).collect();
 
                 $pool {
                     pool: command_pool,

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -1,0 +1,133 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::DerefMut;
+use std::ptr;
+use std::sync::Arc;
+use ash::vk;
+use ash::version::DeviceV1_0;
+
+use core::{self, pool};
+use core::command::{Encoder};
+use core::{CommandPool, GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
+use command::CommandBuffer;
+use native::{self, GeneralCommandBuffer, GraphicsCommandBuffer, ComputeCommandBuffer, TransferCommandBuffer, SubpassCommandBuffer};
+use {CommandQueue, RawDevice};
+
+macro_rules! impl_pool {
+    ($pool:ident, $queue:ident, $buffer:ident) => (
+        pub struct $pool {
+            pool: vk::CommandPool,
+            command_buffers: Vec<$buffer>,
+            next_buffer: usize,
+            device: Arc<RawDevice>,
+        }
+
+        impl core::CommandPool for $pool {
+            type Queue = CommandQueue;
+            type PoolBuffer = $buffer;
+
+            fn acquire_command_buffer<'a>(&'a mut self) -> Encoder<'a, $buffer> {
+                let available_buffers = self.command_buffers.len() as isize - self.next_buffer as isize;
+                if available_buffers <= 0 {
+                    self.reserve((-available_buffers) as usize + 1);
+                }
+
+                let buffer = &mut self.command_buffers[self.next_buffer];
+                self.next_buffer += 1;
+
+                let info = vk::CommandBufferBeginInfo {
+                    s_type: vk::StructureType::CommandBufferBeginInfo,
+                    p_next: ptr::null(),
+                    flags: vk::COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+                    p_inheritance_info: ptr::null(),
+                };
+
+                unsafe {
+                    self.device.0.begin_command_buffer(buffer.0.raw, &info); // TODO: error handling
+                    Encoder::new(buffer)
+                }
+            }
+
+            fn reset(&mut self) {
+                self.next_buffer = 0;
+                unsafe {
+                    self.device.0.fp_v1_0().reset_command_pool(
+                        self.device.0.handle(),
+                        self.pool,
+                        vk::CommandPoolResetFlags::empty()
+                    );
+                }
+            }
+
+            fn reserve(&mut self, additional: usize) {
+                unimplemented!()
+            }
+        }
+
+        impl pool::$pool for $pool {
+            fn from_queue<Q>(queue: &mut Q, capacity: usize) -> $pool
+                where Q: Into<$queue<CommandQueue>> + DerefMut<Target=CommandQueue>
+            {
+                // Create command pool
+                let info = vk::CommandPoolCreateInfo {
+                    s_type: vk::StructureType::CommandPoolCreateInfo,
+                    p_next: ptr::null(),
+                    flags: vk::CommandPoolCreateFlags::empty(),
+                    queue_family_index: queue.family_index,
+                };
+
+                let command_pool = unsafe {
+                    queue.device.0.create_command_pool(&info, None)
+                                .expect("Error on command pool creation") // TODO: better error handling
+                };
+
+                // Allocate initial command buffers
+                let info = vk::CommandBufferAllocateInfo {
+                    s_type: vk::StructureType::CommandBufferAllocateInfo,
+                    p_next: ptr::null(),
+                    command_pool: command_pool,
+                    level: vk::CommandBufferLevel::Primary,
+                    command_buffer_count: capacity as u32,
+                };
+
+                let command_buffers = unsafe {
+                    queue.device.0.allocate_command_buffers(&info)
+                                  .expect("Error on command buffer allocation") // TODO: better error handling
+                };
+                let command_buffers = command_buffers.into_iter().map(|buffer| {
+                    $buffer(
+                        CommandBuffer {
+                            raw: buffer,
+                            device: queue.device.clone(),
+                        }
+                    )
+                }).collect::<Vec<_>>();
+
+                $pool {
+                    pool: command_pool,
+                    command_buffers: command_buffers,
+                    next_buffer: 0,
+                    device: queue.device.clone(),
+                }
+            }
+        }
+    )
+}
+
+impl_pool!{ GeneralCommandPool, GeneralQueue, GeneralCommandBuffer }
+impl_pool!{ GraphicsCommandPool, GraphicsQueue, GraphicsCommandBuffer }
+impl_pool!{ ComputeCommandPool, ComputeQueue, ComputeCommandBuffer }
+impl_pool!{ TransferCommandPool, TransferQueue, TransferCommandBuffer }
+impl_pool!{ SubpassCommandPool, GraphicsQueue, SubpassCommandBuffer }

--- a/src/core/src/command.rs
+++ b/src/core/src/command.rs
@@ -46,6 +46,21 @@ impl<C: CommandBuffer> Submit<C> {
 }
 
 ///
+pub struct Encoder<'a, C: CommandBuffer + 'a>(&'a mut C);
+
+impl<'a, C: CommandBuffer> Encoder<'a, C> {
+    #[doc(hidden)]
+    pub unsafe fn new(buffer: &'a mut C) -> Self {
+        Encoder(buffer)
+    }
+
+    /// Finish recording commands to the command buffers.
+    pub fn finish(self) -> Submit<C> {
+        Submit(unsafe { self.0.end() })
+    }
+}
+
+///
 pub trait CommandBuffer {
     /// Associated `SubmitInfo` type.
     type SubmitInfo;

--- a/src/core/src/dummy.rs
+++ b/src/core/src/dummy.rs
@@ -15,15 +15,9 @@
 //! Dummy backend implementation to test the code for compile errors
 //! outside of the graphics development environment.
 
-use {Capabilities, Device, SubmissionResult, Resources, IndexType, VertexCount};
+use {Capabilities, SubmissionResult, Resources, IndexType, VertexCount};
 use {state, target, handle, mapping, pso, shade, texture};
 use command::{self, AccessInfo};
-
-/// Dummy device which does minimal work, just to allow testing
-/// gfx-rs apps for compilation.
-pub struct DummyDevice {
-    capabilities: Capabilities,
-}
 
 /// Dummy resources phantom type
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -57,30 +51,6 @@ impl mapping::Gate<DummyResources> for DummyMapping {
     unsafe fn set<T>(&self, _index: usize, _val: T) { unimplemented!() }
     unsafe fn slice<'a, 'b, T>(&'a self, _len: usize) -> &'b [T] { unimplemented!() }
     unsafe fn mut_slice<'a, 'b, T>(&'a self, _len: usize) -> &'b mut [T] { unimplemented!() }
-}
-
-impl DummyDevice {
-    /// Create a new dummy device
-    pub fn new() -> DummyDevice {
-        let caps = Capabilities {
-            max_vertex_count: 0,
-            max_index_count: 0,
-            max_texture_size: 0,
-            max_patch_size: 0,
-            instance_base_supported: false,
-            instance_call_supported: false,
-            instance_rate_supported: false,
-            vertex_base_supported: false,
-            srgb_color_supported: false,
-            constant_buffer_supported: false,
-            unordered_access_view_supported: false,
-            separate_blending_slots_supported: false,
-            copy_buffer_supported: false,
-        };
-        DummyDevice {
-            capabilities: caps,
-        }
-    }
 }
 
 /// Dummy command buffer, which ignores all the calls.
@@ -119,34 +89,4 @@ impl command::Buffer<DummyResources> for DummyCommandBuffer {
     fn call_draw(&mut self, _: VertexCount, _: VertexCount, _: Option<command::InstanceParams>) {}
     fn call_draw_indexed(&mut self, _: VertexCount, _: VertexCount,
                          _: VertexCount, _: Option<command::InstanceParams>) {}
-}
-
-impl Device for DummyDevice {
-    type Resources = DummyResources;
-    type CommandBuffer = DummyCommandBuffer;
-
-    fn get_capabilities(&self) -> &Capabilities {
-        &self.capabilities
-    }
-    fn pin_submitted_resources(&mut self, _: &handle::Manager<DummyResources>) {}
-    fn submit(&mut self,
-              _: &mut DummyCommandBuffer,
-              _: &AccessInfo<Self::Resources>)
-              -> SubmissionResult<()> {
-        unimplemented!()
-    }
-
-    fn fenced_submit(&mut self,
-                     _: &mut Self::CommandBuffer,
-                     _: &AccessInfo<Self::Resources>,
-                     _after: Option<handle::Fence<Self::Resources>>)
-                     -> SubmissionResult<handle::Fence<Self::Resources>> {
-        unimplemented!()
-    }
-
-    fn wait_fence(&mut self, _: &handle::Fence<Self::Resources>) {
-        unimplemented!()
-    }
-
-    fn cleanup(&mut self) {}
 }

--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -254,6 +254,9 @@ pub trait Factory<R: Resources> {
 
     fn create_sampler(&mut self, texture::SamplerInfo) -> handle::Sampler<R>;
 
+    ///
+    fn create_semaphore(&mut self) -> R::Semaphore;
+
     /// Acquire a mapping Reader
     ///
     /// See `write_mapping` for more information.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -299,42 +299,6 @@ impl Error for SubmissionError {
 #[allow(missing_docs)]
 pub type SubmissionResult<T> = Result<T, SubmissionError>;
 
-/// A `Device` is responsible for submitting `CommandBuffer`s to the GPU.
-#[deprecated]
-pub trait Device: Sized {
-    /// Associated `Resources` type.
-    type Resources: Resources;
-    /// Associated `CommandBuffer` type. Every `Device` type can only work with one `CommandBuffer`
-    /// type.
-    type CommandBuffer: command::Buffer<Self::Resources>;
-
-    /// Returns the capabilities of this `Ðevice`.
-    fn get_capabilities(&self) -> &Capabilities;
-
-    /// Pin everything from this handle manager to live for a frame.
-    fn pin_submitted_resources(&mut self, &handle::Manager<Self::Resources>);
-
-    /// Submits a `CommandBuffer` to the GPU for execution.
-    fn submit(&mut self,
-              &mut Self::CommandBuffer,
-              access: &command::AccessInfo<Self::Resources>)
-              -> SubmissionResult<()>;
-
-    /// Submits a `CommandBuffer` to the GPU for execution.
-    /// returns a fence that is signaled after the GPU has executed all commands
-    fn fenced_submit(&mut self,
-                     &mut Self::CommandBuffer,
-                     access: &command::AccessInfo<Self::Resources>,
-                     after: Option<handle::Fence<Self::Resources>>)
-                     -> SubmissionResult<handle::Fence<Self::Resources>>;
-
-    /// Stalls the current thread until the fence is satisfied
-    fn wait_fence(&mut self, &handle::Fence<Self::Resources>);
-
-    /// Cleanup unused resources. This should be called between frames. 
-    fn cleanup(&mut self);
-}
-
 ///
 pub struct Device_<R: Resources, F: Factory<R>, Q: CommandQueue> {
     /// Resource factory.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -37,11 +37,13 @@ use std::fmt::{self, Debug};
 use std::error::Error;
 use std::hash::Hash;
 use std::any::Any;
+use std::borrow::Borrow;
 
 pub use draw_state::{state, target};
 pub use self::command::CommandBuffer;
 pub use self::factory::Factory;
-pub use self::queue::{GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
+pub use self::queue::{
+    GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
 
 pub mod buffer;
 pub mod command;
@@ -438,8 +440,9 @@ pub trait Surface {
     fn supports_queue(&self, queue_family: &Self::QueueFamily) -> bool;
 
     /// Create a new swapchain from the current surface with an associated present queue.
-    fn build_swapchain<T>(&self, present_queue: &Self::CommandQueue) -> Self::SwapChain
-        where T: format::RenderFormat;
+    fn build_swapchain<T, Q>(&self, present_queue: Q) -> Self::SwapChain
+        where T: format::RenderFormat,
+              Q: Borrow<Self::CommandQueue>;
 }
 
 /// Handle to a backbuffer of the swapchain.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -395,6 +395,9 @@ pub trait CommandQueue {
     /// Submit command buffers to queue for execution.
     unsafe fn submit<'a, C>(&mut self, submit_infos: &[QueueSubmit<C, Self::Resources>], fence: Option<&'a mut <Self::Resources as Resources>::Fence>)
         where C: CommandBuffer<SubmitInfo = Self::SubmitInfo>;
+
+    ///
+    fn wait_idle(&mut self);
 }
 
 /// `CommandPool` can allocate command buffers of a specific type only.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -447,7 +447,7 @@ pub trait SwapChain {
     type R: Resources;
 
     /// Access the backbuffer images.
-    fn get_images(&mut self) -> &[<Self::R as Resources>::Texture];
+    fn get_images(&mut self) -> &[handle::RawTexture<Self::R>];
 
     /// Acquire a new frame for rendering. This needs to be called before presenting.
     fn acquire_frame(&mut self, sync: FrameSync<Self::R>) -> Frame;

--- a/src/core/src/pool.rs
+++ b/src/core/src/pool.rs
@@ -1,0 +1,59 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Command pools
+
+use std::ops::{DerefMut};
+use {CommandPool, CommandQueue};
+pub use queue::{GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
+
+/// General command pool can allocate general command buffers.
+pub trait GeneralCommandPool: CommandPool {
+    ///
+    fn from_queue<Q>(queue: &mut Q, capacity: usize) -> Self
+        where Q: Into<GeneralQueue<Self::Queue>> +
+                 DerefMut<Target=Self::Queue>;
+}
+
+/// Graphics command pool can allocate graphics command buffers.
+pub trait GraphicsCommandPool: CommandPool {
+    ///
+    fn from_queue<Q>(queue: &mut Q, capacity: usize) -> Self
+        where Q: Into<GraphicsQueue<Self::Queue>> +
+                 DerefMut<Target=Self::Queue>;
+}
+
+/// Compute command pool can allocate compute command buffers.
+pub trait ComputeCommandPool: CommandPool {
+    ///
+    fn from_queue<Q>(queue: &mut Q, capacity: usize) -> Self
+        where Q: Into<ComputeQueue<Self::Queue>> +
+                 DerefMut<Target=Self::Queue>;
+}
+
+/// Transfer command pool can allocate transfer command buffers.
+pub trait TransferCommandPool: CommandPool {
+    ///
+    fn from_queue<Q>(queue: &mut Q, capacity: usize) -> Self
+        where Q: Into<TransferQueue<Self::Queue>> +
+                 DerefMut<Target=Self::Queue>;
+}
+
+/// Subpass command pool can allocate subpass command buffers.
+pub trait SubpassCommandPool: CommandPool {
+    ///
+    fn from_queue<Q>(queue: &mut Q, capacity: usize) -> Self
+        where Q: Into<GraphicsQueue<Self::Queue>> +
+                 DerefMut<Target=Self::Queue>;
+}

--- a/src/core/src/pool.rs
+++ b/src/core/src/pool.rs
@@ -14,6 +14,7 @@
 
 //! Command pools
 
+use std::borrow::BorrowMut;
 use std::ops::{DerefMut};
 use {CommandPool, CommandQueue};
 pub use queue::{GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
@@ -21,39 +22,39 @@ pub use queue::{GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
 /// General command pool can allocate general command buffers.
 pub trait GeneralCommandPool: CommandPool {
     ///
-    fn from_queue<Q>(queue: &mut Q, capacity: usize) -> Self
+    fn from_queue<Q>(queue: Q, capacity: usize) -> Self
         where Q: Into<GeneralQueue<Self::Queue>> +
-                 DerefMut<Target=Self::Queue>;
+                 BorrowMut<Self::Queue>;
 }
 
 /// Graphics command pool can allocate graphics command buffers.
 pub trait GraphicsCommandPool: CommandPool {
     ///
-    fn from_queue<Q>(queue: &mut Q, capacity: usize) -> Self
+    fn from_queue<Q>(queue: Q, capacity: usize) -> Self
         where Q: Into<GraphicsQueue<Self::Queue>> +
-                 DerefMut<Target=Self::Queue>;
+                 BorrowMut<Self::Queue>;
 }
 
 /// Compute command pool can allocate compute command buffers.
 pub trait ComputeCommandPool: CommandPool {
     ///
-    fn from_queue<Q>(queue: &mut Q, capacity: usize) -> Self
+    fn from_queue<Q>(queue: Q, capacity: usize) -> Self
         where Q: Into<ComputeQueue<Self::Queue>> +
-                 DerefMut<Target=Self::Queue>;
+                 BorrowMut<Self::Queue>;
 }
 
 /// Transfer command pool can allocate transfer command buffers.
 pub trait TransferCommandPool: CommandPool {
     ///
-    fn from_queue<Q>(queue: &mut Q, capacity: usize) -> Self
+    fn from_queue<Q>(queue: Q, capacity: usize) -> Self
         where Q: Into<TransferQueue<Self::Queue>> +
-                 DerefMut<Target=Self::Queue>;
+                 BorrowMut<Self::Queue>;
 }
 
 /// Subpass command pool can allocate subpass command buffers.
 pub trait SubpassCommandPool: CommandPool {
     ///
-    fn from_queue<Q>(queue: &mut Q, capacity: usize) -> Self
+    fn from_queue<Q>(queue: Q, capacity: usize) -> Self
         where Q: Into<GraphicsQueue<Self::Queue>> +
-                 DerefMut<Target=Self::Queue>;
+                 BorrowMut<Self::Queue>;
 }

--- a/src/core/src/queue.rs
+++ b/src/core/src/queue.rs
@@ -58,19 +58,51 @@ impl<Q: CommandQueue> DerefMut for GeneralQueue<Q> {
     }
 }
 
-impl<Q: CommandQueue> Into<GraphicsQueue<Q>> for GeneralQueue<Q> {
-    fn into(self) -> GraphicsQueue<Q> {
-        GraphicsQueue(self.0)
+impl<Q: CommandQueue> From<GeneralQueue<Q>> for GraphicsQueue<Q> {
+    fn from(queue: GeneralQueue<Q>) -> GraphicsQueue<Q> {
+        GraphicsQueue(queue.0)
     }
 }
-impl<Q: CommandQueue> Into<ComputeQueue<Q>> for GeneralQueue<Q> {
-    fn into(self) -> ComputeQueue<Q> {
-        ComputeQueue(self.0)
+impl<Q: CommandQueue> From<GeneralQueue<Q>> for ComputeQueue<Q> {
+    fn from(queue: GeneralQueue<Q>) -> ComputeQueue<Q> {
+        ComputeQueue(queue.0)
     }
 }
-impl<Q: CommandQueue> Into<TransferQueue<Q>> for GeneralQueue<Q> {
-    fn into(self) -> TransferQueue<Q> {
-        TransferQueue(self.0)
+impl<Q: CommandQueue> From<GeneralQueue<Q>> for TransferQueue<Q> {
+    fn from(queue: GeneralQueue<Q>) -> TransferQueue<Q> {
+        TransferQueue(queue.0)
+    }
+}
+
+impl<'a, Q: CommandQueue> From<&'a GeneralQueue<Q>> for &'a GraphicsQueue<Q> {
+    fn from(queue: &'a GeneralQueue<Q>) -> &'a GraphicsQueue<Q> {
+        unsafe { &*(queue as *const _ as *const GraphicsQueue<Q>) }
+    }
+}
+impl<'a, Q: CommandQueue> From<&'a GeneralQueue<Q>> for &'a ComputeQueue<Q> {
+    fn from(queue: &'a GeneralQueue<Q>) -> &'a ComputeQueue<Q> {
+        unsafe { &*(queue as *const _ as *const ComputeQueue<Q>) }
+    }
+}
+impl<'a, Q: CommandQueue> From<&'a GeneralQueue<Q>> for &'a TransferQueue<Q> {
+    fn from(queue: &'a GeneralQueue<Q>) -> &'a TransferQueue<Q> {
+        unsafe { &*(queue as *const _ as *const TransferQueue<Q>) }
+    }
+}
+
+impl<'a, Q: CommandQueue> From<&'a mut GeneralQueue<Q>> for &'a mut GraphicsQueue<Q> {
+    fn from(queue: &'a mut GeneralQueue<Q>) -> &'a mut GraphicsQueue<Q> {
+        unsafe { &mut *(queue as *mut _ as *mut GraphicsQueue<Q>) }
+    }
+}
+impl<'a, Q: CommandQueue> From<&'a mut GeneralQueue<Q>> for &'a mut ComputeQueue<Q> {
+    fn from(queue: &'a mut GeneralQueue<Q>) -> &'a mut ComputeQueue<Q> {
+        unsafe { &mut *(queue as *mut _ as *mut ComputeQueue<Q>) }
+    }
+}
+impl<'a, Q: CommandQueue> From<&'a mut GeneralQueue<Q>> for &'a mut TransferQueue<Q> {
+    fn from(queue: &'a mut GeneralQueue<Q>) -> &'a mut TransferQueue<Q> {
+        unsafe { &mut *(queue as *mut _ as *mut TransferQueue<Q>) }
     }
 }
 
@@ -104,9 +136,9 @@ impl<Q: CommandQueue> DerefMut for GraphicsQueue<Q> {
     }
 }
 
-impl<Q: CommandQueue> Into<TransferQueue<Q>> for GraphicsQueue<Q> {
-    fn into(self) -> TransferQueue<Q> {
-        TransferQueue(self.0)
+impl<Q: CommandQueue> From<GraphicsQueue<Q>> for TransferQueue<Q> {
+    fn from(queue: GraphicsQueue<Q>) -> TransferQueue<Q> {
+        TransferQueue(queue.0)
     }
 }
 
@@ -140,9 +172,9 @@ impl<Q: CommandQueue> DerefMut for ComputeQueue<Q> {
     }
 }
 
-impl<Q: CommandQueue> Into<TransferQueue<Q>> for ComputeQueue<Q> {
-    fn into(self) -> TransferQueue<Q> {
-        TransferQueue(self.0)
+impl<Q: CommandQueue> From<ComputeQueue<Q>> for TransferQueue<Q> {
+    fn from(queue: ComputeQueue<Q>) -> TransferQueue<Q> {
+        TransferQueue(queue.0)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,8 @@ extern crate gfx_device_vulkan;
 extern crate gfx_window_vulkan;
 
 use gfx_core::memory::Typed;
-use gfx_core::{Adapter, FrameSync, Surface, SwapChain, QueueFamily, WindowExt};
+use gfx_core::{Adapter, CommandQueue, FrameSync, Surface, SwapChain, QueueFamily, WindowExt};
+use gfx_core::pool::GraphicsCommandPool;
 
 pub mod shade;
 
@@ -148,7 +149,7 @@ A: Sized + Application<gfx_device_gl::Resources>
             }
         });
         // draw a frame
-        app.render_ext();
+        // TODO: app.render_ext();
         window.swap_buffers().unwrap();
         // device.cleanup();
         harness.bump();
@@ -215,7 +216,7 @@ A: Sized + Application<gfx_device_dx11::Resources>
             }
             continue;
         }
-        app.render_ext();
+        // TODO: app.render_ext();
         window.swap_buffers(1);
         // device.cleanup();
         harness.bump();
@@ -256,7 +257,7 @@ A: Sized + Application<gfx_device_metal::Resources>
                 _ => app.on(event),
             }
         });
-        app.render_ext();
+        // TODO: app.render_ext();
         window.swap_buffers().unwrap();
         device.cleanup();
         harness.bump();
@@ -283,15 +284,15 @@ A: Sized + Application<gfx_device_vulkan::Resources>
                                  .filter(|family| surface.supports_queue(&family) )
                                  .map(|family| { (family, family.num_queues()) })
                                  .collect::<Vec<_>>();
-    let mut device = adapters[0].open(&queue_descs);
+    let gfx_core::Device_ { mut factory, mut general_queues, mut graphics_queues, .. } = adapters[0].open(&queue_descs);
 
-    let mut swap_chain = {
-        if !device.general_queues.is_empty() {
-            surface.build_swapchain::<ColorFormat>(&device.general_queues[0])
-        } else {
-            surface.build_swapchain::<ColorFormat>(&device.graphics_queues[0])
-        }
+    let queue = if !general_queues.is_empty() {
+        (&mut general_queues[0]).into()
+    } else {
+        &mut graphics_queues[0]
     };
+
+    let mut swap_chain = surface.build_swapchain::<ColorFormat>(queue);
 
     let (width, height) = win.get_inner_size_points().unwrap();
 
@@ -303,16 +304,16 @@ A: Sized + Application<gfx_device_vulkan::Resources>
                                         level: 0,
                                         layer: None,
                                     };
-                                    let rtv = device.factory.view_texture_as_render_target_raw(image, desc)
+                                    let rtv = factory.view_texture_as_render_target_raw(image, desc)
                                                              .unwrap();
                                     Typed::new(rtv)
                                 })
                                 .collect::<Vec<_>>();
 
-    let main_depth = device.factory.create_depth_stencil::<DepthFormat>(width as Size, height as Size).unwrap();
+    let main_depth = factory.create_depth_stencil::<DepthFormat>(width as Size, height as Size).unwrap();
 
     let backend = shade::Backend::Vulkan;
-    let mut app = A::new(&mut device.factory, backend, WindowTargets {
+    let mut app = A::new(&mut factory, backend, WindowTargets {
         colors: main_colors,
         depth: main_depth.2,
         aspect_ratio: width as f32 / height as f32, //TODO
@@ -320,7 +321,10 @@ A: Sized + Application<gfx_device_vulkan::Resources>
 
     let mut harness = Harness::new();
     let mut running = true;
-    let mut frame_semaphore = device.factory.create_semaphore();
+    let mut frame_semaphore = factory.create_semaphore();
+
+    // TODO: How can we get rid of this checks all the time?
+    let mut graphics_pool = gfx_device_vulkan::GraphicsCommandPool::from_queue(queue, 1);
 
     while running {
         events_loop.poll_events(|winit::Event::WindowEvent{window_id: _, event}| {
@@ -334,7 +338,12 @@ A: Sized + Application<gfx_device_vulkan::Resources>
             }
         });
         let frame = swap_chain.acquire_frame(FrameSync::Semaphore(&mut frame_semaphore));
-        app.render_ext();
+
+        app.render_ext(&mut graphics_pool);
+
+        // Wait til rendering has finished
+        queue.wait_idle();
+
         swap_chain.present();
         harness.bump();
     }
@@ -353,7 +362,7 @@ pub type DefaultResources = gfx_device_vulkan::Resources;
 pub trait Application<R: gfx::Resources>: Sized {
     fn new<F: gfx::Factory<R>>(&mut F, shade::Backend, WindowTargets<R>) -> Self;
     fn render<C: gfx::CommandBuffer<R>>(&mut self, &mut gfx::GraphicsEncoder<R, C>);
-    fn render_ext(&mut self)
+    fn render_ext<P: gfx_core::pool::GraphicsCommandPool>(&mut self, pool: &mut P)
     {
         unimplemented!()
         // TODO: self.app.render(&mut self.encoder);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ impl Drop for Harness {
 
 pub trait ApplicationBase<R: gfx::Resources, C: gfx::CommandBuffer<R>> {
     fn new<F>(&mut F, shade::Backend, WindowTargets<R>) -> Self where F: gfx::Factory<R>;
-    fn render<D>(&mut self, &mut D) where D: gfx::Device<Resources = R, CommandBuffer = C>;
+    fn render<D>(&mut self, &mut D);
     fn get_exit_key() -> Option<winit::VirtualKeyCode>;
     fn on(&mut self, winit::WindowEvent);
     fn on_resize<F>(&mut self, &mut F, WindowTargets<R>) where F: gfx::Factory<R>;
@@ -102,8 +102,6 @@ pub trait ApplicationBase<R: gfx::Resources, C: gfx::CommandBuffer<R>> {
 pub fn launch_gl3<A>(wb: winit::WindowBuilder) where
 A: Sized + Application<gfx_device_gl::Resources>
 {
-    use gfx::traits::Device;
-
     env_logger::init().unwrap();
     let gl_version = glutin::GlRequest::GlThenGles {
         opengl_version: (3, 2), // TODO: try more versions
@@ -152,7 +150,7 @@ A: Sized + Application<gfx_device_gl::Resources>
         // draw a frame
         app.render_ext(&mut device);
         window.swap_buffers().unwrap();
-        device.cleanup();
+        // device.cleanup();
         harness.bump();
     }
 }
@@ -167,11 +165,11 @@ pub type D3D11CommandBufferFake = gfx_device_dx11::CommandBuffer<gfx_device_dx11
 pub fn launch_d3d11<A>(wb: winit::WindowBuilder) where
 A: Sized + Application<gfx_device_dx11::Resources>
 {
-    use gfx::traits::{Device, Factory};
+    use gfx::traits::Factory;
 
     env_logger::init().unwrap();
     let events_loop = winit::EventsLoop::new();
-    let (mut window, device, mut factory, main_color) =
+    let (mut window, mut factory, main_color) =
         gfx_window_dxgi::init::<ColorFormat>(wb, &events_loop).unwrap();
     let main_depth = factory.create_depth_stencil_view_only(window.size.0, window.size.1)
                             .unwrap();
@@ -182,7 +180,7 @@ A: Sized + Application<gfx_device_dx11::Resources>
         depth: main_depth,
         aspect_ratio: window.size.0 as f32 / window.size.1 as f32,
     });
-    let mut device = gfx_device_dx11::Deferred::from(device);
+    // let mut device = gfx_device_dx11::Deferred::from(device);
 
     let mut harness = Harness::new();
     let mut running = true;
@@ -219,7 +217,7 @@ A: Sized + Application<gfx_device_dx11::Resources>
         }
         app.render_ext(&mut device);
         window.swap_buffers(1);
-        device.cleanup();
+        // device.cleanup();
         harness.bump();
     }
 }
@@ -228,7 +226,7 @@ A: Sized + Application<gfx_device_dx11::Resources>
 pub fn launch_metal<A>(wb: winit::WindowBuilder) where
 A: Sized + Application<gfx_device_metal::Resources>
 {
-    use gfx::traits::{Device, Factory};
+    use gfx::traits::Factory;
     use gfx::texture::Size;
 
     env_logger::init().unwrap();
@@ -269,7 +267,7 @@ A: Sized + Application<gfx_device_metal::Resources>
 pub fn launch_vulkan<A>(wb: winit::WindowBuilder) where
 A: Sized + Application<gfx_device_vulkan::Resources>
 {
-    use gfx::traits::{Device, Factory};
+    use gfx::traits::{Factory};
     use gfx::texture::Size;
 
     env_logger::init().unwrap();
@@ -351,7 +349,6 @@ pub trait Application<R: gfx::Resources>: Sized {
     fn new<F: gfx::Factory<R>>(&mut F, shade::Backend, WindowTargets<R>) -> Self;
     fn render<C: gfx::CommandBuffer<R>>(&mut self, &mut gfx::GraphicsEncoder<R, C>);
     fn render_ext<D, C: gfx::CommandBuffer<R>>(&mut self, device: &mut D)
-        where D: gfx::Device<Resources = R, CommandBuffer = C>
     {
         unimplemented!()
         // TODO: self.app.render(&mut self.encoder);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,13 +286,16 @@ A: Sized + Application<gfx_device_vulkan::Resources>
                                  .collect::<Vec<_>>();
     let gfx_core::Device_ { mut factory, mut general_queues, mut graphics_queues, .. } = adapters[0].open(&queue_descs);
 
-    let queue = if !general_queues.is_empty() {
-        (&mut general_queues[0]).into()
+    let queue = if let Some(queue) = general_queues.first_mut() {
+        queue.as_mut().into()
+    } else if let Some(queue) = graphics_queues.first_mut() {
+        queue.as_mut()
     } else {
-        &mut graphics_queues[0]
+        error!("Unable to find a matching general or graphics queue.");
+        return
     };
 
-    let mut swap_chain = surface.build_swapchain::<ColorFormat>(queue);
+    let mut swap_chain = surface.build_swapchain::<ColorFormat, _>(queue);
 
     let (width, height) = win.get_inner_size_points().unwrap();
 
@@ -323,7 +326,6 @@ A: Sized + Application<gfx_device_vulkan::Resources>
     let mut running = true;
     let mut frame_semaphore = factory.create_semaphore();
 
-    // TODO: How can we get rid of this checks all the time?
     let mut graphics_pool = gfx_device_vulkan::GraphicsCommandPool::from_queue(queue, 1);
 
     while running {

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -21,7 +21,7 @@ use std::error::Error;
 use std::any::Any;
 use std::{fmt, mem};
 
-use core::{Device, SubmissionResult, IndexType, Resources, VertexCount};
+use core::{SubmissionResult, IndexType, Resources, VertexCount};
 use core::{command, format, handle, texture};
 use core::memory::{self, cast_slice, Typed, Pod, Usage};
 use slice;
@@ -180,18 +180,17 @@ impl<R: Resources, C: command::Buffer<R>> GraphicsEncoder<R, C> {
     /// processed. Calling flush too often however will result in a performance hit. It is
     /// generally recommended to call flush once per frame, when all draw calls have been made. 
     pub fn flush<D>(&mut self, device: &mut D)
-        where D: Device<Resources=R, CommandBuffer=C>
     {
-        self.flush_no_reset(device).unwrap();
+        // self.flush_no_reset(device).unwrap();
         self.reset();
     }
 
     /// Like `flush` but keeps the encoded commands.
     pub fn flush_no_reset<D>(&mut self, device: &mut D) -> SubmissionResult<()>
-        where D: Device<Resources=R, CommandBuffer=C>
     {
-        device.pin_submitted_resources(&self.handles);
-        device.submit(&mut self.command_buffer, &self.access_info)
+        // device.pin_submitted_resources(&self.handles);
+        // device.submit(&mut self.command_buffer, &self.access_info)
+        unimplemented!()
     }
 
     /// Like `flush_no_reset` but places a fence.
@@ -199,10 +198,11 @@ impl<R: Resources, C: command::Buffer<R>> GraphicsEncoder<R, C> {
                                     device: &mut D,
                                     after: Option<handle::Fence<R>>)
                                     -> SubmissionResult<handle::Fence<R>>
-        where D: Device<Resources=R, CommandBuffer=C>
+        // where D: Device<Resources=R, CommandBuffer=C>
     {
-        device.pin_submitted_resources(&self.handles);
-        device.fenced_submit(&mut self.command_buffer, &self.access_info, after)
+        // device.pin_submitted_resources(&self.handles);
+        // device.fenced_submit(&mut self.command_buffer, &self.access_info, after)
+        unimplemented!()
     }
 
     /// Resets the encoded commands.

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -141,11 +141,11 @@ impl<T: Any + fmt::Debug + fmt::Display> Error for UpdateError<T> {
 /// Graphics Command Encoder
 ///
 /// # Overview
-/// The `Encoder` is a wrapper structure around a `CommandBuffer`. It is responsible for sending
+/// The `GraphicsEncoder` is a wrapper structure around a `CommandBuffer`. It is responsible for sending
 /// commands to the `CommandBuffer`. 
 ///
 /// # Construction & Handling
-/// The `Encoder` implements `From<CommandBuffer>`, which is how it is constructed. There is no
+/// The `GraphicsEncoder` implements `From<CommandBuffer>`, which is how it is constructed. There is no
 /// cross-API way to create a `CommandBuffer`, however, an API back-end should expose a function to
 /// create one in its `Factory` type. See the specific back-end for details on how to construct a
 /// `CommandBuffer`.
@@ -153,16 +153,16 @@ impl<T: Any + fmt::Debug + fmt::Display> Error for UpdateError<T> {
 /// The encoder exposes multiple functions that add commands to its internal `CommandBuffer`. To 
 /// submit these commands to the GPU so they can be rendered, call `flush`. 
 #[derive(Debug)]
-pub struct Encoder<R: Resources, C> {
+pub struct GraphicsEncoder<R: Resources, C> {
     command_buffer: C,
     raw_pso_data: pso::RawDataSet<R>,
     access_info: command::AccessInfo<R>,
     handles: handle::Manager<R>,
 }
 
-impl<R: Resources, C> From<C> for Encoder<R, C> {
-    fn from(combuf: C) -> Encoder<R, C> {
-        Encoder {
+impl<R: Resources, C> From<C> for GraphicsEncoder<R, C> {
+    fn from(combuf: C) -> GraphicsEncoder<R, C> {
+        GraphicsEncoder {
             command_buffer: combuf,
             raw_pso_data: pso::RawDataSet::new(),
             access_info: command::AccessInfo::new(),
@@ -171,8 +171,8 @@ impl<R: Resources, C> From<C> for Encoder<R, C> {
     }
 }
 
-impl<R: Resources, C: command::Buffer<R>> Encoder<R, C> {
-    /// Submits the commands in this `Encoder`'s internal `CommandBuffer` to the GPU, so they can
+impl<R: Resources, C: command::Buffer<R>> GraphicsEncoder<R, C> {
+    /// Submits the commands in this `GraphicsEncoder`'s internal `CommandBuffer` to the GPU, so they can
     /// be executed. 
     /// 
     /// Calling `flush` before swapping buffers is critical as without it the commands of the

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -28,7 +28,7 @@ extern crate gfx_core as core;
 
 /// public re-exported traits
 pub mod traits {
-    pub use core::{Device, Factory};
+    pub use core::{Factory};
     pub use core::memory::Pod;
     pub use factory::FactoryExt;
 }
@@ -38,7 +38,7 @@ pub use draw_state::{preset, state};
 pub use draw_state::target::*;
 
 // public re-exports
-pub use core::{Device, Primitive, Resources, SubmissionError, SubmissionResult};
+pub use core::{Primitive, Resources, SubmissionError, SubmissionResult};
 pub use core::{VertexCount, InstanceCount};
 pub use core::{ShaderSet, VertexShader, HullShader, DomainShader, GeometryShader, PixelShader};
 pub use core::{buffer, format, handle, texture, mapping};

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -49,7 +49,7 @@ pub use core::command::{Buffer as CommandBuffer, InstanceParams};
 pub use core::shade::{ProgramInfo, UniformValue};
 
 pub use encoder::{CopyBufferResult, CopyBufferTextureResult, CopyError,
-                  CopyTextureBufferResult, Encoder, UpdateError};
+                  CopyTextureBufferResult, GraphicsEncoder, UpdateError};
 pub use factory::PipelineStateError;
 pub use slice::{Slice, IntoIndexBuffer, IndexBuffer};
 pub use pso::{PipelineState};

--- a/src/render/src/pso/bundle.rs
+++ b/src/render/src/pso/bundle.rs
@@ -2,7 +2,7 @@
 //!
 //! Suitable for use when PSO is always used with the same one slice.
 
-use { Resources, Slice, PipelineState, Encoder, CommandBuffer };
+use { Resources, Slice, PipelineState, GraphicsEncoder, CommandBuffer };
 use super::PipelineData;
 
 /// Slice-PSO bundle.
@@ -27,7 +27,7 @@ impl<R: Resources, Data: PipelineData<R>> Bundle<R, Data> {
     }
 
     /// Draw bundle using encoder.
-    pub fn encode<C>(&self, encoder: &mut Encoder<R, C>) where
+    pub fn encode<C>(&self, encoder: &mut GraphicsEncoder<R, C>) where
         C: CommandBuffer<R> {
         encoder.draw(&self.slice, &self.pso, &self.data);
     }

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -193,7 +193,7 @@ impl DeviceExt for Device {
 */
 
 /// Update the internal dimensions of the main framebuffer targets. Generic version over the format.
-pub fn update_views<Cf, D>(window: &mut Window, factory: &mut Factory, _device: &mut D, width: u16, height: u16)
+pub fn update_views<Cf>(window: &mut Window, factory: &mut Factory, width: u16, height: u16)
             -> Result<h::RenderTargetView<Resources, Cf>, f::TargetViewError>
 where Cf: format::RenderFormat
 {

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -19,7 +19,7 @@ extern crate gfx_device_gl as device_gl;
 extern crate glutin;
 
 use core::{format, handle, texture};
-use core::memory::Typed;
+use core::memory::{self, Typed};
 use device_gl::Resources as R;
 
 /// Initialize with a window builder.
@@ -180,13 +180,13 @@ pub struct SwapChain<'a> {
     // Underlying window, required for presentation
     window: &'a glutin::Window,
     // Single element backbuffer
-    backbuffer: Vec<device_gl::NewTexture>,
+    backbuffer: Vec<handle::RawTexture<device_gl::Resources>>,
 }
 
 impl<'a> core::SwapChain for SwapChain<'a> {
     type R = device_gl::Resources;
 
-    fn get_images(&mut self) -> &[device_gl::NewTexture] {
+    fn get_images(&mut self) -> &[handle::RawTexture<Self::R>] {
         &self.backbuffer
     }
 
@@ -213,9 +213,23 @@ impl<'a> core::Surface for Surface<'a> {
     fn build_swapchain<T: core::format::RenderFormat>(&self,
                     present_queue: &device_gl::CommandQueue) -> SwapChain<'a>
     {
+        use core::handle::Producer;
+        let dim = get_window_dimensions(self.window);
+        let mut temp = handle::Manager::new();
+        let backbuffer = temp.make_texture(
+            device_gl::NewTexture::Surface(0),
+            texture::Info {
+                levels: 1,
+                kind: texture::Kind::D2(dim.0, dim.1, dim.3),
+                format: T::get_format().0,
+                bind: memory::RENDER_TARGET | memory::TRANSFER_SRC,
+                usage: memory::Usage::Data,
+            },
+        );
+
         SwapChain {
             window: self.window,
-            backbuffer: vec![device_gl::NewTexture::Surface(0)],
+            backbuffer: vec![backbuffer],
         }
     }
 }

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -21,6 +21,7 @@ extern crate glutin;
 use core::{format, handle, texture};
 use core::memory::{self, Typed};
 use device_gl::Resources as R;
+use std::borrow::Borrow;
 
 /// Initialize with a window builder.
 /// Generically parametrized version over the main framebuffer format.
@@ -210,8 +211,9 @@ impl<'a> core::Surface for Surface<'a> {
     type QueueFamily = device_gl::QueueFamily;
 
     fn supports_queue(&self, queue_family: &device_gl::QueueFamily) -> bool { true }
-    fn build_swapchain<T: core::format::RenderFormat>(&self,
-                    present_queue: &device_gl::CommandQueue) -> SwapChain<'a>
+    fn build_swapchain<T, Q>(&self, present_queue: Q) -> SwapChain<'a>
+        where T: core::format::RenderFormat,
+              Q: Borrow<Self::CommandQueue>
     {
         use core::handle::Producer;
         let dim = get_window_dimensions(self.window);

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -27,7 +27,7 @@ use std::ffi::CStr;
 use std::{mem, ptr};
 use std::os::raw;
 use std::sync::Arc;
-use core::format;
+use core::{format, handle};
 use core::FrameSync;
 use core::memory::Typed;
 use device_vulkan::{data, native, CommandQueue, QueueFamily, VK_ENTRY, INSTANCE};
@@ -269,7 +269,7 @@ impl SwapChain {
 impl core::SwapChain for SwapChain {
     type R = device_vulkan::Resources;
 
-    fn get_images(&mut self) -> &[()] {
+    fn get_images(&mut self) -> &[handle::RawTexture<Self::R>] {
         // TODO
         // &self.images
         unimplemented!()

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -323,7 +323,7 @@ impl core::SwapChain for SwapChain {
     }
 }
 
-pub struct Window<'a>(&'a winit::Window);
+pub struct Window<'a>(pub &'a winit::Window);
 
 impl<'a> core::WindowExt for Window<'a> {
     type Surface = Surface;


### PR DESCRIPTION
A larger PR therefore a bit more explanation!

**Goal**: Merge device setup and 'frontend' (adapters, queues, swapchains, etc.) parts into current core. This doesn't include changes to the factory and command buffers.

- **Deprecate the `Device` trait**, the functionality will be split into the queues and the factory. (not everything ported so far)
- Adding **command pools**, which are necessary for creating command buffers/encoders. Current plan for gfx_app is that the user still will receive an `Encoder` (renamed to `GraphicsEncoder`) when implementing `render`. So keeping the changes to the examples to a minimum for the moment.
- We can rethink the application design in the future if there are some compute examples or multi-queue stuff etc. Also due to the unification of the window creation (Surface + Swapchain) we could think of some helper method for easier setup and maybe **merge application somehow into the render**.
- In contrast to OpenGL the other APIs usually expose **multiple rendertargets for rendering to the backbuffers** instead of just one framebuffer. The current d3d11 backend simply uses one backbuffer iirc, but that's poor workaround. We probably need some changes to the examples which select the correct RTV depending on the current frame. It could be either done by the user or the application only sends the current frame color RTV.