### PR TITLE
[ll] Update shadow example and adjust core for multi-threading

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,5 +19,5 @@ build_script:
 test_script:
   - cargo test --all --features vulkan
   - cargo test -p gfx -p gfx_core --features "mint serialize"
-  - cargo test --all --features dx11
-  - cargo test --all --features dx12
+  - if %COMPILER%==msvc cargo test --all --features dx11
+  - if %COMPILER%==msvc cargo test --all --features dx12

--- a/examples/blend/main.rs
+++ b/examples/blend/main.rs
@@ -84,6 +84,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -66,6 +66,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -234,6 +234,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/examples/flowmap/main.rs
+++ b/examples/flowmap/main.rs
@@ -74,6 +74,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -91,6 +91,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -69,6 +69,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -77,6 +77,7 @@ fn create_shader_set<R: gfx::Resources, F: gfx::Factory<R>>(factory: &mut F, vs_
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -90,6 +90,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/examples/terrain/main.rs
+++ b/examples/terrain/main.rs
@@ -78,6 +78,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/examples/terrain_tessellated/main.rs
+++ b/examples/terrain_tessellated/main.rs
@@ -77,6 +77,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/examples/ubo_tilemap/main.rs
+++ b/examples/ubo_tilemap/main.rs
@@ -402,6 +402,7 @@ fn populate_tilemap<B>(tilemap: &mut TileMap<B>, tilemap_size: [usize; 2]) where
 
 impl<B: gfx::Backend> gfx_app::Application<B> for TileMap<B> {
     fn new(factory: &mut B::Factory,
+           _: &mut gfx::queue::GraphicsQueueMut<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -28,7 +28,6 @@ use {Backend, CommandQueue};
 
 struct CommandAllocator {
     inner: ComPtr<winapi::ID3D12CommandAllocator>,
-    
     device: ComPtr<winapi::ID3D12Device>,
     list_type: winapi::D3D12_COMMAND_LIST_TYPE,
 }
@@ -88,6 +87,8 @@ impl CommandAllocator {
         command_list
     }
 }
+
+unsafe impl Send for CommandAllocator { }
 
 pub struct RawCommandPool {
     allocator: CommandAllocator,

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -85,6 +85,9 @@ pub struct SubmitInfo {
     pub(crate) data: *const DataBuffer,
 }
 
+// See the explanation above why this is safe.
+unsafe impl Send for SubmitInfo { }
+
 /// Serialized device command.
 #[derive(Clone, Copy, Debug)]
 pub enum Command {

--- a/src/core/src/command.rs
+++ b/src/core/src/command.rs
@@ -158,7 +158,7 @@ impl<'a, B: Backend> CommandBuffer<B> for TransferCommandBuffer<'a, B> {
 /// An interface of the abstract command buffer. It collects commands in an
 /// efficient API-specific manner, to be ready for execution on the device.
 #[allow(missing_docs)]
-pub trait Buffer<R: Resources>: 'static + Send {
+pub trait Buffer<R: Resources>: 'static {
     /// Reset the command buffer contents, retain the allocated storage
     fn reset(&mut self);
     /// Bind a pipeline state object

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -242,13 +242,13 @@ pub struct HeapType {
 
 /// Different types of a specific API.
 #[allow(missing_docs)]
-pub trait Backend: Sized {
+pub trait Backend: 'static + Sized {
     type Adapter: Adapter<Self>;
     type CommandQueue: CommandQueue<Self>;
     type Factory: Factory<Self::Resources>;
     type QueueFamily: QueueFamily;
     type Resources: Resources;
-    type SubmitInfo;
+    type SubmitInfo: Send;
 
     type RawCommandBuffer: CommandBuffer<Self> + command::Buffer<Self::Resources>;
     type SubpassCommandBuffer: CommandBuffer<Self>; // + SubpassCommandBuffer<Self::R>;

--- a/src/core/src/pool.rs
+++ b/src/core/src/pool.rs
@@ -22,7 +22,7 @@ use std::ops::DerefMut;
 
 /// `CommandPool` can allocate command buffers of a specific type only.
 /// The allocated command buffers are associated with the creating command queue.
-pub trait RawCommandPool<B: Backend> {
+pub trait RawCommandPool<B: Backend>: Send {
     /// Reset the command pool and the corresponding command buffers.
     ///
     /// # Synchronization: You may _not_ free the pool if a command buffer is still in use (pool memory still in use)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,10 @@ extern crate gfx_device_vulkan;
 #[cfg(feature = "vulkan")]
 extern crate gfx_window_vulkan;
 
-use gfx_core::memory::Typed;
-use gfx_core::{Adapter, Backend, CommandQueue, FrameSync, SwapChain, QueueFamily, WindowExt};
-use gfx_core::pool::GraphicsCommandPool;
+use gfx::memory::Typed;
+use gfx::{Adapter, Backend, CommandQueue, FrameSync, GraphicsCommandPool,
+    SwapChain, QueueFamily, WindowExt};
+use gfx::queue::GraphicsQueueMut;
 
 pub mod shade;
 
@@ -194,7 +195,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
             .collect();
 
     let shader_backend = factory.shader_backend();
-    let mut app = A::new(&mut factory, shader_backend, WindowTargets {
+    let mut app = A::new(&mut factory, &mut queue, shader_backend, WindowTargets {
         views: views,
         aspect_ratio: width as f32 / height as f32, //TODO
     });
@@ -258,9 +259,10 @@ pub type DefaultBackend = gfx_device_metal::Backend;
 pub type DefaultBackend = gfx_device_vulkan::Backend;
 
 pub trait Application<B: Backend>: Sized {
-    fn new(&mut B::Factory, shade::Backend, WindowTargets<B::Resources>) -> Self;
+    fn new(&mut B::Factory, &mut GraphicsQueueMut<B>,
+           shade::Backend, WindowTargets<B::Resources>) -> Self;
     fn render(&mut self, frame: (gfx_core::Frame, &gfx::handle::Semaphore<B::Resources>),
-                     pool: &mut GraphicsCommandPool<B>, queue: &mut gfx_core::queue::GraphicsQueueMut<B>);
+                     pool: &mut GraphicsCommandPool<B>, queue: &mut GraphicsQueueMut<B>);
 
     fn get_exit_key() -> Option<winit::VirtualKeyCode> {
         Some(winit::VirtualKeyCode::Escape)

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -38,7 +38,7 @@ pub use draw_state::{preset, state};
 pub use draw_state::target::*;
 
 // public re-exports
-pub use core::{Adapter, Backend, CommandQueue, Device, Frame, FrameSync, Primitive, Resources, SubmissionError,
+pub use core::{Adapter, Backend, CommandQueue, Device, Frame, FrameSync, Primitive, QueueFamily, Resources, SubmissionError,
                SubmissionResult, Surface, SwapChain, SwapchainConfig, WindowExt};
 pub use core::{VertexCount, InstanceCount};
 pub use core::{ShaderSet, VertexShader, HullShader, DomainShader, GeometryShader, PixelShader};

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -29,8 +29,7 @@ use std::rc::Rc;
 use std::os::raw::c_void;
 use std::collections::VecDeque;
 use winit::os::windows::WindowExt;
-use core::{format, handle as h, factory as f, memory, texture as tex};
-use core::texture::Size;
+use core::{handle as h, memory, texture as tex};
 use comptr::ComPtr;
 
 /*
@@ -95,7 +94,7 @@ pub struct Surface11 {
 impl core::Surface<device_dx11::Backend> for Surface11 {
     type SwapChain = SwapChain11;
 
-    fn supports_queue(&self, queue_family: &device_dx11::QueueFamily) -> bool { true }
+    fn supports_queue(&self, _: &device_dx11::QueueFamily) -> bool { true }
     fn build_swapchain<Q>(&mut self, config: core::SwapchainConfig, present_queue: &Q) -> SwapChain11
         where Q: AsRef<device_dx11::CommandQueue>
     {
@@ -226,7 +225,7 @@ pub struct Surface12 {
 impl core::Surface<device_dx12::Backend> for Surface12 {
     type SwapChain = SwapChain12;
 
-    fn supports_queue(&self, queue_family: &device_dx12::QueueFamily) -> bool { true }
+    fn supports_queue(&self, _: &device_dx12::QueueFamily) -> bool { true }
     fn build_swapchain<Q>(&mut self, config: core::SwapchainConfig, present_queue: &Q) -> SwapChain12
         where Q: AsRef<device_dx12::CommandQueue>
     {

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -139,7 +139,7 @@ impl core::Surface<Backend> for Surface {
         where Q: AsRef<device_gl::CommandQueue>
     {
         use core::handle::Producer;
-        let dim = get_window_dimensions(self.window);
+        let dim = get_window_dimensions(&self.window);
         let color = self.manager.make_texture(
             device_gl::NewTexture::Surface(0),
             texture::Info {


### PR DESCRIPTION
* core Add necessary trait bounds for pools and backend
* render: Allow to split finish and submit for GraphicsEncoder, allowing to send submission across threads
* shadow: Instead of having an encoder per thread, we now have a pool per thread, record a command buffer on each thread, finish and send back the submit info to the main thread, where we submit the commands atm.

cc #1321 