### PR TITLE
Fix travis linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ addons:
       - libxcursor-dev
       - libxcursor1
       - libglfw-dev
+      - libxi-dev
+      - libxrandr-dev
 script:
   - export RUST_BACKTRACE=1
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$PATH:$HOME/deps/bin ; fi


### PR DESCRIPTION
Add missing glfw dependencies for the newer trusty images.

Same as #1422 for 0.16 branch