### PR TITLE
[ll] gl: Fix submission, swapchain creation and remove outdated code

### DIFF
--- a/src/backend/gl/src/factory.rs
+++ b/src/backend/gl/src/factory.rs
@@ -511,7 +511,7 @@ impl f::Factory<R> for Factory {
         self.share.handles.borrow_mut().make_sampler(sam, info)
     }
 
-    fn create_semaphore(&mut self) -> () { unimplemented!() }
+    fn create_semaphore(&mut self) -> () { () } // TODO: ?
 
     fn read_mapping<'a, 'b, T>(&'a mut self, buf: &'b handle::Buffer<R, T>)
                                -> Result<mapping::Reader<'b, R, T>,

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -188,15 +188,6 @@ impl Error {
     }
 }
 
-/// Create a new device with a factory.
-pub fn create<F>(fn_proc: F) -> (Device, Factory) where
-    F: FnMut(&str) -> *const std::os::raw::c_void
-{
-    let device = Device::new(fn_proc);
-    let factory = Factory::new(device.share.clone());
-    (device, factory)
-}
-
 /// Create the proxy target views (RTV and DSV) for the attachments of the
 /// main framebuffer. These have GL names equal to 0.
 /// Not supposed to be used by the users directly.
@@ -253,19 +244,16 @@ impl Share {
     }
 }
 
-/// An OpenGL device with GLSL shaders.
-pub struct Device {
+#[allow(missing_copy_implementations)]
+pub struct Adapter {
     share: Rc<Share>,
-    vao: ArrayBuffer,
-    frame_handles: handle::Manager<Resources>,
-    max_resource_count: Option<usize>,
+    adapter_info: c::AdapterInfo,
+    queue_family: Vec<QueueFamily>,
 }
 
-impl Device {
-    /// Create a new device. Each GL context can only have a single
-    /// Device on GFX side to represent it. //TODO: enforce somehow
-    /// Also, load OpenGL symbols and detect driver information.
-    fn new<F>(fn_proc: F) -> Device where
+impl Adapter {
+    #[doc(hidden)]
+    pub fn new<F>(fn_proc: F) -> Self where
         F: FnMut(&str) -> *const std::os::raw::c_void
     {
         let gl = gl::Gl::load_with(fn_proc);
@@ -279,27 +267,14 @@ impl Device {
         for extension in info.extensions.iter() {
             debug!("- {}", *extension);
         }
-        // initialize permanent states
-        if caps.srgb_color_supported {
-            unsafe {
-                gl.Enable(gl::FRAMEBUFFER_SRGB);
-            }
-        }
-        unsafe {
-            gl.PixelStorei(gl::UNPACK_ALIGNMENT, 1);
 
-            if !info.version.is_embedded {
-                gl.Enable(gl::PROGRAM_POINT_SIZE);
-            }
-        }
-        // create main VAO and bind it
-        let mut vao = 0;
-        if private.array_buffer_supported {
-            unsafe {
-                gl.GenVertexArrays(1, &mut vao);
-                gl.BindVertexArray(vao);
-            }
-        }
+        let adapter_info = c::AdapterInfo {
+            name: info.platform_name.renderer.into(),
+            vendor: 0, // TODO
+            device: 0, // TODO
+            software_rendering: true, // not always true ..
+        };
+
         // create the shared context
         let handles = handle::Manager::new();
         let share = Share {
@@ -309,18 +284,66 @@ impl Device {
             private_caps: private,
             handles: RefCell::new(handles),
         };
-        if let Err(err) = share.check() {
-            panic!("Error {:?} after initialization", err)
-        }
-        // create the device
-        Device {
+
+        Adapter {
             share: Rc::new(share),
-            vao: vao,
-            frame_handles: handle::Manager::new(),
-            max_resource_count: Some(999999),
+            adapter_info: adapter_info,
+            queue_family: vec![QueueFamily],
+        }
+    }
+}
+
+impl c::Adapter<Backend> for Adapter {
+    fn open(&self, queue_descs: &[(&QueueFamily, u32)]) -> c::Device_<Backend> {
+        // create main VAO and bind it
+        let mut vao = 0;
+        if self.share.private_caps.array_buffer_supported {
+            let gl = &self.share.context;
+            unsafe {
+                gl.GenVertexArrays(1, &mut vao);
+                gl.BindVertexArray(vao);
+            }
+        }
+
+        let graphics_queue = unsafe {
+            core::GraphicsQueue::new(
+                CommandQueue {
+                    share: self.share.clone(),
+                    vao: vao,
+                    frame_handles: handle::Manager::new(),
+                    max_resource_count: Some(999999),
+                })
+        };
+        c::Device_ {
+            factory: Factory::new(self.share.clone()),
+            general_queues: Vec::new(), // TODO
+            graphics_queues: vec![graphics_queue],
+            compute_queues: Vec::new(),
+            transfer_queues: Vec::new(),
+            heap_types: Vec::new(), // TODO
+            memory_heaps: Vec::new(), // TODO
+
+            _marker: std::marker::PhantomData,
         }
     }
 
+    fn get_info(&self) -> &c::AdapterInfo {
+        &self.adapter_info
+    }
+
+    fn get_queue_families(&self) -> &[QueueFamily] {
+        &self.queue_family
+    }
+}
+
+pub struct CommandQueue {
+    share: Rc<Share>,
+    vao: ArrayBuffer,
+    frame_handles: handle::Manager<Resources>,
+    max_resource_count: Option<usize>,
+}
+
+impl CommandQueue {
     /// Access the OpenGL directly via a closure. OpenGL types and enumerations
     /// can be found in the `gl` crate.
     pub unsafe fn with_gl<F: FnMut(&gl::Gl)>(&mut self, mut fun: F) {
@@ -784,14 +807,12 @@ impl Device {
         }
     }
 
-    /*
-    fn no_fence_submit(&mut self, cb: &mut command::CommandBuffer) {
+    fn no_fence_submit(&mut self, cb: &command::SubmitInfo) {
         self.reset_state();
         for com in &cb.buf {
             self.process(com, &cb.data);
         }
     }
-    */
 
     fn before_submit<'a>(&mut self, gpu_access: &'a com::AccessInfo<Resources>)
                          -> c::SubmissionResult<com::AccessGuard<'a, Resources>> {
@@ -885,16 +906,6 @@ impl Device {
             status.gpu_access(fence.clone());
         }
     }
-}
-
-/*
-impl c::Device for Device {
-    type Resources = Resources;
-    type CommandBuffer = command::CommandBuffer;
-
-    fn get_capabilities(&self) -> &c::Capabilities {
-        &self.share.capabilities
-    }
 
     fn pin_submitted_resources(&mut self, man: &handle::Manager<Resources>) {
         self.frame_handles.extend(man);
@@ -907,37 +918,7 @@ impl c::Device for Device {
         }
     }
 
-    fn submit(&mut self,
-              cb: &mut command::CommandBuffer,
-              access: &com::AccessInfo<Resources>) -> c::SubmissionResult<()>
-    {
-        let mut access = try!(self.before_submit(access));
-        self.no_fence_submit(cb);
-        self.after_submit(&mut access);
-        Ok(())
-    }
-
-    fn fenced_submit(&mut self,
-                     cb: &mut command::CommandBuffer,
-                     access: &com::AccessInfo<Resources>,
-                     after: Option<handle::Fence<Resources>>)
-                     -> c::SubmissionResult<handle::Fence<Resources>> {
-
-        if let Some(fence) = after {
-            let f = self.frame_handles.ref_fence(&fence);
-            let timeout = 1_000_000_000_000;
-            // FIXME: should we use 'glFlush' here ?
-            // see https://www.opengl.org/wiki/Sync_Object
-            unsafe { self.share.context.WaitSync(f.0, 0, timeout); }
-        }
-
-        let mut access = try!(self.before_submit(access));
-        self.no_fence_submit(cb);
-        let fence_opt = self.after_submit(&mut access);
-        Ok(fence_opt.unwrap_or_else(|| self.place_fence()))
-    }
-
-    fn wait_fence(&mut self, fence: &handle::Fence<Self::Resources>) {
+    fn wait_fence(&mut self, fence: &handle::Fence<Resources>) {
         factory::wait_fence(self.frame_handles.ref_fence(&fence),
                             &self.share.context);
     }
@@ -981,90 +962,29 @@ impl c::Device for Device {
         );
     }
 }
-*/
 
-#[allow(missing_copy_implementations)]
-pub struct Adapter {
-    share: Rc<Share>,
-    adapter_info: c::AdapterInfo,
-    queue_family: Vec<QueueFamily>,
-}
-
-impl Adapter {
-    #[doc(hidden)]
-    pub fn new<F>(fn_proc: F) -> Self where
-        F: FnMut(&str) -> *const std::os::raw::c_void
-    {
-        let gl = gl::Gl::load_with(fn_proc);
-        // query information
-        let (info, caps, private) = info::get(&gl);
-        info!("Vendor: {:?}", info.platform_name.vendor);
-        info!("Renderer: {:?}", info.platform_name.renderer);
-        info!("Version: {:?}", info.version);
-        info!("Shading Language: {:?}", info.shading_language);
-        debug!("Loaded Extensions:");
-        for extension in info.extensions.iter() {
-            debug!("- {}", *extension);
-        }
-
-        let adapter_info = c::AdapterInfo {
-            name: info.platform_name.renderer.into(),
-            vendor: 0, // TODO
-            device: 0, // TODO
-            software_rendering: true, // not always true ..
-        };
-
-        // create the shared context
-        let handles = handle::Manager::new();
-        let share = Share {
-            context: gl,
-            info: info,
-            capabilities: caps,
-            private_caps: private,
-            handles: RefCell::new(handles),
-        };
-
-        Adapter {
-            share: Rc::new(share),
-            adapter_info: adapter_info,
-            queue_family: vec![QueueFamily],
-        }
-    }
-}
-
-impl c::Adapter<Backend> for Adapter {
-    fn open(&self, queue_descs: &[(&QueueFamily, u32)]) -> c::Device_<Backend> {
-        c::Device_ {
-            factory: Factory::new(self.share.clone()),
-            general_queues: Vec::new(), // TODO
-            graphics_queues: Vec::new(),
-            compute_queues: Vec::new(),
-            transfer_queues: Vec::new(),
-            heap_types: Vec::new(), // TODO
-            memory_heaps: Vec::new(), // TODO
-
-            _marker: std::marker::PhantomData,
-        }
-    }
-
-    fn get_info(&self) -> &c::AdapterInfo {
-        &self.adapter_info
-    }
-
-    fn get_queue_families(&self) -> &[QueueFamily] {
-        &self.queue_family
-    }
-}
-
-#[allow(missing_copy_implementations)]
-pub struct CommandQueue;
 impl c::CommandQueue<Backend> for CommandQueue {
     unsafe fn submit(&mut self, submit_infos: &[c::QueueSubmit<Backend>], fence: Option<&mut Fence>) {
-        unimplemented!()
+        if let Some(fence) = fence {
+            let timeout = 1_000_000_000_000;
+            // FIXME: should we use 'glFlush' here ?
+            // see https://www.opengl.org/wiki/Sync_Object
+            unsafe { self.share.context.WaitSync(fence.0, 0, timeout); }
+        }
+
+        // TODO
+        // let mut access = try!(self.before_submit(access));
+        for submit in submit_infos {
+            for cb in submit.cmd_buffers {
+                self.no_fence_submit(cb.get_info());
+            }
+        }
+        // let fence_opt = self.after_submit(&mut access);
     }
 
     fn wait_idle(&mut self) {
-        unimplemented!()
+        let gl = &self.share.context;
+        unsafe { gl.Finish() }; // TODO: we need to finish?
     }
 }
 

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -272,7 +272,7 @@ pub trait Resources:          Clone + Hash + Debug + Eq + PartialEq + Any {
 }
 
 /*
-/// Different resource types of a specific API. 
+/// Different resource types of a specific API.
 pub trait Resources:          Clone + Hash + Debug + Any {
     type ShaderLib:           Debug + Any + Send + Sync;
     type RenderPass:          Debug + Any + Send + Sync;
@@ -329,7 +329,7 @@ impl Error for SubmissionError {
 #[allow(missing_docs)]
 pub type SubmissionResult<T> = Result<T, SubmissionError>;
 
-/// 
+///
 pub struct Device_<B: Backend> {
     /// Resource factory.
     pub factory: B::Factory,
@@ -399,7 +399,7 @@ pub struct QueueSubmit<'a, B: Backend + 'a> {
 pub trait CommandQueue<B: Backend> {
     /// Submit command buffers to queue for execution.
     unsafe fn submit(&mut self, submit_infos: &[QueueSubmit<B>], fence: Option<&mut <B::Resources as Resources>::Fence>);
-    
+
     ///
     fn wait_idle(&mut self);
 }
@@ -424,8 +424,8 @@ pub trait Surface<B: Backend> {
     /// Check if the queue family supports presentation for this surface.
     fn supports_queue(&self, queue_family: &B::QueueFamily) -> bool;
 
-    /// 
-    fn build_swapchain<Q>(&self, config: SwapchainConfig, present_queue: &Q) -> Self::SwapChain
+    ///
+    fn build_swapchain<Q>(&mut self, config: SwapchainConfig, present_queue: &Q) -> Self::SwapChain
         where Q: AsRef<B::CommandQueue>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ A: Sized + Application<gfx_device_metal::Backend>
 
 fn run<A, B, S, EL>((width, height): (u32, u32),
                     events_loop: EL,
-                    surface: S,
+                    mut surface: S,
                     adapters: Vec<B::Adapter>)
     where A: Sized + Application<B>,
           B: Backend,

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -29,117 +29,11 @@ use std::borrow::Borrow;
 #[cfg(feature = "headless")]
 mod headless;
 
-/// Initialize with a window builder.
-/// Generically parametrized version over the main framebuffer format.
-///
-/// # Example
-///
-/// ```no_run
-/// extern crate gfx_core;
-/// extern crate gfx_device_gl;
-/// extern crate gfx_window_glutin;
-/// extern crate glutin;
-///
-/// use gfx_core::format::{DepthStencil, Rgba8};
-///
-/// fn main() {
-///     let events_loop = glutin::EventsLoop::new();
-///     let builder = glutin::WindowBuilder::new().with_title("Example".to_string());
-///     let (window, device, factory, rtv, stv) =
-///         gfx_window_glutin::init::<Rgba8, DepthStencil>(builder, &events_loop);
-///
-///     // your code
-/// }
-/// ```
-pub fn init<Cf, Df>(builder: glutin::WindowBuilder, events_loop: &glutin::EventsLoop) ->
-            (glutin::Window, device_gl::Device, device_gl::Factory,
-            handle::RenderTargetView<R, Cf>, handle::DepthStencilView<R, Df>)
-where
-    Cf: format::RenderFormat,
-    Df: format::DepthFormat,
-{
-    let (window, device, factory, color_view, ds_view) = init_raw(builder, events_loop, Cf::get_format(), Df::get_format());
-    (window, device, factory, Typed::new(color_view), Typed::new(ds_view))
-}
-
-/// Initialize with an existing Glutin window.
-/// Generically parametrized version over the main framebuffer format.
-///
-/// # Example (using Piston to create the window)
-///
-/// ```rust,ignore
-/// extern crate piston;
-/// extern crate glutin_window;
-/// extern crate gfx_window_glutin;
-///
-/// // Create window with Piston
-/// let settings = piston::window::WindowSettings::new("Example", [800, 600]);
-/// let mut glutin_window = glutin_window::GlutinWindow::new(&settings).unwrap();
-///
-/// // Initialise gfx
-/// let (mut device, mut factory, main_color, main_depth) =
-///     gfx_window_glutin::init_existing::<ColorFormat, DepthFormat>(&glutin_window.window);
-///
-/// let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
-/// ```
-pub fn init_existing<Cf, Df>(window: &glutin::Window) ->
-            (device_gl::Device, device_gl::Factory,
-            handle::RenderTargetView<R, Cf>, handle::DepthStencilView<R, Df>)
-where
-    Cf: format::RenderFormat,
-    Df: format::DepthFormat,
-{
-    let (device, factory, color_view, ds_view) = init_existing_raw(window, Cf::get_format(), Df::get_format());
-    (device, factory, Typed::new(color_view), Typed::new(ds_view))
-}
-
 fn get_window_dimensions(window: &glutin::Window) -> texture::Dimensions {
     let (width, height) = window.get_inner_size().unwrap();
     let aa = window.get_pixel_format().multisampling
                    .unwrap_or(0) as texture::NumSamples;
     ((width as f32 * window.hidpi_factor()) as texture::Size, (height as f32 * window.hidpi_factor()) as texture::Size, 1, aa.into())
-}
-
-/// Initialize with a window builder. Raw version.
-pub fn init_raw(builder: glutin::WindowBuilder, events_loop: &glutin::EventsLoop,
-                color_format: format::Format, ds_format: format::Format) ->
-                (glutin::Window, device_gl::Device, device_gl::Factory,
-                handle::RawRenderTargetView<R>, handle::RawDepthStencilView<R>)
-{
-    let window = {
-        let color_total_bits = color_format.0.get_total_bits();
-        let alpha_bits = color_format.0.get_alpha_stencil_bits();
-        let depth_total_bits = ds_format.0.get_total_bits();
-        let stencil_bits = ds_format.0.get_alpha_stencil_bits();
-        builder
-            .with_depth_buffer(depth_total_bits - stencil_bits)
-            .with_stencil_buffer(stencil_bits)
-            .with_pixel_format(color_total_bits - alpha_bits, alpha_bits)
-            .with_srgb(Some(color_format.1 == format::ChannelType::Srgb))
-            .build(events_loop)
-    }.unwrap();
-
-    let (device, factory, color_view, ds_view) = init_existing_raw(&window, color_format, ds_format);
-
-    (window, device, factory, color_view, ds_view)
-}
-
-/// Initialize with an existing Glutin window. Raw version.
-pub fn init_existing_raw(window: &glutin::Window,
-                color_format: format::Format, ds_format: format::Format) ->
-                (device_gl::Device, device_gl::Factory,
-                handle::RawRenderTargetView<R>, handle::RawDepthStencilView<R>)
-{
-    unsafe { window.make_current().unwrap() };
-    let (device, factory) = device_gl::create(|s|
-        window.get_proc_address(s) as *const std::os::raw::c_void);
-
-    // create the main color/depth targets
-    let dim = get_window_dimensions(window);
-    let (color_view, ds_view) = device_gl::create_main_targets_raw(dim, color_format.0, ds_format.0);
-
-    // done
-    (device, factory, color_view, ds_view)
 }
 
 /// Update the internal dimensions of the main framebuffer targets. Generic version over the format.
@@ -170,19 +64,6 @@ pub fn update_views_raw(window: &glutin::Window, old_dimensions: texture::Dimens
     }
 }
 
-/// Create new main target views based on the current size of the window.
-/// Best called just after a WindowResize event.
-pub fn new_views<Cf, Df>(window: &glutin::Window)
-        -> (handle::RenderTargetView<R, Cf>, handle::DepthStencilView<R, Df>) where
-    Cf: format::RenderFormat,
-    Df: format::DepthFormat,
-{
-    let dim = get_window_dimensions(window);
-    let (color_view_raw, depth_view_raw) =
-        device_gl::create_main_targets_raw(dim, Cf::get_format().0, Df::get_format().0);
-    (Typed::new(color_view_raw), Typed::new(depth_view_raw))
-}
-
 pub struct SwapChain<'a> {
     // Underlying window, required for presentation
     window: &'a glutin::Window,
@@ -209,19 +90,19 @@ impl<'a> core::SwapChain<device_gl::Backend> for SwapChain<'a> {
 
 pub struct Surface<'a> {
     window: &'a glutin::Window,
+    manager: handle::Manager<R>,
 }
 
 impl<'a> core::Surface<device_gl::Backend> for Surface<'a> {
     type SwapChain = SwapChain<'a>;
 
     fn supports_queue(&self, queue_family: &device_gl::QueueFamily) -> bool { true }
-    fn build_swapchain<Q>(&self, config: core::SwapchainConfig, present_queue: &Q) -> SwapChain<'a>
+    fn build_swapchain<Q>(&mut self, config: core::SwapchainConfig, present_queue: &Q) -> SwapChain<'a>
         where Q: AsRef<device_gl::CommandQueue>
     {
         use core::handle::Producer;
         let dim = get_window_dimensions(self.window);
-        let mut temp = handle::Manager::new();
-        let backbuffer = temp.make_texture(
+        let color = self.manager.make_texture(
             device_gl::NewTexture::Surface(0),
             texture::Info {
                 levels: 1,
@@ -232,11 +113,22 @@ impl<'a> core::Surface<device_gl::Backend> for Surface<'a> {
             },
         );
 
-        // TODO: depth stencil
+        let ds = config.depth_stencil_format.map(|ds_format| {
+            self.manager.make_texture(
+                device_gl::NewTexture::Surface(0),
+                texture::Info {
+                    levels: 1,
+                    kind: texture::Kind::D2(dim.0, dim.1, dim.3),
+                    format: ds_format.0,
+                    bind: memory::DEPTH_STENCIL | memory::TRANSFER_SRC,
+                    usage: memory::Usage::Data,
+                },
+            )
+        });
 
         SwapChain {
             window: self.window,
-            backbuffer: [(backbuffer, None); 1],
+            backbuffer: [(color, ds); 1],
         }
     }
 }
@@ -265,7 +157,10 @@ impl<'a> core::WindowExt<device_gl::Backend> for Window<'a> {
     fn get_surface_and_adapters(&mut self) -> (Surface<'a>, Vec<device_gl::Adapter>) {
         unsafe { self.0.make_current().unwrap() };
         let adapter = device_gl::Adapter::new(|s| self.0.get_proc_address(s) as *const std::os::raw::c_void);
-        let surface = Surface { window: self.0 };
+        let surface = Surface {
+            window: self.0,
+            manager: handle::Manager::new(),
+        };
 
         (surface, vec![adapter])
     }


### PR DESCRIPTION
_Note: Generated diff doesn't reflect the changes very well unfortunately!_

* Fix depth stencil view image creation for app
* Create a `GraphicsQueue` on adapter open
* Add command dispatching on queue submission (based on the old device submit code).

The queue submission part will be fixed on a follow-up PR (if interested see https://github.com/msiglreith/gfx/commit/e689f33eb63fdc9cf7298c1e18d9b453426366b2) to match the current device submission code on master better.