### PR TITLE
[ll] dx11: Implement necessary pieces for cube demo

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -34,6 +34,5 @@ d3d11-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx
 d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-winapi = "0.2.8"
+winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
-lazy_static = "0.2"

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -30,7 +30,10 @@ name = "gfx_device_dx11"
 [dependencies]
 log = "0.3"
 gfx_core = { path = "../../core", version = "0.7" }
-d3d11-sys = "0.2"
-d3dcompiler-sys = "0.2"
-dxguid-sys = "0.2"
+d3d11-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
+d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
+dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
+dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 winapi = "0.2.8"
+comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
+lazy_static = "0.2"

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -30,9 +30,9 @@ name = "gfx_device_dx11"
 [dependencies]
 log = "0.3"
 gfx_core = { path = "../../core", version = "0.7" }
-d3d11-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
+d3d11-sys = "0.2"
+d3dcompiler-sys = "0.2"
+dxgi-sys = "0.2"
+dxguid-sys = "0.2"
+winapi = "0.2"
 comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }

--- a/src/backend/dx11/src/command.rs
+++ b/src/backend/dx11/src/command.rs
@@ -24,9 +24,11 @@ use core::{IndexType, VertexCount};
 use core::{MAX_VERTEX_ATTRIBUTES, MAX_CONSTANT_BUFFERS,
            MAX_RESOURCE_VIEWS, MAX_UNORDERED_VIEWS,
            MAX_SAMPLERS, MAX_COLOR_TARGETS};
-use {native, Backend, Resources, InputLayout, Buffer, Texture, Pipeline, Program};
+use {native, Backend, CommandList, Resources, InputLayout, Buffer, Texture, Pipeline, Program};
 
-pub struct SubmitInfo;
+pub struct SubmitInfo<P> {
+    pub parser: P,
+}
 
 /// The place of some data in the data buffer.
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -35,6 +37,7 @@ pub struct DataPointer {
     size: u32,
 }
 
+#[derive(Clone)]
 pub struct DataBuffer(Vec<u8>);
 impl DataBuffer {
     /// Create a new empty data buffer.
@@ -121,9 +124,11 @@ pub struct RawCommandBuffer<P> {
     cache: Cache,
 }
 
-impl<P> command::CommandBuffer<Backend> for RawCommandBuffer<P> {
-    unsafe fn end(&mut self) -> SubmitInfo {
-        SubmitInfo
+impl command::CommandBuffer<Backend> for RawCommandBuffer<CommandList> {
+    unsafe fn end(&mut self) -> SubmitInfo<CommandList> {
+        SubmitInfo {
+            parser: self.parser.clone(), // TODO: slow
+        }
     }
 }
 pub trait Parser: Sized + Send {
@@ -403,12 +408,14 @@ impl<P: Parser> command::Buffer<Resources> for RawCommandBuffer<P> {
     }
 }
 
-pub struct SubpassCommandBuffer {
-
+pub struct SubpassCommandBuffer<P> {
+    parser: P,
 }
 
-impl command::CommandBuffer<Backend> for SubpassCommandBuffer {
-    unsafe fn end(&mut self) -> SubmitInfo {
-        SubmitInfo
+impl command::CommandBuffer<Backend> for SubpassCommandBuffer<CommandList> {
+    unsafe fn end(&mut self) -> SubmitInfo<CommandList> {
+        SubmitInfo {
+            parser: self.parser.clone(), // TODO: slow
+        }
     }
 }

--- a/src/backend/dx11/src/execute.rs
+++ b/src/backend/dx11/src/execute.rs
@@ -17,8 +17,9 @@ use winapi::{self, UINT};
 use core::{self, texture as tex};
 use command;
 use {Buffer, Texture};
+use comptr::ComPtr;
 
-fn copy_buffer(context: *mut winapi::ID3D11DeviceContext,
+fn copy_buffer(context: &mut ComPtr<winapi::ID3D11DeviceContext>,
                src: &Buffer, dst: &Buffer,
                src_offset: UINT, dst_offset: UINT,
                size: UINT) {
@@ -33,12 +34,12 @@ fn copy_buffer(context: *mut winapi::ID3D11DeviceContext,
         back: 1,
     };
     unsafe {
-        (*context).CopySubresourceRegion(dst_resource, 0, dst_offset, 0, 0,
+        context.CopySubresourceRegion(dst_resource, 0, dst_offset, 0, 0,
                                          src_resource, 0, &src_box)
     };
 }
 
-pub fn update_buffer(context: *mut winapi::ID3D11DeviceContext, buffer: &Buffer,
+pub fn update_buffer(context: &mut ComPtr<winapi::ID3D11DeviceContext>, buffer: &Buffer,
                      data: &[u8], offset_bytes: usize) {
     let dst_resource = (buffer.0).0 as *mut winapi::ID3D11Resource;
 
@@ -46,10 +47,10 @@ pub fn update_buffer(context: *mut winapi::ID3D11DeviceContext, buffer: &Buffer,
     let map_type = winapi::D3D11_MAP_WRITE_DISCARD;
     let hr = unsafe {
         let mut sub = mem::zeroed();
-        let hr = (*context).Map(dst_resource, 0, map_type, 0, &mut sub);
+        let hr = context.Map(dst_resource, 0, map_type, 0, &mut sub);
         let dst = (sub.pData as *mut u8).offset(offset_bytes as isize);
         ptr::copy_nonoverlapping(data.as_ptr(), dst, data.len());
-        (*context).Unmap(dst_resource, 0);
+        context.Unmap(dst_resource, 0);
         hr
     };
     if !winapi::SUCCEEDED(hr) {
@@ -57,7 +58,7 @@ pub fn update_buffer(context: *mut winapi::ID3D11DeviceContext, buffer: &Buffer,
     }
 }
 
-pub fn update_texture(context: *mut winapi::ID3D11DeviceContext, texture: &Texture, kind: tex::Kind,
+pub fn update_texture(context: &mut ComPtr<winapi::ID3D11DeviceContext>, texture: &Texture, kind: tex::Kind,
                       face: Option<tex::CubeFace>, data: &[u8], image: &tex::RawImageInfo) {
     let subres = texture_subres(face, image);
     let dst_resource = texture.as_resource();
@@ -73,10 +74,10 @@ pub fn update_texture(context: *mut winapi::ID3D11DeviceContext, texture: &Textu
     let map_type = winapi::D3D11_MAP_WRITE_DISCARD;
     let hr = unsafe {
         let mut sub = mem::zeroed();
-        let hr = (*context).Map(dst_resource, subres, map_type, 0, &mut sub);
+        let hr = context.Map(dst_resource, subres, map_type, 0, &mut sub);
         let dst = (sub.pData as *mut u8).offset(offset_bytes as isize);
         ptr::copy_nonoverlapping(data.as_ptr(), dst, data.len());
-        (*context).Unmap(dst_resource, 0);
+        context.Unmap(dst_resource, 0);
         hr
     };
     if !winapi::SUCCEEDED(hr) {
@@ -100,7 +101,7 @@ fn texture_subres(face: Option<tex::CubeFace>, image: &tex::RawImageInfo) -> win
     array_slice * num_mipmap_levels + (image.mipmap as UINT)
 }
 
-pub fn process(ctx: *mut winapi::ID3D11DeviceContext, command: &command::Command, data_buf: &command::DataBuffer) {
+pub fn process(ctx: &mut ComPtr<winapi::ID3D11DeviceContext>, command: &command::Command, data_buf: &command::DataBuffer) {
     use winapi::UINT;
     use core::shade::Stage;
     use command::Command::*;
@@ -111,94 +112,94 @@ pub fn process(ctx: *mut winapi::ID3D11DeviceContext, command: &command::Command
     debug!("Processing {:?}", command);
     match *command {
         BindProgram(ref prog) => unsafe {
-            (*ctx).VSSetShader(prog.vs, ptr::null_mut(), 0);
-            (*ctx).HSSetShader(prog.hs, ptr::null_mut(), 0);
-            (*ctx).DSSetShader(prog.ds, ptr::null_mut(), 0);
-            (*ctx).GSSetShader(prog.gs, ptr::null_mut(), 0);
-            (*ctx).PSSetShader(prog.ps, ptr::null_mut(), 0);
+            ctx.VSSetShader(prog.vs, ptr::null_mut(), 0);
+            ctx.HSSetShader(prog.hs, ptr::null_mut(), 0);
+            ctx.DSSetShader(prog.ds, ptr::null_mut(), 0);
+            ctx.GSSetShader(prog.gs, ptr::null_mut(), 0);
+            ctx.PSSetShader(prog.ps, ptr::null_mut(), 0);
         },
         BindInputLayout(layout) => unsafe {
-            (*ctx).IASetInputLayout(layout);
+            ctx.IASetInputLayout(layout);
         },
         BindIndex(ref buf, format) => unsafe {
-            (*ctx).IASetIndexBuffer((buf.0).0, format, 0);
+            ctx.IASetIndexBuffer((buf.0).0, format, 0);
         },
         BindVertexBuffers(ref buffers, ref strides, ref offsets) => unsafe {
-            (*ctx).IASetVertexBuffers(0, core::MAX_VERTEX_ATTRIBUTES as UINT,
+            ctx.IASetVertexBuffers(0, core::MAX_VERTEX_ATTRIBUTES as UINT,
                 &buffers[0].0, strides.as_ptr(), offsets.as_ptr());
         },
         BindConstantBuffers(stage, ref buffers) => match stage {
             Stage::Vertex => unsafe {
-                (*ctx).VSSetConstantBuffers(0, max_cb, &buffers[0].0);
+                ctx.VSSetConstantBuffers(0, max_cb, &buffers[0].0);
             },
             Stage::Hull => unsafe {
-                (*ctx).HSSetConstantBuffers(0, max_cb, &buffers[0].0);
+                ctx.HSSetConstantBuffers(0, max_cb, &buffers[0].0);
             },
             Stage::Domain => unsafe {
-                (*ctx).DSSetConstantBuffers(0, max_cb, &buffers[0].0);
+                ctx.DSSetConstantBuffers(0, max_cb, &buffers[0].0);
             },
             Stage::Geometry => unsafe {
-                (*ctx).GSSetConstantBuffers(0, max_cb, &buffers[0].0);
+                ctx.GSSetConstantBuffers(0, max_cb, &buffers[0].0);
             },
             Stage::Pixel => unsafe {
-                (*ctx).PSSetConstantBuffers(0, max_cb, &buffers[0].0);
+                ctx.PSSetConstantBuffers(0, max_cb, &buffers[0].0);
             },
         },
         BindShaderResources(stage, ref views) => match stage {
             Stage::Vertex => unsafe {
-                (*ctx).VSSetShaderResources(0, max_srv, &views[0].0);
+                ctx.VSSetShaderResources(0, max_srv, &views[0].0);
             },
             Stage::Hull => unsafe {
-                (*ctx).HSSetShaderResources(0, max_srv, &views[0].0);
+                ctx.HSSetShaderResources(0, max_srv, &views[0].0);
             },
             Stage::Domain => unsafe {
-                (*ctx).DSSetShaderResources(0, max_srv, &views[0].0);
+                ctx.DSSetShaderResources(0, max_srv, &views[0].0);
             },
             Stage::Geometry => unsafe {
-                (*ctx).GSSetShaderResources(0, max_srv, &views[0].0);
+                ctx.GSSetShaderResources(0, max_srv, &views[0].0);
             },
             Stage::Pixel => unsafe {
-                (*ctx).PSSetShaderResources(0, max_srv, &views[0].0);
+                ctx.PSSetShaderResources(0, max_srv, &views[0].0);
             },
         },
         BindSamplers(stage, ref samplers) => match stage {
             Stage::Vertex => unsafe {
-                (*ctx).VSSetSamplers(0, max_sm, &samplers[0].0);
+                ctx.VSSetSamplers(0, max_sm, &samplers[0].0);
             },
             Stage::Hull => unsafe {
-                (*ctx).HSSetSamplers(0, max_sm, &samplers[0].0);
+                ctx.HSSetSamplers(0, max_sm, &samplers[0].0);
             },
             Stage::Domain => unsafe {
-                (*ctx).DSSetSamplers(0, max_sm, &samplers[0].0);
+                ctx.DSSetSamplers(0, max_sm, &samplers[0].0);
             },
             Stage::Geometry => unsafe {
-                (*ctx).GSSetSamplers(0, max_sm, &samplers[0].0);
+                ctx.GSSetSamplers(0, max_sm, &samplers[0].0);
             },
             Stage::Pixel => unsafe {
-                (*ctx).PSSetSamplers(0, max_sm, &samplers[0].0);
+                ctx.PSSetSamplers(0, max_sm, &samplers[0].0);
             },
         },
         BindPixelTargets(ref colors, ds) => unsafe {
-            (*ctx).OMSetRenderTargets(core::MAX_COLOR_TARGETS as UINT,
+            ctx.OMSetRenderTargets(core::MAX_COLOR_TARGETS as UINT,
                 &colors[0].0, ds.0);
         },
         SetPrimitive(topology) => unsafe {
-            (*ctx).IASetPrimitiveTopology(topology);
+            ctx.IASetPrimitiveTopology(topology);
         },
         SetViewport(ref viewport) => unsafe {
-            (*ctx).RSSetViewports(1, viewport);
+            ctx.RSSetViewports(1, viewport);
         },
         SetScissor(ref rect) => unsafe {
-            (*ctx).RSSetScissorRects(1, rect);
+            ctx.RSSetScissorRects(1, rect);
         },
         SetRasterizer(rast) => unsafe {
-            (*ctx).RSSetState(rast as *mut _);
+            ctx.RSSetState(rast as *mut _);
         },
         SetDepthStencil(ds, value) => unsafe {
-            (*ctx).OMSetDepthStencilState(ds as *mut _, value);
+            ctx.OMSetDepthStencilState(ds as *mut _, value);
         },
         SetBlend(blend, ref value, mask) => unsafe {
-            (*ctx).OMSetBlendState(blend as *mut _, value, mask);
+            ctx.OMSetBlendState(blend as *mut _, value, mask);
         },
         CopyBuffer(ref src, ref dst, src_offset, dst_offset, size) => {
             copy_buffer(ctx, src, dst, src_offset, dst_offset, size);
@@ -212,25 +213,25 @@ pub fn process(ctx: *mut winapi::ID3D11DeviceContext, command: &command::Command
             update_texture(ctx, tex, kind, face, data, image);
         },
         GenerateMips(ref srv) => unsafe {
-            (*ctx).GenerateMips(srv.0);
+            ctx.GenerateMips(srv.0);
         },
         ClearColor(target, ref data) => unsafe {
-            (*ctx).ClearRenderTargetView(target.0, data);
+            ctx.ClearRenderTargetView(target.0, data);
         },
         ClearDepthStencil(target, flags, depth, stencil) => unsafe {
-            (*ctx).ClearDepthStencilView(target.0, flags.0, depth, stencil);
+            ctx.ClearDepthStencilView(target.0, flags.0, depth, stencil);
         },
         Draw(nvert, svert) => unsafe {
-            (*ctx).Draw(nvert, svert);
+            ctx.Draw(nvert, svert);
         },
         DrawInstanced(nvert, ninst, svert, sinst) => unsafe {
-            (*ctx).DrawInstanced(nvert, ninst, svert, sinst);
+            ctx.DrawInstanced(nvert, ninst, svert, sinst);
         },
         DrawIndexed(nind, svert, base) => unsafe {
-            (*ctx).DrawIndexed(nind, svert, base);
+            ctx.DrawIndexed(nind, svert, base);
         },
         DrawIndexedInstanced(nind, ninst, sind, base, sinst) => unsafe {
-            (*ctx).DrawIndexedInstanced(nind, ninst, sind, base, sinst);
+            ctx.DrawIndexedInstanced(nind, ninst, sind, base, sinst);
         },
     }
 }

--- a/src/backend/dx11/src/factory.rs
+++ b/src/backend/dx11/src/factory.rs
@@ -910,7 +910,7 @@ impl core::Factory<R> for Factory {
         }
     }
 
-    fn create_semaphore(&mut self) -> () { unimplemented!() }
+    fn create_semaphore(&mut self) -> () { () }
 
     fn read_mapping<'a, 'b, T>(&'a mut self, buf: &'b h::Buffer<R, T>)
                                -> Result<mapping::Reader<'b, R, T>,
@@ -971,11 +971,11 @@ pub fn ensure_mapped(mapping: &mut MappingGate,
 
 pub fn ensure_unmapped(mapping: &mut MappingGate,
                        buffer: &buffer::Raw<R>,
-                       context: *mut winapi::ID3D11DeviceContext) {
+                       context: &mut ComPtr<winapi::ID3D11DeviceContext>) {
     if !mapping.pointer.is_null() {
         let raw_handle = *buffer.resource();
         unsafe {
-            (*context).Unmap(raw_handle.as_resource() as *mut winapi::d3d11::ID3D11Resource, 0);
+            context.Unmap(raw_handle.as_resource() as *mut winapi::d3d11::ID3D11Resource, 0);
         }
 
         mapping.pointer = ptr::null_mut();

--- a/src/backend/dx11/src/native.rs
+++ b/src/backend/dx11/src/native.rs
@@ -1,0 +1,49 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use winapi::*;
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Buffer(pub *mut ID3D11Buffer);
+unsafe impl Send for Buffer {}
+unsafe impl Sync for Buffer {}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum Texture {
+    D1(*mut ID3D11Texture1D),
+    D2(*mut ID3D11Texture2D),
+    D3(*mut ID3D11Texture3D),
+}
+unsafe impl Send for Texture {}
+unsafe impl Sync for Texture {}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Rtv(pub *mut ID3D11RenderTargetView);
+unsafe impl Send for Rtv {}
+unsafe impl Sync for Rtv {}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Dsv(pub *mut ID3D11DepthStencilView);
+unsafe impl Send for Dsv {}
+unsafe impl Sync for Dsv {}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Srv(pub *mut ID3D11ShaderResourceView);
+unsafe impl Send for Srv {}
+unsafe impl Sync for Srv {}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Sampler(pub *mut ID3D11SamplerState);
+unsafe impl Send for Sampler {}
+unsafe impl Sync for Sampler {}

--- a/src/backend/dx11/src/state.rs
+++ b/src/backend/dx11/src/state.rs
@@ -16,8 +16,9 @@ use std::ptr;
 use winapi::*;
 use core::{pso, state};
 use data::map_function;
+use comptr::ComPtr;
 
-pub fn make_rasterizer(device: *mut ID3D11Device, rast: &state::Rasterizer, use_scissor: bool)
+pub fn make_rasterizer(device: &mut ComPtr<ID3D11Device>, rast: &state::Rasterizer, use_scissor: bool)
                        -> *const ID3D11RasterizerState {
     let desc = D3D11_RASTERIZER_DESC {
         FillMode: match rast.method {
@@ -57,7 +58,7 @@ pub fn make_rasterizer(device: *mut ID3D11Device, rast: &state::Rasterizer, use_
 
     let mut handle = ptr::null_mut();
     let hr = unsafe {
-        (*device).CreateRasterizerState(&desc, &mut handle)
+        device.CreateRasterizerState(&desc, &mut handle)
     };
     if !SUCCEEDED(hr) {
         error!("Failed to create rasterizer state {:?}, descriptor {:#?}, code {:x}", rast, desc, hr);
@@ -103,7 +104,7 @@ fn map_stencil_mask<F>(dsi: &pso::DepthStencilInfo, name: &str, accessor: F) -> 
     }
 }
 
-pub fn make_depth_stencil(device: *mut ID3D11Device, dsi: &pso::DepthStencilInfo)
+pub fn make_depth_stencil(device: &mut ComPtr<ID3D11Device>, dsi: &pso::DepthStencilInfo)
                           -> *const ID3D11DepthStencilState {
     let desc = D3D11_DEPTH_STENCIL_DESC {
         DepthEnable: if dsi.depth.is_some() {TRUE} else {FALSE},
@@ -124,7 +125,7 @@ pub fn make_depth_stencil(device: *mut ID3D11Device, dsi: &pso::DepthStencilInfo
 
     let mut handle = ptr::null_mut();
     let hr = unsafe {
-        (*device).CreateDepthStencilState(&desc, &mut handle)
+        device.CreateDepthStencilState(&desc, &mut handle)
     };
     if !SUCCEEDED(hr) {
         error!("Failed to create depth-stencil state {:?}, descriptor {:#?}, error {:x}", dsi, desc, hr);
@@ -170,7 +171,7 @@ fn map_blend_op(equation: state::Equation) -> D3D11_BLEND_OP {
     }
 }
 
-pub fn make_blend(device: *mut ID3D11Device, targets: &[Option<pso::ColorTargetDesc>])
+pub fn make_blend(device: &mut ComPtr<ID3D11Device>, targets: &[Option<pso::ColorTargetDesc>])
                   -> *const ID3D11BlendState {
     let dummy_target = D3D11_RENDER_TARGET_BLEND_DESC {
         BlendEnable: FALSE,
@@ -213,7 +214,7 @@ pub fn make_blend(device: *mut ID3D11Device, targets: &[Option<pso::ColorTargetD
 
     let mut handle = ptr::null_mut();
     let hr = unsafe {
-        (*device).CreateBlendState(&desc, &mut handle)
+        device.CreateBlendState(&desc, &mut handle)
     };
     if !SUCCEEDED(hr) {
         error!("Failed to create blend state {:?}, descriptor {:#?}, error {:x}", targets, desc, hr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,10 +300,12 @@ pub trait Application<B: Backend>: Sized {
         where Self: Application<DefaultBackend>
     {
         let events_loop = winit::EventsLoop::new();
-        let (mut window, mut factory, main_color) =
-            gfx_window_dxgi::init::<ColorFormat>(wb, &events_loop).unwrap();
+        let win = wb.build(&events_loop).unwrap();
+        let dim = win.get_inner_size_points().unwrap();
+        let mut window = gfx_window_dxgi::Window(&win);
 
-        unimplemented!()
+        let (surface, adapters) = window.get_surface_and_adapters();
+        run::<Self, _, _, _>(dim, events_loop, surface, adapters)
     }
     #[cfg(feature = "metal")]
     fn launch_default(wb: winit::WindowBuilder)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
                 let ds_desc = texture::DepthStencilDesc {
                     level: 0,
                     layer: None,
-                    flags: texture::RO_DEPTH_STENCIL,
+                    flags: texture::DepthStencilFlags::empty(),
                 };
                 let dsv = factory.view_texture_as_depth_stencil_raw(
                                     ds.as_ref().unwrap(),

--- a/src/shade.rs
+++ b/src/shade.rs
@@ -56,7 +56,7 @@ impl ShadeExt for ::gfx_device_gl::Factory {
 #[cfg(feature = "dx11")]
 impl ShadeExt for ::gfx_device_dx11::Factory {
     fn shader_backend(&self) -> Backend {
-        unimplemented!()
+        Backend::Hlsl(self.get_shader_model())
     }
 }
 

--- a/src/shade.rs
+++ b/src/shade.rs
@@ -53,6 +53,13 @@ impl ShadeExt for ::gfx_device_gl::Factory {
     }
 }
 
+#[cfg(feature = "dx11")]
+impl ShadeExt for ::gfx_device_dx11::Factory {
+    fn shader_backend(&self) -> Backend {
+        unimplemented!()
+    }
+}
+
 #[cfg(feature = "vulkan")]
 impl ShadeExt for ::gfx_device_vulkan::Factory {
     fn shader_backend(&self) -> Backend {

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -31,7 +31,8 @@ log = "0.3"
 kernel32-sys = "0.2"
 user32-sys = "0.2"
 dxguid-sys = "0.2"
-winapi = "0.2"
+winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 winit = "0.6"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.6" }
+comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.3"
 kernel32-sys = "0.2"
 user32-sys = "0.2"
 dxguid-sys = "0.2"
-winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
+winapi = "0.2"
 winit = "0.6"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.6" }

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -324,12 +324,14 @@ impl<'a> core::Surface<device_dx11::Backend> for Surface<'a> {
         };
 
         SwapChain {
+            swap_chain,
             images: [backbuffer],
         }
     }
 }
 
 pub struct SwapChain {
+    swap_chain: ComPtr<winapi::IDXGISwapChain1>,
     images: [core::Backbuffer<device_dx11::Backend>; 1],
 }
 
@@ -339,13 +341,14 @@ impl core::SwapChain<device_dx11::Backend> for SwapChain {
     }
 
     fn acquire_frame(&mut self, sync: core::FrameSync<device_dx11::Resources>) -> core::Frame {
-        unimplemented!()
+        // TODO: sync
+        core::Frame::new(0)
     }
 
-    fn present<Q>(&mut self, present_queue: &mut Q)
+    fn present<Q>(&mut self, _present_queue: &mut Q)
         where Q: AsMut<device_dx11::CommandQueue>
     {
-        unimplemented!()
+        unsafe { self.swap_chain.Present(1, 0); }
     }
 }
 

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -28,7 +28,7 @@ use core::{format, handle as h, factory as f, memory, texture as tex};
 use core::texture::Size;
 use device_dx11::{Factory, Resources};
 
-
+/*
 pub struct Window {
     inner: winit::Window,
     swap_chain: *mut winapi::IDXGISwapChain,
@@ -174,30 +174,12 @@ pub fn init_raw(wb: winit::WindowBuilder, events_loop: &winit::EventsLoop, color
     Err(InitError::DriverType)
 }
 
-/*
-pub trait DeviceExt: core::Device {
-    fn clear_state(&self);
-}
-
-impl DeviceExt for device_dx11::Deferred {
-     fn clear_state(&self) {
-         self.clear_state();
-     }
-}
-
-impl DeviceExt for Device {
-    fn clear_state(&self) {
-        self.clear_state();
-    }
-}
-*/
-
 /// Update the internal dimensions of the main framebuffer targets. Generic version over the format.
 pub fn update_views<Cf>(window: &mut Window, factory: &mut Factory, width: u16, height: u16)
             -> Result<h::RenderTargetView<Resources, Cf>, f::TargetViewError>
 where Cf: format::RenderFormat
 {
-    
+
     factory.cleanup();
     // device.clear_state();
     // device.cleanup();
@@ -207,5 +189,48 @@ where Cf: format::RenderFormat
             error!("Resize failed with code {:X}", hr);
             f::TargetViewError::NotDetached
         }
-    )    
+    )
+}
+*/
+
+pub struct Surface;
+
+impl core::Surface<device_dx11::Backend> for Surface {
+    type SwapChain = SwapChain;
+
+    fn supports_queue(&self, queue_family: &device_dx11::QueueFamily) -> bool { true }
+    fn build_swapchain<Q>(&mut self, config: core::SwapchainConfig, present_queue: &Q) -> SwapChain
+        where Q: AsRef<device_dx11::CommandQueue>
+    {
+        unimplemented!()
+    }
+}
+
+pub struct SwapChain;
+
+impl core::SwapChain<device_dx11::Backend> for SwapChain {
+    fn get_backbuffers(&mut self) -> &[core::Backbuffer<device_dx11::Backend>] {
+        unimplemented!()
+    }
+
+    fn acquire_frame(&mut self, sync: core::FrameSync<device_dx11::Resources>) -> core::Frame {
+        unimplemented!()
+    }
+
+    fn present<Q>(&mut self, present_queue: &mut Q)
+        where Q: AsMut<device_dx11::CommandQueue>
+    {
+        unimplemented!()
+    }
+}
+
+pub struct Window<'a>(pub &'a winit::Window);
+
+impl<'a> core::WindowExt<device_dx11::Backend> for Window<'a> {
+    type Surface = Surface;
+    type Adapter = device_dx11::Adapter;
+
+    fn get_surface_and_adapters(&mut self) -> (Surface, Vec<device_dx11::Adapter>) {
+        unimplemented!()
+    }
 }


### PR DESCRIPTION
* dx11: Implement swapchain, command queue and surface creation
* dx11: Implement command pools
* dx11: Use `ComPtr` for d3d11 objects instead of raw pointers
* app: Fix wrong DSV flag

(`comptr` is currently an unpublished crate sitting in my repo, which I've been using for the dx12 backend as well.)