### PR TITLE
Use MTLHeap when possible for resource allocation

### DIFF
--- a/src/backend/metalll/Cargo.toml
+++ b/src/backend/metalll/Cargo.toml
@@ -10,8 +10,6 @@ authors = ["The Gfx-rs Developers"]
 [features]
 default = []
 argument_buffer = []
-native_heap = []
-native_fence = []
 
 [dependencies]
 log = "0.3"
@@ -19,7 +17,7 @@ gfx_corell = { path = "../../corell", version = "0.1.0" }
 winit = "0.7"
 cocoa = "0.9"
 objc = "0.2"
-metal-rs = "0.4.1"
+metal-rs = "0.4.2"
 io-surface = "0.7"
 core-foundation = "0.3"
 core-graphics = "0.8"

--- a/src/backend/metalll/src/lib.rs
+++ b/src/backend/metalll/src/lib.rs
@@ -180,19 +180,35 @@ impl core::Adapter for Adapter {
             unsafe { core::GeneralQueue::new(command::CommandQueue::new(self.device)) }
         }).collect();
 
-        let heap_types;
-        let memory_heaps;
-
-        #[cfg(not(feature = "native_heap"))]
-        {
-            // TODO: heap types for each memory binding
-            heap_types = vec![core::HeapType {
+        let heap_types = vec![
+            core::HeapType {
                 id: 0,
-                properties: memory::HeapProperties::all(),
+                properties: memory::CPU_VISIBLE | memory::CPU_CACHED,
                 heap_index: 0,
-            }];
-            memory_heaps = Vec::new();
-        }
+            },
+            core::HeapType {
+                id: 1,
+                properties: memory::CPU_VISIBLE | memory::CPU_CACHED | memory::WRITE_COMBINED,
+                heap_index: 1,
+            },
+            core::HeapType {
+                id: 2,
+                properties: memory::CPU_VISIBLE | memory::COHERENT | memory::CPU_CACHED,
+                heap_index: 2,
+            },
+            core::HeapType {
+                id: 3,
+                properties: memory::CPU_VISIBLE | memory::COHERENT 
+                    | memory::CPU_CACHED | memory::WRITE_COMBINED,
+                heap_index: 3,
+            },
+            core::HeapType {
+                id: 4,
+                properties: memory::DEVICE_LOCAL,
+                heap_index: 4,
+            },
+        ];
+        let memory_heaps = Vec::new();
 
         core::Device {
             factory,


### PR DESCRIPTION
Adds MTLHeap support to the Metal backend, and uses it whenever possible for memory allocations.

This isn't quite ready to merge, https://github.com/gfx-rs/metal-rs/pull/7 needs to make it into crates.io first.