### PR TITLE
Fix travis linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ addons:
       - libxcursor1
       - libglfw-dev
       - libosmesa6-dev
+      - libxi-dev
+      - libxrandr-dev
 
 script:
   - bash scripts/travis-script.sh


### PR DESCRIPTION
Add missing glfw dependencies for the newer trusty images.