### PR TITLE
Implement buffer texture format selection for GL backend

### DIFF
--- a/src/backend/dx11/src/factory.rs
+++ b/src/backend/dx11/src/factory.rs
@@ -142,7 +142,7 @@ impl Factory {
                 (D3D11_BIND_FLAG(0), info.size)
         };
 
-        assert!(size >= info.size);        
+        assert!(size >= info.size);
         let (usage, cpu) = map_usage(info.usage, info.bind);
         let bind = map_bind(info.bind) | subind;
         if info.bind.contains(memory::RENDER_TARGET) | info.bind.contains(memory::DEPTH_STENCIL) {
@@ -326,10 +326,10 @@ impl Factory {
             Err(hr)
         }
     }
-    
+
     pub fn cleanup(&mut self) {
         self.frame_handles.clear();
-    }    
+    }
 }
 
 impl core::Factory<R> for Factory {
@@ -473,7 +473,7 @@ impl core::Factory<R> for Factory {
             },
             &core::ShaderSet::Tessellated(ref vs, ref hs, ref ds, ref ps) => {
                 let (vs, hs, ds, ps) = (vs.reference(fh), hs.reference(fh), ds.reference(fh), ps.reference(fh));
-              
+
                 populate_info(&mut info, Stage::Vertex, vs.reflection);
                 populate_info(&mut info, Stage::Hull,   hs.reflection);
                 populate_info(&mut info, Stage::Domain, ds.reflection);
@@ -602,7 +602,7 @@ impl core::Factory<R> for Factory {
                           data_opt: Option<&[&[u8]]>) -> Result<h::RawTexture<R>, texture::CreationError> {
         use core::texture::{AaMode, CreationError, Kind};
         use data::{map_bind, map_usage, map_surface, map_format};
-        
+
         let (usage, cpu_access) = map_usage(desc.usage, desc.bind);
         let tparam = TextureParam {
             levels: desc.levels as winapi::UINT,
@@ -668,7 +668,7 @@ impl core::Factory<R> for Factory {
         }
     }
 
-    fn view_buffer_as_shader_resource_raw(&mut self, _hbuf: &h::RawBuffer<R>)
+    fn view_buffer_as_shader_resource_raw(&mut self, _hbuf: &h::RawBuffer<R>, _: core::format::Format)
                                       -> Result<h::RawShaderResourceView<R>, f::ResourceViewError> {
         Err(f::ResourceViewError::Unsupported) //TODO
     }
@@ -931,24 +931,24 @@ pub fn ensure_mapped(mapping: &mut MappingGate,
                      map_type: winapi::d3d11::D3D11_MAP,
                      factory: &Factory) {
     if mapping.pointer.is_null() {
-        let raw_handle = *buffer.resource();                  
+        let raw_handle = *buffer.resource();
         let mut ctx = ptr::null_mut();
-            
+
         unsafe {
             (*factory.device).GetImmediateContext(&mut ctx);
         }
-        
+
         let mut sres = winapi::d3d11::D3D11_MAPPED_SUBRESOURCE {
             pData: ptr::null_mut(),
             RowPitch: 0,
             DepthPitch: 0,
         };
-            
+
         let dst = raw_handle.as_resource() as *mut winapi::d3d11::ID3D11Resource;
         let hr = unsafe {
             (*ctx).Map(dst, 0, map_type, 0, &mut sres)
         };
-        
+
         if winapi::SUCCEEDED(hr) {
             mapping.pointer = sres.pData;
         } else {

--- a/src/backend/gl/src/factory.rs
+++ b/src/backend/gl/src/factory.rs
@@ -18,7 +18,7 @@ use std::{slice, ptr};
 use {gl, tex};
 use core::{self as d, factory as f, texture as t, buffer, mapping};
 use core::memory::{self, Bind, SHADER_RESOURCE, UNORDERED_ACCESS, Typed};
-use core::format::ChannelType;
+use core::format::{ChannelType, Format};
 use core::handle::{self, Producer};
 use core::target::{Layer, Level};
 
@@ -436,12 +436,13 @@ impl f::Factory<R> for Factory {
         Ok(self.share.handles.borrow_mut().make_texture(object, desc))
     }
 
-    fn view_buffer_as_shader_resource_raw(&mut self, hbuf: &handle::RawBuffer<R>)
+    fn view_buffer_as_shader_resource_raw(&mut self, hbuf: &handle::RawBuffer<R>, format: Format)
                                       -> Result<handle::RawShaderResourceView<R>, f::ResourceViewError> {
         let gl = &self.share.context;
         let mut name = 0 as gl::types::GLuint;
         let buf_name = *self.frame_handles.ref_buffer(hbuf);
-        let format = gl::R8; //TODO: get from the buffer handle
+        let format = tex::format_to_glfull(format)
+            .map_err(|_| f::ResourceViewError::Unsupported)?;
         unsafe {
             gl.GenTextures(1, &mut name);
             gl.BindTexture(gl::TEXTURE_BUFFER, name);

--- a/src/backend/gl/src/tex.rs
+++ b/src/backend/gl/src/tex.rs
@@ -100,7 +100,7 @@ fn format_to_gltype(format: NewFormat) -> Result<GLenum, ()> {
     })
 }
 
-fn format_to_glfull(format: NewFormat) -> Result<GLenum, ()> {
+pub fn format_to_glfull(format: NewFormat) -> Result<GLenum, ()> {
     use core::format::SurfaceType as S;
     use core::format::ChannelType as C;
     let cty = format.1;

--- a/src/backend/metal/src/factory.rs
+++ b/src/backend/metal/src/factory.rs
@@ -617,7 +617,8 @@ impl core::Factory<Resources> for Factory {
 
     fn view_buffer_as_shader_resource_raw
         (&mut self,
-         _hbuf: &handle::RawBuffer<Resources>)
+         _hbuf: &handle::RawBuffer<Resources>,
+         _: core::format::Format)
          -> Result<handle::RawShaderResourceView<Resources>, factory::ResourceViewError> {
         unimplemented!()
         // Err(factory::ResourceViewError::Unsupported) //TODO

--- a/src/backend/vulkan/src/factory.rs
+++ b/src/backend/vulkan/src/factory.rs
@@ -17,7 +17,7 @@ use std::os::raw::c_void;
 use core::{self, handle as h, pso, state, texture, buffer, mapping};
 use core::memory::{self, Bind};
 use core::factory::{self as f};
-use core::format::ChannelType;
+use core::format::{ChannelType, Format};
 use core::target::Layer;
 use vk;
 use {command, data, native};
@@ -820,7 +820,7 @@ impl core::Factory<R> for Factory {
         Ok(self.share.handles.lock().unwrap().make_texture(tex, desc))
     }
 
-    fn view_buffer_as_shader_resource_raw(&mut self, _hbuf: &h::RawBuffer<R>)
+    fn view_buffer_as_shader_resource_raw(&mut self, _hbuf: &h::RawBuffer<R>, _: Format)
                                       -> Result<h::RawShaderResourceView<R>, f::ResourceViewError> {
         Err(f::ResourceViewError::Unsupported) //TODO
     }

--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -15,7 +15,7 @@
 //! Resource factory
 //!
 //! This module exposes the `Factory` trait, used for creating and managing graphics resources, and
-//! includes several items to facilitate this. 
+//! includes several items to facilitate this.
 
 use std::error::Error;
 use std::{mem, fmt};
@@ -110,7 +110,7 @@ impl Error for TargetViewError {
             TargetViewError::Unsupported =>
                 "The backend was refused for some reason",
             TargetViewError::NotDetached =>
-                "The RTV cannot be changed due to the references to it existing",    
+                "The RTV cannot be changed due to the references to it existing",
         }
     }
 
@@ -179,7 +179,7 @@ impl From<TargetViewError> for CombinedError {
 }
 
 /// A `Factory` is responsible for creating and managing resources for the context it was created
-/// with. 
+/// with.
 ///
 /// # Construction and Handling
 /// A `Factory` is typically created along with other objects using a helper function of the
@@ -221,11 +221,11 @@ pub trait Factory<R: Resources> {
     /// `FactoryExt` trait and `pso` module, both in the `gfx` crate.
     fn create_pipeline_state_raw(&mut self, &handle::Program<R>, &pso::Descriptor)
                                  -> Result<handle::RawPipelineState<R>, pso::CreationError>;
-                                 
+
     /// Creates a new shader `Program` for the supplied `ShaderSet`.
     fn create_program(&mut self, shader_set: &ShaderSet<R>)
                       -> Result<handle::Program<R>, shade::CreateProgramError>;
-    
+
     /// Compiles a shader source into a `Shader` object that can be used to create a shader
     /// `Program`.
     fn create_shader(&mut self, stage: shade::Stage, code: &[u8]) ->
@@ -281,7 +281,7 @@ pub trait Factory<R: Resources> {
     fn create_texture_raw(&mut self, texture::Info, Option<format::ChannelType>, Option<&[&[u8]]>)
                           -> Result<handle::RawTexture<R>, texture::CreationError>;
 
-    fn view_buffer_as_shader_resource_raw(&mut self, &handle::RawBuffer<R>)
+    fn view_buffer_as_shader_resource_raw(&mut self, &handle::RawBuffer<R>, format::Format)
         -> Result<handle::RawShaderResourceView<R>, ResourceViewError>;
     fn view_buffer_as_unordered_access_raw(&mut self, &handle::RawBuffer<R>)
         -> Result<handle::RawUnorderedAccessView<R>, ResourceViewError>;
@@ -310,11 +310,11 @@ pub trait Factory<R: Resources> {
         Ok(Typed::new(raw))
     }
 
-    fn view_buffer_as_shader_resource<T>(&mut self, buf: &handle::Buffer<R, T>)
+    fn view_buffer_as_shader_resource<T: format::Formatted>(&mut self, buf: &handle::Buffer<R, T>)
                                       -> Result<handle::ShaderResourceView<R, T>, ResourceViewError>
     {
         //TODO: check bind flags
-        self.view_buffer_as_shader_resource_raw(buf.raw()).map(Typed::new)
+        self.view_buffer_as_shader_resource_raw(buf.raw(), T::get_format()).map(Typed::new)
     }
 
     fn view_buffer_as_unordered_access<T>(&mut self, buf: &handle::Buffer<R, T>)


### PR DESCRIPTION
"Fixes" #1328 (although buffer textures aren't implemented at all for other backends)

Hopefully I managed to update all the function signatures for the different backends. I could only test the GL backend on my computer.