### PR TITLE
Enable Bgra8 on OpenGL backend

### DIFF
--- a/src/backend/gl/src/tex.rs
+++ b/src/backend/gl/src/tex.rs
@@ -55,9 +55,9 @@ fn kind_face_to_gl(kind: t::Kind, face: Option<t::CubeFace>) -> GLenum {
 fn format_to_glpixel(format: NewFormat) -> GLenum {
     use core::format::SurfaceType as S;
     use core::format::ChannelType as C;
-    let (r, rg, rgb, rgba) = match format.1 {
-        C::Int | C::Uint => (gl::RED_INTEGER, gl::RG_INTEGER, gl::RGB_INTEGER, gl::RGBA_INTEGER),
-        _ => (gl::RED, gl::RG, gl::RGB, gl::RGBA),
+    let (r, rg, rgb, rgba, bgra) = match format.1 {
+        C::Int | C::Uint => (gl::RED_INTEGER, gl::RG_INTEGER, gl::RGB_INTEGER, gl::RGBA_INTEGER, gl::BGRA_INTEGER),
+        _ => (gl::RED, gl::RG, gl::RGB, gl::RGBA, gl::BGRA),
     };
     match format.0 {
         S::R8 | S::R16 | S::R32=> r,
@@ -67,7 +67,7 @@ fn format_to_glpixel(format: NewFormat) -> GLenum {
         S::R4_G4_B4_A4 | S::R5_G5_B5_A1 | S::R10_G10_B10_A2 => rgba,
         S::D24_S8 => gl::DEPTH_STENCIL,
         S::D16 | S::D24 | S::D32 => gl::DEPTH,
-        S::B8_G8_R8_A8 => unimplemented!(), // TODO
+        S::B8_G8_R8_A8 => bgra,
     }
 }
 
@@ -87,12 +87,11 @@ fn format_to_gltype(format: NewFormat) -> Result<GLenum, ()> {
         S::R4_G4_B4_A4 => gl::UNSIGNED_SHORT_4_4_4_4,
         S::R5_G5_B5_A1 => gl::UNSIGNED_SHORT_5_5_5_1,
         S::R5_G6_B5 => gl::UNSIGNED_SHORT_5_6_5,
-        S::R8 | S::R8_G8 | S::R8_G8_B8_A8 => fm8,
+        S::B8_G8_R8_A8 | S::R8 | S::R8_G8 | S::R8_G8_B8_A8 => fm8,
         S::R10_G10_B10_A2 => gl::UNSIGNED_INT_10_10_10_2,
         S::R11_G11_B10 => return Err(()),
         S::R16 | S::R16_G16 | S::R16_G16_B16 | S::R16_G16_B16_A16 => fm16,
         S::R32 | S::R32_G32 | S::R32_G32_B32 | S::R32_G32_B32_A32 => fm32,
-        S::B8_G8_R8_A8 => return Err(()), // TODO
         S::D16 => gl::UNSIGNED_SHORT,
         S::D24 => gl::UNSIGNED_INT,
         S::D24_S8 => gl::UNSIGNED_INT_24_8,
@@ -208,7 +207,10 @@ fn format_to_glfull(format: NewFormat) -> Result<GLenum, ()> {
             C::Float => gl::RGBA32F,
             _ => return Err(()),
         },
-        S::B8_G8_R8_A8 => return Err(()), // TODO
+        S::B8_G8_R8_A8 => match cty {
+            C::Unorm => gl::RGBA8,
+            _ => return Err(()),
+        },
         // depth-stencil
         S::D16 => gl::DEPTH_COMPONENT16,
         S::D24 => gl::DEPTH_COMPONENT24,


### PR DESCRIPTION
Replacing the TODO parts related to `B8_G8_R8_A8`, since using Bgra8 format type with OpenGL backend causes runtime panics, because of these unhandled cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/1279)
<!-- Reviewable:end -->
