### PR TITLE
Fix glutin headless GlContext compile issue

### DIFF
--- a/src/window/glutin/src/headless.rs
+++ b/src/window/glutin/src/headless.rs
@@ -15,7 +15,7 @@
 use std::os::raw::c_void;
 
 use device_gl::{Device, Factory, Resources as Res, create as gl_create, create_main_targets_raw};
-use glutin::{HeadlessContext};
+use glutin::{GlContext, HeadlessContext};
 
 use core::format::{Format, DepthFormat, RenderFormat};
 use core::handle::{DepthStencilView, RawDepthStencilView, RawRenderTargetView, RenderTargetView};


### PR DESCRIPTION
I missed this compile issue for `gfx_window_glutin` in headless mode in PR #1362.
This was obscured by the current mac build issue, as travis only builds this feature on mac.