### PR TITLE
Update v0.16 dependencies & examples to glutin 0.9 / winit 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_app"
-version = "0.6.0"
+version = "0.7.0"
 description = "GFX example application framework"
 homepage = "https://github.com/gfx-rs/gfx"
 keywords = ["graphics", "gamedev"]
@@ -23,14 +23,14 @@ name = "gfx_app"
 [dependencies]
 log = "0.3"
 env_logger = "0.4"
-glutin = "0.8.0"
-winit = "0.6.0"
+glutin = "0.9"
+winit = "0.7"
 gfx_core = { path = "src/core", version = "0.7.1" }
 gfx_corell = { path = "src/corell", version = "0.1" }
 gfx = { path = "src/render", version = "0.16" }
 gfx_macros = { path = "src/macros", version = "0.2" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.14" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.16" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.17" }
 
 [dependencies.gfx_device_vulkan]
 path = "src/backend/vulkan"
@@ -44,7 +44,7 @@ optional = true
 
 [dependencies.gfx_window_vulkan]
 path = "src/window/vulkan"
-version = "0.2"
+version = "0.3"
 optional = true
 
 [dependencies.gfx_device_metal]
@@ -69,7 +69,7 @@ gfx_window_sdl = { path = "src/window/sdl", version = "0.6" }
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.6" }
 # gfx_device_dx12ll = { path = "src/backend/dx12ll", version = "0.1" }
-gfx_window_dxgi = { path = "src/window/dxgi", version = "0.8" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.9" }
 
 [[example]]
 name = "blend"
@@ -142,4 +142,4 @@ rand = "0.3"
 genmesh = "0.4"
 noise = "0.1"
 image = "0.13"
-winit = "0.6"
+winit = "0.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,19 @@
 environment:
+  RUST_BACKTRACE: full
   matrix:
-    - TARGET: 1.16.0-x86_64-pc-windows
-      COMPILER: gnu
-    - TARGET: 1.16.0-x86_64-pc-windows
-      COMPILER: msvc
-    - TARGET: nightly-x86_64-pc-windows
-      COMPILER: msvc
+  - channel: stable
+    target: x86_64-pc-windows-msvc
+  - channel: stable
+    target: x86_64-pc-windows-gnu
+  - channel: nightly
+    target: x86_64-pc-windows-msvc
 install:
-  - if %COMPILER%==gnu choco install -y mingw
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}-${env:COMPILER}.exe" -FileName "rust-install.exe"
-  - ps: .\rust-install.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null
-  - ps: $env:PATH="$env:PATH;C:\rust\bin;C:\tools\mingw64\bin"
-  - if %COMPILER%==gnu gcc -v
-  - rustc -vV
-  - cargo -vV
-build_script:
-  - cargo build --features vulkan
+- appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+- rustup-init -yv --default-toolchain %channel% --default-host %target%
+- set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+- rustc -vV
+- cargo -vV
+build: false
 test_script:
-  - cargo test --all --features vulkan
-  - cargo test -p gfx -p gfx_core --features "cgmath-types serialize"
+- cargo test --all --features vulkan
+- cargo test -p gfx -p gfx_core --features "cgmath-types serialize"

--- a/examples/blend/main.rs
+++ b/examples/blend/main.rs
@@ -152,15 +152,18 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
     }
 
     fn on(&mut self, event: winit::WindowEvent) {
-        match event {
-            winit::WindowEvent::KeyboardInput(winit::ElementState::Pressed, _, Some(winit::VirtualKeyCode::B), _) => {
-                self.id += 1;
-                if self.id as usize >= BLENDS.len() {
-                    self.id = 0;
-                }
-                println!("Using '{}' blend equation", BLENDS[self.id as usize]);
-            },
-            _ => ()
+        if let winit::WindowEvent::KeyboardInput {
+                input: winit::KeyboardInput {
+                    state: winit::ElementState::Pressed,
+                    virtual_keycode: Some(winit::VirtualKeyCode::B),
+                    ..
+                },
+                .. } = event {
+            self.id += 1;
+            if self.id as usize >= BLENDS.len() {
+                self.id = 0;
+            }
+            println!("Using '{}' blend equation", BLENDS[self.id as usize]);
         }
     }
 

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -51,7 +51,7 @@ use genmesh::generators::{SharedVertex, IndexedPolygon};
 use noise::{Seed, perlin2};
 use rand::Rng;
 use std::time::{Instant};
-use winit::{WindowEvent, VirtualKeyCode, WindowBuilder};
+use winit::{WindowEvent, WindowBuilder};
 
 // Remember to also change the constants in the shaders
 const NUM_LIGHTS: usize = 250;
@@ -555,18 +555,21 @@ impl<R: gfx::Resources> gfx_app::Application<R> for App<R> {
     }
 
     fn on(&mut self, event: WindowEvent) {
-        match event {
-            WindowEvent::KeyboardInput(_, _, Some(VirtualKeyCode::Key1), _) =>
-                self.debug_buf = Some(self.light.data.tex_pos.0.clone()),
-            WindowEvent::KeyboardInput(_, _, Some(VirtualKeyCode::Key2), _) =>
-                self.debug_buf = Some(self.light.data.tex_normal.0.clone()),
-            WindowEvent::KeyboardInput(_, _, Some(VirtualKeyCode::Key3), _) =>
-                self.debug_buf = Some(self.light.data.tex_diffuse.0.clone()),
-            WindowEvent::KeyboardInput(_, _, Some(VirtualKeyCode::Key4), _) =>
-                self.debug_buf = Some(self.depth_resource.clone()),
-            WindowEvent::KeyboardInput(_, _, Some(VirtualKeyCode::Key0), _) =>
-                self.debug_buf = None,
-            _ => (),
+        if let WindowEvent::KeyboardInput {
+            input: winit::KeyboardInput {
+                virtual_keycode: Some(key),
+                ..
+            },
+            .. } = event {
+            use winit::VirtualKeyCode::*;
+            match key {
+                Key1 => self.debug_buf = Some(self.light.data.tex_pos.0.clone()),
+                Key2 => self.debug_buf = Some(self.light.data.tex_normal.0.clone()),
+                Key3 => self.debug_buf = Some(self.light.data.tex_diffuse.0.clone()),
+                Key4 => self.debug_buf = Some(self.depth_resource.clone()),
+                Key0 => self.debug_buf = None,
+                _ => (),
+            }
         }
     }
 

--- a/examples/gamma/main.rs
+++ b/examples/gamma/main.rs
@@ -19,6 +19,7 @@ extern crate glutin;
 
 use gfx::traits::FactoryExt;
 use gfx::Device;
+use glutin::GlContext;
 
 pub type ColorFormat = gfx::format::Rgba8;
 pub type DepthFormat = gfx::format::DepthStencil;
@@ -45,13 +46,14 @@ const QUAD: [Vertex; 4] = [
 const CLEAR_COLOR: [f32; 4] = [0.5, 0.5, 0.5, 1.0];
 
 pub fn main() {
-    let events_loop = glutin::EventsLoop::new();
-    let builder = glutin::WindowBuilder::new()
+    let mut events_loop = glutin::EventsLoop::new();
+    let window_builder = glutin::WindowBuilder::new()
         .with_title("Gamma example".to_string())
-        .with_dimensions(1024, 768)
-        .with_vsync();
+        .with_dimensions(1024, 768);
+    let context = glutin::ContextBuilder::new()
+        .with_vsync(true);
     let (window, mut device, mut factory, main_color, mut main_depth) =
-        gfx_window_glutin::init::<ColorFormat, DepthFormat>(builder, &events_loop);
+        gfx_window_glutin::init::<ColorFormat, DepthFormat>(window_builder, context, &events_loop);
     let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
     let pso = factory.create_pipeline_simple(
         include_bytes!("shader/quad_150.glslv"),
@@ -66,14 +68,20 @@ pub fn main() {
 
     let mut running = true;
     while running {
-        events_loop.poll_events(|glutin::Event::WindowEvent{window_id: _, event}| {
-            match event {
-                glutin::WindowEvent::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape), _) |
-                glutin::WindowEvent::Closed => running = false,
-                glutin::WindowEvent::Resized(_width, _height) => {
-                    gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);
-                },
-                _ => {},
+        events_loop.poll_events(|event| {
+            if let glutin::Event::WindowEvent { event, .. } = event {
+                match event {
+                    glutin::WindowEvent::KeyboardInput {
+                        input: glutin::KeyboardInput {
+                            virtual_keycode: Some(glutin::VirtualKeyCode::Escape),
+                            .. },
+                        ..
+                    } | glutin::WindowEvent::Closed => running = false,
+                    glutin::WindowEvent::Resized(_width, _height) => {
+                        gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);
+                    },
+                    _ => (),
+                }
             }
         });
 

--- a/examples/gamma/main.rs
+++ b/examples/gamma/main.rs
@@ -77,7 +77,8 @@ pub fn main() {
                             .. },
                         ..
                     } | glutin::WindowEvent::Closed => running = false,
-                    glutin::WindowEvent::Resized(_width, _height) => {
+                    glutin::WindowEvent::Resized(width, height) => {
+                        window.resize(width, height);
                         gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);
                     },
                     _ => (),

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -78,7 +78,8 @@ pub fn main() {
                             .. },
                         ..
                     } | glutin::WindowEvent::Closed => running = false,
-                    glutin::WindowEvent::Resized(_width, _height) => {
+                    glutin::WindowEvent::Resized(width, height) => {
+                        window.resize(width, height);
                         gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);
                     },
                     _ => (),

--- a/examples/trianglell/main.rs
+++ b/examples/trianglell/main.rs
@@ -57,7 +57,7 @@ const TRIANGLE: [Vertex; 6] = [
 #[cfg(any(feature = "vulkan", target_os = "windows"))]
 fn main() {
     env_logger::init().unwrap();
-    let events_loop = winit::EventsLoop::new();
+    let mut events_loop = winit::EventsLoop::new();
     let window = winit::WindowBuilder::new()
         .with_dimensions(1024, 768)
         .with_title("triangle (Low Level)".to_string())
@@ -370,11 +370,17 @@ fn main() {
     //
     let mut running = true;
     while running {
-        events_loop.poll_events(|winit::Event::WindowEvent{window_id: _, event}| {
-            match event {
-                winit::WindowEvent::KeyboardInput(_, _, Some(winit::VirtualKeyCode::Escape), _) |
-                winit::WindowEvent::Closed => running = false,
-                _ => {},
+        events_loop.poll_events(|event| {
+            if let winit::Event::WindowEvent { event, .. } = event {
+                match event {
+                    winit::WindowEvent::KeyboardInput {
+                        input: winit::KeyboardInput {
+                            virtual_keycode: Some(winit::VirtualKeyCode::Escape),
+                            .. },
+                        ..
+                    } | winit::WindowEvent::Closed => running = false,
+                    _ => (),
+                }
             }
         });
 

--- a/examples/ubo_tilemap/main.rs
+++ b/examples/ubo_tilemap/main.rs
@@ -471,44 +471,30 @@ impl<R: gfx::Resources> gfx_app::Application<R> for TileMap<R> {
     }
 
     fn on(&mut self, event: winit::WindowEvent) {
-        use winit::VirtualKeyCode as Key;
-        use winit::WindowEvent::KeyboardInput;
-        use winit::ElementState::Pressed;
-        let i = self.input.clone();
-        match event {
-            // zooming in/out
-            KeyboardInput(Pressed, _, Some(Key::Equals), _) => {
-                self.input.distance -= i.move_amt;
+        if let winit::WindowEvent::KeyboardInput {
+            input: winit::KeyboardInput {
+                state: winit::ElementState::Pressed,
+                virtual_keycode: Some(key),
+                .. },
+            .. } = event {
+            use winit::VirtualKeyCode::*;
+            let i = self.input.clone();
+
+            match key {
+                // zooming in/out
+                Equals => self.input.distance -= i.move_amt,
+                Minus | Subtract => self.input.distance += i.move_amt,
+                // panning around
+                Up => self.input.y_pos -= i.move_amt,
+                Down => self.input.y_pos += i.move_amt,
+                Left => self.input.x_pos -= i.move_amt,
+                Right => self.input.x_pos += i.move_amt,
+                W => self.apply_y_offset(i.offset_amt),
+                S => self.apply_y_offset(-i.offset_amt),
+                D => self.apply_x_offset(i.offset_amt),
+                A => self.apply_x_offset(-i.offset_amt),
+                _ => ()
             }
-            KeyboardInput(Pressed, _, Some(Key::Minus), _) => {
-                self.input.distance += i.move_amt;
-            }
-            // panning around
-            KeyboardInput(Pressed, _, Some(Key::Up), _) => {
-                self.input.y_pos -= i.move_amt;
-            }
-            KeyboardInput(Pressed, _, Some(Key::Down), _) => {
-                self.input.y_pos += i.move_amt;
-            }
-            KeyboardInput(Pressed, _, Some(Key::Left), _) => {
-                self.input.x_pos -= i.move_amt;
-            }
-            KeyboardInput(Pressed, _, Some(Key::Right), _) => {
-                self.input.x_pos += i.move_amt;
-            }
-            KeyboardInput(Pressed, _, Some(Key::W), _) => {
-                self.apply_y_offset(i.offset_amt);
-            }
-            KeyboardInput(Pressed, _, Some(Key::S), _) => {
-                self.apply_y_offset(-i.offset_amt);
-            }
-            KeyboardInput(Pressed, _, Some(Key::D), _) => {
-                self.apply_x_offset(i.offset_amt);
-            }
-            KeyboardInput(Pressed, _, Some(Key::A), _) => {
-                self.apply_x_offset(-i.offset_amt);
-            }
-            _ => ()
         }
     }
 

--- a/src/backend/dx12ll/Cargo.toml
+++ b/src/backend/dx12ll/Cargo.toml
@@ -15,7 +15,7 @@
 
 [package]
 name = "gfx_device_dx12ll"
-version = "0.1.0"
+version = "0.1.1"
 description = "DirectX-12 (Low Level) backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -35,4 +35,4 @@ dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx"
 dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
 winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-winit = "0.6"
+winit = "0.7"

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -18,6 +18,5 @@ log = "0.3"
 vk = "0.0"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 shared_library = "0.1"
-winit = "0.6"
 gfx_core = { path = "../../core", version = "0.7" }
 spirv-utils = { git = "https://github.com/msiglreith/spirv-utils.git", branch = "gfx" }

--- a/src/backend/vulkanll/Cargo.toml
+++ b/src/backend/vulkanll/Cargo.toml
@@ -32,7 +32,7 @@ shared_library = "0.1"
 gfx_corell = { path = "../../corell", version = "0.1.0" }
 ash = "0.15.7"
 spirv-utils = { git = "https://github.com/msiglreith/spirv-utils.git", branch = "gfx" }
-winit = "0.6"
+winit = "0.7"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,7 @@ A: Sized + ApplicationBase<gfx_device_gl::Resources, gfx_device_gl::CommandBuffe
                         ..
                     } if key == A::get_exit_key() => return,
                     winit::WindowEvent::Resized(width, height) => if width != cur_width || height != cur_height {
+                        window.resize(width, height);
                         cur_width = width;
                         cur_height = height;
                         let (new_color, new_depth) = gfx_window_glutin::new_views(&window);

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.8.0"
+version = "0.9.0"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -32,6 +32,6 @@ kernel32-sys = "0.2"
 user32-sys = "0.2"
 dxguid-sys = "0.2"
 winapi = "0.2"
-winit = "0.6"
+winit = "0.7"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.6" }

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.16.0"
+version = "0.17.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,6 +28,6 @@ documentation = "https://docs.rs/gfx_window_glutin"
 name = "gfx_window_glutin"
 
 [dependencies]
-glutin = "0.8"
+glutin = "0.9"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.14" }

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -30,7 +30,7 @@ name = "gfx_window_metal"
 log = "0.3"
 cocoa = "0.5"
 objc = "0.2"
-winit = "0.6"
+winit = "0.7"
 metal-rs = "0.3"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.2" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_window_vulkan"
-version = "0.2.0"
+version = "0.3.0"
 description = "Vulkan window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/gfx_window_vulkan"
 name = "gfx_window_vulkan"
 
 [dependencies]
-winit = "0.6"
+winit = "0.7"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.2" }


### PR DESCRIPTION
I cherry picked the glutin/winit upgrade commits on master and updated the appveyor config as some dependencies now require a more recent rustc than 1.16