### PR TITLE
Improved Metal rendering and presentation for corell

### DIFF
--- a/examples/trianglell/shader/triangle.metal
+++ b/examples/trianglell/shader/triangle.metal
@@ -7,17 +7,21 @@ struct VsInput {
 
 struct VsOutput {
   float4 pos [[position]];
-  float3 color;
+  float2 uv;
 };
 
 vertex VsOutput vs_main(VsInput in [[stage_in]]) {
   VsOutput out;
   out.pos = float4(in.a_Pos, 1.0);
-  out.color = in.a_Color;
+  // Texture coordinates are in OpenGL/Vulkan (origin bottom left)
+  // convert them to Metal (origin top left)
+  out.uv = float2(in.a_Color.x, 1 - in.a_Color.y);
   return out;
 }
 
-fragment float4 ps_main(VsOutput in [[stage_in]]) {
-  return float4(in.color, 1.0);
+fragment float4 ps_main(VsOutput in [[stage_in]], 
+                        texture2d<float> tex2D [[ texture(0) ]],
+                        sampler sampler2D [[ sampler(0) ]]) {
+  return tex2D.sample(sampler2D, in.uv);
 }
 

--- a/src/backend/metalll/Cargo.toml
+++ b/src/backend/metalll/Cargo.toml
@@ -22,8 +22,6 @@ metal-rs = "0.3"
 io-surface = "0.7"
 core-foundation = "0.3"
 core-graphics = "0.7"
-cgl = "0.1"
-gfx_gl = "0.3.1"
 scopeguard = "0.3"
 block = "0.1"
 

--- a/src/corell/src/factory.rs
+++ b/src/corell/src/factory.rs
@@ -66,6 +66,7 @@ pub struct DescriptorPoolDesc {
 /// The binding point is only valid for the pipelines stages specified.
 ///
 /// The binding _must_ match with the corresponding shader interface.
+#[derive(Debug, Copy, Clone)]
 pub struct DescriptorSetLayoutBinding {
     /// Integer identifier of the binding.
     pub binding: usize,


### PR DESCRIPTION
Metal's SwapChain implementation now presents the backbuffers directly, without any copying,
by setting the IOSurface backing the Metal texture as the contents of a CALayer. This hands
our renderbuffer straight to the compositor, just as the native swapchain in CAMetalLayer does.

Additionally, the trianglell example now displays almost correctly when using Metal; it now samples
the texture properly instead of displaying the texture coordinates as colors. However blend mode
interpretation is still not implemented, so the background of the rectangle is white, not transparent.