### PR TITLE
[ll] Add semaphore handle [18/..]

### DIFF
--- a/examples/blend/main.rs
+++ b/examples/blend/main.rs
@@ -148,7 +148,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
         }
     }
 
-    fn render<Gp>(&mut self, (frame, semaphore): (gfx::Frame, &<B::Resources as gfx::Resources>::Semaphore),
+    fn render<Gp>(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
                   pool: &mut Gp, queue: &mut gfx::queue::GraphicsQueueMut<B>)
         where Gp: gfx::GraphicsCommandPool<B>
     {

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -166,7 +166,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
         }
     }
 
-    fn render<Gp>(&mut self, (frame, semaphore): (gfx::Frame, &<B::Resources as gfx::Resources>::Semaphore),
+    fn render<Gp>(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
                   pool: &mut Gp, queue: &mut gfx::queue::GraphicsQueueMut<B>)
         where Gp: gfx::GraphicsCommandPool<B>
     {

--- a/examples/flowmap/main.rs
+++ b/examples/flowmap/main.rs
@@ -136,7 +136,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
         }
     }
 
-    fn render<Gp>(&mut self, (frame, semaphore): (gfx::Frame, &<B::Resources as gfx::Resources>::Semaphore),
+    fn render<Gp>(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
                   pool: &mut Gp, queue: &mut gfx::queue::GraphicsQueueMut<B>)
         where Gp: gfx::GraphicsCommandPool<B>
     {

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -147,7 +147,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
         }
     }
 
-    fn render<Gp>(&mut self, (frame, semaphore): (gfx::Frame, &<B::Resources as gfx::Resources>::Semaphore),
+    fn render<Gp>(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
                   pool: &mut Gp, queue: &mut gfx::queue::GraphicsQueueMut<B>)
         where Gp: gfx::GraphicsCommandPool<B>
     {

--- a/src/backend/dx11/src/factory.rs
+++ b/src/backend/dx11/src/factory.rs
@@ -910,7 +910,9 @@ impl core::Factory<R> for Factory {
         }
     }
 
-    fn create_semaphore(&mut self) -> () { () }
+    fn create_semaphore(&mut self) -> h::Semaphore<R> {
+        self.share.handles.borrow_mut().make_semaphore(())
+    }
 
     fn read_mapping<'a, 'b, T>(&'a mut self, buf: &'b h::Buffer<R, T>)
                                -> Result<mapping::Reader<'b, R, T>,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -447,7 +447,7 @@ impl CommandQueue {
 }
 
 impl core::CommandQueue<Backend> for CommandQueue {
-    unsafe fn submit(&mut self, submit_infos: &[core::QueueSubmit<Backend>], fence: Option<&mut Fence>, access: &com::AccessInfo<Resources>) {
+    unsafe fn submit(&mut self, submit_infos: &[core::QueueSubmit<Backend>], fence: Option<&h::Fence<Resources>>, access: &com::AccessInfo<Resources>) {
         let _guard = self.before_submit(access).unwrap();
         for submit in submit_infos {
             for cb in submit.cmd_buffers {
@@ -516,6 +516,7 @@ impl core::CommandQueue<Backend> for CommandQueue {
             |_, v| unsafe { (*v.0).Release(); }, //DSV
             |_, v| unsafe { (*v.0).Release(); }, //sampler
             |_, _fence| {},
+            |_, _| {}, // Semaphore
         );
     }
 }

--- a/src/backend/gl/src/factory.rs
+++ b/src/backend/gl/src/factory.rs
@@ -250,13 +250,13 @@ impl Factory {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 pub enum MappingKind {
     Persistent(mapping::Status<R>),
     Temporary,
 }
 
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Debug)]
 #[allow(missing_copy_implementations)]
 pub struct MappingGate {
     pub kind: MappingKind,
@@ -511,7 +511,9 @@ impl f::Factory<R> for Factory {
         self.share.handles.borrow_mut().make_sampler(sam, info)
     }
 
-    fn create_semaphore(&mut self) -> () { () } // TODO: ?
+    fn create_semaphore(&mut self) -> handle::Semaphore<R> {
+        self.share.handles.borrow_mut().make_semaphore(())
+    }
 
     fn read_mapping<'a, 'b, T>(&'a mut self, buf: &'b handle::Buffer<R, T>)
                                -> Result<mapping::Reader<'b, R, T>,
@@ -523,7 +525,7 @@ impl f::Factory<R> for Factory {
         unsafe {
             mapping::read(buf.raw(), |mapping| match mapping.kind {
                 MappingKind::Persistent(ref mut status) =>
-                    status.cpu_access(|fence| wait_fence(&handles.ref_fence(&fence), gl)),
+                    status.cpu_access(|fence| wait_fence(&*handles.ref_fence(&fence).lock().unwrap(), gl)),
                 MappingKind::Temporary =>
                     temporary_ensure_mapped(&mut mapping.pointer,
                                             role_to_target(buf.get_info().role),
@@ -544,7 +546,7 @@ impl f::Factory<R> for Factory {
         unsafe {
             mapping::write(buf.raw(), |mapping| match mapping.kind {
                 MappingKind::Persistent(ref mut status) =>
-                    status.cpu_write_access(|fence| wait_fence(&handles.ref_fence(&fence), gl)),
+                    status.cpu_write_access(|fence| wait_fence(&*handles.ref_fence(&fence).lock().unwrap(), gl)),
                 MappingKind::Temporary =>
                     temporary_ensure_mapped(&mut mapping.pointer,
                                             role_to_target(buf.get_info().role),

--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -15,7 +15,7 @@
 //! Resource factory
 //!
 //! This module exposes the `Factory` trait, used for creating and managing graphics resources, and
-//! includes several items to facilitate this. 
+//! includes several items to facilitate this.
 
 use std::error::Error;
 use std::{mem, fmt};
@@ -110,7 +110,7 @@ impl Error for TargetViewError {
             TargetViewError::Unsupported =>
                 "The backend was refused for some reason",
             TargetViewError::NotDetached =>
-                "The RTV cannot be changed due to the references to it existing",    
+                "The RTV cannot be changed due to the references to it existing",
         }
     }
 
@@ -179,7 +179,7 @@ impl From<TargetViewError> for CombinedError {
 }
 
 /// A `Factory` is responsible for creating and managing resources for the context it was created
-/// with. 
+/// with.
 ///
 /// # Construction and Handling
 /// A `Factory` is typically created along with other objects using a helper function of the
@@ -221,11 +221,11 @@ pub trait Factory<R: Resources> {
     /// `FactoryExt` trait and `pso` module, both in the `gfx` crate.
     fn create_pipeline_state_raw(&mut self, &handle::Program<R>, &pso::Descriptor)
                                  -> Result<handle::RawPipelineState<R>, pso::CreationError>;
-                                 
+
     /// Creates a new shader `Program` for the supplied `ShaderSet`.
     fn create_program(&mut self, shader_set: &ShaderSet<R>)
                       -> Result<handle::Program<R>, shade::CreateProgramError>;
-    
+
     /// Compiles a shader source into a `Shader` object that can be used to create a shader
     /// `Program`.
     fn create_shader(&mut self, stage: shade::Stage, code: &[u8]) ->
@@ -255,7 +255,7 @@ pub trait Factory<R: Resources> {
     fn create_sampler(&mut self, texture::SamplerInfo) -> handle::Sampler<R>;
 
     ///
-    fn create_semaphore(&mut self) -> R::Semaphore;
+    fn create_semaphore(&mut self) -> handle::Semaphore<R>;
 
     /// Acquire a mapping Reader
     ///

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -265,7 +265,7 @@ pub trait Resources:          Clone + Hash + Debug + Eq + PartialEq + Any {
     type Sampler:             Clone + Hash + Debug + Eq + PartialEq + Any + Send + Sync + Copy;
     type Fence:               Debug + Hash + Eq + PartialEq + Any + Send + Sync;
     type Semaphore:           Debug + Any + Send + Sync;
-    type Mapping:             Hash + Debug + Eq + PartialEq + Any + Send + Sync + mapping::Gate<Self>;
+    type Mapping:             Debug + Any + Send + Sync + mapping::Gate<Self>;
 }
 
 /*
@@ -386,9 +386,9 @@ pub struct QueueSubmit<'a, B: Backend + 'a> {
     /// Command buffers to submit.
     pub cmd_buffers: &'a [command::Submit<B>],
     /// Semaphores to wait being signaled before submission.
-    pub wait_semaphores: &'a [(&'a mut <B::Resources as Resources>::Semaphore, pso::PipelineStage)],
+    pub wait_semaphores: &'a [(&'a handle::Semaphore<B::Resources>, pso::PipelineStage)],
     /// Semaphores which get signaled after submission.
-    pub signal_semaphores: &'a [&'a mut <B::Resources as Resources>::Semaphore],
+    pub signal_semaphores: &'a [&'a handle::Semaphore<B::Resources>],
 }
 
 /// Dummy trait for command queues.
@@ -398,7 +398,7 @@ pub trait CommandQueue<B: Backend> {
     /// `fence` will be signalled after submission and _must_ be unsignalled.
     // TODO: `access` legacy (handle API)
     #[doc(hidden)]
-    unsafe fn submit(&mut self, submit_infos: &[QueueSubmit<B>], fence: Option<&mut <B::Resources as Resources>::Fence>,
+    unsafe fn submit(&mut self, submit_infos: &[QueueSubmit<B>], fence: Option<&handle::Fence<B::Resources>>,
         access: &command::AccessInfo<B::Resources>);
 
     ///
@@ -462,12 +462,12 @@ pub enum FrameSync<'a, R: Resources> {
     /// Semaphore used for synchronization.
     ///
     /// Will be signaled once the frame backbuffer is available.
-    Semaphore(&'a R::Semaphore),
+    Semaphore(&'a handle::Semaphore<R>),
 
     /// Fence used for synchronization.
     ///
     /// Will be signaled once the frame backbuffer is available.
-    Fence(&'a R::Fence)
+    Fence(&'a handle::Semaphore<R>)
 }
 
 /// Allows you to configure a `SwapChain` for creation.

--- a/src/core/src/mapping.rs
+++ b/src/core/src/mapping.rs
@@ -213,7 +213,7 @@ impl<'a, R: Resources, T: 'a + Copy> DerefMut for Writer<'a, R, T> {
 }
 
 /// A service struct that can be used by backends to track the mapping status
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Debug)]
 #[doc(hidden)]
 pub struct Status<R: Resources> {
     cpu_wrote: bool,

--- a/src/core/src/queue.rs
+++ b/src/core/src/queue.rs
@@ -43,7 +43,7 @@ macro_rules! define_queue {
             where B::CommandQueue: 'a;
 
         impl<B: Backend> CommandQueue<B> for $queue<B> {
-            unsafe fn submit(&mut self, submit_infos: &[QueueSubmit<B>], fence: Option<&mut <B::Resources as Resources>::Fence>,
+            unsafe fn submit(&mut self, submit_infos: &[QueueSubmit<B>], fence: Option<&handle::Fence<B::Resources>>,
                 access: &AccessInfo<B::Resources>) {
                 self.0.submit(submit_infos, fence, access)
             }
@@ -62,7 +62,7 @@ macro_rules! define_queue {
         }
 
         impl<'a, B: Backend> CommandQueue<B> for $queue_mut<'a, B> {
-            unsafe fn submit(&mut self, submit_infos: &[QueueSubmit<B>], fence: Option<&mut <B::Resources as Resources>::Fence>,
+            unsafe fn submit(&mut self, submit_infos: &[QueueSubmit<B>], fence: Option<&handle::Fence<B::Resources>>,
                 access: &AccessInfo<B::Resources>) {
                 self.0.submit(submit_infos, fence, access)
             }
@@ -194,14 +194,14 @@ macro_rules! define_queue {
     (
         impl<B: Backend> $queue<B> {
             /// Submit command buffers for execution.
-            pub fn $submit(&mut self, submit: &[QueueSubmit<B>], fence: Option<&mut <B::Resources as Resources>::Fence>, access: &AccessInfo<B::Resources>) {
+            pub fn $submit(&mut self, submit: &[QueueSubmit<B>], fence: Option<&handle::Fence<B::Resources>>, access: &AccessInfo<B::Resources>) {
                 unsafe { self.0.submit(submit, fence, access) }
             }
         }
 
         impl<'a, B: Backend> $queue_mut<'a, B> {
             /// Submit command buffers for execution.
-            pub fn $submit(&mut self, submit: &[QueueSubmit<B>], fence: Option<&mut <B::Resources as Resources>::Fence>, access: &AccessInfo<B::Resources>) {
+            pub fn $submit(&mut self, submit: &[QueueSubmit<B>], fence: Option<&handle::Fence<B::Resources>>, access: &AccessInfo<B::Resources>) {
                 unsafe { self.0.submit(submit, fence, access) }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
 
     let mut harness = Harness::new();
     let mut running = true;
-    let mut frame_semaphore = factory.create_semaphore();
+    let frame_semaphore = factory.create_semaphore();
 
     let mut graphics_pool = B::GraphicsCommandPool::from_queue(queue.as_ref(), 1);
 
@@ -218,7 +218,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
             }
         });
 
-        let frame = swap_chain.acquire_frame(FrameSync::Semaphore(&mut frame_semaphore));
+        let frame = swap_chain.acquire_frame(FrameSync::Semaphore(&frame_semaphore));
 
         app.render((frame, &frame_semaphore), &mut graphics_pool, &mut queue);
 
@@ -257,7 +257,7 @@ pub type DefaultBackend = gfx_device_vulkan::Backend;
 
 pub trait Application<B: Backend>: Sized {
     fn new(&mut B::Factory, shade::Backend, WindowTargets<B::Resources>) -> Self;
-    fn render<Gp>(&mut self, frame: (gfx_core::Frame, &<B::Resources as gfx::Resources>::Semaphore),
+    fn render<Gp>(&mut self, frame: (gfx_core::Frame, &gfx::handle::Semaphore<B::Resources>),
                      pool: &mut Gp, queue: &mut gfx_core::queue::GraphicsQueueMut<B>)
         where Gp: GraphicsCommandPool<B>;
 


### PR DESCRIPTION
Update the corresponding API parts to use the new handles.
Semaphores and fences are hidden behind mutexes to ensure explicit synchronization (important for vulkan),

cc #1321 