### PR TITLE
Exclude the nightly compiler from bors builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,7 @@ notifications:
     on_start: false
 
 before_install:
-  - "export DISPLAY=:99.0"
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
-  # Extract SDL2 .deb into a cached directory (see cache section above and LIBRARY_PATH exports below)
-  # Will no longer be needed when Trusty build environment goes out of beta at Travis CI
-  # (assuming it will have libsdl2-dev and Rust by then)
-  # see https://docs.travis-ci.com/user/trusty-ci-environment/
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then scripts/travis-install-sdl2.sh ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl2; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated cmake || brew upgrade cmake; fi
+  - bash scripts/travis-before_install.sh
 
 addons:
   apt:
@@ -55,19 +46,4 @@ addons:
       - libosmesa6-dev
 
 script:
-  - export RUST_BACKTRACE=1
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$PATH:$HOME/deps/bin ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export LIBRARY_PATH=$HOME/deps/usr/lib/x86_64-linux-gnu ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export LD_LIBRARY_PATH=$LIBRARY_PATH ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo build --features vulkan; else cargo build; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cargo build --features metal; else cargo build; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then HEADLESS_FEATURE="--features headless"; fi
-  - cargo test --all
-  - cargo test -p gfx -p gfx_core --features "mint serialize"
-  - cargo test -p gfx_window_sdl
-  - cargo test -p gfx_device_gl
-  - cargo test -p gfx_window_glutin $HEADLESS_FEATURE
-  - cargo test -p gfx_window_glfw
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --all --features vulkan; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cargo test --all --features metal; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cargo test --features "metal metal_argument_buffer"; fi
+  - bash scripts/travis-script.sh

--- a/scripts/travis-before_install.sh
+++ b/scripts/travis-before_install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  export DISPLAY=:99.0
+  sh -e /etc/init.d/xvfb start
+  # Extract SDL2 .deb into a cached directory (see cache section above and LIBRARY_PATH exports below)
+  # Will no longer be needed when Trusty build environment goes out of beta at Travis CI
+  # (assuming it will have libsdl2-dev and Rust by then)
+  # see https://docs.travis-ci.com/user/trusty-ci-environment/
+  bash scripts/travis-install-sdl2.sh
+elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  brew update
+  brew install sdl2
+  brew outdated cmake || brew upgrade cmake
+fi

--- a/scripts/travis-before_install.sh
+++ b/scripts/travis-before_install.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -ex
+if [[ $TRAVIS_RUST_VERSION == "nightly" && $TRAVIS_BRANCH == "staging" ]]; then
+  # Do not run bors builds against the nightly compiler.
+  # We want to find out about nightly bugs, so they're done in master, but we don't block on them.
+  exit
+fi
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   export DISPLAY=:99.0
   sh -e /etc/init.d/xvfb start

--- a/scripts/travis-script.sh
+++ b/scripts/travis-script.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -ex
+export RUST_BACKTRACE=1
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  export PATH=$PATH:$HOME/deps/bin
+  export LIBRARY_PATH=$HOME/deps/usr/lib/x86_64-linux-gnu
+  export LD_LIBRARY_PATH=$LIBRARY_PATH
+  cargo build --features vulkan
+elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  GLUTIN_HEADLESS_FEATURE="--features headless"
+  cargo build --features metal
+else
+  cargo build
+fi
+cargo test --all
+cargo test -p gfx -p gfx_core --features "mint serialize"
+cargo test -p gfx_window_sdl
+cargo test -p gfx_device_gl
+cargo test -p gfx_window_glutin $GLUTIN_HEADLESS_FEATURE
+cargo test -p gfx_window_glfw
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  cargo test --all --features vulkan
+elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  cargo test --all --features metal
+  cargo test --all --features "metal metal_argument_buffer"
+fi

--- a/scripts/travis-script.sh
+++ b/scripts/travis-script.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -ex
+if [[ $TRAVIS_RUST_VERSION == "nightly" && $TRAVIS_BRANCH == "staging" ]]; then
+  # Do not run bors builds against the nightly compiler.
+  # We want to find out about nightly bugs, so they're done in master, but we don't block on them.
+  exit
+fi
 export RUST_BACKTRACE=1
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   export PATH=$PATH:$HOME/deps/bin


### PR DESCRIPTION
The [internal compiler errors][ICE] are annoying.

[ICE]: https://travis-ci.org/gfx-rs/gfx/jobs/257898756#L500