### PR TITLE
Fix mask_to_vector in dx11 mirroring

### DIFF
--- a/src/backend/dx11/src/mirror.rs
+++ b/src/backend/dx11/src/mirror.rs
@@ -117,12 +117,12 @@ pub fn populate_info(info: &mut s::ProgramInfo, stage: s::Stage,
         (desc, level)
     };
     fn mask_to_vector(mask: u8) -> s::ContainerType {
-        s::ContainerType::Vector(match mask {
-            0...1 => 1,
-            2...3 => 2,
-            4...7 => 3,
-            _ => 4,
-        })
+        match mask {
+            0...1 => s::ContainerType::Single,
+            2...3 => s::ContainerType::Vector(2),
+            4...7 => s::ContainerType::Vector(3),
+            _ => s::ContainerType::Vector(4),
+        }
     }
     if stage == s::Stage::Vertex {
         // record vertex attributes

--- a/src/render/src/pso/buffer.rs
+++ b/src/render/src/pso/buffer.rs
@@ -139,6 +139,7 @@ fn match_attribute(attr: &shade::AttributeVar, fmt: Format) -> bool {
         (BaseType::F32, ChannelType::Unorm) |
         (BaseType::U32, ChannelType::Uint) => match (attr.container, fmt.0) {
                 (ContainerType::Single, _) |
+                (ContainerType::Vector(1), _) |
                 (ContainerType::Vector(2), _) |
                 (ContainerType::Vector(3), _) |
                 (ContainerType::Vector(4), _) => true,


### PR DESCRIPTION
Also adds addititonal condition in `match_attribute` function to handle `Vector(1)`.

Fixes #1306 