### PR TITLE
core: Split adapter into module and extend documentation

### DIFF
--- a/src/backend/dx12ll/Cargo.toml
+++ b/src/backend/dx12ll/Cargo.toml
@@ -34,6 +34,6 @@ d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch 
 dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 kernel32-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
+comptr = { git = "https://github.com/msiglreith/comptr-rs.git", branch = "gfx" }
 winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 winit = "0.7"

--- a/src/core/src/adapter.rs
+++ b/src/core/src/adapter.rs
@@ -1,0 +1,121 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Logical device adapters.
+//!
+//! Adapters are the main entry point for opening a [Device](../struct.Device).
+
+use {Backend, Device, QueueType};
+
+/// Represents a physical or virtual device, which is capable of running the backend.
+pub trait Adapter<B: Backend>: Sized {
+    /// Create a new device with the specified queues.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use gfx_core::{Adapter, QueueFamily};
+    /// # use gfx_core::dummy::DummyAdapter;
+    ///
+    /// # let adapter: DummyAdapter = return;
+    /// let queue_desc = adapter.get_queue_families()
+    ///                         .iter()
+    ///                         .map(|&(ref family, ty)|
+    ///                             (family, ty, family.num_queues()))
+    ///                         .collect::<Vec<_>>();
+    /// let device = adapter.open(&queue_desc);
+    /// ```
+    fn open(&self, queue_descs: &[(&B::QueueFamily, QueueType, u32)]) -> Device<B>;
+
+    /// Create a new device with the specified queues.
+    ///
+    /// Takes an closure and creates the number of queues for each queue type
+    /// as returned by the closure. Queues returning a number of 0 will be filtered out.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use gfx_core::{Adapter, QueueType, Surface};
+    /// # use gfx_core::dummy::{DummyAdapter, DummySurface};
+    ///
+    /// # let adapter: DummyAdapter = return;
+    /// # let surface: DummySurface = return;
+    /// // Open a device with a graphics queue, which can be used for presentation.
+    /// // GeneralQueues will be downcasted to GraphicsQueues.
+    /// let device = adapter.open_with(|family, ty| {
+    ///     ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, QueueType::Graphics)
+    /// });
+    ///
+    /// ```
+    fn open_with<F>(&self, mut f: F) -> Device<B>
+    where
+        F: FnMut(&B::QueueFamily, QueueType) -> (u32, QueueType),
+    {
+        let queue_desc = self.get_queue_families()
+            .iter()
+            .filter_map(|&(ref family, ty)| {
+                let (num_queues, ty) = f(family, ty);
+                if num_queues > 0 {
+                    Some((family, ty, num_queues))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        self.open(&queue_desc)
+    }
+
+    /// Get the `AdapterInfo` for this adapter.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use gfx_core::Adapter;
+    ///
+    /// # let adapter: gfx_core::dummy::DummyAdapter = return;
+    /// println!("Adapter info: {:?}", adapter.get_info());
+    /// ```
+    fn get_info(&self) -> &AdapterInfo;
+
+    /// Return the supported queue families for this adapter.
+    ///
+    /// * `QueueType` will be the one with the most capabilities.
+    /// * There can be multiple families with the same queue type.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use gfx_core::Adapter;
+    ///
+    /// # let adapter: gfx_core::dummy::DummyAdapter = return;
+    /// for (i, &(_, ty)) in adapter.get_queue_families().into_iter().enumerate() {
+    ///     println!("Queue family ({:?}) type: {:?}", i, ty);
+    /// }
+    /// ```
+    fn get_queue_families(&self) -> &[(B::QueueFamily, QueueType)];
+}
+
+/// Information about a backend adapter.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct AdapterInfo {
+    /// Adapter name
+    pub name: String,
+    /// Vendor PCI id of the adapter
+    pub vendor: usize,
+    /// PCI id of the adapter
+    pub device: usize,
+    /// The device is based on a software rasterizer
+    pub software_rendering: bool,
+}

--- a/src/core/src/dummy.rs
+++ b/src/core/src/dummy.rs
@@ -17,7 +17,7 @@
 
 use {Adapter, AdapterInfo, Backend, Capabilities, Resources, IndexType, VertexCount, QueueType,
      Device, Factory, CommandQueue, QueueFamily, QueueSubmit, ShaderSet, Surface, SwapChain,
-     Frame, FrameSync, SwapchainConfig, Backbuffer};
+     Frame, FrameSync, SwapchainConfig, Backbuffer, WindowExt};
 use {buffer, format, state, target, handle, mapping, pool, pso, shade, texture};
 use command::{self, AccessInfo};
 use factory::{ResourceViewError, TargetViewError, WaitFor};
@@ -398,6 +398,17 @@ impl SwapChain<DummyBackend> for DummySwapChain {
         _: &mut Q,
         _: &[&handle::Semaphore<DummyResources>],
     ) {
+        unimplemented!()
+    }
+}
+
+/// Dummy window.
+pub struct DummyWindow;
+impl WindowExt<DummyBackend> for DummyWindow {
+    type Surface = DummySurface;
+    type Adapter = DummyAdapter;
+
+    fn get_surface_and_adapters(&mut self) -> (DummySurface, Vec<DummyAdapter>) {
         unimplemented!()
     }
 }


### PR DESCRIPTION
* Moving adapter parts into separate module, allowing better documentation and move stuff out of `lib.rs`
* Extend documentation for window, adapter and queues (still early, API isn't totally fixed atm)

cc #1321 