### PR TITLE
[ll] Remove trait bounds and simplify device opening [29/..]

### DIFF
--- a/src/core/src/command.rs
+++ b/src/core/src/command.rs
@@ -50,20 +50,16 @@ impl<B: Backend> Submit<B> {
 ///
 /// Pools will always return an Encoder on `acquire_command_buffer` to provide a safe interface.
 #[derive(Debug)]
-pub struct Encoder<B: Backend, C: CommandBuffer<B>>(C, PhantomData<B>);
+pub struct Encoder<B, C>(C, PhantomData<B>);
 
-impl<B, C> Deref for Encoder<B, C>
-    where B: Backend, C: CommandBuffer<B>
-{
+impl<B, C> Deref for Encoder<B, C> {
     type Target = C;
     fn deref(&self) -> &C {
         &self.0
     }
 }
 
-impl<B, C> DerefMut for Encoder<B, C>
-    where B: Backend, C: CommandBuffer<B>
-{
+impl<B, C> DerefMut for Encoder<B, C> {
     fn deref_mut(&mut self) -> &mut C {
         &mut self.0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,11 +149,8 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
     use gfx::texture;
 
     // Init device
-    let queue_descs = adapters[0].get_queue_families().iter()
-                                 .filter(|family| surface.supports_queue(&family) )
-                                 .map(|family| { (family, family.num_queues()) })
-                                 .collect::<Vec<_>>();
-    let gfx_core::Device { mut factory, mut general_queues, mut graphics_queues, .. } = adapters[0].open(&queue_descs);
+    let gfx_core::Device { mut factory, mut general_queues, mut graphics_queues, .. } =
+        adapters[0].open_with(|family| if surface.supports_queue(&family) { 1 } else { 0 });
 
     let mut queue = if let Some(queue) = general_queues.first_mut() {
         queue.as_mut().into()


### PR DESCRIPTION
Follow to #1359 
- Remove `Encoder` trait bounds
- Add `open_with` to `Adapter` which takes an closure returning the number of queues for each family