### PR TITLE
Call GlWindow#resize on resize events in examples

### DIFF
--- a/examples/gamma/main.rs
+++ b/examples/gamma/main.rs
@@ -77,7 +77,8 @@ pub fn main() {
                             .. },
                         ..
                     } | glutin::WindowEvent::Closed => running = false,
-                    glutin::WindowEvent::Resized(_width, _height) => {
+                    glutin::WindowEvent::Resized(width, height) => {
+                        window.resize(width, height);
                         gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);
                     },
                     _ => (),

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -78,7 +78,8 @@ pub fn main() {
                             .. },
                         ..
                     } | glutin::WindowEvent::Closed => running = false,
-                    glutin::WindowEvent::Resized(_width, _height) => {
+                    glutin::WindowEvent::Resized(width, height) => {
+                        window.resize(width, height);
                         gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);
                     },
                     _ => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,7 @@ A: Sized + ApplicationBase<gfx_device_gl::Resources, gfx_device_gl::CommandBuffe
                         ..
                     } if key == A::get_exit_key() => return,
                     winit::WindowEvent::Resized(width, height) => if width != cur_width || height != cur_height {
+                        window.resize(width, height);
                         cur_width = width;
                         cur_height = height;
                         let (new_color, new_depth) = gfx_window_glutin::new_views(&window);


### PR DESCRIPTION
Additional call is required on mac/wayland, see [glutin docs](https://docs.rs/glutin/0.9.0/glutin/trait.GlContext.html#tymethod.resize) & [this comment](https://github.com/gfx-rs/gfx/pull/1362#issuecomment-314512747)