### PR TITLE
Some doc improvements

### DIFF
--- a/src/core/src/memory.rs
+++ b/src/core/src/memory.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Memory stuff
+//! Types to describe the properties of memory allocated for gfx resources.
 
 use std::mem;
 
-/// How this memory will be used.
+/// How this memory will be used on the GPU and/or the CPU.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(u8)]
@@ -36,7 +36,13 @@ pub enum Usage {
 }
 
 bitflags!(
-    /// Memory access
+    /// Flags providing information about the type of memory access to a resource.
+    ///
+    /// An `Access` value can be a combination of the the following bit patterns:
+    ///
+    /// - [`READ`](constant.READ.html)
+    /// - [`WRITE`](constant.WRITE.html)
+    /// - Or [`RW`](constant.RW.html) which is equivalent to `READ` and `WRITE`.
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub flags Access: u8 {
         /// Read access
@@ -49,7 +55,16 @@ bitflags!(
 );
 
 bitflags!(
-    /// Bind flags
+    /// Flags providing information about the usage of a resource.
+    ///
+    /// A `Bind` value can be a combination of the following bit patterns:
+    ///
+    /// - [`RENDER_TARGET`](constant.RENDER_TARGET.html)
+    /// - [`DEPTH_STENCIL`](constant.DEPTH_STENCIL.html)
+    /// - [`SHADER_RESOURCE`](constant.SHADER_RESOURCE.html)
+    /// - [`UNORDERED_ACCESS`](constant.UNORDERED_ACCESS.html)
+    /// - [`TRANSFER_SRC`](constant.TRANSFER_SRC.html)
+    /// - [`TRANSFER_DST`](constant.TRANSFER_DST.html)
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub flags Bind: u8 {
         /// Can be rendered into.
@@ -91,6 +106,8 @@ pub trait Typed: Sized {
 ///
 /// A POD type does not have invalid bit patterns and can be safely
 /// created from arbitrary bit pattern.
+/// The `Pod` trait is implemented for standard integer and floating point numbers as well as
+/// common arrays of them (for example `[f32; 2]`).
 pub unsafe trait Pod {}
 
 macro_rules! impl_pod {


### PR DESCRIPTION
When I have a bit of time I'll go through things that I find lacking or confusing in the doc and try to improve a bit with what I know. I'll add more doc to this PR as I go but don't hesitate to give feedback and corrections along the way.

First thing to note is that rustdoc doesn't do justice to some of the attempts at documenting the code. For example it's hard to see from the docs what the different bit patterns for a particular bitflags are. Landing on the page for `Bind` for instance isn't very informative: https://docs.rs/gfx/0.16.1/gfx/struct.Bind.html
It could probably be improved by the bit_flags macro but in the mean time, listing the different bit patterns in the doc of the bitflag itself helps a great deal I think (from the point of view of someone who tries to make something out of docs.rs.