### PR TITLE
dx11/dx12: Replace comptr with wio

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -35,4 +35,4 @@ d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch 
 dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
+wio = { git = "https://github.com/msiglreith/wio-rs.git", branch = "stable" }

--- a/src/backend/dx11/src/execute.rs
+++ b/src/backend/dx11/src/execute.rs
@@ -17,7 +17,7 @@ use winapi::{self, UINT};
 use core::{self, texture as tex};
 use command;
 use {Buffer, Texture};
-use comptr::ComPtr;
+use wio::com::ComPtr;
 
 fn copy_buffer(context: &mut ComPtr<winapi::ID3D11DeviceContext>,
                src: &Buffer, dst: &Buffer,

--- a/src/backend/dx11/src/factory.rs
+++ b/src/backend/dx11/src/factory.rs
@@ -24,7 +24,7 @@ use {Resources as R, Share, Buffer, Fence, Texture, Pipeline, Program, Shader};
 use command::RawCommandBuffer;
 use {CommandList, DeferredContext, ShaderModel};
 use native;
-use comptr::ComPtr;
+use wio::com::ComPtr;
 
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -120,9 +120,9 @@ impl Factory {
     }
 
     pub fn create_command_buffer_native(&mut self) -> RawCommandBuffer<DeferredContext> {
-        let mut dc = ComPtr::<winapi::ID3D11DeviceContext>::new(ptr::null_mut());
+        let mut dc = unsafe { ComPtr::<winapi::ID3D11DeviceContext>::new(ptr::null_mut()) };
         let hr = unsafe {
-            self.device.CreateDeferredContext(0, dc.as_mut() as *mut *mut _)
+            self.device.CreateDeferredContext(0, &mut dc.as_mut() as *mut &mut _ as *mut *mut _)
         };
         if winapi::SUCCEEDED(hr) {
             DeferredContext::new(dc).into()

--- a/src/backend/dx11/src/state.rs
+++ b/src/backend/dx11/src/state.rs
@@ -16,7 +16,7 @@ use std::ptr;
 use winapi::*;
 use core::{pso, state};
 use data::map_function;
-use comptr::ComPtr;
+use wio::com::ComPtr;
 
 pub fn make_rasterizer(device: &mut ComPtr<ID3D11Device>, rast: &state::Rasterizer, use_scissor: bool)
                        -> *const ID3D11RasterizerState {

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -34,5 +34,5 @@ d3d12-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx
 d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
 winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
+wio = { git = "https://github.com/msiglreith/wio-rs.git", branch = "stable" }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use comptr::ComPtr;
+use wio::com::ComPtr;
 use core::{command, pso, shade, state, target, texture as tex};
 use core::{IndexType, VertexCount};
 use winapi;

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -36,4 +36,4 @@ winit = "0.7"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.6" }
 gfx_device_dx12 = { path = "../../backend/dx12", version = "0.1" }
-comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
+wio = { git = "https://github.com/msiglreith/wio-rs.git", branch = "stable" }


### PR DESCRIPTION
Temporary refering to my `wio` fork as we are blocked on winapi 0.3 (or a new 0.2 release) anyway and this might require an `wio` version bump again.

Closes #1402 