### PR TITLE
[ll] Headless initialization [33/..]

### DIFF
--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -403,3 +403,12 @@ pub struct AdapterInfo {
     pub software_rendering: bool,
 }
 
+/// Main entry point for window-less backend initialization.
+pub trait Headless<B: Backend> {
+    /// Associated `Adapter` type.
+    type Adapter: Adapter<B>;
+
+    /// Enumerate all available adapters.
+    fn get_adapters(&mut self) -> Vec<Self::Adapter>;
+}
+

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -38,7 +38,7 @@ pub use draw_state::{preset, state};
 pub use draw_state::target::*;
 
 // public re-exports
-pub use core::{Adapter, Backend, CommandQueue, Device, Frame, FrameSync, Primitive, QueueFamily, QueueType,
+pub use core::{Adapter, Backend, CommandQueue, Device, Frame, FrameSync, Headless, Primitive, QueueFamily, QueueType,
                Resources, SubmissionError, SubmissionResult, Surface, SwapChain, SwapchainConfig, WindowExt};
 pub use core::{VertexCount, InstanceCount};
 pub use core::{ShaderSet, VertexShader, HullShader, DomainShader, GeometryShader, PixelShader};

--- a/src/window/glutin/src/headless.rs
+++ b/src/window/glutin/src/headless.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gfx-rs Developers.
+// Copyright 2017 The Gfx-rs Developers.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,19 +14,13 @@
 
 use std::os::raw::c_void;
 
-use device_gl::{Device, Factory, Resources as Res, create as gl_create, create_main_targets_raw};
+use core;
+use device_gl;
 use glutin::{HeadlessContext};
-
-use core::format::{Format, DepthFormat, RenderFormat};
-use core::handle::{DepthStencilView, RawDepthStencilView, RawRenderTargetView, RenderTargetView};
-use core::memory::Typed;
-use core::texture::Dimensions;
 
 /// Initializes device and factory from a headless context.
 /// This is useful for testing as it does not require a
 /// X server, thus runs on CI.
-///
-/// Only compiled with `headless` feature.
 ///
 /// # Example
 ///
@@ -35,9 +29,8 @@ use core::texture::Dimensions;
 /// extern crate gfx_window_glutin;
 /// extern crate glutin;
 ///
-/// use gfx_core::format::{DepthStencil, Rgba8};
 /// use gfx_core::texture::AaMode;
-/// use gfx_window_glutin::init_headless;
+/// use gfx_core::Headless;
 /// use glutin::HeadlessRendererBuilder;
 ///
 /// # fn main() {
@@ -47,61 +40,36 @@ use core::texture::Dimensions;
 ///     .build()
 ///     .expect("Failed to build headless context");
 ///
-/// let (mut device, _, _, _) = init_headless::<Rgba8, DepthStencil>(&context, dim);
+/// let mut headless = gfx_window_glutin::Headless(context);
+/// let adapters = headless.get_adapters();
 /// # }
 /// ```
-pub fn init_headless<Cf, Df>(context: &HeadlessContext, dim: Dimensions)
-                             -> (Device, Factory,
-                                 RenderTargetView<Res, Cf>, DepthStencilView<Res, Df>)
-    where
-        Cf: RenderFormat,
-        Df: DepthFormat,
-{
-    let (device, factory, color_view, ds_view) = init_headless_raw(context, dim,
-                                                                   Cf::get_format(),
-                                                                   Df::get_format());
-    (device, factory, Typed::new(color_view), Typed::new(ds_view))
-}
 
-/// Raw version of [`init_headless`].
-///
-/// [`init_headless`]: fn.init_headless.html
-pub fn init_headless_raw(context: &HeadlessContext, dim: Dimensions, color: Format, depth: Format)
-                         -> (Device, Factory,
-                             RawRenderTargetView<Res>, RawDepthStencilView<Res>)
-{
-    unsafe { context.make_current().unwrap() };
+pub struct Headless(pub HeadlessContext);
 
-    let (device, factory) = gl_create(|s|
-        context.get_proc_address(s) as *const c_void);
+impl core::Headless<device_gl::Backend> for Headless {
+    type Adapter = device_gl::Adapter;
 
-    // create the main color/depth targets
-    let (color_view, ds_view) = create_main_targets_raw(dim, color.0, depth.0);
-
-    // done
-    (device, factory, color_view, ds_view)
+    fn get_adapters(&mut self) -> Vec<device_gl::Adapter> {
+        unsafe { self.0.make_current().unwrap() };
+        let adapter = device_gl::Adapter::new(|s| self.0.get_proc_address(s) as *const c_void);
+        vec![adapter]
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use core::format::{DepthStencil, Rgba8};
-    use core::texture::AaMode;
-    use core::Device;
-
     #[test]
     fn test_headless() {
+        use core::Headless;
         use glutin::{HeadlessRendererBuilder};
-
-        let dim = (256, 256, 8, AaMode::Multi(4));
-
-        let context: HeadlessContext = HeadlessRendererBuilder::new(dim.0 as u32, dim.1 as u32)
+        let context: HeadlessContext = HeadlessRendererBuilder::new(256, 256)
             .build()
             .expect("Failed to build headless context");
 
-        let (mut device, _, _, _) = init_headless::<Rgba8, DepthStencil>(&context, dim);
-
-        device.cleanup();
+        let mut headless = Headless(context);
+        let adapters = headless.get_adapters();
     }
 }

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -18,16 +18,13 @@ extern crate gfx_core as core;
 extern crate gfx_device_gl as device_gl;
 extern crate glutin;
 
-#[cfg(feature = "headless")]
-pub use headless::{init_headless, init_headless_raw};
+pub use headless::Headless;
 
 use core::{format, handle, texture};
-use core::memory::{self, Typed};
+use core::memory;
 use device_gl::Resources as R;
-use std::borrow::Borrow;
 use std::rc::Rc;
 
-#[cfg(feature = "headless")]
 mod headless;
 
 fn get_window_dimensions(window: &glutin::Window) -> texture::Dimensions {
@@ -37,6 +34,7 @@ fn get_window_dimensions(window: &glutin::Window) -> texture::Dimensions {
     ((width as f32 * window.hidpi_factor()) as texture::Size, (height as f32 * window.hidpi_factor()) as texture::Size, 1, aa.into())
 }
 
+/*
 /// Update the internal dimensions of the main framebuffer targets. Generic version over the format.
 pub fn update_views<Cf, Df>(window: &glutin::Window, color_view: &mut handle::RenderTargetView<R, Cf>,
                     ds_view: &mut handle::DepthStencilView<R, Df>)
@@ -64,6 +62,7 @@ pub fn update_views_raw(window: &glutin::Window, old_dimensions: texture::Dimens
         None
     }
 }
+*/
 
 pub struct SwapChain {
     // Underlying window, required for presentation
@@ -97,7 +96,7 @@ pub struct Surface {
 impl core::Surface<device_gl::Backend> for Surface {
     type SwapChain = SwapChain;
 
-    fn supports_queue(&self, queue_family: &device_gl::QueueFamily) -> bool { true }
+    fn supports_queue(&self, _: &device_gl::QueueFamily) -> bool { true }
     fn build_swapchain<Q>(&mut self, config: core::SwapchainConfig, present_queue: &Q) -> SwapChain
         where Q: AsRef<device_gl::CommandQueue>
     {

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -18,6 +18,7 @@ extern crate gfx_core as core;
 extern crate gfx_device_gl as device_gl;
 extern crate glutin;
 
+#[cfg(feature = "headless")]
 pub use headless::Headless;
 
 use core::{format, handle, texture};
@@ -25,6 +26,7 @@ use core::memory;
 use device_gl::Resources as R;
 use std::rc::Rc;
 
+#[cfg(feature = "headless")]
 mod headless;
 
 fn get_window_dimensions(window: &glutin::Window) -> texture::Dimensions {


### PR DESCRIPTION
Adding support for headless init as alternative to acquiring a surface and adapters from `WindowsExt`.