### PR TITLE
core: Add queue submission promotion

### DIFF
--- a/src/core/src/queue/submission.rs
+++ b/src/core/src/queue/submission.rs
@@ -99,4 +99,20 @@ where
             marker: PhantomData,
         }
     }
+
+    /// Promote a submission to a higher capability type.
+    ///
+    /// Submission promotion is only necessary for shoving multiple submissions
+    /// of different capabilities into one submit call.
+    pub fn promote<P>(self) -> Submission<'a, B, P>
+    where
+        P: Supports<C>
+    {
+        Submission {
+            cmd_buffers: self.cmd_buffers,
+            wait_semaphores: self.wait_semaphores,
+            signal_semaphores: self.signal_semaphores,
+            marker: PhantomData,
+        }
+    }
 }


### PR DESCRIPTION
Allow the user to manually promote a submission object in order to be submitted with submissions of the same capability with a single submit.

e.g we have a submission with graphics capability and one with compute capability. Trying to batch them into one `submit` call would fail due to type difference. We could try to add a submission list builder but that's tricky without possible overhead I believe.
The implemented approach here is quite straightforward imo and the error messages are ok-ish if we try to promote the submission into an illegal state.

```
error[E0277]: the trait bound `core::queue::Transfer: core::queue::Supports<core::queue::Graphics>` is not satisfied
   --> src\render\src\encoder.rs:204:48
    |
204 |                     .signal(signal_semaphores).promote::<core::queue::Transfer>();
    |                                                ^^^^^^^ the trait `core::queue::Supports<core::queue::Graphics>` is not implemented for `core::queue::Transfer`
```