### PR TITLE
[ll] Adopt the new Backend trait for app and render [08/..]

### DIFF
--- a/src/core/src/command.rs
+++ b/src/core/src/command.rs
@@ -15,7 +15,7 @@
 //! Command Buffer device interface
 
 use std::marker::PhantomData;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::collections::hash_set::{self, HashSet};
 use {Backend, Resources, IndexType, InstanceCount, VertexCount,
      SubmissionResult, SubmissionError};
@@ -47,7 +47,25 @@ impl<B: Backend> Submit<B> {
 }
 
 ///
+#[derive(Debug)]
 pub struct Encoder<'a, B: Backend, C: CommandBuffer<B> + 'a>(&'a mut C, PhantomData<B>);
+
+impl<'a, B, C> Deref for Encoder<'a, B, C>
+    where B: Backend, C: CommandBuffer<B> + 'a
+{
+    type Target = C;
+    fn deref(&self) -> &C {
+        self.0
+    }
+}
+
+impl<'a, B, C> DerefMut for Encoder<'a, B,C>
+    where B: Backend, C: CommandBuffer<B> + 'a
+{
+    fn deref_mut(&mut self) -> &mut C {
+        self.0
+    }
+}
 
 impl<'a, B: Backend, C: CommandBuffer<B>> Encoder<'a, B, C> {
     #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ extern crate gfx_device_vulkan;
 extern crate gfx_window_vulkan;
 
 use gfx_core::memory::Typed;
-use gfx_core::{Adapter, CommandQueue, FrameSync, Surface, SwapChain, QueueFamily, WindowExt};
+use gfx_core::{Adapter, Backend, CommandQueue, FrameSync, Surface, SwapChain, QueueFamily, WindowExt};
 use gfx_core::pool::GraphicsCommandPool;
 
 pub mod shade;
@@ -60,12 +60,6 @@ pub struct WindowTargets<R: gfx::Resources> {
     pub colors: Vec<gfx::handle::RenderTargetView<R, ColorFormat>>,
     pub depth: gfx::handle::DepthStencilView<R, DepthFormat>,
     pub aspect_ratio: f32,
-}
-
-pub enum Backend {
-    OpenGL2,
-    Direct3D11 { pix_mode: bool },
-    Metal,
 }
 
 struct Harness {
@@ -94,17 +88,17 @@ impl Drop for Harness {
     }
 }
 
-pub trait ApplicationBase<R: gfx::Resources, C: gfx::CommandBuffer<R>> {
-    fn new<F>(&mut F, shade::Backend, WindowTargets<R>) -> Self where F: gfx::Factory<R>;
+pub trait ApplicationBase<B: Backend, C: gfx::CommandBuffer<B::Resources>> {
+    fn new(&mut B::Factory, shade::Backend, WindowTargets<B::Resources>) -> Self;
     fn render<D>(&mut self, &mut D);
     fn get_exit_key() -> Option<winit::VirtualKeyCode>;
     fn on(&mut self, winit::WindowEvent);
-    fn on_resize<F>(&mut self, &mut F, WindowTargets<R>) where F: gfx::Factory<R>;
+    fn on_resize(&mut self, &mut B::Factory, WindowTargets<B::Resources>);
 }
 
 #[cfg(feature = "gl")]
 pub fn launch_gl3<A>(wb: winit::WindowBuilder) where
-A: Sized + Application<gfx_device_gl::Resources>
+A: Sized + Application<gfx_device_gl::Backend>
 {
     env_logger::init().unwrap();
     let gl_version = glutin::GlRequest::GlThenGles {
@@ -167,7 +161,7 @@ pub type D3D11CommandBufferFake = gfx_device_dx11::CommandBuffer<gfx_device_dx11
 
 #[cfg(feature = "dx11")]
 pub fn launch_d3d11<A>(wb: winit::WindowBuilder) where
-A: Sized + Application<gfx_device_dx11::Resources>
+A: Sized + Application<gfx_device_dx11::Backend>
 {
     use gfx::traits::Factory;
 
@@ -228,7 +222,7 @@ A: Sized + Application<gfx_device_dx11::Resources>
 
 #[cfg(feature = "metal")]
 pub fn launch_metal<A>(wb: winit::WindowBuilder) where
-A: Sized + Application<gfx_device_metal::Resources>
+A: Sized + Application<gfx_device_metal::Backend>
 {
     use gfx::traits::Factory;
     use gfx::texture::Size;
@@ -269,7 +263,7 @@ A: Sized + Application<gfx_device_metal::Resources>
 
 #[cfg(feature = "vulkan")]
 pub fn launch_vulkan<A>(wb: winit::WindowBuilder) where
-A: Sized + Application<gfx_device_vulkan::Resources>
+A: Sized + Application<gfx_device_vulkan::Backend>
 {
     use gfx::traits::{Factory};
     use gfx::texture::{self, Size};
@@ -355,18 +349,18 @@ A: Sized + Application<gfx_device_vulkan::Resources>
 }
 
 #[cfg(feature = "gl")]
-pub type DefaultResources = gfx_device_gl::Resources;
+pub type DefaultBackend = gfx_device_gl::Backend;
 #[cfg(feature = "dx11")]
-pub type DefaultResources = gfx_device_dx11::Resources;
+pub type DefaultBackend = gfx_device_dx11::Backend;
 #[cfg(feature = "metal")]
-pub type DefaultResources = gfx_device_metal::Resources;
+pub type DefaultBackend = gfx_device_metal::Backend;
 #[cfg(feature = "vulkan")]
-pub type DefaultResources = gfx_device_vulkan::Resources;
+pub type DefaultBackend = gfx_device_vulkan::Backend;
 
-pub trait Application<R: gfx::Resources>: Sized {
-    fn new<F: gfx::Factory<R>>(&mut F, shade::Backend, WindowTargets<R>) -> Self;
-    fn render<C: gfx::CommandBuffer<R>>(&mut self, &mut gfx::GraphicsEncoder<R, C>);
-    fn render_ext<P: gfx_core::pool::GraphicsCommandPool>(&mut self, pool: &mut P)
+pub trait Application<B: Backend>: Sized {
+    fn new(&mut B::Factory, shade::Backend, WindowTargets<B::Resources>) -> Self;
+    fn render(&mut self, &mut gfx::GraphicsEncoder<B>);
+    fn render_ext<P: gfx_core::pool::GraphicsCommandPool<B>>(&mut self, pool: &mut P)
     {
         unimplemented!()
         // TODO: self.app.render(&mut self.encoder);
@@ -376,30 +370,30 @@ pub trait Application<R: gfx::Resources>: Sized {
     fn get_exit_key() -> Option<winit::VirtualKeyCode> {
         Some(winit::VirtualKeyCode::Escape)
     }
-    fn on_resize(&mut self, WindowTargets<R>) {}
-    fn on_resize_ext<F: gfx::Factory<R>>(&mut self, _factory: &mut F, targets: WindowTargets<R>) {
+    fn on_resize(&mut self, WindowTargets<B::Resources>) {}
+    fn on_resize_ext(&mut self, _factory: &mut B::Factory, targets: WindowTargets<B::Resources>) {
         self.on_resize(targets);
     }
     fn on(&mut self, _event: winit::WindowEvent) {}
 
-    fn launch_simple(name: &str) where Self: Application<DefaultResources> {
+    fn launch_simple(name: &str) where Self: Application<DefaultBackend> {
         let wb = winit::WindowBuilder::new().with_title(name);
-        <Self as Application<DefaultResources>>::launch_default(wb)
+        <Self as Application<DefaultBackend>>::launch_default(wb)
     }
     #[cfg(feature = "gl")]
-    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultResources> {
+    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultBackend> {
         launch_gl3::<Self>(wb);
     }
     #[cfg(feature = "dx11")]
-    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultResources> {
+    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultBackend> {
         launch_d3d11::<Self>(wb);
     }
     #[cfg(feature = "metal")]
-    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultResources> {
+    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultBackend> {
         launch_metal::<Self>(wb);
     }
     #[cfg(feature = "vulkan")]
-    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultResources> {
+    fn launch_default(wb: winit::WindowBuilder) where Self: Application<DefaultBackend> {
         launch_vulkan::<Self>(wb);
     }
 }

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -38,7 +38,7 @@ pub use draw_state::{preset, state};
 pub use draw_state::target::*;
 
 // public re-exports
-pub use core::{Primitive, Resources, SubmissionError, SubmissionResult};
+pub use core::{Backend, Primitive, Resources, SubmissionError, SubmissionResult};
 pub use core::{VertexCount, InstanceCount};
 pub use core::{ShaderSet, VertexShader, HullShader, DomainShader, GeometryShader, PixelShader};
 pub use core::{buffer, format, handle, texture, mapping};

--- a/src/render/src/pso/bundle.rs
+++ b/src/render/src/pso/bundle.rs
@@ -2,22 +2,22 @@
 //!
 //! Suitable for use when PSO is always used with the same one slice.
 
-use { Resources, Slice, PipelineState, GraphicsEncoder, CommandBuffer };
+use {Backend, Resources, Slice, PipelineState, GraphicsEncoder, CommandBuffer };
 use super::PipelineData;
 
 /// Slice-PSO bundle.
-pub struct Bundle<R: Resources, Data: PipelineData<R>> {
+pub struct Bundle<B: Backend, Data: PipelineData<B::Resources>> {
     /// Slice
-    pub slice: Slice<R>,
+    pub slice: Slice<B::Resources>,
     /// Pipeline state
-    pub pso: PipelineState<R, Data::Meta>,
+    pub pso: PipelineState<B::Resources, Data::Meta>,
     /// Pipeline data
     pub data: Data,
 }
 
-impl<R: Resources, Data: PipelineData<R>> Bundle<R, Data> {
+impl<B: Backend, Data: PipelineData<B::Resources>> Bundle<B, Data> {
     /// Create new Bundle
-    pub fn new(slice: Slice<R>, pso: PipelineState<R, Data::Meta>, data: Data) -> Self
+    pub fn new(slice: Slice<B::Resources>, pso: PipelineState<B::Resources, Data::Meta>, data: Data) -> Self
     {
         Bundle {
             slice: slice,
@@ -27,8 +27,7 @@ impl<R: Resources, Data: PipelineData<R>> Bundle<R, Data> {
     }
 
     /// Draw bundle using encoder.
-    pub fn encode<C>(&self, encoder: &mut GraphicsEncoder<R, C>) where
-        C: CommandBuffer<R> {
+    pub fn encode(&self, encoder: &mut GraphicsEncoder<B>) {
         encoder.draw(&self.slice, &self.pso, &self.data);
     }
 }


### PR DESCRIPTION
GraphicsEncoder and Application are now generic over `Backend` instead of `Resources`.
(Related to #1291)