### PR TITLE
Support field attributes on vertex and constant structures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-    - TARGET: 1.18.0-x86_64-pc-windows
+    - TARGET: 1.20.0-x86_64-pc-windows
       COMPILER: gnu
-    - TARGET: 1.18.0-x86_64-pc-windows
+    - TARGET: 1.20.0-x86_64-pc-windows
       COMPILER: msvc
     - TARGET: nightly-x86_64-pc-windows
       COMPILER: msvc

--- a/src/render/src/macros/mod.rs
+++ b/src/render/src/macros/mod.rs
@@ -137,15 +137,15 @@ macro_rules! gfx_format {
 #[macro_export]
 macro_rules! gfx_defines {
     ($(#[$attr:meta])* vertex $name:ident {
-            $( $field:ident : $ty:ty = $e:expr, )+
+            $( $(#[$field_attr:meta])* $field:ident : $ty:ty = $e:expr, )+
     }) => {
-        gfx_vertex_struct_meta!($(#[$attr])* vertex_struct_meta $name {$($field:$ty = $e,)+});
+        gfx_vertex_struct_meta!($(#[$attr])* vertex_struct_meta $name {$( $(#[$field_attr])* $field:$ty = $e,)+});
     };
 
     ($(#[$attr:meta])* constant $name:ident {
-            $( $field:ident : $ty:ty = $e:expr, )+
+            $( $(#[$field_attr:meta])* $field:ident : $ty:ty = $e:expr, )+
     }) => {
-        gfx_constant_struct_meta!($(#[$attr])* constant_struct_meta $name {$($field:$ty = $e,)+});
+        gfx_constant_struct_meta!($(#[$attr])* constant_struct_meta $name {$( $(#[$field_attr])* $field:$ty = $e,)+});
     };
 
     (pipeline $name:ident {
@@ -156,22 +156,22 @@ macro_rules! gfx_defines {
 
     // The recursive case for vertex structs
     ($(#[$attr:meta])* vertex $name:ident {
-            $( $field:ident : $ty:ty = $e:expr, )+
+            $( $(#[$field_attr:meta])* $field:ident : $ty:ty = $e:expr, )+
     } $($tail:tt)+) => {
         gfx_defines! {
             $(#[$attr])*
-            vertex $name { $($field : $ty = $e,)+ }
+            vertex $name { $( $(#[$field_attr])* $field : $ty = $e,)+ }
         }
         gfx_defines!($($tail)+);
     };
 
     // The recursive case for constant structs
     ($(#[$attr:meta])* constant $name:ident {
-            $( $field:ident : $ty:ty = $e:expr, )+
+            $( $(#[$field_attr:meta])* $field:ident : $ty:ty = $e:expr, )+
     } $($tail:tt)+) => {
         gfx_defines! {
             $(#[$attr])*
-            constant $name { $($field : $ty = $e,)+ }
+            constant $name { $( $(#[$field_attr])* $field : $ty = $e,)+ }
         }
         gfx_defines!($($tail)+);
     };

--- a/src/render/src/macros/structure.rs
+++ b/src/render/src/macros/structure.rs
@@ -28,13 +28,13 @@ macro_rules! gfx_impl_struct {
 #[macro_export]
 macro_rules! gfx_impl_struct_meta {
     ($(#[$attr:meta])* impl_struct_meta $runtime_format:ty : $compile_format:path = $root:ident {
-        $( $field:ident: $ty:ty = $name:expr, )*
+        $( $(#[$field_attr:meta])* $field:ident: $ty:ty = $name:expr, )*
     }) => {
         #[allow(missing_docs)]
         #[derive(Clone, Copy, Debug, PartialEq)]
         $(#[$attr])*
         pub struct $root {
-            $( pub $field: $ty, )*
+            $( $(#[$field_attr])* pub $field: $ty, )*
         }
 
         unsafe impl $crate::traits::Pod for $root {}
@@ -90,12 +90,12 @@ macro_rules! gfx_vertex_struct {
 #[macro_export]
 macro_rules! gfx_vertex_struct_meta {
     ($(#[$attr:meta])* vertex_struct_meta $root:ident {
-        $( $field:ident: $ty:ty = $name:expr, )*
+        $( $(#[$field_attr:meta])* $field:ident: $ty:ty = $name:expr, )*
     }) => (gfx_impl_struct_meta!{
         $(#[$attr])* impl_struct_meta
         $crate::format::Format : $crate::format::Formatted =
         $root {
-            $( $field: $ty = $name, )*
+            $( $(#[$field_attr])* $field: $ty = $name, )*
         }
     })
 }
@@ -114,12 +114,12 @@ macro_rules! gfx_constant_struct {
 #[macro_export]
 macro_rules! gfx_constant_struct_meta {
     ($(#[$attr:meta])* constant_struct_meta $root:ident {
-        $( $field:ident: $ty:ty = $name:expr, )*
+        $( $(#[$field_attr:meta])* $field:ident: $ty:ty = $name:expr, )*
     }) => (gfx_impl_struct_meta!{
         $(#[$attr])* impl_struct_meta
         $crate::shade::ConstFormat : $crate::shade::Formatted =
         $root {
-            $( $field: $ty = $name, )*
+            $( $(#[$field_attr])* $field: $ty = $name, )*
         }
     })
 }


### PR DESCRIPTION
Adds support for attributes on struct fields, such as doc comments. This doesn't work on stable because of a macro parser bug. Wait until rust-lang/rust#42913 is in a stable release (1.20 probably) before merging this.