### PR TITLE
core: Rework queue submission

### DIFF
--- a/src/backend/dx11/src/command.rs
+++ b/src/backend/dx11/src/command.rs
@@ -26,6 +26,7 @@ use core::{MAX_VERTEX_ATTRIBUTES, MAX_CONSTANT_BUFFERS,
            MAX_SAMPLERS, MAX_COLOR_TARGETS};
 use {native, Backend, CommandList, Resources, InputLayout, Buffer, Texture, Pipeline, Program};
 
+#[derive(Clone)]
 pub struct SubmitInfo<P> {
     pub parser: P,
 }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -435,11 +435,15 @@ impl CommandQueue {
 }
 
 impl core::CommandQueue<Backend> for CommandQueue {
-    unsafe fn submit(&mut self, submit_infos: &[core::QueueSubmit<Backend>], fence: Option<&h::Fence<Resources>>, access: &com::AccessInfo<Resources>) {
+    unsafe fn submit_raw<'a, I>(
+        &mut self,
+        submit_infos: I,
+        fence: Option<&h::Fence<Resources>>,
+        access: &com::AccessInfo<Resources>,
+    ) where I: Iterator<Item=core::RawSubmission<'a, Backend>> {
         let _guard = self.before_submit(access).unwrap();
         for submit in submit_infos {
             for cb in submit.cmd_buffers {
-                let cb = cb.get_info();
                 unsafe { self.context.ClearState(); }
                 for com in &cb.parser.0 {
                     execute::process(&mut self.context, com, &cb.parser.1);

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -28,6 +28,7 @@ unsafe impl Send for CommandBuffer { }
 pub struct SubpassCommandBuffer {
 }
 
+#[derive(Clone)]
 pub struct SubmitInfo; // TODO
 
 // CommandBuffer trait implementation

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -141,8 +141,12 @@ pub struct CommandQueue {
 }
 
 impl core::CommandQueue<Backend> for CommandQueue {
-    unsafe fn submit(&mut self, submit_infos: &[core::QueueSubmit<Backend>],
-        fence: Option<&handle::Fence<Resources>>, access: &com::AccessInfo<Resources>) {
+    unsafe fn submit_raw<'a, I>(
+        &mut self,
+        submit_infos: I,
+        fence: Option<&handle::Fence<Resources>>,
+        access: &com::AccessInfo<Resources>,
+    ) where I: Iterator<Item=core::RawSubmission<'a, Backend>> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -73,6 +73,7 @@ impl DataBuffer {
 }
 
 #[allow(missing_copy_implementations)]
+#[derive(Clone)]
 pub struct SubmitInfo {
     // Raw pointer optimization:
     // Command buffers are stored inside the command pools.

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -967,11 +967,15 @@ impl CommandQueue {
 }
 
 impl c::CommandQueue<Backend> for CommandQueue {
-    unsafe fn submit(&mut self, submit_infos: &[c::QueueSubmit<Backend>], fence: Option<&handle::Fence<Resources>>, access: &com::AccessInfo<Resources>) {
+    unsafe fn submit_raw<'a, I>(
+        &mut self,
+        submit_infos: I,
+        fence: Option<&handle::Fence<Resources>>,
+        access: &com::AccessInfo<Resources>,
+    ) where I: Iterator<Item=c::RawSubmission<'a, Backend>> {
         let mut access = self.before_submit(access).unwrap();
         for submit in submit_infos {
             for cb in submit.cmd_buffers {
-                let cb = cb.get_info();
                 self.reset_state();
                 for com in &*cb.buf {
                     self.process(com, &*cb.data);

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -32,6 +32,7 @@ use metal::*;
 use std::ptr;
 use std::collections::hash_map::{HashMap, Entry};
 
+#[derive(Clone)]
 pub struct SubmitInfo {
     pub(crate) command_buffer: MTLCommandBuffer
 }

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -229,9 +229,12 @@ impl CommandQueue {
 }
 
 impl core::CommandQueue<Backend> for CommandQueue {
-    unsafe fn submit(&mut self, submit_infos: &[core::QueueSubmit<Backend>],
-        fence: Option<&handle::Fence<Resources>>, access: &AccessInfo<Resources>)
-    {
+    unsafe fn submit_raw<'a, I>(
+        &mut self,
+        submit_infos: I,
+        fence: Option<&handle::Fence<Resources>>,
+        access: &AccessInfo<Resources>,
+    ) where I: Iterator<Item=core::RawSubmission<'a, Backend>> {
         for submit in submit_infos {
             // FIXME: wait for semaphores!
 
@@ -250,7 +253,7 @@ impl core::CommandQueue<Backend> for CommandQueue {
             };
 
             for buffer in submit.cmd_buffers {
-                let command_buffer = buffer.get_info().command_buffer;
+                let command_buffer = buffer.command_buffer;
                 if let Some(ref signal_block) = signal_block {
                     msg_send![command_buffer.0, addCompletedHandler: signal_block.deref() as *const _];
                 }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -19,6 +19,7 @@ use core::{IndexType, VertexCount};
 use {Backend, RawDevice, Resources};
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct SubmitInfo {
     pub command_buffer: vk::CommandBuffer,
 }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -385,9 +385,12 @@ impl CommandQueue {
 }
 
 impl core::CommandQueue<Backend> for CommandQueue {
-    unsafe fn submit(&mut self, submit_infos: &[core::QueueSubmit<Backend>],
-        fence: Option<&handle::Fence<Resources>>, access: &com::AccessInfo<Resources>)
-    {
+    unsafe fn submit_raw<'a, I>(
+        &mut self,
+        submit_infos: I,
+        fence: Option<&handle::Fence<Resources>>,
+        access: &com::AccessInfo<Resources>,
+    ) where I: Iterator<Item=core::RawSubmission<'a, Backend>> {
         unimplemented!()
     }
 

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -35,6 +35,7 @@ draw_state = "0.7"
 log = "0.3"
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
+smallvec = "0.4.1"
 
 [features]
 serialize = ["serde", "serde_derive", "draw_state/serialize"]

--- a/src/core/src/dummy.rs
+++ b/src/core/src/dummy.rs
@@ -16,8 +16,8 @@
 //! outside of the graphics development environment.
 
 use {Adapter, AdapterInfo, Backend, Capabilities, Resources, IndexType, VertexCount, QueueType,
-     Device, Factory, CommandQueue, QueueFamily, QueueSubmit, ShaderSet, Surface, SwapChain,
-     Frame, FrameSync, SwapchainConfig, Backbuffer, WindowExt};
+     Device, Factory, CommandQueue, QueueFamily, ShaderSet, Surface, SwapChain,
+     Frame, FrameSync, SwapchainConfig, Backbuffer, WindowExt, RawSubmission};
 use {buffer, format, state, target, handle, mapping, pool, pso, shade, texture};
 use command::{self, AccessInfo};
 use factory::{ResourceViewError, TargetViewError, WaitFor};
@@ -59,12 +59,12 @@ impl Adapter<DummyBackend> for DummyAdapter {
 /// Dummy command queue doing nothing.
 pub struct DummyQueue;
 impl CommandQueue<DummyBackend> for DummyQueue {
-    unsafe fn submit(
+    unsafe fn submit_raw<'a, I>(
         &mut self,
-        _: &[QueueSubmit<DummyBackend>],
+        _: I,
         _: Option<&handle::Fence<DummyResources>>,
         _: &AccessInfo<DummyResources>,
-    ) {
+    ) where I: Iterator<Item=RawSubmission<'a, DummyBackend>> {
         unimplemented!()
     }
 
@@ -222,6 +222,7 @@ impl QueueFamily for DummyFamily {
 }
 
 /// Dummy submit info containing nothing.
+#[derive(Clone)]
 pub struct DummySubmitInfo;
 
 /// Dummy subpass command buffer.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -23,6 +23,7 @@ extern crate bitflags;
 extern crate derivative;
 extern crate draw_state;
 extern crate log;
+extern crate smallvec;
 
 #[cfg(feature = "mint")]
 extern crate mint;
@@ -45,8 +46,8 @@ pub use self::command::CommandBuffer;
 pub use self::factory::Factory;
 pub use self::pool::{ComputeCommandPool, GeneralCommandPool, GraphicsCommandPool, RawCommandPool,
                      SubpassCommandPool, TransferCommandPool};
-pub use self::queue::{CommandQueue, ComputeQueue, GeneralQueue, GraphicsQueue, QueueFamily,
-                      QueueSubmit, QueueType, TransferQueue};
+pub use self::queue::{CommandQueue, QueueType, RawSubmission, Submission, QueueFamily,
+                      ComputeQueue, GeneralQueue, GraphicsQueue, TransferQueue};
 pub use self::window::{Backbuffer, Frame, FrameSync, Surface, SwapChain, SwapchainConfig,
                        WindowExt};
 pub use draw_state::{state, target};
@@ -253,7 +254,7 @@ pub trait Backend: 'static + Sized {
     type Factory: Factory<Self::Resources>;
     type QueueFamily: QueueFamily;
     type Resources: Resources;
-    type SubmitInfo: Send;
+    type SubmitInfo: Clone + Send;
 
     type RawCommandBuffer: CommandBuffer<Self> + command::Buffer<Self::Resources>;
     type SubpassCommandBuffer: CommandBuffer<Self>; // + SubpassCommandBuffer<Self::R>;

--- a/src/core/src/queue/capability.rs
+++ b/src/core/src/queue/capability.rs
@@ -1,0 +1,63 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Type system encoded queue capabilities.
+
+/// General capability, supporting graphics, compute and transfer operations.
+pub struct General;
+/// Graphics capability, supporting graphics and transfer operations.
+pub struct Graphics;
+/// Compute capability, supporting compute and transfer operations.
+pub struct Compute;
+/// Transfer capability, supporting only transfer operations.
+pub struct Transfer;
+
+/// Tag trait, annotating the capability to a certain struct (e.g Submission).
+pub trait Capability {
+    ///
+    type Capability;
+}
+
+///
+pub trait Supports<T> { }
+impl<T> Supports<T> for T { }
+impl Supports<Graphics> for General { }
+impl Supports<Compute> for General { }
+impl Supports<Transfer> for General { }
+impl Supports<Transfer> for Graphics { }
+impl Supports<Transfer> for Compute { }
+
+///
+pub trait SupportedBy<T> { }
+impl<U, T> SupportedBy<T> for U where T: Supports<U> { }
+
+/// Encoding the minimal capability to support a combination of other capabilities.
+pub trait Upper {
+    /// Resulting mininmal required capability.
+    type Result;
+}
+
+impl<T> Upper for (T, T) { type Result = T; }
+impl Upper for (General,  Graphics) { type Result = General; }
+impl Upper for (General,  Compute)  { type Result = General; }
+impl Upper for (General,  Transfer) { type Result = General; }
+impl Upper for (Graphics, General)  { type Result = General; }
+impl Upper for (Graphics, Compute)  { type Result = General; }
+impl Upper for (Graphics, Transfer) { type Result = Graphics; }
+impl Upper for (Compute,  General)  { type Result = General; }
+impl Upper for (Compute,  Graphics) { type Result = General; }
+impl Upper for (Compute,  Transfer) { type Result = Compute; }
+impl Upper for (Transfer, General)  { type Result = General; }
+impl Upper for (Transfer, Graphics) { type Result = Graphics; }
+impl Upper for (Transfer, Compute)  { type Result = Compute; }

--- a/src/core/src/queue/submission.rs
+++ b/src/core/src/queue/submission.rs
@@ -1,0 +1,102 @@
+// Copyright 2017 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Queue submission.
+//!
+//! // TODO
+
+use {handle, pso, Backend};
+use command::{Submit, GeneralCommandBuffer, GraphicsCommandBuffer,
+              ComputeCommandBuffer, TransferCommandBuffer};
+use super::capability::{General, Graphics, Compute, Transfer, Supports, Upper};
+use std::marker::PhantomData;
+use smallvec::SmallVec;
+
+use super::{GeneralQueue, GraphicsQueue, ComputeQueue, TransferQueue};
+
+/// Raw submission information for a command queue.
+pub struct RawSubmission<'a, B: Backend + 'a> {
+    /// Command buffers to submit.
+    pub cmd_buffers: &'a [B::SubmitInfo],
+    /// Semaphores to wait being signalled before submission.
+    pub wait_semaphores: &'a [(&'a handle::Semaphore<B::Resources>, pso::PipelineStage)],
+    /// Semaphores which get signalled after submission.
+    pub signal_semaphores: &'a [&'a handle::Semaphore<B::Resources>],
+}
+
+/// Submission information for a command queue.
+pub struct Submission<'a, B: Backend, C> {
+    cmd_buffers: SmallVec<[B::SubmitInfo; 16]>,
+    wait_semaphores: SmallVec<[(&'a handle::Semaphore<B::Resources>, pso::PipelineStage); 16]>,
+    signal_semaphores: SmallVec<[&'a handle::Semaphore<B::Resources>; 16]>,
+    marker: PhantomData<C>,
+}
+
+impl<'a, B: Backend> Submission<'a, B, Transfer> {
+    /// Create a new empty (transfer) submission.
+    ///
+    /// Transfer is the minimum supported capability by all queues.
+    pub fn new() -> Submission<'a, B, Transfer> {
+        Submission {
+            cmd_buffers: SmallVec::new(),
+            wait_semaphores: SmallVec::new(),
+            signal_semaphores: SmallVec::new(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, B, C> Submission<'a, B, C>
+where
+    B: Backend
+{
+    /// Set semaphores which will waited on to be signalled before the submission will be executed.
+    pub fn wait_on(mut self, semaphores: &[(&'a handle::Semaphore<B::Resources>, pso::PipelineStage)]) -> Self {
+        self.wait_semaphores.extend_from_slice(semaphores);
+        self
+    }
+
+    /// Set semaphores which will be signalled once this submission has finished executing.
+    pub fn signal(mut self, semaphores: &[&'a handle::Semaphore<B::Resources>]) -> Self {
+        self.signal_semaphores.extend_from_slice(semaphores);
+        self
+    }
+
+    /// Convert strong-typed submission object into untyped equivalent.
+    pub(super) fn as_raw(&self) -> RawSubmission<B> {
+        RawSubmission {
+            cmd_buffers: &self.cmd_buffers,
+            wait_semaphores: &self.wait_semaphores,
+            signal_semaphores: &self.signal_semaphores,
+        }
+    }
+
+    /// Append a new list of finished command buffers to this submission.
+    ///
+    /// All submits for this call must be of the same capability.
+    /// Submission will be automatically promoted to to the minimum required capability
+    /// to hold all passed submits.
+    pub fn submit<S>(mut self, submits: &[Submit<B, S>]) -> Submission<'a, B, <(C, S) as Upper>::Result>
+    where
+        (C, S): Upper
+    {
+        self.cmd_buffers.extend(submits.iter().map(|submit| unsafe { submit.get_info().clone() }));
+        Submission {
+            cmd_buffers: self.cmd_buffers,
+            wait_semaphores: self.wait_semaphores,
+            signal_semaphores: self.signal_semaphores,
+            marker: PhantomData,
+        }
+    }
+}


### PR DESCRIPTION
Current queue submission allowed to submit all kind of buffers to a queue which could cause issues on some backends. We provide now untyped and a strong-typed interface for command buffer submission employing a builder pattern internally.

Queue capabilities and hierarchies are fully encoded into the type systems. Submissions will be upcasted to the match the required capabilities needed for executing the passed command buffers. Only queue with matching capabilities can execute this submissions.

A missing point which will be addressed in a followup would to allow submission of different Submission objects, currently required to have the same capability, possibly with an additional builder for a collection of submissions.

Example for submission building:
```rust
let submission_a =
    Submission::new()
        .wait_on(&[&landscape_semaphore, &sky_semaphore]) // wait_semaphores
        .wait_on(&[&ocean_height_sync])                   // wait_semaphores
        .submit(&[buffer_tree1, buffer_tree2])            // push graphics command buffers
        .submit(&[buffer_ocean])                          // push more graphics command buffers!
        .submit(&[ocean_propagation])                      // push some compute stuff
        .signal(&[&terrain_semaphore]);                   // signal semaphores
```
The resulting submission would require `General` capability as it contains compute and graphics commands.