### PR TITLE
[ll] Update glfw and sdl window [21/..]

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -63,7 +63,7 @@ pub struct Instance {
     pub raw: ash::Instance<ash::version::V1_0>,
 
     /// Supported surface extensions of this instance.
-    surface_extensions: Vec<&'static str>,
+    pub surface_extensions: Vec<&'static str>,
 }
 
 impl Instance {

--- a/src/window/glfw/src/lib.rs
+++ b/src/window/glfw/src/lib.rs
@@ -123,6 +123,12 @@ impl<'a> core::Surface<device_gl::Backend> for Surface {
 }
 
 pub struct Window(pub Rc<RefCell<glfw::Window>>);
+impl Window {
+    pub fn new(window: glfw::Window) -> Self {
+        Window(Rc::new(RefCell::new(window)))
+    }
+}
+
 impl<'a> core::WindowExt<device_gl::Backend> for Window {
     type Surface = Surface;
     type Adapter = device_gl::Adapter;

--- a/src/window/glfw/src/lib.rs
+++ b/src/window/glfw/src/lib.rs
@@ -12,62 +12,129 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[deny(missing_docs)]
+//! Initialize with a window.
+//!
+//! # Example
+//!
+//! ```no_run
+//! extern crate gfx_window_glfw;
+//! extern crate glfw;
+//!
+//! fn main() {
+//!     use glfw::Context;
+//!
+//!     let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS)
+//!         .ok().expect("Failed to initialize GLFW");
+//!
+//!     glfw.window_hint(glfw::WindowHint::ContextVersion(3, 2));
+//!     glfw.window_hint(glfw::WindowHint::OpenGlForwardCompat(true));
+//!     glfw.window_hint(glfw::WindowHint::OpenGlProfile(glfw::OpenGlProfileHint::Core));
+//!
+//!     let (window, events) = glfw
+//!         .create_window(800, 600, "Example", glfw::WindowMode::Windowed)
+//!         .expect("Failed to create GLFW window.");
+//!
+//!     let window = gfx_window_glfw::Window(Rc::new(RefCell::new(window)));
+//!     glfw.set_error_callback(glfw::FAIL_ON_ERRORS);
+//!     let (surface, adapters) = window.get_surface_and_adapters();
+//!
+//!     // some code...
+//! }
+//! ```
 
 extern crate gfx_core as core;
 extern crate gfx_device_gl as device_gl;
 extern crate glfw;
 
+use std::rc::Rc;
+use std::cell::RefCell;
 use core::format::{Rgba8, DepthStencil, SurfaceType};
-use core::handle;
-use core::memory::Typed;
-use core::texture::{AaMode, Size};
+use core::{handle, memory};
+use core::texture::{self, AaMode, Size};
 use glfw::Context;
 
-/// Initialize with a window.
-///
-/// # Example
-///
-/// ```no_run
-/// extern crate gfx_window_glfw;
-/// extern crate glfw;
-/// 
-/// fn main() {
-///     use glfw::Context;
-///
-///     let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS)
-///         .ok().expect("Failed to initialize GLFW");
-/// 
-///     glfw.window_hint(glfw::WindowHint::ContextVersion(3, 2));
-///     glfw.window_hint(glfw::WindowHint::OpenGlForwardCompat(true));
-///     glfw.window_hint(glfw::WindowHint::OpenGlProfile(glfw::OpenGlProfileHint::Core));
-/// 
-///     let (mut window, events) = glfw
-///         .create_window(800, 600, "Example", glfw::WindowMode::Windowed)
-///         .expect("Failed to create GLFW window.");
-/// 
-///     window.make_current();
-///     glfw.set_error_callback(glfw::FAIL_ON_ERRORS);
-///     let (device, mut factory, color_view, depth_view) =
-///         gfx_window_glfw::init(&mut window);
-///
-///     // some code...
-/// }
-/// ```
-pub fn init(window: &mut glfw::Window) ->
-    (device_gl::Device,
-     device_gl::Factory,
-     handle::RenderTargetView<device_gl::Resources, Rgba8>,
-     handle::DepthStencilView<device_gl::Resources, DepthStencil>)
-{
-    window.make_current();
-    let (device, factory) = device_gl::create(|s|
-        window.get_proc_address(s) as *const std::os::raw::c_void);
-    // create the main color/depth targets
-    let (width, height) = window.get_framebuffer_size();
-    let dim = (width as Size, height as Size, 1, AaMode::Single);
-    let (color_view, ds_view) = device_gl::create_main_targets_raw(
-        dim, SurfaceType::R8_G8_B8_A8, SurfaceType::D24);
-    // done
-    (device, factory, Typed::new(color_view), Typed::new(ds_view))
+pub struct SwapChain {
+    // Underlying window, required for presentation
+    window: Rc<RefCell<glfw::Window>>,
+    // Single element backbuffer
+    backbuffer: [core::Backbuffer<device_gl::Backend>; 1],
+}
+
+impl<'a> core::SwapChain<device_gl::Backend> for SwapChain {
+    fn get_backbuffers(&mut self) -> &[core::Backbuffer<device_gl::Backend>] {
+        &self.backbuffer
+    }
+
+    fn acquire_frame(&mut self, sync: core::FrameSync<device_gl::Resources>) -> core::Frame {
+        // TODO: fence sync
+        core::Frame::new(0)
+    }
+
+    fn present<Q>(&mut self, _: &mut Q)
+        where Q: AsMut<device_gl::CommandQueue> {
+        self.window.borrow_mut().swap_buffers();
+    }
+}
+
+pub struct Surface {
+    window: Rc<RefCell<glfw::Window>>,
+    manager: handle::Manager<device_gl::Resources>,
+}
+
+impl<'a> core::Surface<device_gl::Backend> for Surface {
+    type SwapChain = SwapChain;
+
+    fn supports_queue(&self, _: &device_gl::QueueFamily) -> bool { true }
+    fn build_swapchain<Q>(&mut self, config: core::SwapchainConfig, _: &Q) -> SwapChain
+        where Q: AsRef<device_gl::CommandQueue>
+    {
+        use core::handle::Producer;
+        let (width, height) = self.window.borrow_mut().get_framebuffer_size();
+        let dim = (width as Size, height as Size, 1, AaMode::Single);
+        let color = self.manager.make_texture(
+            device_gl::NewTexture::Surface(0),
+            texture::Info {
+                levels: 1,
+                kind: texture::Kind::D2(dim.0, dim.1, dim.3),
+                format: config.color_format.0,
+                bind: memory::RENDER_TARGET | memory::TRANSFER_SRC,
+                usage: memory::Usage::Data,
+            },
+        );
+
+        let ds = config.depth_stencil_format.map(|ds_format| {
+            self.manager.make_texture(
+                device_gl::NewTexture::Surface(0),
+                texture::Info {
+                    levels: 1,
+                    kind: texture::Kind::D2(dim.0, dim.1, dim.3),
+                    format: ds_format.0,
+                    bind: memory::DEPTH_STENCIL | memory::TRANSFER_SRC,
+                    usage: memory::Usage::Data,
+                },
+            )
+        });
+
+        SwapChain {
+            window: self.window.clone(),
+            backbuffer: [(color, ds); 1],
+        }
+    }
+}
+
+pub struct Window(pub Rc<RefCell<glfw::Window>>);
+impl<'a> core::WindowExt<device_gl::Backend> for Window {
+    type Surface = Surface;
+    type Adapter = device_gl::Adapter;
+
+    fn get_surface_and_adapters(&mut self) -> (Surface, Vec<device_gl::Adapter>) {
+        self.0.borrow_mut().make_current();
+        let adapter = device_gl::Adapter::new(|s| self.0.borrow_mut().get_proc_address(s) as *const std::os::raw::c_void);
+        let surface = Surface {
+            window: self.0.clone(),
+            manager: handle::Manager::new(),
+        };
+
+        (surface, vec![adapter])
+    }
 }

--- a/src/window/glfw/src/lib.rs
+++ b/src/window/glfw/src/lib.rs
@@ -19,6 +19,9 @@
 //! ```no_run
 //! extern crate gfx_window_glfw;
 //! extern crate glfw;
+//! extern crate gfx_core;
+//!
+//! use gfx_core::WindowExt;
 //!
 //! fn main() {
 //!     use glfw::Context;
@@ -34,7 +37,7 @@
 //!         .create_window(800, 600, "Example", glfw::WindowMode::Windowed)
 //!         .expect("Failed to create GLFW window.");
 //!
-//!     let window = gfx_window_glfw::Window(Rc::new(RefCell::new(window)));
+//!     let mut window = gfx_window_glfw::Window::new(window);
 //!     glfw.set_error_callback(glfw::FAIL_ON_ERRORS);
 //!     let (surface, adapters) = window.get_surface_and_adapters();
 //!

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -21,13 +21,15 @@
 //! extern crate gfx_window_sdl;
 //! extern crate sdl2;
 //!
-//! use gfx_core::format::{DepthStencil, Rgba8};
+//! use gfx_core::WindowExt;
+//! use gfx_core::format::{Formatted, DepthStencil, Rgba8};
 //!
 //! fn main() {
 //!     let sdl = sdl2::init().unwrap();
 //!
 //!     let builder = sdl.video().unwrap().window("Example", 800, 600);
-//!     let (window, glcontext) = gfx_window_sdl::build(window, Rgba8::get_format(), DepthStencil::get_format());
+//!     let (window, glcontext) = gfx_window_sdl::build(
+//!             builder, Rgba8::get_format(), DepthStencil::get_format()).unwrap();
 //!     let mut window = gfx_window_sdl::Window::new(&window);
 //!     let (surface, adapters) = window.get_surface_and_adapters();
 //!

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -16,16 +16,17 @@
 extern crate log;
 extern crate sdl2;
 extern crate gfx_core as core;
-extern crate gfx_device_gl;
+extern crate gfx_device_gl as device_gl;
 
 use core::handle;
 use core::format::{ChannelType, DepthFormat, Format, RenderFormat};
-pub use gfx_device_gl::{Device, Factory, Resources};
-use sdl2::video::{DisplayMode, GLContext, Window, WindowBuilder, WindowBuildError};
+pub use device_gl::{Backend, Factory, Resources};
+use sdl2::video::{DisplayMode, GLContext, WindowBuilder, WindowBuildError};
 use sdl2::pixels::PixelFormatEnum;
-use core::{format, texture};
+use core::{format, memory, texture};
+use core::texture::Size;
 use core::memory::Typed;
-use gfx_device_gl::Resources as R;
+use device_gl::Resources as R;
 
 #[derive(Debug)]
 pub enum InitError {
@@ -69,13 +70,11 @@ fn sdl2_pixel_format_from_gfx(format: Format) -> Option<PixelFormatEnum> {
     }
 }
 
-pub type InitRawOk = (Window, GLContext, Device, Factory,
-    handle::RawRenderTargetView<Resources>, handle::RawDepthStencilView<Resources>);
-
-pub type InitOk<Cf, Df> =
-    (Window, GLContext, Device, Factory,
-     handle::RenderTargetView<Resources, Cf>,
-     handle::DepthStencilView<Resources, Df>);
+fn get_window_dimensions(window: &sdl2::video::Window) -> texture::Dimensions {
+    let (width, height) = window.size();
+    let aa = window.subsystem().gl_attr().multisample_samples() as texture::NumSamples;
+    (width as texture::Size, height as texture::Size, 1, aa.into())
+}
 
 /// Builds an SDL2 window from a WindowBuilder struct.
 ///
@@ -92,27 +91,107 @@ pub type InitOk<Cf, Df> =
 ///     let sdl = sdl2::init().unwrap();
 ///
 ///     let builder = sdl.video().unwrap().window("Example", 800, 600);
-///     let (window, glcontext, device, factory, color_view, depth_view) =
-///         gfx_window_sdl::init::<Rgba8, DepthStencil>(builder).expect("gfx_window_sdl::init failed!");
+///     let (window, glcontext) = gfx_window_sdl::build(window, Rgba8::get_format(), DepthStencil::get_format());
+///     let mut window = gfx_window_sdl::Window::new(&window);
+///     let (surface, adapters) = window.get_surface_and_adapters();
 ///
 ///     // some code...
 /// }
 /// ```
-pub fn init<Cf, Df>(builder: WindowBuilder) -> Result<InitOk<Cf, Df>, InitError>
-where
-    Cf: RenderFormat,
-    Df: DepthFormat,
-{
-    use core::memory::Typed;
-    init_raw(builder, Cf::get_format(), Df::get_format())
-        .map(|(w, gl, d, f, color_view, ds_view)|
-            (w, gl, d, f, Typed::new(color_view), Typed::new(ds_view)))
+
+pub struct SwapChain<'a> {
+    // Underlying window, required for presentation
+    window: &'a sdl2::video::Window,
+    // Single element backbuffer
+    backbuffer: [core::Backbuffer<Backend>; 1],
 }
 
-pub fn init_raw(mut builder: WindowBuilder, cf: Format, df: Format)
-                -> Result<InitRawOk, InitError> {
-    use core::texture::{AaMode, Size};
+impl<'a> core::SwapChain<Backend> for SwapChain<'a> {
+    fn get_backbuffers(&mut self) -> &[core::Backbuffer<Backend>] {
+        &self.backbuffer
+    }
 
+    fn acquire_frame(&mut self, sync: core::FrameSync<R>) -> core::Frame {
+        // TODO: fence sync
+        core::Frame::new(0)
+    }
+
+    fn present<Q>(&mut self, _: &mut Q)
+        where Q: AsMut<device_gl::CommandQueue> {
+        self.window.gl_swap_window();
+    }
+}
+
+pub struct Surface<'a> {
+    window: &'a sdl2::video::Window,
+    manager: handle::Manager<R>,
+}
+
+impl<'a> core::Surface<Backend> for Surface<'a> {
+    type SwapChain = SwapChain<'a>;
+
+    fn supports_queue(&self, _: &device_gl::QueueFamily) -> bool { true }
+    fn build_swapchain<Q>(&mut self, config: core::SwapchainConfig, _: &Q) -> SwapChain<'a>
+        where Q: AsRef<device_gl::CommandQueue>
+    {
+        use core::handle::Producer;
+        let dim = get_window_dimensions(self.window);
+        let color = self.manager.make_texture(
+            device_gl::NewTexture::Surface(0),
+            texture::Info {
+                levels: 1,
+                kind: texture::Kind::D2(dim.0, dim.1, dim.3),
+                format: config.color_format.0,
+                bind: memory::RENDER_TARGET | memory::TRANSFER_SRC,
+                usage: memory::Usage::Data,
+            },
+        );
+
+        let ds = config.depth_stencil_format.map(|ds_format| {
+            self.manager.make_texture(
+                device_gl::NewTexture::Surface(0),
+                texture::Info {
+                    levels: 1,
+                    kind: texture::Kind::D2(dim.0, dim.1, dim.3),
+                    format: ds_format.0,
+                    bind: memory::DEPTH_STENCIL | memory::TRANSFER_SRC,
+                    usage: memory::Usage::Data,
+                },
+            )
+        });
+
+        SwapChain {
+            window: self.window.clone(),
+            backbuffer: [(color, ds); 1],
+        }
+    }
+}
+
+pub struct Window<'a>(&'a sdl2::video::Window);
+impl<'a> Window<'a> {
+    pub fn new(window: &'a sdl2::video::Window) -> Self {
+        Window(window)
+    }
+}
+
+impl<'a> core::WindowExt<Backend> for Window<'a> {
+    type Surface = Surface<'a>;
+    type Adapter = device_gl::Adapter;
+
+    fn get_surface_and_adapters(&mut self) -> (Surface<'a>, Vec<device_gl::Adapter>) {
+        let adapter = device_gl::Adapter::new(|s|
+            self.0.subsystem().gl_get_proc_address(s) as *const std::os::raw::c_void);
+        let surface = Surface {
+            window: self.0,
+            manager: handle::Manager::new(),
+        };
+
+        (surface, vec![adapter])
+    }
+}
+
+/// Helper function for setting up an GL window and context
+pub fn build(mut builder: WindowBuilder, cf: Format, df: Format) -> Result<(sdl2::video::Window, GLContext), InitError> {
     let mut window = builder.opengl().build()?;
 
     let display_mode = DisplayMode {
@@ -134,47 +213,5 @@ pub fn init_raw(mut builder: WindowBuilder, cf: Format, df: Format)
 
     let context = window.gl_create_context()?;
 
-    let (device, factory) = gfx_device_gl::create(|s| {
-        window.subsystem().gl_get_proc_address(s) as *const std::os::raw::c_void
-    });
-
-    let (width, height) = window.drawable_size();
-    let dim = (width as Size, height as Size, 1, AaMode::Single);
-    let (color_view, ds_view) = gfx_device_gl::create_main_targets_raw(dim, cf.0, df.0);
-
-    Ok((window, context, device, factory, color_view, ds_view))
-}
-
-fn get_window_dimensions(window: &sdl2::video::Window) -> texture::Dimensions {
-    let (width, height) = window.size();
-    let aa = window.subsystem().gl_attr().multisample_samples() as texture::NumSamples;
-    (width as texture::Size, height as texture::Size, 1, aa.into())
-}
-
-/// Update the internal dimensions of the main framebuffer targets. Generic version over the format.
-pub fn update_views<Cf, Df>(window: &sdl2::video::Window, color_view: &mut handle::RenderTargetView<R, Cf>,
-                            ds_view: &mut handle::DepthStencilView<R, Df>)
-where
-    Cf: format::RenderFormat,
-    Df: format::DepthFormat
-{
-    let dim = color_view.get_dimensions();
-    assert_eq!(dim, ds_view.get_dimensions());
-    if let Some((cv, dv)) = update_views_raw(window, dim, Cf::get_format(), Df::get_format()) {
-        *color_view = Typed::new(cv);
-        *ds_view = Typed::new(dv);
-    }
-}
-
-/// Return new main target views if the window resolution has changed from the old dimensions.
-pub fn update_views_raw(window: &sdl2::video::Window, old_dimensions: texture::Dimensions,
-                        color_format: format::Format, ds_format: format::Format)
-                        -> Option<(handle::RawRenderTargetView<R>, handle::RawDepthStencilView<R>)>
-{
-    let dim = get_window_dimensions(window);
-    if dim != old_dimensions {
-        Some(gfx_device_gl::create_main_targets_raw(dim, color_format.0, ds_format.0))
-    } else {
-        None
-    }
+    Ok((window, context))
 }

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -12,6 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Builds an SDL2 window from a WindowBuilder struct.
+//!
+//! # Example
+//!
+//! ```no_run
+//! extern crate gfx_core;
+//! extern crate gfx_window_sdl;
+//! extern crate sdl2;
+//!
+//! use gfx_core::format::{DepthStencil, Rgba8};
+//!
+//! fn main() {
+//!     let sdl = sdl2::init().unwrap();
+//!
+//!     let builder = sdl.video().unwrap().window("Example", 800, 600);
+//!     let (window, glcontext) = gfx_window_sdl::build(window, Rgba8::get_format(), DepthStencil::get_format());
+//!     let mut window = gfx_window_sdl::Window::new(&window);
+//!     let (surface, adapters) = window.get_surface_and_adapters();
+//!
+//!     // some code...
+//! }
+//! ```
+
 #[macro_use]
 extern crate log;
 extern crate sdl2;
@@ -75,29 +98,6 @@ fn get_window_dimensions(window: &sdl2::video::Window) -> texture::Dimensions {
     let aa = window.subsystem().gl_attr().multisample_samples() as texture::NumSamples;
     (width as texture::Size, height as texture::Size, 1, aa.into())
 }
-
-/// Builds an SDL2 window from a WindowBuilder struct.
-///
-/// # Example
-///
-/// ```no_run
-/// extern crate gfx_core;
-/// extern crate gfx_window_sdl;
-/// extern crate sdl2;
-///
-/// use gfx_core::format::{DepthStencil, Rgba8};
-///
-/// fn main() {
-///     let sdl = sdl2::init().unwrap();
-///
-///     let builder = sdl.video().unwrap().window("Example", 800, 600);
-///     let (window, glcontext) = gfx_window_sdl::build(window, Rgba8::get_format(), DepthStencil::get_format());
-///     let mut window = gfx_window_sdl::Window::new(&window);
-///     let (surface, adapters) = window.get_surface_and_adapters();
-///
-///     // some code...
-/// }
-/// ```
 
 pub struct SwapChain<'a> {
     // Underlying window, required for presentation

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -87,7 +87,7 @@ impl Surface {
     fn from_window(window: &winit::Window, instance: Arc<Instance>) -> Surface {
         let entry = VK_ENTRY.as_ref().expect("Unable to load vulkan entry points");
 
-        let surface = self.surface_extensions.iter().map(|&extension| {
+        let surface = instance.surface_extensions.iter().map(|&extension| {
             match extension {
                 vk::VK_KHR_XLIB_SURFACE_EXTENSION_NAME => {
                     use winit::os::unix::WindowExt;


### PR DESCRIPTION
Adapt glfw and sdl window creation to the new model (Window-> Surface -> SwapChain).
The swapchains of these backends are restricted as mentioned in #1304 (set surface format at the beginning and swapchain config has to match those).

Backbuffer image creation could be abstracted in a followup PR as it's similar on all three (glutin, glfw, sdl) window backends.

Edit: I need to fix sdl build on my linux system later - done