### PR TITLE
Fix depth pixel format in GL

### DIFF
--- a/src/backend/gl/src/tex.rs
+++ b/src/backend/gl/src/tex.rs
@@ -67,7 +67,7 @@ fn format_to_glpixel(format: NewFormat) -> GLenum {
         S::R8_G8_B8_A8 | S::R16_G16_B16_A16 | S::R32_G32_B32_A32 |
         S::R4_G4_B4_A4 | S::R5_G5_B5_A1 | S::R10_G10_B10_A2 => rgba,
         S::D24_S8 => gl::DEPTH_STENCIL,
-        S::D16 | S::D24 | S::D32 => gl::DEPTH,
+        S::D16 | S::D24 | S::D32 => gl::DEPTH_COMPONENT,
         S::B8_G8_R8_A8 => bgra,
     }
 }


### PR DESCRIPTION
The mistake was using `GL_DEPTH`, which is the depth buffer handle, instead of one of the [allowed pixel formats](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexSubImage2D.xhtml).