### PR TITLE
[ll] Working on app unification [09/..]

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -37,10 +37,10 @@ mod command;
 mod factory;
 mod info;
 mod native;
+mod pool;
 mod shade;
 mod state;
 mod tex;
-
 
 pub type Buffer         = gl::types::GLuint;
 pub type ArrayBuffer    = gl::types::GLuint;
@@ -59,6 +59,7 @@ unsafe impl Sync for Fence {}
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Backend {}
 impl c::Backend for Backend {
+    type Adapter = Adapter;
     type Resources = Resources;
     type CommandQueue = CommandQueue;
     type GeneralCommandBuffer = command::GeneralCommandBuffer;
@@ -69,6 +70,12 @@ impl c::Backend for Backend {
     type SubmitInfo = command::SubmitInfo;
     type Factory = Factory;
     type QueueFamily = QueueFamily;
+
+    type GeneralCommandPool = pool::GeneralCommandPool;
+    type GraphicsCommandPool = pool::GraphicsCommandPool;
+    type ComputeCommandPool = pool::ComputeCommandPool;
+    type TransferCommandPool = pool::TransferCommandPool;
+    type SubpassCommandPool = pool::SubpassCommandPool;
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -1,0 +1,74 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::{self, pool};
+use core::command::{Encoder};
+use core::queue::{Compatible,
+    GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue,
+    GeneralQueueRef, GraphicsQueueRef, ComputeQueueRef, TransferQueueRef};
+use command::{self, GeneralCommandBuffer, GraphicsCommandBuffer, ComputeCommandBuffer, TransferCommandBuffer, SubpassCommandBuffer};
+use {Backend, CommandQueue, Resources};
+use core::CommandPool;
+
+macro_rules! impl_pool {
+    ($pool:ident, $queue:ident, $queue_ref:ident, $buffer:ident) => (
+        pub struct $pool {
+            command_buffers: Vec<$buffer>,
+            next_buffer: usize,
+        }
+
+        impl core::CommandPool<Backend> for $pool {
+            fn reset(&mut self) {
+                self.next_buffer = 0;
+            }
+
+            fn reserve(&mut self, additional: usize) {
+                for _ in 0..additional {
+                    self.command_buffers.push($buffer::new(0));
+                }
+            }
+        }
+
+        impl pool::$pool<Backend> for $pool {
+            fn from_queue<'a, Q>(mut _queue: Q, capacity: usize) -> Self
+                where Q: Compatible<$queue<Backend>> + AsRef<CommandQueue>
+            {
+                let buffers = (0..capacity).map(|_| $buffer::new(0))
+                                           .collect();
+                $pool {
+                    command_buffers: buffers,
+                    next_buffer: 0,
+                }
+            }
+
+            fn acquire_command_buffer<'a>(&'a mut self) -> Encoder<'a, Backend, $buffer> {
+                let available_buffers = self.command_buffers.len() as isize - self.next_buffer as isize;
+                if available_buffers <= 0 {
+                    self.reserve((-available_buffers) as usize + 1);
+                }
+
+                let buffer = &mut self.command_buffers[self.next_buffer];
+                self.next_buffer += 1;
+
+                unsafe { Encoder::new(buffer) }
+            }
+        }
+    )
+}
+
+impl_pool!{ GeneralCommandPool, GeneralQueue, GeneralQueueRef, GeneralCommandBuffer }
+impl_pool!{ GraphicsCommandPool, GraphicsQueue, GraphicsQueueRef, GraphicsCommandBuffer }
+impl_pool!{ ComputeCommandPool, ComputeQueue, ComputeQueueRef, ComputeCommandBuffer }
+impl_pool!{ TransferCommandPool, TransferQueue, TransferQueueRef, TransferCommandBuffer }
+impl_pool!{ SubpassCommandPool, GraphicsQueue, GraphicsQueueRef, SubpassCommandBuffer }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -397,6 +397,7 @@ pub struct Factory {
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Backend {}
 impl core::Backend for Backend {
+    type Adapter = Adapter;
     type Resources = Resources;
     type CommandQueue = CommandQueue;
     type GeneralCommandBuffer = native::GeneralCommandBuffer;
@@ -407,6 +408,12 @@ impl core::Backend for Backend {
     type SubmitInfo = command::SubmitInfo;
     type Factory = Factory;
     type QueueFamily = QueueFamily;
+
+    type GeneralCommandPool = pool::GeneralCommandPool;
+    type GraphicsCommandPool = pool::GraphicsCommandPool;
+    type ComputeCommandPool = pool::ComputeCommandPool;
+    type TransferCommandPool = pool::TransferCommandPool;
+    type SubpassCommandPool = pool::SubpassCommandPool;
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -30,7 +30,7 @@ use core::memory;
 use core::{CommandBuffer, FrameSync};
 use std::{mem, ptr};
 use std::ffi::{CStr, CString};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::collections::VecDeque;
 
 mod command;
@@ -351,8 +351,7 @@ impl Drop for RawDevice {
 }
 
 // Need to explicitly synchronize on submission and present.
-// TODO: Can we avoid somehow the use of a mutex?
-pub type RawCommandQueue = Arc<Mutex<vk::Queue>>;
+pub type RawCommandQueue = Arc<vk::Queue>;
 
 pub struct CommandQueue {
     raw: RawCommandQueue,
@@ -385,7 +384,7 @@ impl core::CommandQueue<Backend> for CommandQueue {
 
     fn wait_idle(&mut self) {
         unsafe {
-            self.device.0.queue_wait_idle(*self.raw.lock().unwrap());
+            self.device.0.queue_wait_idle(*self.raw);
         }
     }
 }

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::BorrowMut;
 use std::ops::DerefMut;
 use std::ptr;
 use std::sync::Arc;
@@ -22,6 +21,7 @@ use ash::version::DeviceV1_0;
 use core::{self, pool};
 use core::command::{Encoder};
 use core::{CommandPool, GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
+use core::queue::Compatible;
 use command::CommandBuffer;
 use native::{self, GeneralCommandBuffer, GraphicsCommandBuffer, ComputeCommandBuffer, TransferCommandBuffer, SubpassCommandBuffer};
 use {Backend, CommandQueue, RawDevice};
@@ -76,9 +76,9 @@ macro_rules! impl_pool {
             }
 
             fn from_queue<Q>(mut queue: Q, capacity: usize) -> $pool
-                where Q: Into<$queue<Backend>> + BorrowMut<CommandQueue>
+                where Q: Compatible<$queue<Backend>> + AsRef<CommandQueue>
             {
-                let queue = queue.borrow_mut();
+                let queue = queue.as_ref();
 
                 // Create command pool
                 let info = vk::CommandPoolCreateInfo {

--- a/src/core/src/pool.rs
+++ b/src/core/src/pool.rs
@@ -14,17 +14,16 @@
 
 //! Command pools
 
-use std::borrow::BorrowMut;
 use std::ops::{DerefMut};
 use {command, Backend, CommandPool, CommandQueue};
-pub use queue::{GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
+pub use queue::{Compatible, GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
 
 /// General command pool can allocate general command buffers.
 pub trait GeneralCommandPool<B: Backend>: CommandPool<B> {
     ///
     fn from_queue<Q>(queue: Q, capacity: usize) -> Self
-        where Q: Into<GeneralQueue<B>> +
-                 BorrowMut<B::CommandQueue>;
+        where Q: Compatible<GeneralQueue<B>> +
+                 AsRef<B::CommandQueue>;
 
     /// Get a command buffer for recording.
     ///
@@ -38,8 +37,8 @@ pub trait GeneralCommandPool<B: Backend>: CommandPool<B> {
 pub trait GraphicsCommandPool<B: Backend>: CommandPool<B> {
     ///
     fn from_queue<Q>(queue: Q, capacity: usize) -> Self
-        where Q: Into<GraphicsQueue<B>> +
-                 BorrowMut<B::CommandQueue>;
+        where Q: Compatible<GraphicsQueue<B>> +
+                 AsRef<B::CommandQueue>;
 
     /// Get a command buffer for recording.
     ///
@@ -53,8 +52,8 @@ pub trait GraphicsCommandPool<B: Backend>: CommandPool<B> {
 pub trait ComputeCommandPool<B: Backend>: CommandPool<B> {
     ///
     fn from_queue<Q>(queue: Q, capacity: usize) -> Self
-        where Q: Into<ComputeQueue<B>> +
-                 BorrowMut<B::CommandQueue>;
+        where Q: Compatible<ComputeQueue<B>> +
+                 AsRef<B::CommandQueue>;
 
     /// Get a command buffer for recording.
     ///
@@ -68,8 +67,8 @@ pub trait ComputeCommandPool<B: Backend>: CommandPool<B> {
 pub trait TransferCommandPool<B: Backend>: CommandPool<B> {
     ///
     fn from_queue<Q>(queue: Q, capacity: usize) -> Self
-        where Q: Into<TransferQueue<B>> +
-                 BorrowMut<B::CommandQueue>;
+        where Q: Compatible<TransferQueue<B>> +
+                 AsRef<B::CommandQueue>;
 
     /// Get a command buffer for recording.
     ///
@@ -83,8 +82,8 @@ pub trait TransferCommandPool<B: Backend>: CommandPool<B> {
 pub trait SubpassCommandPool<B: Backend>: CommandPool<B> {
     ///
     fn from_queue<Q>(queue: Q, capacity: usize) -> Self
-        where Q: Into<GraphicsQueue<B>> +
-                 BorrowMut<B::CommandQueue>;
+        where Q: Compatible<GraphicsQueue<B>> +
+                 AsRef<B::CommandQueue>;
 
     /// Get a command buffer for recording.
     ///

--- a/src/core/src/queue.rs
+++ b/src/core/src/queue.rs
@@ -105,13 +105,25 @@ macro_rules! define_queue {
 
         impl<'a, B: Backend> AsRef<B::CommandQueue> for $queue_ref<'a, B> {
             fn as_ref(&self) -> &B::CommandQueue {
-                &self.0
+                self.0
             }
         }
 
         impl<'a, B: Backend> AsRef<B::CommandQueue> for $queue_mut<'a, B> {
             fn as_ref(&self) -> &B::CommandQueue {
-                &self.0
+                self.0
+            }
+        }
+
+        impl<B: Backend> AsMut<B::CommandQueue> for $queue<B> {
+            fn as_mut(&mut self) -> &mut B::CommandQueue {
+                &mut self.0
+            }
+        }
+
+        impl<'a, B: Backend> AsMut<B::CommandQueue> for $queue_mut<'a, B> {
+            fn as_mut(&mut self) -> &mut B::CommandQueue {
+                self.0
             }
         }
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,11 +290,12 @@ fn run<A, B, S>(backend: shade::Backend,
         return
     };
 
-    let mut swap_chain = surface.build_swapchain::<ColorFormat, _>(queue.as_ref());
+    let config = gfx_core::SwapchainConfig::new().with_color::<ColorFormat>();
+    let mut swap_chain = surface.build_swapchain(config, &queue);
 
-    let main_colors = swap_chain.get_images()
+    let main_colors = swap_chain.get_backbuffers()
                                 .iter()
-                                .map(|image| {
+                                .map(|&(ref image, _)| {
                                     let desc = texture::RenderDesc {
                                         channel: ColorFormat::get_format().1,
                                         level: 0,
@@ -338,7 +339,7 @@ fn run<A, B, S>(backend: shade::Backend,
         // Wait til rendering has finished
         queue.wait_idle();
 
-        swap_chain.present();
+        swap_chain.present(&mut queue);
         harness.bump();
     }
 }

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -209,7 +209,7 @@ impl<'a> core::Surface<device_gl::Backend> for Surface<'a> {
     fn supports_queue(&self, queue_family: &device_gl::QueueFamily) -> bool { true }
     fn build_swapchain<T, Q>(&self, present_queue: Q) -> SwapChain<'a>
         where T: core::format::RenderFormat,
-              Q: Borrow<device_gl::CommandQueue>
+              Q: AsRef<device_gl::CommandQueue>
     {
         use core::handle::Producer;
         let dim = get_window_dimensions(self.window);

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -158,7 +158,7 @@ impl core::Surface<device_vulkan::Backend> for Surface {
 
     fn build_swapchain<T, Q>(&self, present_queue: Q) -> Self::SwapChain
         where T: core::format::RenderFormat,
-              Q: Borrow<device_vulkan::CommandQueue>
+              Q: AsRef<device_vulkan::CommandQueue>
     {
         let entry = VK_ENTRY.as_ref().expect("Unable to load vulkan entry points");
         let loader = vk::SwapchainFn::load(|name| {
@@ -171,7 +171,7 @@ impl core::Surface<device_vulkan::Backend> for Surface {
 
         // TODO: check for better ones if available
         let present_mode = vk::PresentModeKHR::Fifo; // required to be supported
-        let present_queue = present_queue.borrow();
+        let present_queue = present_queue.as_ref();
 
         let format = <T as format::Formatted>::get_format();
 


### PR DESCRIPTION
Currently trying to merge the current `launch_` functions into one backend-agnostic `run` function for app. Only surface and adapter setup should be then backend specific.

Other changes induced by the mentioned goal above (note: focusing on GL and Vulkan atm):
* Implement command pools for GL (maybe pool implementations can be moved towards `core` similar to CommandQueues, which would reduce code size.. )
* Add `SwapchainConfig`, which allows to specify color and depth-stencil formats for the backbuffers. Should be extended in the future for present modes (if possible), swapchain size and possible other options.
* `present` now takes the present queue, which allows to remove the `Mutex` for CommandQueues on Vulkan