### PR TITLE
More documentation

### DIFF
--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Resource factory
+//! # Resource factory
 //!
 //! This module exposes the `Factory` trait, used for creating and managing graphics resources, and
 //! includes several items to facilitate this.
@@ -187,17 +187,52 @@ pub enum WaitFor {
     All,
 }
 
+/// # Overview
+///
 /// A `Factory` is responsible for creating and managing resources for the context it was created
 /// with.
 ///
-/// # Construction and Handling
+/// ## Construction and Handling
+///
 /// A `Factory` is typically created along with other objects using a helper function of the
 /// appropriate gfx_window module (e.g. gfx_window_glutin::init()).
 ///
 /// This factory structure can then be used to create and manage different resources, like buffers,
 /// shader programs and textures. See the individual methods for more information.
 ///
-/// Also see the `FactoryExt` trait inside the `gfx` module for additional methods.
+/// This trait is extended by the [`gfx::FactoryExt` trait](https://docs.rs/gfx/*/gfx/traits/trait.FactoryExt.html).
+/// All types implementing `Factory` also implement `FactoryExt`.
+///
+/// ## Immutable resources
+///
+/// Immutable buffers and textures can only be read by the GPU. They cannot be written by the GPU and
+/// cannot be accessed at all by the CPU.
+///
+/// See:
+///  - [`Factory::create_texture_immutable`](trait.Factory.html#tymethod.create_texture_immutable),
+///  - [`Factory::create_buffer_immutable`](trait.Factory.html#tymethod.create_buffer_immutable).
+///
+/// ## Raw resources
+///
+/// The term "raw" is used in the context of types of functions that have a strongly typed and an
+/// untyped equivalent, to refer to the untyped equivalent.
+///
+/// For example ['Encloder::create_buffer_raw'](trait.Factory.html#tymethod.create_buffer_raw) and
+/// ['Encloder::create_buffer'](trait.Factory.html#tymethod.create_buffer)
+///
+/// ## Shader resource views and unordered access views
+///
+/// This terminology is borrowed from D3D.
+///
+/// Shader resource views typically wrap textures and buffers to provide read-only access in shaders.
+/// An unordered access view provides similar functionality, but enables reading and writing to
+/// the buffer or texture in any order.
+///
+/// See:
+///
+/// - [The gfx::UNORDERED_ACCESS bit in the gfx::Bind flags](../gfx/struct.Bind.html).
+/// - [Factory::view_buffer_as_unordered_access](trait.Factory.html#method.view_buffer_as_unordered_access).
+///
 #[allow(missing_docs)]
 pub trait Factory<R: Resources> {
     /// Returns the capabilities of this `Factory`. This usually depends on the graphics API being

--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -217,8 +217,8 @@ pub enum WaitFor {
 /// The term "raw" is used in the context of types of functions that have a strongly typed and an
 /// untyped equivalent, to refer to the untyped equivalent.
 ///
-/// For example ['Encloder::create_buffer_raw'](trait.Factory.html#tymethod.create_buffer_raw) and
-/// ['Encloder::create_buffer'](trait.Factory.html#tymethod.create_buffer)
+/// For example ['Factory::create_buffer_raw'](trait.Factory.html#tymethod.create_buffer_raw) and
+/// ['Factory::create_buffer'](trait.Factory.html#tymethod.create_buffer)
 ///
 /// ## Shader resource views and unordered access views
 ///

--- a/src/core/src/memory.rs
+++ b/src/core/src/memory.rs
@@ -16,7 +16,12 @@
 
 use std::mem;
 
-/// How this memory will be used on the GPU and/or the CPU.
+// TODO: It would be useful to document what parameters these map to in D3D, vulkan, etc.
+
+/// How this memory will be used regarding GPU-CPU data flow.
+///
+/// This information is used to create resources
+/// (see [gfx::Factory](../trait.Factory.html#overview)).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(u8)]
@@ -43,6 +48,9 @@ bitflags!(
     /// - [`READ`](constant.READ.html)
     /// - [`WRITE`](constant.WRITE.html)
     /// - Or [`RW`](constant.RW.html) which is equivalent to `READ` and `WRITE`.
+    ///
+    /// This information is used to create resources
+    /// (see [gfx::Factory](trait.Factory.html#overview)).
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub flags Access: u8 {
         /// Read access
@@ -65,6 +73,10 @@ bitflags!(
     /// - [`UNORDERED_ACCESS`](constant.UNORDERED_ACCESS.html)
     /// - [`TRANSFER_SRC`](constant.TRANSFER_SRC.html)
     /// - [`TRANSFER_DST`](constant.TRANSFER_DST.html)
+    ///
+    ///
+    /// This information is used to create resources
+    /// (see [gfx::Factory](trait.Factory.html#overview)).
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub flags Bind: u8 {
         /// Can be rendered into.

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -14,8 +14,79 @@
 
 #![deny(missing_docs)]
 
-//! An efficient, low-level, bindless graphics API for Rust. See [the
-//! blog](http://gfx-rs.github.io/) for explanations and annotated examples.
+//! # gfx
+//!
+//! An efficient, low-level, bindless graphics API for Rust.
+//!
+//! # Overview
+//!
+//! ## Command buffers and encoders
+//!
+//! A command buffer is a serialized list of drawing and compute commands.
+//! Unlike with vulkan, command buffers are not what you use to create commands, but only
+//! the result of creating these commands. Gfx, borrowing metal's terminology, uses
+//! encoders to build command buffers. This means that, in general, users of the gfx crate
+//! don't manipulate command buffers directly much and interact mostly with encoders.
+//!
+//! Manipulating an `Encoder` in gfx corresponds to interacting with:
+//!
+//! - a `VkCommandBuffer` in vulkan,
+//! - a `MTLCommandEncoder` in metal,
+//! - an `ID3D12GraphicsCommandList` in D3D12.
+//!
+//! OpenGL and earlier versions of D3D don't have an explicit notion of command buffers
+//! or encoders (with the exception of draw indirect commands in late versions of OpenGL,
+//! which can be seen as a GPU-side command buffer). They are managed implicitly by the driver.
+//!
+//! See:
+//!
+//! - The [`Encoder` struct documentation](struct.Encoder.html).
+//! - The [`Command buffer` trait documentation](trait.CommandBuffer.html).
+//!
+//! ## Factory
+//!
+//! The factory is what lets you allocate GPU resources such as buffers and textures.
+//!
+//! Each gfx backend provides its own factory type which implements both:
+//!
+//! - The [`Factory` trait](traits/trait.Factory.html#overview).
+//! - The [`FactoryExt` trait](traits/trait.FactoryExt.html).
+//!
+//! `gfx::Factory` is roughly equivalent to:
+//!
+//! - `VkDevice` in vulkan,
+//! - `ID3D11Device` in D3D11,
+//! - `MTLDevice` in metal.
+//!
+//! OpenGL does not have a notion of factory (resources are created directly off of the global
+//! context). D3D11 has a DXGI factory but it is only used to interface with other processes
+//! and the window manager, resources like textures are usually created using the device.
+//!
+//! ## Device
+//!
+//! See [the `gfx::Device` trait](trait.Device.html).
+//!
+//! ## Pipeline state (PSO)
+//!
+//! See [the documentation of the gfx::pso module](pso/index.html).
+//!
+//! ## Memory management
+//!
+//! Handles internally use atomically reference counted pointers to deal with memory management.
+//! GPU resources are not destroyed right away when all references to them are gone. Instead they
+//! are destroyed the next time [Device::cleanup](trait.Device.html#tymethod.cleanup) is called.
+//!
+//! # Examples
+//!
+//! See [the examples in the repository](https://github.com/gfx-rs/gfx/tree/master/examples).
+//!
+//! # Useful resources
+//!
+//!  - [Documentation for some of the technical terms](doc/terminology/index.html)
+//! used in the API.
+//!  - [Learning gfx](https://wiki.alopex.li/LearningGfx) tutorial.
+//!  - See [the blog](http://gfx-rs.github.io/) for more explanations and annotated examples.
+//!
 
 #[cfg(feature = "mint")]
 extern crate mint;

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -14,34 +14,40 @@
 
 #![deny(missing_docs)]
 
+// TODO(doc) clarify the different type of queues and what is accessible from the high-level API
+// vs what belongs to core-ll. There doesn't seem to be a "ComputeEncoder" can I submit something
+// built with a GraphicsEncoder to a ComputeQueue?
+
 //! # gfx
 //!
 //! An efficient, low-level, bindless graphics API for Rust.
 //!
 //! # Overview
 //!
-//! ## Command buffers and encoders
+//! ## Command buffers and encoders and queues
 //!
 //! A command buffer is a serialized list of drawing and compute commands.
 //! Unlike with vulkan, command buffers are not what you use to create commands, but only
 //! the result of creating these commands. Gfx, borrowing metal's terminology, uses
 //! encoders to build command buffers. This means that, in general, users of the gfx crate
-//! don't manipulate command buffers directly much and interact mostly with encoders.
+//! don't manipulate command buffers directly much and interact mostly with graphics encoders.
+//! In order to be executed, a command buffer is then submitted to a queue.
 //!
-//! Manipulating an `Encoder` in gfx corresponds to interacting with:
+//! Manipulating a `GraphicsEncoder` in gfx corresponds to interacting with:
 //!
 //! - a `VkCommandBuffer` in vulkan,
 //! - a `MTLCommandEncoder` in metal,
 //! - an `ID3D12GraphicsCommandList` in D3D12.
 //!
 //! OpenGL and earlier versions of D3D don't have an explicit notion of command buffers
-//! or encoders (with the exception of draw indirect commands in late versions of OpenGL,
+//! encoders or queues (with the exception of draw indirect commands in late versions of OpenGL,
 //! which can be seen as a GPU-side command buffer). They are managed implicitly by the driver.
 //!
 //! See:
 //!
-//! - The [`Encoder` struct documentation](struct.Encoder.html).
-//! - The [`Command buffer` trait documentation](trait.CommandBuffer.html).
+//! - The [`GraphicsEncoder` struct](struct.GraphicsEncoder.html).
+//! - The [`CommandBuffer` trait](trait.CommandBuffer.html).
+//! - The [`CommandQueue` struct](struct.CommandQueue.html).
 //!
 //! ## Factory
 //!
@@ -64,7 +70,7 @@
 //!
 //! ## Device
 //!
-//! See [the `gfx::Device` trait](trait.Device.html).
+//! The `Device` contains the `Factory` and the `Queue`s.
 //!
 //! ## Pipeline state (PSO)
 //!
@@ -74,7 +80,7 @@
 //!
 //! Handles internally use atomically reference counted pointers to deal with memory management.
 //! GPU resources are not destroyed right away when all references to them are gone. Instead they
-//! are destroyed the next time [Device::cleanup](trait.Device.html#tymethod.cleanup) is called.
+//! are destroyed the next time `cleanup` is called on the queue.
 //!
 //! # Examples
 //!

--- a/src/render/src/slice.rs
+++ b/src/render/src/slice.rs
@@ -28,6 +28,8 @@ use pso;
 /// processing a PSO.
 ///
 /// # Overview
+/// A `Slice` in gfx has a different meaning from the term slice as employed more broadly in rust (`&[T]`).
+///
 /// A `Slice` object in essence dictates in what order the vertices in a `VertexBuffer` get
 /// processed. To do this, it contains an internal index-buffer. This `Buffer` is a list of
 /// indices into this `VertexBuffer` (vertex-index). A vertex-index of 0 represents the first


### PR DESCRIPTION
This is a work in progress. This PR adds the gfx::doc::terminology module which only contains rustdoc documentation. The idea is to have a centralized place with information about what various gfx concepts map to in other APIs. I am not quite certain what the best way to present this information is. For example we could also have sections "OpenGL to gfx", "D3D11 to gfx", etc which would only link to the documentation of each term in gfx concisely (like: " - GL thing: [gfx thing](link to thing in the doc)".

What I am trying to address here is that for someone who does not know the internals of gfx, using this crate currently is a small exercise in reverse-engineering, especially when you know what you want to do (but not how it is called in gfx).

The other thing that I want to move towards, is for each module (or at least each crate) to have a large doc block with sections `Overview` and `Examples` that give some info about the general design and what the most important concepts are with link to teh relevant pieces. Rustoc is not good at making the important things stand out, so it has to be done somewhat manually in the crate/module doc.

Ultimately, gfx should strive to get to a documentation at the level of [glium's](https://docs.rs/glium) which I took a lot of inspiration from when documenting [lyon](https://docs.rs/lyon). I received some positive feedback from the work on lyon and I think that gfx could really use some doc that is structured similarly.

I don't think should land as is with all of the TODO's. Don't hesitate to review this while the work is in progress to help me fill the holes and rewrite/rearrange as needed.