### PR TITLE
[ll] Re-introduce Backend trait [06/..]

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use comptr::ComPtr;
-use core::command;
+use core::{command, pso, shade, state, target, texture as tex};
+use core::{IndexType, VertexCount};
 use native::{GeneralCommandBuffer, GraphicsCommandBuffer, ComputeCommandBuffer, TransferCommandBuffer, SubpassCommandBuffer};
 use winapi;
+use {Backend, Resources};
 
 pub struct CommandBuffer {
     pub raw: ComPtr<winapi::ID3D12GraphicsCommandList>,
@@ -32,10 +34,114 @@ impl CommandBuffer {
 // CommandBuffer trait implementation
 macro_rules! impl_cmd_buffer {
     ($buffer:ident) => (
-        impl command::CommandBuffer for $buffer {
-            type SubmitInfo = SubmitInfo;
+        impl command::CommandBuffer<Backend> for $buffer {
             unsafe fn end(&mut self) -> SubmitInfo {
                 self.0.end()
+            }
+        }
+
+        // temp, can be removed later
+        impl command::Buffer<Resources> for $buffer {
+            fn reset(&mut self) {
+                unimplemented!()
+            }
+
+            fn bind_pipeline_state(&mut self, _: ()) {
+                unimplemented!()
+            }
+
+            fn bind_vertex_buffers(&mut self, _: pso::VertexBufferSet<Resources>) {
+                unimplemented!()
+            }
+
+            fn bind_constant_buffers(&mut self, _: &[pso::ConstantBufferParam<Resources>]) {
+                unimplemented!()
+            }
+
+            fn bind_global_constant(&mut self, _: shade::Location, _: shade::UniformValue) {
+                unimplemented!()
+            }
+
+            fn bind_resource_views(&mut self, _: &[pso::ResourceViewParam<Resources>]) {
+                unimplemented!()
+            }
+
+            fn bind_unordered_views(&mut self, _: &[pso::UnorderedViewParam<Resources>]) {
+                unimplemented!()
+            }
+
+            fn bind_samplers(&mut self, _: &[pso::SamplerParam<Resources>]) {
+                unimplemented!()
+            }
+
+            fn bind_pixel_targets(&mut self, _: pso::PixelTargetSet<Resources>) {
+                unimplemented!()
+            }
+
+            fn bind_index(&mut self, _: (), _: IndexType) {
+                unimplemented!()
+            }
+
+            fn set_scissor(&mut self, _: target::Rect) {
+                unimplemented!()
+            }
+
+            fn set_ref_values(&mut self, _: state::RefValues) {
+                unimplemented!()
+            }
+
+            fn copy_buffer(&mut self, src: (), dst: (),
+                           src_offset_bytes: usize, dst_offset_bytes: usize,
+                           size_bytes: usize) {
+                unimplemented!()
+            }
+
+            fn copy_buffer_to_texture(&mut self, src: (), src_offset_bytes: usize,
+                                      dst: (),
+                                      kind: tex::Kind,
+                                      face: Option<tex::CubeFace>,
+                                      img: tex::RawImageInfo) {
+                unimplemented!()
+            }
+
+            fn copy_texture_to_buffer(&mut self,
+                                      src: (),
+                                      kind: tex::Kind,
+                                      face: Option<tex::CubeFace>,
+                                      img: tex::RawImageInfo,
+                                      dst: (), dst_offset_bytes: usize) {
+                unimplemented!()
+            }
+
+            fn update_buffer(&mut self, buf: (), data: &[u8], offset: usize) {
+                unimplemented!()
+            }
+
+            fn update_texture(&mut self, tex: (), kind: tex::Kind, face: Option<tex::CubeFace>,
+                              data: &[u8], image: tex::RawImageInfo) {
+                unimplemented!()
+            }
+
+            fn generate_mipmap(&mut self, srv: ()) {
+                unimplemented!()
+            }
+
+            fn clear_color(&mut self, target: (), value: command::ClearColor) {
+                unimplemented!()
+            }
+
+            fn clear_depth_stencil(&mut self, target: (), depth: Option<target::Depth>,
+                                   stencil: Option<target::Stencil>) {
+                unimplemented!()
+            }
+
+            fn call_draw(&mut self, start: VertexCount, count: VertexCount, instances: Option<command::InstanceParams>) {
+                unimplemented!();
+            }
+
+            fn call_draw_indexed(&mut self, start: VertexCount, count: VertexCount,
+                                 base: VertexCount, instances: Option<command::InstanceParams>) {
+                unimplemented!()
             }
         }
     )

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -42,13 +42,8 @@ pub struct Adapter {
     queue_families: Vec<QueueFamily>,
 }
 
-impl core::Adapter for Adapter {
-    type CommandQueue = CommandQueue;
-    type Resources = Resources;
-    type Factory = Factory;
-    type QueueFamily = QueueFamily;
-
-    fn open(&self, queue_descs: &[(&QueueFamily, u32)]) -> core::Device_<Resources, Factory, CommandQueue>
+impl core::Adapter<Backend> for Adapter {
+    fn open(&self, queue_descs: &[(&QueueFamily, u32)]) -> core::Device_<Backend>
     {
         // Create D3D12 device
         let mut device = ComPtr::<winapi::ID3D12Device>::new(ptr::null_mut());
@@ -119,7 +114,7 @@ impl core::Adapter for Adapter {
         unimplemented!()
     }
 
-    fn get_queue_families(&self) -> &[Self::QueueFamily] {
+    fn get_queue_families(&self) -> &[QueueFamily] {
         unimplemented!()
     }
 }
@@ -130,18 +125,8 @@ pub struct CommandQueue {
     list_type: winapi::D3D12_COMMAND_LIST_TYPE,
 }
 
-impl core::CommandQueue for CommandQueue {
-    type Resources = Resources;
-    type SubmitInfo = command::SubmitInfo;
-    type GeneralCommandBuffer = native::GeneralCommandBuffer;
-    type GraphicsCommandBuffer = native::GraphicsCommandBuffer;
-    type ComputeCommandBuffer = native::ComputeCommandBuffer;
-    type TransferCommandBuffer = native::TransferCommandBuffer;
-    type SubpassCommandBuffer = native::SubpassCommandBuffer;
-
-    unsafe fn submit<'a, C>(&mut self, submit_infos: &[core::QueueSubmit<C, Resources>], fence: Option<&'a mut ()>)
-        where C: core::CommandBuffer<SubmitInfo = command::SubmitInfo>
-    {
+impl core::CommandQueue<Backend> for CommandQueue {
+    unsafe fn submit(&mut self, submit_infos: &[core::QueueSubmit<Backend>], fence: Option<&mut ()>) {
         unimplemented!()
     }
 
@@ -163,7 +148,22 @@ impl Factory {
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Resources { }
+pub enum Backend {}
+impl core::Backend for Backend {
+    type Resources = Resources;
+    type CommandQueue = CommandQueue;
+    type GeneralCommandBuffer = native::GeneralCommandBuffer;
+    type GraphicsCommandBuffer = native::GraphicsCommandBuffer;
+    type ComputeCommandBuffer = native::ComputeCommandBuffer;
+    type TransferCommandBuffer = native::TransferCommandBuffer;
+    type SubpassCommandBuffer = native::SubpassCommandBuffer;
+    type SubmitInfo = command::SubmitInfo;
+    type Factory = Factory;
+    type QueueFamily = QueueFamily;
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Resources {}
 impl core::Resources for Resources {
     type Buffer = ();
     type Shader = ();

--- a/src/backend/gl/src/factory.rs
+++ b/src/backend/gl/src/factory.rs
@@ -22,7 +22,7 @@ use core::format::ChannelType;
 use core::handle::{self, Producer};
 use core::target::{Layer, Level};
 
-use command::{CommandBuffer, COLOR_DEFAULT};
+use command::{COLOR_DEFAULT};
 use {Resources as R, Share, OutputMerger};
 use {Buffer, BufferElement, FatSampler, NewTexture,
      PipelineState, ResourceView, TargetView, Fence};
@@ -86,10 +86,6 @@ impl Factory {
             share: share,
             frame_handles: handle::Manager::new(),
         }
-    }
-
-    pub fn create_command_buffer(&mut self) -> CommandBuffer {
-        CommandBuffer::new(self.create_fbo_internal())
     }
 
     fn create_fbo_internal(&mut self) -> gl::types::GLuint {

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -11,11 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-use command::CommandBuffer;
-
-pub struct GeneralCommandBuffer(pub CommandBuffer);
-pub struct GraphicsCommandBuffer(pub CommandBuffer);
-pub struct ComputeCommandBuffer(pub CommandBuffer);
-pub struct TransferCommandBuffer(pub CommandBuffer);
-pub struct SubpassCommandBuffer(pub CommandBuffer);

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -17,7 +17,7 @@ use ash::version::DeviceV1_0;
 use core::{command, pso, shade, state, target, texture as tex};
 use core::{IndexType, VertexCount};
 use native::{GeneralCommandBuffer, GraphicsCommandBuffer, ComputeCommandBuffer, TransferCommandBuffer, SubpassCommandBuffer};
-use {RawDevice, Resources};
+use {Backend, RawDevice, Resources};
 use std::sync::Arc;
 
 pub struct SubmitInfo {
@@ -44,11 +44,116 @@ impl CommandBuffer {
 // CommandBuffer trait implementation
 macro_rules! impl_cmd_buffer {
     ($buffer:ident) => (
-        impl command::CommandBuffer for $buffer {
-            type SubmitInfo = SubmitInfo;
+        impl command::CommandBuffer<Backend> for $buffer {
             unsafe fn end(&mut self) -> SubmitInfo {
                 self.0.end()
             }
+        }
+
+        // TEMPORARY!
+        impl command::Buffer<Resources> for $buffer {
+            fn reset(&mut self) {
+                unimplemented!()
+            }
+
+            fn bind_pipeline_state(&mut self, _: ()) {
+                unimplemented!()
+            }
+
+            fn bind_vertex_buffers(&mut self, _: pso::VertexBufferSet<Resources>) {
+                unimplemented!()
+            }
+
+            fn bind_constant_buffers(&mut self, _: &[pso::ConstantBufferParam<Resources>]) {
+                unimplemented!()
+            }
+
+            fn bind_global_constant(&mut self, _: shade::Location, _: shade::UniformValue) {
+                unimplemented!()
+            }
+
+            fn bind_resource_views(&mut self, _: &[pso::ResourceViewParam<Resources>]) {
+                unimplemented!()
+            }
+
+            fn bind_unordered_views(&mut self, _: &[pso::UnorderedViewParam<Resources>]) {
+                unimplemented!()
+            }
+
+            fn bind_samplers(&mut self, _: &[pso::SamplerParam<Resources>]) {
+                unimplemented!()
+            }
+
+            fn bind_pixel_targets(&mut self, _: pso::PixelTargetSet<Resources>) {
+                unimplemented!()
+            }
+
+            fn bind_index(&mut self, _: (), _: IndexType) {
+                unimplemented!()
+            }
+
+            fn set_scissor(&mut self, _: target::Rect) {
+                unimplemented!()
+            }
+
+            fn set_ref_values(&mut self, _: state::RefValues) {
+                unimplemented!()
+            }
+
+            fn copy_buffer(&mut self, src: (), dst: (),
+                           src_offset_bytes: usize, dst_offset_bytes: usize,
+                           size_bytes: usize) {
+                unimplemented!()
+            }
+
+            fn copy_buffer_to_texture(&mut self, src: (), src_offset_bytes: usize,
+                                      dst: (),
+                                      kind: tex::Kind,
+                                      face: Option<tex::CubeFace>,
+                                      img: tex::RawImageInfo) {
+                unimplemented!()
+            }
+
+            fn copy_texture_to_buffer(&mut self,
+                                      src: (),
+                                      kind: tex::Kind,
+                                      face: Option<tex::CubeFace>,
+                                      img: tex::RawImageInfo,
+                                      dst: (), dst_offset_bytes: usize) {
+                unimplemented!()
+            }
+
+            fn update_buffer(&mut self, buf: (), data: &[u8], offset: usize) {
+                unimplemented!()
+            }
+
+            fn update_texture(&mut self, tex: (), kind: tex::Kind, face: Option<tex::CubeFace>,
+                              data: &[u8], image: tex::RawImageInfo) {
+                unimplemented!()
+            }
+
+            fn generate_mipmap(&mut self, srv: ()) {
+                unimplemented!()
+            }
+
+            fn clear_color(&mut self, target: (), value: command::ClearColor) {
+                unimplemented!()
+            }
+
+            fn clear_depth_stencil(&mut self, target: (), depth: Option<target::Depth>,
+                                   stencil: Option<target::Stencil>) {
+                unimplemented!()
+            }
+
+            fn call_draw(&mut self, start: VertexCount, count: VertexCount, instances: Option<command::InstanceParams>) {
+                unimplemented!();
+            }
+
+            fn call_draw_indexed(&mut self, start: VertexCount, count: VertexCount,
+                                 base: VertexCount, instances: Option<command::InstanceParams>) {
+                unimplemented!()
+            }
+
         }
     )
 }
@@ -60,108 +165,4 @@ impl_cmd_buffer!(TransferCommandBuffer);
 impl_cmd_buffer!(SubpassCommandBuffer);
 
 
-// TEMPORARY!
-impl command::Buffer<Resources> for GraphicsCommandBuffer {
-    fn reset(&mut self) {
-        unimplemented!()
-    }
 
-    fn bind_pipeline_state(&mut self, _: ()) {
-        unimplemented!()
-    }
-
-    fn bind_vertex_buffers(&mut self, _: pso::VertexBufferSet<Resources>) {
-        unimplemented!()
-    }
-
-    fn bind_constant_buffers(&mut self, _: &[pso::ConstantBufferParam<Resources>]) {
-        unimplemented!()
-    }
-
-    fn bind_global_constant(&mut self, _: shade::Location, _: shade::UniformValue) {
-        unimplemented!()
-    }
-
-    fn bind_resource_views(&mut self, _: &[pso::ResourceViewParam<Resources>]) {
-        unimplemented!()
-    }
-
-    fn bind_unordered_views(&mut self, _: &[pso::UnorderedViewParam<Resources>]) {
-        unimplemented!()
-    }
-
-    fn bind_samplers(&mut self, _: &[pso::SamplerParam<Resources>]) {
-        unimplemented!()
-    }
-
-    fn bind_pixel_targets(&mut self, _: pso::PixelTargetSet<Resources>) {
-        unimplemented!()
-    }
-
-    fn bind_index(&mut self, _: (), _: IndexType) {
-        unimplemented!()
-    }
-
-    fn set_scissor(&mut self, _: target::Rect) {
-        unimplemented!()
-    }
-
-    fn set_ref_values(&mut self, _: state::RefValues) {
-        unimplemented!()
-    }
-
-    fn copy_buffer(&mut self, src: (), dst: (),
-                   src_offset_bytes: usize, dst_offset_bytes: usize,
-                   size_bytes: usize) {
-        unimplemented!()
-    }
-
-    fn copy_buffer_to_texture(&mut self, src: (), src_offset_bytes: usize,
-                              dst: (),
-                              kind: tex::Kind,
-                              face: Option<tex::CubeFace>,
-                              img: tex::RawImageInfo) {
-        unimplemented!()
-    }
-
-    fn copy_texture_to_buffer(&mut self,
-                              src: (),
-                              kind: tex::Kind,
-                              face: Option<tex::CubeFace>,
-                              img: tex::RawImageInfo,
-                              dst: (), dst_offset_bytes: usize) {
-        unimplemented!()
-    }
-
-    fn update_buffer(&mut self, buf: (), data: &[u8], offset: usize) {
-        unimplemented!()
-    }
-
-    fn update_texture(&mut self, tex: (), kind: tex::Kind, face: Option<tex::CubeFace>,
-                      data: &[u8], image: tex::RawImageInfo) {
-        unimplemented!()
-    }
-
-    fn generate_mipmap(&mut self, srv: ()) {
-        unimplemented!()
-    }
-
-    fn clear_color(&mut self, target: (), value: command::ClearColor) {
-        unimplemented!()
-    }
-
-    fn clear_depth_stencil(&mut self, target: (), depth: Option<target::Depth>,
-                           stencil: Option<target::Stencil>) {
-        unimplemented!()
-    }
-
-    fn call_draw(&mut self, start: VertexCount, count: VertexCount, instances: Option<command::InstanceParams>) {
-        unimplemented!();
-    }
-
-    fn call_draw_indexed(&mut self, start: VertexCount, count: VertexCount,
-                         base: VertexCount, instances: Option<command::InstanceParams>) {
-        unimplemented!()
-    }
-
-}

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -217,13 +217,8 @@ impl Adapter {
     }
 }
 
-impl core::Adapter for Adapter {
-    type CommandQueue = CommandQueue;
-    type Resources = Resources;
-    type Factory = Factory;
-    type QueueFamily = QueueFamily;
-
-    fn open(&self, queue_descs: &[(&QueueFamily, u32)]) -> core::Device_<Resources, Factory, CommandQueue>
+impl core::Adapter<Backend> for Adapter {
+    fn open(&self, queue_descs: &[(&QueueFamily, u32)]) -> core::Device_<Backend>
     {
         let mut queue_priorities = Vec::with_capacity(queue_descs.len());
 
@@ -342,7 +337,7 @@ impl core::Adapter for Adapter {
         &self.info
     }
 
-    fn get_queue_families(&self) -> &[Self::QueueFamily] {
+    fn get_queue_families(&self) -> &[QueueFamily] {
         &self.queue_families
     }
 }
@@ -382,18 +377,8 @@ impl CommandQueue {
     }
 }
 
-impl core::CommandQueue for CommandQueue {
-    type Resources = Resources;
-    type SubmitInfo = command::SubmitInfo;
-    type GeneralCommandBuffer = native::GeneralCommandBuffer;
-    type GraphicsCommandBuffer = native::GraphicsCommandBuffer;
-    type ComputeCommandBuffer = native::ComputeCommandBuffer;
-    type TransferCommandBuffer = native::TransferCommandBuffer;
-    type SubpassCommandBuffer = native::SubpassCommandBuffer;
-
-    unsafe fn submit<'a, C>(&mut self, submit_infos: &[core::QueueSubmit<C, Resources>], fence: Option<&'a mut native::Fence>)
-        where C: CommandBuffer<SubmitInfo = command::SubmitInfo>
-    {
+impl core::CommandQueue<Backend> for CommandQueue {
+    unsafe fn submit(&mut self, submit_infos: &[core::QueueSubmit<Backend>], fence: Option<&mut native::Fence>) {
 
         unimplemented!()
     }
@@ -407,6 +392,21 @@ impl core::CommandQueue for CommandQueue {
 
 pub struct Factory {
     device: Arc<RawDevice>,
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Backend {}
+impl core::Backend for Backend {
+    type Resources = Resources;
+    type CommandQueue = CommandQueue;
+    type GeneralCommandBuffer = native::GeneralCommandBuffer;
+    type GraphicsCommandBuffer = native::GraphicsCommandBuffer;
+    type ComputeCommandBuffer = native::ComputeCommandBuffer;
+    type TransferCommandBuffer = native::TransferCommandBuffer;
+    type SubpassCommandBuffer = native::SubpassCommandBuffer;
+    type SubmitInfo = command::SubmitInfo;
+    type Factory = Factory;
+    type QueueFamily = QueueFamily;
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/core/src/pool.rs
+++ b/src/core/src/pool.rs
@@ -16,45 +16,80 @@
 
 use std::borrow::BorrowMut;
 use std::ops::{DerefMut};
-use {CommandPool, CommandQueue};
+use {command, Backend, CommandPool, CommandQueue};
 pub use queue::{GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
 
 /// General command pool can allocate general command buffers.
-pub trait GeneralCommandPool: CommandPool {
+pub trait GeneralCommandPool<B: Backend>: CommandPool<B> {
     ///
     fn from_queue<Q>(queue: Q, capacity: usize) -> Self
-        where Q: Into<GeneralQueue<Self::Queue>> +
-                 BorrowMut<Self::Queue>;
+        where Q: Into<GeneralQueue<B>> +
+                 BorrowMut<B::CommandQueue>;
+
+    /// Get a command buffer for recording.
+    ///
+    /// You can only record to one command buffer per pool at the same time.
+    /// If more command buffers are requested than allocated, new buffers will be reserved.
+    /// The command buffer will be returned in 'recording' state.
+    fn acquire_command_buffer<'a>(&'a mut self) -> command::Encoder<'a, B, B::GeneralCommandBuffer>;
 }
 
 /// Graphics command pool can allocate graphics command buffers.
-pub trait GraphicsCommandPool: CommandPool {
+pub trait GraphicsCommandPool<B: Backend>: CommandPool<B> {
     ///
     fn from_queue<Q>(queue: Q, capacity: usize) -> Self
-        where Q: Into<GraphicsQueue<Self::Queue>> +
-                 BorrowMut<Self::Queue>;
+        where Q: Into<GraphicsQueue<B>> +
+                 BorrowMut<B::CommandQueue>;
+
+    /// Get a command buffer for recording.
+    ///
+    /// You can only record to one command buffer per pool at the same time.
+    /// If more command buffers are requested than allocated, new buffers will be reserved.
+    /// The command buffer will be returned in 'recording' state.
+    fn acquire_command_buffer<'a>(&'a mut self) -> command::Encoder<'a, B, B::GraphicsCommandBuffer>;
 }
 
 /// Compute command pool can allocate compute command buffers.
-pub trait ComputeCommandPool: CommandPool {
+pub trait ComputeCommandPool<B: Backend>: CommandPool<B> {
     ///
     fn from_queue<Q>(queue: Q, capacity: usize) -> Self
-        where Q: Into<ComputeQueue<Self::Queue>> +
-                 BorrowMut<Self::Queue>;
+        where Q: Into<ComputeQueue<B>> +
+                 BorrowMut<B::CommandQueue>;
+
+    /// Get a command buffer for recording.
+    ///
+    /// You can only record to one command buffer per pool at the same time.
+    /// If more command buffers are requested than allocated, new buffers will be reserved.
+    /// The command buffer will be returned in 'recording' state.
+    fn acquire_command_buffer<'a>(&'a mut self) -> command::Encoder<'a, B, B::ComputeCommandBuffer>;
 }
 
 /// Transfer command pool can allocate transfer command buffers.
-pub trait TransferCommandPool: CommandPool {
+pub trait TransferCommandPool<B: Backend>: CommandPool<B> {
     ///
     fn from_queue<Q>(queue: Q, capacity: usize) -> Self
-        where Q: Into<TransferQueue<Self::Queue>> +
-                 BorrowMut<Self::Queue>;
+        where Q: Into<TransferQueue<B>> +
+                 BorrowMut<B::CommandQueue>;
+
+    /// Get a command buffer for recording.
+    ///
+    /// You can only record to one command buffer per pool at the same time.
+    /// If more command buffers are requested than allocated, new buffers will be reserved.
+    /// The command buffer will be returned in 'recording' state.
+    fn acquire_command_buffer<'a>(&'a mut self) -> command::Encoder<'a, B, B::TransferCommandBuffer>;
 }
 
 /// Subpass command pool can allocate subpass command buffers.
-pub trait SubpassCommandPool: CommandPool {
+pub trait SubpassCommandPool<B: Backend>: CommandPool<B> {
     ///
     fn from_queue<Q>(queue: Q, capacity: usize) -> Self
-        where Q: Into<GraphicsQueue<Self::Queue>> +
-                 BorrowMut<Self::Queue>;
+        where Q: Into<GraphicsQueue<B>> +
+                 BorrowMut<B::CommandQueue>;
+
+    /// Get a command buffer for recording.
+    ///
+    /// You can only record to one command buffer per pool at the same time.
+    /// If more command buffers are requested than allocated, new buffers will be reserved.
+    /// The command buffer will be returned in 'recording' state.
+    fn acquire_command_buffer<'a>(&'a mut self) -> command::Encoder<'a, B, B::SubpassCommandBuffer>;
 }

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -184,10 +184,8 @@ pub struct SwapChain<'a> {
     backbuffer: Vec<handle::RawTexture<device_gl::Resources>>,
 }
 
-impl<'a> core::SwapChain for SwapChain<'a> {
-    type R = device_gl::Resources;
-
-    fn get_images(&mut self) -> &[handle::RawTexture<Self::R>] {
+impl<'a> core::SwapChain<device_gl::Backend> for SwapChain<'a> {
+    fn get_images(&mut self) -> &[handle::RawTexture<device_gl::Resources>] {
         &self.backbuffer
     }
 
@@ -205,15 +203,13 @@ pub struct Surface<'a> {
     window: &'a glutin::Window,
 }
 
-impl<'a> core::Surface for Surface<'a> {
-    type CommandQueue = device_gl::CommandQueue;
+impl<'a> core::Surface<device_gl::Backend> for Surface<'a> {
     type SwapChain = SwapChain<'a>;
-    type QueueFamily = device_gl::QueueFamily;
 
     fn supports_queue(&self, queue_family: &device_gl::QueueFamily) -> bool { true }
     fn build_swapchain<T, Q>(&self, present_queue: Q) -> SwapChain<'a>
         where T: core::format::RenderFormat,
-              Q: Borrow<Self::CommandQueue>
+              Q: Borrow<device_gl::CommandQueue>
     {
         use core::handle::Producer;
         let dim = get_window_dimensions(self.window);
@@ -238,7 +234,7 @@ impl<'a> core::Surface for Surface<'a> {
 
 pub struct Window<'a>(&'a glutin::Window);
 
-impl<'a> core::WindowExt for Window<'a> {
+impl<'a> core::WindowExt<device_gl::Backend> for Window<'a> {
     type Surface = Surface<'a>;
     type Adapter = device_gl::Adapter;
 

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -141,12 +141,10 @@ impl Surface {
     }
 }
 
-impl core::Surface for Surface {
-    type CommandQueue = device_vulkan::CommandQueue;
+impl core::Surface<device_vulkan::Backend> for Surface {
     type SwapChain = SwapChain;
-    type QueueFamily = device_vulkan::QueueFamily;
 
-    fn supports_queue(&self, queue_family: &Self::QueueFamily) -> bool {
+    fn supports_queue(&self, queue_family: &device_vulkan::QueueFamily) -> bool {
         unsafe {
             let mut support = mem::uninitialized();
             self.raw.loader.get_physical_device_surface_support_khr(
@@ -158,9 +156,9 @@ impl core::Surface for Surface {
         }
     }
 
-    fn build_swapchain<T, Q>(&self, present_queue: Q) -> SwapChain
+    fn build_swapchain<T, Q>(&self, present_queue: Q) -> Self::SwapChain
         where T: core::format::RenderFormat,
-              Q: Borrow<Self::CommandQueue>
+              Q: Borrow<device_vulkan::CommandQueue>
     {
         let entry = VK_ENTRY.as_ref().expect("Unable to load vulkan entry points");
         let loader = vk::SwapchainFn::load(|name| {
@@ -270,10 +268,8 @@ impl SwapChain {
     }
 }
 
-impl core::SwapChain for SwapChain {
-    type R = device_vulkan::Resources;
-
-    fn get_images(&mut self) -> &[handle::RawTexture<Self::R>] {
+impl core::SwapChain<device_vulkan::Backend> for SwapChain {
+    fn get_images(&mut self) -> &[handle::RawTexture<device_vulkan::Resources>] {
         // TODO
         // &self.images
         unimplemented!()
@@ -329,7 +325,7 @@ impl core::SwapChain for SwapChain {
 
 pub struct Window<'a>(pub &'a winit::Window);
 
-impl<'a> core::WindowExt for Window<'a> {
+impl<'a> core::WindowExt<device_vulkan::Backend> for Window<'a> {
     type Surface = Surface;
     type Adapter = device_vulkan::Adapter;
 


### PR DESCRIPTION
Addresses the mentioned Backend trait from #1291 (first bullet point) for `ll` integration.

Introducing a new `Backend` trait in similar fashion to the current `Resource` trait simplifies the API and helps higher-level layers for operating on the core. For more details regarding the current problems with associated trait approach please checkout the mentioned issue!
Implemented the Backend changes for GL, Vulkan and D3D12 backend so far,

For reviewing: [Backend trait](https://github.com/msiglreith/gfx/blob/pr_asteria_06v2/src/core/src/lib.rs#L229-L242)

Other notable changes:
- Remove `Send` from Buffer, anticipating the upcoming changes towards allocation of command pools instead of sending around Encoder. Also, added dummy implementation for the Buffer trait to allow merging the first parts of the integration branch once the setup stuff is done without needing to additionally rewrite all the command buffer stuff.
- Macrofiy the `Queue` definitions [src/core/queue.rs](https://github.com/msiglreith/gfx/blob/pr_asteria_06v2/src/core/src/queue.rs), helps to reduce code duplication. Will be extended if further conversions and trait impls are needed. Some occurences of `Borrow<Queue>` etc will be revised in the future..

cc @JohnColanduoni 