### PR TITLE
Add Resource trait for generic resource destruction

### DIFF
--- a/src/backend/dx12ll/src/factory.rs
+++ b/src/backend/dx12ll/src/factory.rs
@@ -459,6 +459,10 @@ impl core::Factory<R> for Factory {
         unimplemented!()
     }
 
+    fn destroy_depth_stencil_view(&mut self, dsv: native::DepthStencilView) {
+        unimplemented!()
+    }
+
     fn destroy_constant_buffer_view(&mut self, _: native::ConstantBufferView) {
         unimplemented!()
     }

--- a/src/backend/dx12ll/src/lib.rs
+++ b/src/backend/dx12ll/src/lib.rs
@@ -19,6 +19,7 @@ extern crate d3d12;
 extern crate d3dcompiler;
 extern crate dxgi;
 extern crate dxguid;
+#[macro_use]
 extern crate gfx_corell as core;
 extern crate winapi;
 extern crate winit;

--- a/src/backend/dx12ll/src/native.rs
+++ b/src/backend/dx12ll/src/native.rs
@@ -138,3 +138,5 @@ pub struct DescriptorSet {
 #[derive(Debug)]
 pub struct DescriptorSetLayout {
 }
+
+gfx_impl_resources!();

--- a/src/backend/metalll/src/factory.rs
+++ b/src/backend/metalll/src/factory.rs
@@ -473,6 +473,10 @@ impl core::Factory<Resources> for Factory {
         unsafe { view.0.release(); }
     }
 
+    fn destroy_depth_stencil_view(&mut self, view: DepthStencilView) {
+        unsafe { view.0.release(); }
+    }
+
     fn destroy_constant_buffer_view(&mut self, view: ConstantBufferView) {
         unimplemented!()
     }

--- a/src/backend/metalll/src/lib.rs
+++ b/src/backend/metalll/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate gfx_corell as core;
+#[macro_use] extern crate gfx_corell as core;
 extern crate winit;
 extern crate cocoa;
 #[macro_use] extern crate objc;

--- a/src/backend/metalll/src/native.rs
+++ b/src/backend/metalll/src/native.rs
@@ -235,6 +235,8 @@ mod fence_related {
     pub struct Fence {}
 }
 
+gfx_impl_resources!();
+
 pub unsafe fn objc_err_description(object: *mut objc::runtime::Object) -> String {
     let description: *mut objc::runtime::Object = msg_send![object, localizedDescription];
     let utf16_len: NSUInteger = msg_send![description, length];

--- a/src/backend/vulkanll/src/factory.rs
+++ b/src/backend/vulkanll/src/factory.rs
@@ -1274,6 +1274,10 @@ impl core::Factory<R> for Factory {
         unsafe { self.inner.0.destroy_image_view(rtv.view, None); }
     }
 
+    fn destroy_depth_stencil_view(&mut self, dsv: native::DepthStencilView) {
+        unsafe { self.inner.0.destroy_image_view(dsv.view, None); }
+    }
+
     fn destroy_constant_buffer_view(&mut self, _: native::ConstantBufferView) { }
 
     fn destroy_shader_resource_view(&mut self, srv: native::ShaderResourceView) {

--- a/src/backend/vulkanll/src/lib.rs
+++ b/src/backend/vulkanll/src/lib.rs
@@ -16,6 +16,7 @@
 extern crate log;
 
 extern crate ash;
+#[macro_use]
 extern crate gfx_corell as core;
 #[macro_use]
 extern crate lazy_static;

--- a/src/backend/vulkanll/src/native.rs
+++ b/src/backend/vulkanll/src/native.rs
@@ -168,3 +168,5 @@ pub struct Semaphore(pub vk::Semaphore);
 
 #[derive(Debug)]
 pub struct Fence(pub vk::Fence);
+
+gfx_impl_resources!();

--- a/src/corell/src/factory.rs
+++ b/src/corell/src/factory.rs
@@ -273,6 +273,9 @@ pub trait Factory<R: Resources> {
     fn destroy_render_target_view(&mut self, R::RenderTargetView);
 
     ///
+    fn destroy_depth_stencil_view(&mut self, R::DepthStencilView);
+
+    ///
     fn destroy_constant_buffer_view(&mut self, R::ConstantBufferView);
 
     ///

--- a/src/corell/src/lib.rs
+++ b/src/corell/src/lib.rs
@@ -261,30 +261,30 @@ pub trait SwapChain {
 
 /// Different resource types of a specific API. 
 pub trait Resources:          Clone + Hash + Debug + Any {
-    type ShaderLib:           Debug + Any + Send + Sync + Resource<Self>;
-    type RenderPass:          Debug + Any + Send + Sync + Resource<Self>;
-    type PipelineLayout:      Debug + Any + Send + Sync + Resource<Self>;
-    type GraphicsPipeline:    Debug + Any + Send + Sync + Resource<Self>;
-    type ComputePipeline:     Debug + Any + Send + Sync + Resource<Self>;
+    type ShaderLib:           Send + Sync + Resource<Self>;
+    type RenderPass:          Send + Sync + Resource<Self>;
+    type PipelineLayout:      Send + Sync + Resource<Self>;
+    type GraphicsPipeline:    Send + Sync + Resource<Self>;
+    type ComputePipeline:     Send + Sync + Resource<Self>;
     type UnboundBuffer:       Debug + Any + Send + Sync;
-    type Buffer:              Debug + Any + Send + Sync + Resource<Self>;
+    type Buffer:              Send + Sync + Resource<Self>;
     type UnboundImage:        Debug + Any + Send + Sync;
-    type Image:               Debug + Any + Send + Sync + Resource<Self>;
-    type ConstantBufferView:  Debug + Any + Send + Sync + Resource<Self>;
-    type ShaderResourceView:  Debug + Any + Send + Sync + Resource<Self>;
-    type UnorderedAccessView: Debug + Any + Send + Sync + Resource<Self>;
-    type RenderTargetView:    Debug + Any + Send + Sync + Resource<Self>;
-    type DepthStencilView:    Debug + Any + Send + Sync + Resource<Self>;
-    type FrameBuffer:         Debug + Any + Send + Sync + Resource<Self>;
-    type Sampler:             Debug + Any + Send + Sync + Resource<Self>;
-    type Semaphore:           Debug + Any + Send + Sync + Resource<Self>;
-    type Fence:               Debug + Any + Send + Sync + Resource<Self>;
-    type Heap:                Debug + Any + Resource<Self>;
+    type Image:               Send + Sync + Resource<Self>;
+    type ConstantBufferView:  Send + Sync + Resource<Self>;
+    type ShaderResourceView:  Send + Sync + Resource<Self>;
+    type UnorderedAccessView: Send + Sync + Resource<Self>;
+    type RenderTargetView:    Send + Sync + Resource<Self>;
+    type DepthStencilView:    Send + Sync + Resource<Self>;
+    type FrameBuffer:         Send + Sync + Resource<Self>;
+    type Sampler:             Send + Sync + Resource<Self>;
+    type Semaphore:           Send + Sync + Resource<Self>;
+    type Fence:               Send + Sync + Resource<Self>;
+    type Heap:                Resource<Self>;
     type Mapping;
-    type DescriptorHeap:      Debug + Any + Resource<Self>;
-    type DescriptorSetPool:   Debug + Any + Resource<Self>;
+    type DescriptorHeap:      Resource<Self>;
+    type DescriptorSetPool:   Resource<Self>;
     type DescriptorSet:       Debug + Any;
-    type DescriptorSetLayout: Debug + Any + Resource<Self>;
+    type DescriptorSetLayout: Resource<Self>;
 }
 
 pub trait Resource<R: Resources>: Debug + Any {


### PR DESCRIPTION
I'm not sure if this is something that others want/need but I was playing around with it and thought I'd put it up for comments.

Adds a trait Resource implemented by all Resources associated types that have a destroy_* method in corell::Factory. This makes it much easier to write abstractions/macros for cleanup that work over multiple resource types. DepthStencilView also appeared to be missing a corresponding method in Factory so I added one.

This functionality is basically impossible to implement on top of corell due to coherency issues; any implementations of a trait for both Resources::X and Resources::Y will be marked as conflicting even if they never do in actuality.