### PR TITLE
[ll] Support queue family casting and remove queue ref wrappers

### DIFF
--- a/examples/blend/main.rs
+++ b/examples/blend/main.rs
@@ -84,7 +84,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -150,7 +150,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         let (cur_color, _) = self.views[frame.id()].clone();
         self.bundle.data.out = cur_color;

--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -66,7 +66,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -168,7 +168,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         let (cur_color, cur_depth) = self.views[frame.id()].clone();
         self.bundle.data.out_color = cur_color;

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -234,7 +234,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -480,7 +480,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         let elapsed = self.start_time.elapsed();
         let time = elapsed.as_secs() as f32 + elapsed.subsec_nanos() as f32 / 1000_000_000.0;

--- a/examples/flowmap/main.rs
+++ b/examples/flowmap/main.rs
@@ -74,7 +74,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -138,7 +138,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         let delta = self.time_start.elapsed();
         self.time_start = Instant::now();

--- a/examples/gamma/main.rs
+++ b/examples/gamma/main.rs
@@ -61,11 +61,7 @@ pub fn main() {
         adapters[0].open_with(|family, ty| {
             ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, gfx::QueueType::Graphics)
         });
-    let mut graphics_queue = if let Some(queue) = graphics_queues.pop() {
-        queue
-    } else {
-        panic!("Unable to find a graphics queue.");
-    };
+    let mut graphics_queue = graphics_queues.pop().expect("Unable to find a graphics queue.");
 
     // Create swapchain
     let config = gfx::SwapchainConfig::new()

--- a/examples/gamma/main.rs
+++ b/examples/gamma/main.rs
@@ -111,7 +111,7 @@ pub fn main() {
         let mut encoder = graphics_pool.acquire_graphics_encoder();
         encoder.clear(&data.out, CLEAR_COLOR);
         encoder.draw(&slice, &pso, &data);
-        encoder.synced_flush(&mut graphics_queue.as_mut(), &[&frame_semaphore], &[&draw_semaphore], None);
+        encoder.synced_flush(&mut graphics_queue, &[&frame_semaphore], &[&draw_semaphore], None);
         swap_chain.present(&mut graphics_queue, &[&draw_semaphore]);
         graphics_queue.wait_idle();
         graphics_queue.cleanup();

--- a/examples/gamma/main.rs
+++ b/examples/gamma/main.rs
@@ -57,14 +57,14 @@ pub fn main() {
 
     let (mut surface, adapters) = window.get_surface_and_adapters();
     // Open device (factory and queues)
-    let gfx::Device { mut factory, mut general_queues, mut graphics_queues, .. } =
-        adapters[0].open_with(|family| surface.supports_queue(&family) as u32);
-    let mut graphics_queue = if let Some(queue) = general_queues.first_mut() {
-        queue.as_mut().into()
-    } else if let Some(queue) = graphics_queues.first_mut() {
-        queue.as_mut()
+    let gfx::Device { mut factory, mut graphics_queues, .. } =
+        adapters[0].open_with(|family, ty| {
+            ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, gfx::QueueType::Graphics)
+        });
+    let mut graphics_queue = if let Some(queue) = graphics_queues.pop() {
+        queue
     } else {
-        panic!("Unable to find a matching general or graphics queue.");
+        panic!("Unable to find a graphics queue.");
     };
 
     // Create swapchain
@@ -105,13 +105,13 @@ pub fn main() {
 
         // Get next frame
         let frame = swap_chain.acquire_frame(FrameSync::Semaphore(&frame_semaphore));
-        data.out = views[frame.id()].clone();        
+        data.out = views[frame.id()].clone();
 
         // Draw a frame
         let mut encoder = graphics_pool.acquire_graphics_encoder();
         encoder.clear(&data.out, CLEAR_COLOR);
         encoder.draw(&slice, &pso, &data);
-        encoder.synced_flush(&mut graphics_queue, &[&frame_semaphore], &[&draw_semaphore], None);
+        encoder.synced_flush(&mut graphics_queue.as_mut(), &[&frame_semaphore], &[&draw_semaphore], None);
         swap_chain.present(&mut graphics_queue, &[&draw_semaphore]);
         graphics_queue.wait_idle();
         graphics_queue.cleanup();

--- a/examples/instancing/main.rs
+++ b/examples/instancing/main.rs
@@ -91,7 +91,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -161,7 +161,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         let mut encoder = pool.acquire_graphics_encoder();
         if self.uploading {

--- a/examples/mipmap/main.rs
+++ b/examples/mipmap/main.rs
@@ -69,7 +69,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -128,7 +128,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         let (cur_color, _) = self.views[frame.id()].clone();
         self.data.out = cur_color;

--- a/examples/particle/main.rs
+++ b/examples/particle/main.rs
@@ -77,7 +77,7 @@ fn create_shader_set<R: gfx::Resources, F: gfx::Factory<R>>(factory: &mut F, vs_
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -148,7 +148,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         // Compute the time since last frame
         let delta = self.time_start.elapsed();

--- a/examples/performance/main.rs
+++ b/examples/performance/main.rs
@@ -125,11 +125,7 @@ impl GFX {
         adapters[0].open_with(|family, ty| {
             ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, gfx::QueueType::Graphics)
         });
-        let mut queue = if let Some(queue) = graphics_queues.pop() {
-            queue
-        } else {
-            panic!("Unable to find a graphics queue.");
-        };
+        let mut queue = graphics_queues.pop().expect("Unable to find a graphics queue.");
 
         // Create swapchain
         let config = gfx::SwapchainConfig::new()
@@ -190,7 +186,7 @@ impl Renderer for GFX {
 
         let pre_submit = start.elapsed();
         encoder.synced_flush(
-            &mut self.queue.as_mut(),
+            &mut self.queue,
             &[&self.frame_semaphore],
             &[&self.draw_semaphore],
             None);

--- a/examples/shadow/main.rs
+++ b/examples/shadow/main.rs
@@ -205,7 +205,7 @@ struct Scene<B: gfx::Backend> {
 /// Create a full scene
 fn create_scene<B>(
     factory: &mut B::Factory,
-    queue: &mut gfx::queue::GraphicsQueueMut<B>,
+    queue: &mut gfx::queue::GraphicsQueue<B>,
     out_color: gfx::handle::RenderTargetView<B::Resources, ColorFormat>,
     out_depth: gfx::handle::DepthStencilView<B::Resources, DepthFormat>,
     shadow_pso: gfx::PipelineState<B::Resources, shadow::Meta>) -> Scene<B>
@@ -429,7 +429,7 @@ impl<B: gfx::Backend> App<B> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           queue: &mut gfx::queue::GraphicsQueueMut<B>,
+           queue: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -506,7 +506,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, mut queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, mut queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         let (cur_color, cur_depth) = self.window_targets.views[frame.id()].clone();
         let mut encoder = pool.acquire_graphics_encoder();

--- a/examples/skybox/main.rs
+++ b/examples/skybox/main.rs
@@ -90,7 +90,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -149,7 +149,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         let (cur_color, _) = self.views[frame.id()].clone();
         self.bundle.data.out = cur_color;

--- a/examples/terrain/main.rs
+++ b/examples/terrain/main.rs
@@ -78,7 +78,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -147,7 +147,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         let elapsed = self.start_time.elapsed();
         let time = elapsed.as_secs() as f32 + elapsed.subsec_nanos() as f32 / 1000_000_000.0;

--- a/examples/terrain_tessellated/main.rs
+++ b/examples/terrain_tessellated/main.rs
@@ -77,7 +77,7 @@ struct App<B: gfx::Backend> {
 
 impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -162,7 +162,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for App<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         let elapsed = self.start_time.elapsed();
         let time = elapsed.as_secs() as f32 + elapsed.subsec_nanos() as f32 / 1000_000_000.0;

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -59,14 +59,14 @@ pub fn main() {
     let (mut surface, adapters) = gfx_window_glutin::Window::new(window).get_surface_and_adapters();
 
     // Open device (factory and queues)
-    let gfx::Device { mut factory, mut general_queues, mut graphics_queues, .. } =
-        adapters[0].open_with(|family| surface.supports_queue(&family) as u32);
-    let mut graphics_queue = if let Some(queue) = general_queues.first_mut() {
-        queue.as_mut().into()
-    } else if let Some(queue) = graphics_queues.first_mut() {
-        queue.as_mut()
+    let gfx::Device { mut factory, mut graphics_queues, .. } =
+        adapters[0].open_with(|family, ty| {
+            ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, gfx::QueueType::Graphics)
+        });
+    let mut graphics_queue = if let Some(queue) = graphics_queues.pop() {
+        queue
     } else {
-        panic!("Unable to find a matching general or graphics queue.");
+        panic!("Unable to find a graphics queue.");
     };
 
     // Create swapchain
@@ -107,14 +107,14 @@ pub fn main() {
 
         // Get next frame
         let frame = swap_chain.acquire_frame(FrameSync::Semaphore(&frame_semaphore));
-        data.out = views[frame.id()].clone();        
+        data.out = views[frame.id()].clone();
 
         // draw a frame
         // wait for frame -> draw -> signal -> present
         let mut encoder = graphics_pool.acquire_graphics_encoder();
         encoder.clear(&data.out, CLEAR_COLOR);
         encoder.draw(&slice, &pso, &data);
-        encoder.synced_flush(&mut graphics_queue, &[&frame_semaphore], &[&draw_semaphore], None);
+        encoder.synced_flush(&mut graphics_queue.as_mut(), &[&frame_semaphore], &[&draw_semaphore], None);
         swap_chain.present(&mut graphics_queue, &[&draw_semaphore]);
         graphics_queue.cleanup();
     }

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -63,11 +63,7 @@ pub fn main() {
         adapters[0].open_with(|family, ty| {
             ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, gfx::QueueType::Graphics)
         });
-    let mut graphics_queue = if let Some(queue) = graphics_queues.pop() {
-        queue
-    } else {
-        panic!("Unable to find a graphics queue.");
-    };
+    let mut graphics_queue = graphics_queues.pop().expect("Unable to find a graphics queue.");
 
     // Create swapchain
     let config = gfx::SwapchainConfig::new()

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -114,7 +114,7 @@ pub fn main() {
         let mut encoder = graphics_pool.acquire_graphics_encoder();
         encoder.clear(&data.out, CLEAR_COLOR);
         encoder.draw(&slice, &pso, &data);
-        encoder.synced_flush(&mut graphics_queue.as_mut(), &[&frame_semaphore], &[&draw_semaphore], None);
+        encoder.synced_flush(&mut graphics_queue, &[&frame_semaphore], &[&draw_semaphore], None);
         swap_chain.present(&mut graphics_queue, &[&draw_semaphore]);
         graphics_queue.cleanup();
     }

--- a/examples/ubo_tilemap/main.rs
+++ b/examples/ubo_tilemap/main.rs
@@ -402,7 +402,7 @@ fn populate_tilemap<B>(tilemap: &mut TileMap<B>, tilemap_size: [usize; 2]) where
 
 impl<B: gfx::Backend> gfx_app::Application<B> for TileMap<B> {
     fn new(factory: &mut B::Factory,
-           _: &mut gfx::queue::GraphicsQueueMut<B>,
+           _: &mut gfx::queue::GraphicsQueue<B>,
            backend: gfx_app::shade::Backend,
            window_targets: gfx_app::WindowTargets<B::Resources>) -> Self
     {
@@ -463,7 +463,7 @@ impl<B: gfx::Backend> gfx_app::Application<B> for TileMap<B> {
     }
 
     fn render(&mut self, (frame, semaphore): (gfx::Frame, &gfx::handle::Semaphore<B::Resources>),
-              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueueMut<B>)
+              pool: &mut gfx::GraphicsCommandPool<B>, queue: &mut gfx::queue::GraphicsQueue<B>)
     {
         // view configuration based on current position
         let view = Matrix4::look_at(

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -27,7 +27,7 @@ mod factory;
 mod native;
 mod pool;
 
-use core::{command as com, handle};
+use core::{command as com, handle, QueueType};
 use comptr::ComPtr;
 use std::ptr;
 use std::os::raw::c_void;
@@ -47,11 +47,11 @@ impl core::QueueFamily for QueueFamily {
 pub struct Adapter {
     adapter: ComPtr<winapi::IDXGIAdapter2>,
     info: core::AdapterInfo,
-    queue_families: Vec<QueueFamily>,
+    queue_families: Vec<(QueueFamily, QueueType)>,
 }
 
 impl core::Adapter<Backend> for Adapter {
-    fn open(&self, queue_descs: &[(&QueueFamily, u32)]) -> core::Device<Backend>
+    fn open(&self, queue_descs: &[(&QueueFamily, QueueType, u32)]) -> core::Device<Backend>
     {
         // Create D3D12 device
         let mut device = ComPtr::<winapi::ID3D12Device>::new(ptr::null_mut());
@@ -69,7 +69,7 @@ impl core::Adapter<Backend> for Adapter {
 
         // TODO: other queue types
         // Create command queues
-        let mut general_queues = queue_descs.iter().flat_map(|&(_family, queue_count)| {
+        let mut general_queues = queue_descs.iter().flat_map(|&(_family, _ty, queue_count)| {
             (0..queue_count).map(|_| {
                 let mut queue = ComPtr::<winapi::ID3D12CommandQueue>::new(ptr::null_mut());
                 let queue_desc = winapi::D3D12_COMMAND_QUEUE_DESC {
@@ -124,7 +124,7 @@ impl core::Adapter<Backend> for Adapter {
         unimplemented!()
     }
 
-    fn get_queue_families(&self) -> &[QueueFamily] {
+    fn get_queue_families(&self) -> &[(QueueFamily, QueueType)] {
         unimplemented!()
     }
 }
@@ -308,7 +308,7 @@ impl Instance {
                     Adapter {
                         adapter: adapter,
                         info: info,
-                        queue_families: vec![QueueFamily], // TODO:
+                        queue_families: vec![(QueueFamily, QueueType::General)], // TODO:
                     });
             }
 

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -60,7 +60,7 @@ impl CommandAllocator {
     fn reset(&mut self) {
         unsafe { self.inner.Reset(); }
     }
-    
+
     fn create_command_list(&mut self) -> ComPtr<winapi::ID3D12GraphicsCommandList> {
         // allocate command lists
         let mut command_list = ComPtr::<winapi::ID3D12GraphicsCommandList>::new(ptr::null_mut());

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -64,13 +64,13 @@ pub struct Instance {
 }
 
 fn map_queue_type(flags: vk::QueueFlags) -> QueueType {
-    if flags.intersects(vk::QUEUE_GRAPHICS_BIT | vk::QUEUE_COMPUTE_BIT) { // TRANSER_BIT optional
+    if flags.subset(vk::QUEUE_GRAPHICS_BIT | vk::QUEUE_COMPUTE_BIT) { // TRANSER_BIT optional
         QueueType::General
-    } else if flags.intersects(vk::QUEUE_GRAPHICS_BIT) { // TRANSER_BIT optional
+    } else if flags.subset(vk::QUEUE_GRAPHICS_BIT) { // TRANSER_BIT optional
         QueueType::Graphics
-    } else if flags.intersects(vk::QUEUE_COMPUTE_BIT) { // TRANSER_BIT optional
+    } else if flags.subset(vk::QUEUE_COMPUTE_BIT) { // TRANSER_BIT optional
         QueueType::Compute
-    } else if flags.intersects(vk::QUEUE_TRANSFER_BIT) {
+    } else if flags.subset(vk::QUEUE_TRANSFER_BIT) {
         QueueType::Transfer
     } else {
         // TODO: present only queues?

--- a/src/core/src/queue.rs
+++ b/src/core/src/queue.rs
@@ -24,6 +24,34 @@ use std::borrow::{Borrow, BorrowMut};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
+///
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum QueueType {
+    ///
+    General,
+    ///
+    Graphics,
+    ///
+    Compute,
+    ///
+    Transfer,
+}
+
+impl QueueType {
+    ///
+    pub fn supports_graphics(&self) -> bool {
+        *self == QueueType::General || *self == QueueType::Graphics
+    }
+
+    ///
+    pub fn supports_compute(&self) -> bool {
+        *self == QueueType::General || *self == QueueType::Compute
+    }
+
+    ///
+    pub fn supports_transfer(&self) -> bool { true }
+}
+
 /// `QueueFamily` denotes a group of command queues provided by the backend
 /// with the same properties/type.
 pub trait QueueFamily: 'static {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,9 @@ extern crate gfx_device_vulkan;
 extern crate gfx_window_vulkan;
 
 use gfx::memory::Typed;
+use gfx::queue::GraphicsQueue;
 use gfx::{Adapter, Backend, CommandQueue, FrameSync, GraphicsCommandPool,
-    SwapChain, QueueFamily, QueueType, WindowExt};
-use gfx::queue::GraphicsQueueMut;
+          SwapChain, QueueFamily, QueueType, WindowExt};
 
 pub mod shade;
 
@@ -193,7 +193,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
             .collect();
 
     let shader_backend = factory.shader_backend();
-    let mut app = A::new(&mut factory, &mut queue.as_mut(), shader_backend, WindowTargets {
+    let mut app = A::new(&mut factory, &mut queue, shader_backend, WindowTargets {
         views: views,
         aspect_ratio: width as f32 / height as f32, //TODO
     });
@@ -218,7 +218,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
 
         let frame = swap_chain.acquire_frame(FrameSync::Semaphore(&frame_semaphore));
 
-        app.render((frame, &frame_semaphore), &mut graphics_pool, &mut queue.as_mut());
+        app.render((frame, &frame_semaphore), &mut graphics_pool, &mut queue);
 
         // Wait til rendering has finished
         queue.wait_idle();
@@ -257,10 +257,10 @@ pub type DefaultBackend = gfx_device_metal::Backend;
 pub type DefaultBackend = gfx_device_vulkan::Backend;
 
 pub trait Application<B: Backend>: Sized {
-    fn new(&mut B::Factory, &mut GraphicsQueueMut<B>,
+    fn new(&mut B::Factory, &mut GraphicsQueue<B>,
            shade::Backend, WindowTargets<B::Resources>) -> Self;
     fn render(&mut self, frame: (gfx_core::Frame, &gfx::handle::Semaphore<B::Resources>),
-                     pool: &mut GraphicsCommandPool<B>, queue: &mut GraphicsQueueMut<B>);
+                     pool: &mut GraphicsCommandPool<B>, queue: &mut GraphicsQueue<B>);
 
     fn get_exit_key() -> Option<winit::VirtualKeyCode> {
         Some(winit::VirtualKeyCode::Escape)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ extern crate gfx_window_vulkan;
 
 use gfx::memory::Typed;
 use gfx::{Adapter, Backend, CommandQueue, FrameSync, GraphicsCommandPool,
-    SwapChain, QueueFamily, WindowExt};
+    SwapChain, QueueFamily, QueueType, WindowExt};
 use gfx::queue::GraphicsQueueMut;
 
 pub mod shade;
@@ -149,16 +149,14 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
     use gfx::traits::Factory;
     use gfx::texture;
 
-    // Init device
-    let gfx_core::Device { mut factory, mut general_queues, mut graphics_queues, .. } =
-        adapters[0].open_with(|family| surface.supports_queue(&family) as u32);
+    // Init device, requesting (at least) one graphics queue with presentation support
+    let gfx_core::Device { mut factory, mut graphics_queues, .. } =
+        adapters[0].open_with(|family, ty| ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, QueueType::Graphics));
 
-    let mut queue = if let Some(queue) = general_queues.first_mut() {
-        queue.as_mut().into()
-    } else if let Some(queue) = graphics_queues.first_mut() {
-        queue.as_mut()
+    let mut queue = if let Some(queue) = graphics_queues.pop() {
+        queue
     } else {
-        error!("Unable to find a matching general or graphics queue.");
+        error!("Unable to find a graphics queue.");
         return
     };
 
@@ -195,7 +193,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
             .collect();
 
     let shader_backend = factory.shader_backend();
-    let mut app = A::new(&mut factory, &mut queue, shader_backend, WindowTargets {
+    let mut app = A::new(&mut factory, &mut queue.as_mut(), shader_backend, WindowTargets {
         views: views,
         aspect_ratio: width as f32 / height as f32, //TODO
     });
@@ -220,7 +218,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
 
         let frame = swap_chain.acquire_frame(FrameSync::Semaphore(&frame_semaphore));
 
-        app.render((frame, &frame_semaphore), &mut graphics_pool, &mut queue);
+        app.render((frame, &frame_semaphore), &mut graphics_pool, &mut queue.as_mut());
 
         // Wait til rendering has finished
         queue.wait_idle();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,13 +152,7 @@ fn run<A, B, S, EL>((width, height): (u32, u32),
     // Init device, requesting (at least) one graphics queue with presentation support
     let gfx_core::Device { mut factory, mut graphics_queues, .. } =
         adapters[0].open_with(|family, ty| ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, QueueType::Graphics));
-
-    let mut queue = if let Some(queue) = graphics_queues.pop() {
-        queue
-    } else {
-        error!("Unable to find a graphics queue.");
-        return
-    };
+    let mut queue = graphics_queues.pop().expect("Unable to find a graphics queue.");
 
     let config = gfx_core::SwapchainConfig::new()
                     .with_color::<ColorFormat>()

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -21,11 +21,11 @@ use std::error::Error;
 use std::any::Any;
 use std::{fmt, mem};
 
-use core::{Backend, CommandQueue, SubmissionResult, IndexType, Resources, VertexCount, GraphicsCommandPool, QueueSubmit};
+use core::{Backend, CommandQueue, GraphicsCommandPool, GraphicsQueue, IndexType,
+           QueueSubmit, Resources, SubmissionResult, VertexCount};
 use core::{self, command, format, handle, texture};
 use core::command::{Buffer, Encoder, GraphicsCommandBuffer, Submit};
 use core::memory::{self, cast_slice, Typed, Pod, Usage};
-use core::queue::GraphicsQueueMut;
 use slice;
 use pso;
 
@@ -182,14 +182,14 @@ impl<'a, B: Backend> From<Encoder<B, GraphicsCommandBuffer<'a, B>>> for Graphics
 pub struct GraphicsSubmission<B: Backend> {
     submission: Submit<B>,
     access_info: command::AccessInfo<B::Resources>,
-    handles: handle::Manager<B::Resources>, 
+    handles: handle::Manager<B::Resources>,
 }
 
 impl<B: Backend> GraphicsSubmission<B> {
      /// Submits the commands in the internal `CommandBuffer` to the GPU, so they can
     /// be executed.
     pub fn synced_flush(self,
-                        queue: &mut GraphicsQueueMut<B>,
+                        queue: &mut GraphicsQueue<B>,
                         wait_semaphores: &[&handle::Semaphore<B::Resources>],
                         signal_semaphores: &[&handle::Semaphore<B::Resources>],
                         fence: Option<&handle::Fence<B::Resources>>) -> SubmissionResult<()> {
@@ -220,14 +220,14 @@ impl<'a, B: Backend> GraphicsEncoder<'a, B> {
     /// internal ´CommandBuffer´ will not be sent to the GPU, and as a result they will not be
     /// processed. Calling flush too often however will result in a performance hit. It is
     /// generally recommended to call flush once per frame, when all draw calls have been made.
-    pub fn flush(self, queue: &mut GraphicsQueueMut<B>) -> SubmissionResult<()> {
+    pub fn flush(self, queue: &mut GraphicsQueue<B>) -> SubmissionResult<()> {
         self.synced_flush(queue, &[], &[], None)
     }
 
     /// Submits the commands in the internal `CommandBuffer` to the GPU, so they can
     /// be executed.
     pub fn synced_flush(self,
-                        queue: &mut GraphicsQueueMut<B>,
+                        queue: &mut GraphicsQueue<B>,
                         wait_semaphores: &[&handle::Semaphore<B::Resources>],
                         signal_semaphores: &[&handle::Semaphore<B::Resources>],
                         fence: Option<&handle::Fence<B::Resources>>) -> SubmissionResult<()> {

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -38,8 +38,8 @@ pub use draw_state::{preset, state};
 pub use draw_state::target::*;
 
 // public re-exports
-pub use core::{Adapter, Backend, CommandQueue, Device, Frame, FrameSync, Primitive, QueueFamily, Resources, SubmissionError,
-               SubmissionResult, Surface, SwapChain, SwapchainConfig, WindowExt};
+pub use core::{Adapter, Backend, CommandQueue, Device, Frame, FrameSync, Primitive, QueueFamily, QueueType,
+               Resources, SubmissionError, SubmissionResult, Surface, SwapChain, SwapchainConfig, WindowExt};
 pub use core::{VertexCount, InstanceCount};
 pub use core::{ShaderSet, VertexShader, HullShader, DomainShader, GeometryShader, PixelShader};
 pub use core::{GeneralCommandPool, GraphicsCommandPool, ComputeCommandPool, SubpassCommandPool};

--- a/src/window/glfw/examples/window.rs
+++ b/src/window/glfw/examples/window.rs
@@ -45,11 +45,7 @@ pub fn main() {
         adapters[0].open_with(|family, ty| {
             ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, gfx::QueueType::Graphics)
         });
-    let mut graphics_queue = if let Some(queue) = graphics_queues.pop() {
-        queue
-    } else {
-        panic!("Unable to find a graphics queue.");
-    };
+    let mut queue = graphics_queues.pop().expect("Unable to find a graphics queue.");
 
     let config = gfx_core::SwapchainConfig::new();
     let mut swap_chain = surface.build_swapchain(config, &queue);

--- a/src/window/sdl/examples/window.rs
+++ b/src/window/sdl/examples/window.rs
@@ -38,11 +38,7 @@ pub fn main() {
         adapters[0].open_with(|family, ty| {
             ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, gfx::QueueType::Graphics)
         });
-    let mut graphics_queue = if let Some(queue) = graphics_queues.pop() {
-        queue
-    } else {
-        panic!("Unable to find a graphics queue.");
-    };
+    let mut queue = graphics_queues.pop().expect("Unable to find a graphics queue.");
 
     let config = gfx_core::SwapchainConfig::new();
     let mut swap_chain = surface.build_swapchain(config, &queue);

--- a/src/window/sdl/examples/window.rs
+++ b/src/window/sdl/examples/window.rs
@@ -34,18 +34,14 @@ pub fn main() {
     let mut window = gfx_window_sdl::Window::new(window);
     let (mut surface, adapters) = window.get_surface_and_adapters();
 
-    let queue_descs = adapters[0].get_queue_families().iter()
-                                 .filter(|family| surface.supports_queue(&family) )
-                                 .map(|family| { (family, family.num_queues()) })
-                                 .collect::<Vec<_>>();
-    let gfx_core::Device { mut general_queues, mut graphics_queues, .. } = adapters[0].open(&queue_descs);
-
-    let mut queue = if let Some(queue) = general_queues.first_mut() {
-        queue.as_mut().into()
-    } else if let Some(queue) = graphics_queues.first_mut() {
-        queue.as_mut()
+    let gfx::Device { mut factory, mut graphics_queues, .. } =
+        adapters[0].open_with(|family, ty| {
+            ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, gfx::QueueType::Graphics)
+        });
+    let mut graphics_queue = if let Some(queue) = graphics_queues.pop() {
+        queue
     } else {
-        return
+        panic!("Unable to find a graphics queue.");
     };
 
     let config = gfx_core::SwapchainConfig::new();


### PR DESCRIPTION
Allow to specify the queue type on initialization (e.g create a graphics queue from a general queue family).
Due to this queue 'casting' the queue reference wrappers become more or less obsolete as the user can now specify the wished queue type upfront and doesn't need to cast after they have been created.