### PR TITLE
[ll] Update triangle example [27/..]

### DIFF
--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -14,11 +14,10 @@
 
 #[macro_use]
 extern crate gfx;
-extern crate gfx_device_gl as device_gl;
 extern crate gfx_window_glutin;
 extern crate glutin;
 
-use gfx::{Adapter, Factory, FrameSync, GraphicsCommandPool, GraphicsPoolExt,
+use gfx::{Adapter, Factory, FrameSync, GraphicsPoolExt,
           Surface, SwapChain, SwapChainExt, WindowExt};
 use gfx::texture;
 use gfx::memory::Typed;
@@ -86,7 +85,7 @@ pub fn main() {
         pipe::new()
     ).unwrap();
     let (vertex_buffer, slice) = factory.create_vertex_buffer_with_slice(&TRIANGLE, ());
-    let mut graphics_pool = <device_gl::Backend as gfx::Backend>::GraphicsCommandPool::from_queue(graphics_queue.as_ref(), 1);
+    let mut graphics_pool = graphics_queue.create_graphics_pool(1);
     let frame_semaphore = factory.create_semaphore();
     let draw_semaphore = factory.create_semaphore();
 

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -19,7 +19,7 @@ extern crate gfx_window_glutin;
 extern crate glutin;
 
 use gfx::{Adapter, Factory, FrameSync, GraphicsCommandPool, GraphicsPoolExt,
-          Surface, SwapChain, WindowExt};
+          Surface, SwapChain, SwapChainExt, WindowExt};
 use gfx::texture;
 use gfx::memory::Typed;
 use gfx::traits::FactoryExt;
@@ -78,24 +78,9 @@ pub fn main() {
     let config = gfx::SwapchainConfig::new()
                     .with_color::<ColorFormat>();
     let mut swap_chain = surface.build_swapchain(config, &graphics_queue);
+    let views = swap_chain.create_color_views(&mut factory);
 
-    let views: Vec<gfx::handle::RenderTargetView<device_gl::Resources, ColorFormat>> =
-        swap_chain
-            .get_backbuffers()
-            .iter()
-            .map(|&(ref color, ref ds)| {
-                let color_desc = texture::RenderDesc {
-                    channel: ColorFormat::get_format().1,
-                    level: 0,
-                    layer: None,
-                };
-                let rtv = factory.view_texture_as_render_target_raw(color, color_desc)
-                                 .unwrap();
-                Typed::new(rtv)
-            })
-            .collect();
-
-   let pso = factory.create_pipeline_simple(
+    let pso = factory.create_pipeline_simple(
         include_bytes!("shader/triangle_150.glslv"),
         include_bytes!("shader/triangle_150.glslf"),
         pipe::new()

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -14,10 +14,16 @@
 
 #[macro_use]
 extern crate gfx;
+extern crate gfx_device_gl as device_gl;
 extern crate gfx_window_glutin;
 extern crate glutin;
 
+use gfx::{Adapter, Factory, FrameSync, GraphicsCommandPool, GraphicsPoolExt,
+          Surface, SwapChain, WindowExt};
+use gfx::texture;
+use gfx::memory::Typed;
 use gfx::traits::FactoryExt;
+use gfx::format::Formatted;
 
 pub type ColorFormat = gfx::format::Rgba8;
 pub type DepthFormat = gfx::format::DepthStencil;
@@ -43,26 +49,67 @@ const TRIANGLE: [Vertex; 3] = [
 const CLEAR_COLOR: [f32; 4] = [0.1, 0.2, 0.3, 1.0];
 
 pub fn main() {
+    // Create window
     let events_loop = glutin::EventsLoop::new();
     let builder = glutin::WindowBuilder::new()
         .with_title("Triangle example".to_string())
         .with_dimensions(1024, 768)
         .with_vsync();
-    let (window, mut device, mut factory, main_color, mut main_depth) =
-        gfx_window_glutin::init::<ColorFormat, DepthFormat>(builder, &events_loop);
-    let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
-    let pso = factory.create_pipeline_simple(
+    let window = gfx_window_glutin::build(builder, &events_loop, ColorFormat::get_format(), DepthFormat::get_format());
+
+    // Acquire surface and adapters
+    let (mut surface, adapters) = gfx_window_glutin::Window(&window).get_surface_and_adapters();
+    let queue_descs = adapters[0].get_queue_families().iter()
+                                 .filter(|family| surface.supports_queue(&family) )
+                                 .map(|family| { (family, 1) })
+                                 .collect::<Vec<_>>();
+
+    // Open device (factory and queues)
+    let gfx::Device { mut factory, mut general_queues, mut graphics_queues, .. } = adapters[0].open(&queue_descs);
+    let mut graphics_queue = if let Some(queue) = general_queues.first_mut() {
+        queue.as_mut().into()
+    } else if let Some(queue) = graphics_queues.first_mut() {
+        queue.as_mut()
+    } else {
+        panic!("Unable to find a matching general or graphics queue.");
+    };
+
+    // Create swapchain
+    let config = gfx::SwapchainConfig::new()
+                    .with_color::<ColorFormat>();
+    let mut swap_chain = surface.build_swapchain(config, &graphics_queue);
+
+    let views: Vec<gfx::handle::RenderTargetView<device_gl::Resources, ColorFormat>> =
+        swap_chain
+            .get_backbuffers()
+            .iter()
+            .map(|&(ref color, ref ds)| {
+                let color_desc = texture::RenderDesc {
+                    channel: ColorFormat::get_format().1,
+                    level: 0,
+                    layer: None,
+                };
+                let rtv = factory.view_texture_as_render_target_raw(color, color_desc)
+                                 .unwrap();
+                Typed::new(rtv)
+            })
+            .collect();
+
+   let pso = factory.create_pipeline_simple(
         include_bytes!("shader/triangle_150.glslv"),
         include_bytes!("shader/triangle_150.glslf"),
         pipe::new()
     ).unwrap();
     let (vertex_buffer, slice) = factory.create_vertex_buffer_with_slice(&TRIANGLE, ());
+    let mut graphics_pool = <device_gl::Backend as gfx::Backend>::GraphicsCommandPool::from_queue(graphics_queue.as_ref(), 1);
+    let semaphore = factory.create_semaphore();
+
     let mut data = pipe::Data {
         vbuf: vertex_buffer,
-        out: main_color
+        out: views[0].clone(),
     };
 
-
+    // main loop
     let mut running = true;
     while running {
         // fetch events
@@ -71,17 +118,24 @@ pub fn main() {
                 glutin::WindowEvent::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape), _) |
                 glutin::WindowEvent::Closed => running = false,
                 glutin::WindowEvent::Resized(_width, _height) => {
-                    gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);
+                    // TODO
                 },
                 _ => {},
             }
         });
 
+        // Get next frame
+        let frame = swap_chain.acquire_frame(FrameSync::Semaphore(&semaphore));
+        data.out = views[frame.id()].clone();        
+
         // draw a frame
+        let mut encoder = graphics_pool.acquire_graphics_encoder();
         encoder.clear(&data.out, CLEAR_COLOR);
         encoder.draw(&slice, &pso, &data);
-        encoder.flush(&mut device);
-        window.swap_buffers().unwrap();
-        device.cleanup();
+        encoder.synced_flush(&mut graphics_queue, &[&semaphore], &[], None);
+
+        // present
+        swap_chain.present(&mut graphics_queue);
+        // factory.cleanup();
     }
 }

--- a/src/core/src/window.rs
+++ b/src/core/src/window.rs
@@ -140,7 +140,11 @@ pub trait SwapChain<B: Backend> {
     ///
     /// # Safety
     /// The passed queue _must_ be the **same** queue as used for creation.
-    fn present<Q: AsMut<B::CommandQueue>>(&mut self, present_queue: &mut Q);
+    fn present<Q: AsMut<B::CommandQueue>>(
+        &mut self,
+        present_queue: &mut Q,
+        wait_semaphores: &[&handle::Semaphore<B::Resources>],
+    );
 }
 
 /// Extension for windows.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
     let mut running = true;
     let frame_semaphore = factory.create_semaphore();
 
-    let mut graphics_pool = B::GraphicsCommandPool::from_queue(queue.as_ref(), 1);
+    let mut graphics_pool = queue.create_graphics_pool(1);
 
     while running {
         events_loop.poll_events(|winit::Event::WindowEvent{window_id: _, event}| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
         // Wait til rendering has finished
         queue.wait_idle();
 
-        swap_chain.present(&mut queue);
+        swap_chain.present(&mut queue, &[]);
         harness.bump();
     }
 }

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -54,6 +54,7 @@ pub use encoder::{CopyBufferResult, CopyBufferTextureResult, CopyError,
                   CopyTextureBufferResult, GraphicsEncoder, UpdateError, GraphicsPoolExt};
 pub use factory::PipelineStateError;
 pub use slice::{Slice, IntoIndexBuffer, IndexBuffer};
+pub use swapchain::SwapChainExt;
 pub use pso::{PipelineState};
 pub use pso::buffer::{VertexBuffer, InstanceBuffer, RawVertexBuffer,
                       ConstantBuffer, RawConstantBuffer, Global, RawGlobal};
@@ -69,6 +70,8 @@ mod encoder;
 mod factory;
 /// Slices
 mod slice;
+/// Swapchain extensions
+mod swapchain;
 // Pipeline states
 pub mod pso;
 /// Shaders

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -38,7 +38,8 @@ pub use draw_state::{preset, state};
 pub use draw_state::target::*;
 
 // public re-exports
-pub use core::{Backend, Frame, Primitive, Resources, SubmissionError, SubmissionResult};
+pub use core::{Adapter, Backend, Device, Frame, FrameSync, Primitive, Resources, SubmissionError,
+               SubmissionResult, Surface, SwapChain, SwapchainConfig, WindowExt};
 pub use core::{VertexCount, InstanceCount};
 pub use core::{ShaderSet, VertexShader, HullShader, DomainShader, GeometryShader, PixelShader};
 pub use core::{GeneralCommandPool, GraphicsCommandPool, ComputeCommandPool, SubpassCommandPool};

--- a/src/render/src/swapchain.rs
+++ b/src/render/src/swapchain.rs
@@ -1,0 +1,46 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Swapchain extension.
+//!
+//! This module serves as an extension to the `SwapChain` trait from the core. This module
+//! exposes extension functions and shortcuts to aid with handling the swapchain.
+
+use {format, handle, texture, Backend, Factory, SwapChain};
+use memory::Typed;
+
+/// Extension trait for SwapChains
+///
+/// Every `SwapChain` automatically implements `SwapChainExt`. 
+pub trait SwapChainExt<B: Backend>: SwapChain<B> {
+    /// Create color RTVs for all backbuffer images.
+    // TODO: error handling
+    fn create_color_views<T: format::RenderFormat>(&mut self, factory: &mut B::Factory) -> Vec<handle::RenderTargetView<B::Resources, T>> {
+        self.get_backbuffers()
+            .iter()
+            .map(|&(ref color, _)| {
+                let color_desc = texture::RenderDesc {
+                    channel: T::get_format().1,
+                    level: 0,
+                    layer: None,
+                };
+                let rtv = factory.view_texture_as_render_target_raw(color, color_desc)
+                                 .unwrap();
+                Typed::new(rtv)
+            })
+            .collect()
+    }
+}
+
+impl <T, B: Backend> SwapChainExt<B> for T where T: SwapChain<B> { }

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -446,9 +446,10 @@ impl core::SwapChain<device_dx11::Backend> for SwapChain11 {
         core::Frame::new(0)
     }
 
-    fn present<Q>(&mut self, _present_queue: &mut Q)
+    fn present<Q>(&mut self, _present_queue: &mut Q, wait_semaphores: &[&h::Semaphore<device_dx11::Resources>])
         where Q: AsMut<device_dx11::CommandQueue>
     {
+        // TODO: wait semaphores
         unsafe { self.swap_chain.Present(1, 0); }
     }
 }
@@ -479,9 +480,10 @@ impl core::SwapChain<device_dx12::Backend> for SwapChain12 {
         unsafe { core::Frame::new(index as usize) }
     }
 
-    fn present<Q>(&mut self, _present_queue: &mut Q)
+    fn present<Q>(&mut self, _present_queue: &mut Q, wait_semaphores: &[&h::Semaphore<device_dx12::Resources>])
         where Q: AsMut<device_dx12::CommandQueue>
     {
+        // TODO: wait semaphores
         unsafe { self.inner.Present(1, 0); }
     }
 }

--- a/src/window/glfw/src/lib.rs
+++ b/src/window/glfw/src/lib.rs
@@ -73,8 +73,9 @@ impl<'a> core::SwapChain<device_gl::Backend> for SwapChain {
         core::Frame::new(0)
     }
 
-    fn present<Q>(&mut self, _: &mut Q)
-        where Q: AsMut<device_gl::CommandQueue> {
+    fn present<Q>(&mut self, _: &mut Q, _: &[&handle::Semaphore<device_gl::Resources>])
+        where Q: AsMut<device_gl::CommandQueue>
+    {
         self.window.borrow_mut().swap_buffers();
     }
 }

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -81,7 +81,7 @@ impl<'a> core::SwapChain<device_gl::Backend> for SwapChain<'a> {
         core::Frame::new(0)
     }
 
-    fn present<Q>(&mut self, present_queue: &mut Q)
+    fn present<Q>(&mut self, _: &mut Q, _: &[&handle::Semaphore<device_gl::Resources>])
         where Q: AsMut<device_gl::CommandQueue>
     {
         self.window.swap_buffers();

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -118,8 +118,9 @@ impl<'a> core::SwapChain<Backend> for SwapChain<'a> {
         core::Frame::new(0)
     }
 
-    fn present<Q>(&mut self, _: &mut Q)
-        where Q: AsMut<device_gl::CommandQueue> {
+    fn present<Q>(&mut self, _: &mut Q, _: &[&handle::Semaphore<device_gl::Resources>])
+        where Q: AsMut<device_gl::CommandQueue>
+    {
         self.window.gl_swap_window();
     }
 }

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -305,11 +305,12 @@ impl core::SwapChain<device_vulkan::Backend> for SwapChain {
         unsafe { core::Frame::new(index as usize) }
     }
 
-    fn present<Q>(&mut self, present_queue: &mut Q)
+    fn present<Q>(&mut self, present_queue: &mut Q, wait_semaphores: &[&handle::Semaphore<device_vulkan::Resources>])
         where Q: AsMut<device_vulkan::CommandQueue>
     {
         let frame = self.frame_queue.pop_front().expect("No frame currently queued up. Need to acquire a frame first.");
 
+        // TODO: wait semaphores
         let info = vk::PresentInfoKHR {
             s_type: vk::StructureType::PresentInfoKhr,
             p_next: ptr::null(),


### PR DESCRIPTION
- Port the triangle example to the new core. Due to the ll changes this requires a lot more boilerplate for the setup. Interesting direction would be providing some shortcuts for the user for specific scenarios (e.g single queue setup)

- Add API support for waiting on semaphores on present to allow patterns like acquire frame -> wait -> draw -> signal -> present. Not implemented for the backends so far (vk and dx12 are non-functional atm anyway..)

cc #1321 