### PR TITLE
[ll] Implement clear, copy and resolve commands for vulkan [38/..]

### DIFF
--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -87,9 +87,9 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         let contents = map_subpass_contents(first_subpass);
         unsafe {
             self.device.0.cmd_begin_render_pass(
-                self.raw, // commandBuffer
-                &info,    // pRenderPassBegin
-                contents, // contents
+                self.raw,
+                &info,
+                contents,
             );
         }
     }
@@ -211,12 +211,12 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
             .collect();
         unsafe {
             self.device.0.cmd_resolve_image(
-                self.raw,                           // commandBuffer
-                src.raw,                            // srcImage
-                data::map_image_layout(src_layout), // srcImageLayout
-                dst.raw,                            // dstImage
-                data::map_image_layout(dst_layout), // dstImageLayout
-                &regions,                           // pRegions
+                self.raw,
+                src.raw,
+                data::map_image_layout(src_layout),
+                dst.raw,
+                data::map_image_layout(dst_layout),
+                &regions,
             );
         }
     }
@@ -224,10 +224,10 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
     fn bind_index_buffer(&mut self, ibv: IndexBufferView<Backend>) {
         unsafe {
             self.device.0.cmd_bind_index_buffer(
-                self.raw,                             // commandBuffer
-                ibv.buffer.raw,                       // buffer
-                ibv.offset,                           // offset
-                data::map_index_type(ibv.index_type), // indexType
+                self.raw,
+                ibv.buffer.raw,
+                ibv.offset,
+                data::map_index_type(ibv.index_type),
             );
         }
     }
@@ -329,15 +329,16 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         sets: &[&n::DescriptorSet],
     ) {
         let sets: SmallVec<[vk::DescriptorSet; 16]> = sets.iter().map(|set| set.raw).collect();
+        let dynamic_offsets = &[]; // TODO
 
         unsafe {
             self.device.0.cmd_bind_descriptor_sets(
-                self.raw,                        // commandBuffer
-                vk::PipelineBindPoint::Graphics, // pipelineBindPoint
-                layout.raw,                      // layout
-                first_set as u32,                // firstSet
-                &sets,                           // pDescriptorSets
-                &[],                             // pDynamicOffsets // TODO
+                self.raw,
+                vk::PipelineBindPoint::Graphics,
+                layout.raw,
+                first_set as u32,
+                &sets,
+                dynamic_offsets,
             );
         }
     }
@@ -353,10 +354,10 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
     fn dispatch(&mut self, x: u32, y: u32, z: u32) {
         unsafe {
             self.device.0.cmd_dispatch(
-                self.raw, // commandBuffer
-                x,        // groupCountX
-                y,        // groupCountY
-                z,        // groupCountZ
+                self.raw,
+                x,
+                y,
+                z,
             )
         }
     }
@@ -446,11 +447,11 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
 
         unsafe {
             self.device.0.cmd_copy_buffer_to_image(
-                self.raw,                       // commandBuffer
-                src.raw,                        // srcBuffer
-                dst.raw,                        // dstImage
-                data::map_image_layout(layout), // dstImageLayout
-                &regions,                       // pRegions
+                self.raw,
+                src.raw,
+                dst.raw,
+                data::map_image_layout(layout),
+                &regions,
             );
         }
     }
@@ -473,11 +474,11 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
 
         unsafe {
             self.device.0.cmd_draw(
-                self.raw,       // commandBuffer
-                count,          // vertexCount
-                num_instances,  // instanceCount
-                start,          // firstVertex
-                start_instance, // firstInstance
+                self.raw,
+                count,
+                num_instances,
+                start,
+                start_instance,
             )
         }
     }
@@ -496,12 +497,12 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
 
         unsafe {
             self.device.0.cmd_draw_indexed(
-                self.raw,       // commandBuffer
-                count,          // indexCount
-                num_instances,  // instanceCount
-                start,          // firstIndex
-                base,           // vertexOffset
-                start_instance, // firstInstance
+                self.raw,
+                count,
+                num_instances,
+                start,
+                base,
+                start_instance,
             )
         }
     }
@@ -509,11 +510,11 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
     fn draw_indirect(&mut self, buffer: &n::Buffer, offset: u64, draw_count: u32, stride: u32) {
         unsafe {
             self.device.0.cmd_draw_indirect(
-                self.raw,   // commandBuffer
-                buffer.raw, // buffer
-                offset,     // offset
-                draw_count, // drawCount
-                stride,     // stride
+                self.raw,
+                buffer.raw,
+                offset,
+                draw_count,
+                stride,
             )
         }
     }
@@ -527,11 +528,11 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
     ) {
         unsafe {
             self.device.0.cmd_draw_indexed_indirect(
-                self.raw,   // commandBuffer
-                buffer.raw, // buffer
-                offset,     // offset
-                draw_count, // drawCount
-                stride,     // stride
+                self.raw,
+                buffer.raw,
+                offset,
+                draw_count,
+                stride,
             )
         }
     }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -17,7 +17,8 @@ use ash::version::DeviceV1_0;
 use core::{command, memory, pso, shade, state, target, texture};
 use core::{IndexType, VertexCount, VertexOffset};
 use core::buffer::IndexBufferView;
-use core::command::{BufferCopy, BufferImageCopy, ClearColor, ClearValue, InstanceParams, SubpassContents};
+use core::command::{BufferCopy, BufferImageCopy, ClearColor, ClearValue, ImageCopy, ImageResolve,
+                    InstanceParams, SubpassContents};
 use {data, native as n, Backend, RawDevice};
 use std::ptr;
 use std::sync::Arc;
@@ -59,22 +60,19 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         clear_values: &[ClearValue],
         first_subpass: SubpassContents,
     ) {
-        let render_area =
-            vk::Rect2D {
-                offset: vk::Offset2D {
-                    x: render_area.x as i32,
-                    y: render_area.y as i32,
-                },
-                extent: vk::Extent2D {
-                    width: render_area.w as u32,
-                    height: render_area.h as u32,
-                },
-            };
+        let render_area = vk::Rect2D {
+            offset: vk::Offset2D {
+                x: render_area.x as i32,
+                y: render_area.y as i32,
+            },
+            extent: vk::Extent2D {
+                width: render_area.w as u32,
+                height: render_area.h as u32,
+            },
+        };
 
         let clear_values: SmallVec<[vk::ClearValue; 16]> =
-            clear_values.iter()
-                        .map(data::map_clear_value)
-                        .collect();
+            clear_values.iter().map(data::map_clear_value).collect();
 
         let info = vk::RenderPassBeginInfo {
             s_type: vk::StructureType::RenderPassBeginInfo,
@@ -109,20 +107,20 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn pipeline_barrier(
-        &mut self,
-        _memory_barries: &[memory::MemoryBarrier],
-        _buffer_barriers: &[memory::BufferBarrier],
-        _image_barriers: &[memory::ImageBarrier],
-    ) {
+    fn pipeline_barrier(&mut self, _barriers: &[memory::Barrier]) {
         unimplemented!()
     }
 
-    fn clear_color(&mut self, rtv: &n::RenderTargetView, layout: texture::ImageLayout, color: ClearColor) {
+    fn clear_color(
+        &mut self,
+        rtv: &n::RenderTargetView,
+        layout: texture::ImageLayout,
+        color: ClearColor,
+    ) {
         let clear_value = data::map_clear_color(color);
 
         let range = {
-            let (_, ref mip_levels, ref array_layers) = rtv.range;
+            let (ref mip_levels, ref array_layers) = rtv.range;
             vk::ImageSubresourceRange {
                 aspect_mask: vk::IMAGE_ASPECT_COLOR_BIT,
                 base_mip_level: mip_levels.start as u32,
@@ -143,52 +141,124 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         };
     }
 
-    fn clear_depth_stencil(&mut self, dsv: &n::DepthStencilView, depth: Option<target::Depth>, stencil: Option<target::Stencil>) {
-        unimplemented!()
+    fn clear_depth_stencil(
+        &mut self,
+        dsv: &n::DepthStencilView,
+        layout: texture::ImageLayout,
+        depth: Option<target::Depth>,
+        stencil: Option<target::Stencil>,
+    ) {
+        let clear_value = vk::ClearDepthStencilValue {
+            depth: depth.unwrap_or(0.0),
+            stencil: stencil.unwrap_or(0) as u32,
+        };
+
+        let range = {
+            let (ref mip_levels, ref array_layers) = dsv.range;
+            let mut aspect_mask = vk::ImageAspectFlags::empty();
+            if depth.is_some() {
+                aspect_mask |= vk::IMAGE_ASPECT_DEPTH_BIT;
+            }
+            if stencil.is_some() {
+                aspect_mask |= vk::IMAGE_ASPECT_STENCIL_BIT;
+            }
+
+            vk::ImageSubresourceRange {
+                aspect_mask,
+                base_mip_level: mip_levels.start as u32,
+                level_count: (mip_levels.end - mip_levels.start) as u32,
+                base_array_layer: array_layers.start as u32,
+                layer_count: (array_layers.end - array_layers.start) as u32,
+            }
+        };
+
+        unsafe {
+            self.device.0.cmd_clear_depth_stencil_image(
+                self.raw,
+                dsv.image,
+                data::map_image_layout(layout),
+                &clear_value,
+                &[range],
+            )
+        };
     }
 
-    fn resolve_image(&mut self) {
-        unimplemented!()
+    fn resolve_image(
+        &mut self,
+        src: &n::Image,
+        src_layout: texture::ImageLayout,
+        dst: &n::Image,
+        dst_layout: texture::ImageLayout,
+        regions: &[ImageResolve],
+    ) {
+        let regions: SmallVec<[vk::ImageResolve; 16]> = regions
+            .iter()
+            .map(|region| {
+                vk::ImageResolve {
+                    src_subresource: data::map_subresource_layers(
+                        vk::IMAGE_ASPECT_COLOR_BIT, // Specs [1.0.42] 18.6
+                        &region.src_subresource,
+                    ),
+                    src_offset: data::map_offset(region.src_offset),
+                    dst_subresource: data::map_subresource_layers(
+                        vk::IMAGE_ASPECT_COLOR_BIT, // Specs [1.0.42] 18.6
+                        &region.dst_subresource,
+                    ),
+                    dst_offset: data::map_offset(region.dst_offset),
+                    extent: data::map_extent(region.extent),
+                }
+            })
+            .collect();
+        unsafe {
+            self.device.0.cmd_resolve_image(
+                self.raw,                           // commandBuffer
+                src.raw,                            // srcImage
+                data::map_image_layout(src_layout), // srcImageLayout
+                dst.raw,                            // dstImage
+                data::map_image_layout(dst_layout), // dstImageLayout
+                &regions,                           // pRegions
+            );
+        }
     }
 
     fn bind_index_buffer(&mut self, ibv: IndexBufferView<Backend>) {
         unsafe {
             self.device.0.cmd_bind_index_buffer(
-                self.raw,       // commandBuffer
-                ibv.buffer.raw, // buffer
-                ibv.offset,     // offset
+                self.raw,                             // commandBuffer
+                ibv.buffer.raw,                       // buffer
+                ibv.offset,                           // offset
                 data::map_index_type(ibv.index_type), // indexType
             );
         }
     }
 
     fn bind_vertex_buffers(&mut self, vbs: pso::VertexBufferSet<Backend>) {
-        let buffers: SmallVec<[vk::Buffer; 16]>     = vbs.0.iter().map(|&(ref buffer, _)| buffer.raw).collect();
-        let offsets: SmallVec<[vk::DeviceSize; 16]> = vbs.0.iter().map(|&(_, offset)| offset as u64).collect();
+        let buffers: SmallVec<[vk::Buffer; 16]> =
+            vbs.0.iter().map(|&(ref buffer, _)| buffer.raw).collect();
+        let offsets: SmallVec<[vk::DeviceSize; 16]> =
+            vbs.0.iter().map(|&(_, offset)| offset as u64).collect();
 
         unsafe {
-            self.device.0.cmd_bind_vertex_buffers(
-                self.raw,
-                0,
-                &buffers,
-                &offsets,
-            );
+            self.device
+                .0
+                .cmd_bind_vertex_buffers(self.raw, 0, &buffers, &offsets);
         }
     }
 
     fn set_viewports(&mut self, viewports: &[target::Rect]) {
-        let viewports: SmallVec<[vk::Viewport; 16]> =
-            viewports.iter()
-                     .map(|viewport| {
-                        vk::Viewport {
-                            x: viewport.x as f32,
-                            y: viewport.y as f32,
-                            width: viewport.w as f32,
-                            height: viewport.h as f32,
-                            min_depth: 0.0,
-                            max_depth: 1.0,
-                        }
-                     }).collect();
+        let viewports: SmallVec<[vk::Viewport; 16]> = viewports
+            .iter()
+            .map(|viewport| {
+                vk::Viewport {
+                    x: viewport.x as f32,
+                    y: viewport.y as f32,
+                    width: viewport.w as f32,
+                    height: viewport.h as f32,
+                    min_depth: 0.0,
+                    max_depth: 1.0,
+                }
+            })
+            .collect();
 
         unsafe {
             self.device.0.cmd_set_viewport(self.raw, &viewports);
@@ -196,20 +266,21 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn set_scissors(&mut self, scissors: &[target::Rect]) {
-        let scissors: SmallVec<[vk::Rect2D; 16]> =
-            scissors.iter()
-                    .map(|scissor| {
-                        vk::Rect2D {
-                            offset: vk::Offset2D {
-                                x: scissor.x as i32,
-                                y: scissor.y as i32,
-                            },
-                            extent: vk::Extent2D {
-                                width: scissor.w as u32,
-                                height: scissor.h as u32,
-                            }
-                        }
-                    }).collect();
+        let scissors: SmallVec<[vk::Rect2D; 16]> = scissors
+            .iter()
+            .map(|scissor| {
+                vk::Rect2D {
+                    offset: vk::Offset2D {
+                        x: scissor.x as i32,
+                        y: scissor.y as i32,
+                    },
+                    extent: vk::Extent2D {
+                        width: scissor.w as u32,
+                        height: scissor.h as u32,
+                    },
+                }
+            })
+            .collect();
 
         unsafe {
             self.device.0.cmd_set_scissor(self.raw, &scissors);
@@ -218,10 +289,7 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn set_ref_values(&mut self, rv: state::RefValues) {
         unsafe {
-            self.device.0.cmd_set_blend_constants(
-                self.raw,
-                rv.blend,
-            );
+            self.device.0.cmd_set_blend_constants(self.raw, rv.blend);
 
             if rv.stencil.0 == rv.stencil.1 {
                 // set front _and_ back
@@ -248,25 +316,37 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {
         unsafe {
-            self.device.0.cmd_bind_pipeline(
-                self.raw,
-                vk::PipelineBindPoint::Graphics,
-                pipeline.0,
-            )
+            self.device
+                .0
+                .cmd_bind_pipeline(self.raw, vk::PipelineBindPoint::Graphics, pipeline.0)
         }
     }
 
-    fn bind_graphics_descriptor_sets(&mut self, layout: &n::PipelineLayout, first_set: usize, sets: &[&()]) {
-        unimplemented!()
+    fn bind_graphics_descriptor_sets(
+        &mut self,
+        layout: &n::PipelineLayout,
+        first_set: usize,
+        sets: &[&n::DescriptorSet],
+    ) {
+        let sets: SmallVec<[vk::DescriptorSet; 16]> = sets.iter().map(|set| set.raw).collect();
+
+        unsafe {
+            self.device.0.cmd_bind_descriptor_sets(
+                self.raw,                        // commandBuffer
+                vk::PipelineBindPoint::Graphics, // pipelineBindPoint
+                layout.raw,                      // layout
+                first_set as u32,                // firstSet
+                &sets,                           // pDescriptorSets
+                &[],                             // pDynamicOffsets // TODO
+            );
+        }
     }
 
     fn bind_compute_pipeline(&mut self, pipeline: &n::ComputePipeline) {
         unsafe {
-            self.device.0.cmd_bind_pipeline(
-                self.raw,
-                vk::PipelineBindPoint::Compute,
-                pipeline.0,
-            )
+            self.device
+                .0
+                .cmd_bind_pipeline(self.raw, vk::PipelineBindPoint::Compute, pipeline.0)
         }
     }
 
@@ -283,47 +363,71 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn dispatch_indirect(&mut self, buffer: &n::Buffer, offset: u64) {
         unsafe {
-            self.device.0.cmd_dispatch_indirect(
-                self.raw,
-                buffer.raw,
-                offset,
-            )
+            self.device
+                .0
+                .cmd_dispatch_indirect(self.raw, buffer.raw, offset)
         }
     }
-
-    /*
-    fn update_buffer(&mut self, buffer: &n::Buffer, data: &[u8], offset: usize) {
-        unsafe {
-            self.device.0.cmd_update_buffer(
-                self.raw,
-                offset,
-                data,
-            )
-        }
-    }
-    */
 
     fn copy_buffer(&mut self, src: &n::Buffer, dst: &n::Buffer, regions: &[BufferCopy]) {
-        unimplemented!()
+        let regions: SmallVec<[vk::BufferCopy; 16]> = regions
+            .iter()
+            .map(|region| {
+                vk::BufferCopy {
+                    src_offset: region.src,
+                    dst_offset: region.dst,
+                    size: region.size,
+                }
+            })
+            .collect();
+
+        unsafe {
+            self.device
+                .0
+                .cmd_copy_buffer(self.raw, src.raw, dst.raw, &regions)
+        }
     }
 
-    fn copy_image(&mut self, src: &n::Image, dst: &n::Image) {
-        unimplemented!()
+    fn copy_image(
+        &mut self,
+        src: &n::Image,
+        src_layout: texture::ImageLayout,
+        dst: &n::Image,
+        dst_layout: texture::ImageLayout,
+        regions: &[ImageCopy],
+    ) {
+        let regions: SmallVec<[vk::ImageCopy; 16]> = regions
+            .iter()
+            .map(|region| {
+                let aspect_mask = data::map_image_aspects(region.aspect_mask);
+                vk::ImageCopy {
+                    src_subresource: data::map_subresource_layers(aspect_mask, &region.src_subresource),
+                    src_offset: data::map_offset(region.src_offset),
+                    dst_subresource: data::map_subresource_layers(aspect_mask, &region.dst_subresource),
+                    dst_offset: data::map_offset(region.dst_offset),
+                    extent: data::map_extent(region.extent),
+                }
+            })
+            .collect();
     }
 
-    fn copy_buffer_to_image(&mut self, src: &n::Buffer, dst: &n::Image, layout: texture::ImageLayout, regions: &[BufferImageCopy]) {
+    fn copy_buffer_to_image(
+        &mut self,
+        src: &n::Buffer,
+        dst: &n::Image,
+        layout: texture::ImageLayout,
+        regions: &[BufferImageCopy],
+    ) {
         fn div(a: u32, b: u32) -> u32 {
             assert_eq!(a % b, 0);
             a / b
         };
-        let regions: SmallVec<[vk::BufferImageCopy; 16]> =
-            regions.iter().map(|region| {
-                let subresource_layers = vk::ImageSubresourceLayers {
-                    aspect_mask: data::map_image_aspects(region.image_subresource.0),
-                    mip_level: region.image_subresource.1 as u32,
-                    base_array_layer: region.image_subresource.2.start as u32,
-                    layer_count: region.image_subresource.2.end as u32,
-                };
+        let regions: SmallVec<[vk::BufferImageCopy; 16]> = regions
+            .iter()
+            .map(|region| {
+                let aspect_mask = data::map_image_aspects(region.image_aspect);
+                let subresource_layers =
+                    data::map_subresource_layers(aspect_mask, &region.image_subresource);
                 let row_length = div(region.buffer_row_pitch, dst.bytes_per_texel as u32);
                 vk::BufferImageCopy {
                     buffer_offset: region.buffer_offset,
@@ -337,20 +441,27 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
                     },
                     image_extent: dst.extent.clone(),
                 }
-            }).collect();
+            })
+            .collect();
 
         unsafe {
             self.device.0.cmd_copy_buffer_to_image(
-                self.raw, // commandBuffer
-                src.raw, // srcBuffer
-                dst.raw, // dstImage
+                self.raw,                       // commandBuffer
+                src.raw,                        // srcBuffer
+                dst.raw,                        // dstImage
                 data::map_image_layout(layout), // dstImageLayout
-                &regions, // pRegions
+                &regions,                       // pRegions
             );
         }
     }
 
-    fn copy_image_to_buffer(&mut self, src: &n::Image, dst: &n::Buffer, layout: texture::ImageLayout, regions: &[BufferImageCopy]) {
+    fn copy_image_to_buffer(
+        &mut self,
+        src: &n::Image,
+        dst: &n::Buffer,
+        layout: texture::ImageLayout,
+        regions: &[BufferImageCopy],
+    ) {
         unimplemented!()
     }
 
@@ -371,7 +482,13 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn draw_indexed(&mut self, start: VertexCount, count: VertexCount, base: VertexOffset, instances: Option<InstanceParams>) {
+    fn draw_indexed(
+        &mut self,
+        start: VertexCount,
+        count: VertexCount,
+        base: VertexOffset,
+        instances: Option<InstanceParams>,
+    ) {
         let (num_instances, start_instance) = match instances {
             Some((num_instances, start_instance)) => (num_instances, start_instance),
             None => (1, 0),
@@ -401,7 +518,13 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn draw_indexed_indirect(&mut self, buffer: &n::Buffer, offset: u64, draw_count: u32, stride: u32) {
+    fn draw_indexed_indirect(
+        &mut self,
+        buffer: &n::Buffer,
+        offset: u64,
+        draw_count: u32,
+        stride: u32,
+    ) {
         unsafe {
             self.device.0.cmd_draw_indexed_indirect(
                 self.raw,   // commandBuffer

--- a/src/backend/vulkan/src/data.rs
+++ b/src/backend/vulkan/src/data.rs
@@ -14,7 +14,7 @@
 
 use ash::vk;
 // use core::{buffer, image, shade};
-use core::command::{ClearColor, ClearValue};
+use core::command::{ClearColor, ClearValue, Extent, Offset};
 // use core::factory::DescriptorType;
 use core::format::{SurfaceType, ChannelType};
 use core::texture::{self, ImageAspectFlags, ImageLayout};
@@ -220,6 +220,31 @@ pub fn map_clear_value(value: &ClearValue) -> vk::ClearValue {
 
             vk::ClearValue::new_depth_stencil(dsv)
         },
+    }
+}
+
+pub fn map_offset(offset: Offset) -> vk::Offset3D {
+    vk::Offset3D {
+        x: offset.x,
+        y: offset.y,
+        z: offset.z,
+    }
+}
+
+pub fn map_extent(offset: Extent) -> vk::Extent3D {
+    vk::Extent3D {
+        width: offset.width,
+        height: offset.height,
+        depth: offset.depth,
+    }
+}
+
+pub fn map_subresource_layers(aspect_mask: vk::ImageAspectFlags, subresource: &texture::SubresourceLayers) -> vk::ImageSubresourceLayers {
+    vk::ImageSubresourceLayers {
+        aspect_mask,
+        mip_level: subresource.0 as u32,
+        base_array_layer: subresource.1.start as u32,
+        layer_count: subresource.1.end as u32,
     }
 }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -41,14 +41,14 @@ impl d::Device<B> for Device {
 
     fn create_graphics_pipelines(
         &mut self,
-        descs: &[(n::ShaderLib, n::PipelineLayout, pass::SubPass<B>, &pso::GraphicsPipelineDesc)],
+        descs: &[(&n::ShaderLib, &n::PipelineLayout, pass::SubPass<B>, &pso::GraphicsPipelineDesc)],
     ) -> Vec<Result<handle::GraphicsPipeline<B>, pso::CreationError>> {
         unimplemented!()
     }
 
     fn create_compute_pipelines(
         &mut self,
-        descs: &[(n::ShaderLib, pso::EntryPoint, n::PipelineLayout)],
+        descs: &[(&n::ShaderLib, pso::EntryPoint, &n::PipelineLayout)],
     ) -> Vec<Result<handle::ComputePipeline<B>, pso::CreationError>> {
         unimplemented!()
     }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -444,7 +444,7 @@ impl core::Backend for Backend {
     type ComputePipeline = native::ComputePipeline;
     type GraphicsPipeline = native::GraphicsPipeline;
     type PipelineLayout = native::PipelineLayout;
-    type DescriptorSet = ();
+    type DescriptorSet = native::DescriptorSet;
     type ShaderLib = native::ShaderLib;
     type RenderPass = native::RenderPass;
     type FrameBuffer = native::FrameBuffer;

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -57,6 +57,11 @@ pub struct DescriptorSetLayout {
     pub raw: vk::DescriptorSetLayout,
 }
 
+#[derive(Debug)]
+pub struct DescriptorSet {
+    pub raw: vk::DescriptorSet,
+}
+
 #[derive(Debug, Hash)]
 pub struct PipelineLayout {
     pub raw: vk::PipelineLayout,
@@ -79,4 +84,5 @@ pub struct RenderTargetView {
 pub struct DepthStencilView {
     pub image: vk::Image,
     pub view: vk::ImageView,
+    pub range: SubresourceRange
 }

--- a/src/core/src/command/compute.rs
+++ b/src/core/src/command/compute.rs
@@ -15,11 +15,12 @@
 use Backend;
 use {memory, pso, state, target, texture};
 use queue::capability::{Capability, Compute};
-use super::{BufferCopy, BufferImageCopy, CommandBufferShim, RawCommandBuffer, Submit};
+use super::{BufferCopy, BufferImageCopy, CommandBufferShim, ImageCopy, RawCommandBuffer, Submit};
 
 /// Command buffer with compute and transfer functionality.
 pub struct ComputeCommandBuffer<'a, B: Backend>(pub(crate) &'a mut B::RawCommandBuffer)
-where B::RawCommandBuffer: 'a;
+where
+    B::RawCommandBuffer: 'a;
 
 impl<'a, B: Backend> Capability for ComputeCommandBuffer<'a, B> {
     type Capability = Compute;
@@ -41,26 +42,19 @@ impl<'a, B: Backend> ComputeCommandBuffer<'a, B> {
     }
 
     ///
-    fn bind_compute_pipeline(&mut self, pipeline: &B::ComputePipeline) {
+    pub fn bind_compute_pipeline(&mut self, pipeline: &B::ComputePipeline) {
         self.0.bind_compute_pipeline(pipeline)
     }
 
     ///
-    fn dispatch(&mut self, x: u32, y: u32, z: u32) {
+    pub fn dispatch(&mut self, x: u32, y: u32, z: u32) {
         self.0.dispatch(x, y, z)
     }
 
     ///
-    fn dispatch_indirect(&mut self, buffer: &B::Buffer, offset: u64) {
+    pub fn dispatch_indirect(&mut self, buffer: &B::Buffer, offset: u64) {
         self.0.dispatch_indirect(buffer, offset)
     }
-
-    /*
-    ///
-    pub fn update_buffer(&mut self, buffer: &B::Buffer, data: &[u8], offset: usize) {
-        self.0.update_buffer(buffer, data, offset)
-    }
-    */
 
     ///
     pub fn copy_buffer(&mut self, src: &B::Buffer, dst: &B::Buffer, regions: &[BufferCopy]) {
@@ -68,17 +62,36 @@ impl<'a, B: Backend> ComputeCommandBuffer<'a, B> {
     }
 
     ///
-    pub fn copy_image(&mut self, src: &B::Image, dst: &B::Image) {
-        self.0.copy_image(src, dst)
+    pub fn copy_image(
+        &mut self,
+        src: &B::Image,
+        src_layout: texture::ImageLayout,
+        dst: &B::Image,
+        dst_layout: texture::ImageLayout,
+        regions: &[ImageCopy],
+    ) {
+        self.0.copy_image(src, src_layout, dst, dst_layout, regions)
     }
 
     ///
-    pub fn copy_buffer_to_image(&mut self, src: &B::Buffer, dst: &B::Image, layout: texture::ImageLayout, regions: &[BufferImageCopy]) {
+    pub fn copy_buffer_to_image(
+        &mut self,
+        src: &B::Buffer,
+        dst: &B::Image,
+        layout: texture::ImageLayout,
+        regions: &[BufferImageCopy],
+    ) {
         self.0.copy_buffer_to_image(src, dst, layout, regions)
     }
 
     ///
-    pub fn copy_image_to_buffer(&mut self, src: &B::Image, dst: &B::Buffer, layout: texture::ImageLayout, regions: &[BufferImageCopy]) {
+    pub fn copy_image_to_buffer(
+        &mut self,
+        src: &B::Image,
+        dst: &B::Buffer,
+        layout: texture::ImageLayout,
+        regions: &[BufferImageCopy],
+    ) {
         self.0.copy_image_to_buffer(src, dst, layout, regions)
     }
 }

--- a/src/core/src/command/general.rs
+++ b/src/core/src/command/general.rs
@@ -16,11 +16,12 @@ use Backend;
 use {memory, pso, state, target, texture};
 use buffer::IndexBufferView;
 use queue::capability::{Capability, General};
-use super::{BufferCopy, BufferImageCopy, CommandBufferShim, RawCommandBuffer, Submit};
+use super::{BufferCopy, BufferImageCopy, CommandBufferShim, ImageCopy, RawCommandBuffer, Submit};
 
 /// Command buffer with compute, graphics and transfer functionality.
 pub struct GeneralCommandBuffer<'a, B: Backend>(pub(crate) &'a mut B::RawCommandBuffer)
-where B::RawCommandBuffer: 'a;
+where
+    B::RawCommandBuffer: 'a;
 
 impl<'a, B: Backend> Capability for GeneralCommandBuffer<'a, B> {
     type Capability = General;
@@ -42,13 +43,8 @@ impl<'a, B: Backend> GeneralCommandBuffer<'a, B> {
     }
 
     ///
-    pub fn pipeline_barrier(
-        &mut self,
-        memory_barriers: &[memory::MemoryBarrier],
-        buffer_barriers: &[memory::BufferBarrier],
-        image_barriers: &[memory::ImageBarrier])
-    {
-        self.0.pipeline_barrier(memory_barriers, buffer_barriers, image_barriers)
+    pub fn pipeline_barrier(&mut self, barriers: &[memory::Barrier]) {
+        self.0.pipeline_barrier(barriers)
     }
 
     ///
@@ -80,17 +76,17 @@ impl<'a, B: Backend> GeneralCommandBuffer<'a, B> {
     }
 
     ///
-    fn set_viewports(&mut self, viewports: &[target::Rect]) {
+    pub fn set_viewports(&mut self, viewports: &[target::Rect]) {
         self.0.set_viewports(viewports)
     }
 
     ///
-    fn set_scissors(&mut self, scissors: &[target::Rect]) {
+    pub fn set_scissors(&mut self, scissors: &[target::Rect]) {
         self.0.set_scissors(scissors)
     }
 
     ///
-    fn set_ref_values(&mut self, rv: state::RefValues) {
+    pub fn set_ref_values(&mut self, rv: state::RefValues) {
         self.0.set_ref_values(rv)
     }
 
@@ -100,17 +96,36 @@ impl<'a, B: Backend> GeneralCommandBuffer<'a, B> {
     }
 
     ///
-    pub fn copy_image(&mut self, src: &B::Image, dst: &B::Image) {
-        self.0.copy_image(src, dst)
+    pub fn copy_image(
+        &mut self,
+        src: &B::Image,
+        src_layout: texture::ImageLayout,
+        dst: &B::Image,
+        dst_layout: texture::ImageLayout,
+        regions: &[ImageCopy],
+    ) {
+        self.0.copy_image(src, src_layout, dst, dst_layout, regions)
     }
 
     ///
-    pub fn copy_buffer_to_image(&mut self, src: &B::Buffer, dst: &B::Image, layout: texture::ImageLayout, regions: &[BufferImageCopy]) {
+    pub fn copy_buffer_to_image(
+        &mut self,
+        src: &B::Buffer,
+        dst: &B::Image,
+        layout: texture::ImageLayout,
+        regions: &[BufferImageCopy],
+    ) {
         self.0.copy_buffer_to_image(src, dst, layout, regions)
     }
 
     ///
-    pub fn copy_image_to_buffer(&mut self, src: &B::Image, dst: &B::Buffer, layout: texture::ImageLayout, regions: &[BufferImageCopy]) {
+    pub fn copy_image_to_buffer(
+        &mut self,
+        src: &B::Image,
+        dst: &B::Buffer,
+        layout: texture::ImageLayout,
+        regions: &[BufferImageCopy],
+    ) {
         self.0.copy_image_to_buffer(src, dst, layout, regions)
     }
 }

--- a/src/core/src/command/graphics.rs
+++ b/src/core/src/command/graphics.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use {Backend};
+use Backend;
 use {memory, pso, state, target, texture};
 use buffer::IndexBufferView;
 use queue::capability::{Capability, Graphics};
-use super::{BufferCopy, BufferImageCopy, CommandBufferShim,
-    RawCommandBuffer, Submit};
+use super::{BufferCopy, BufferImageCopy, CommandBufferShim, ImageCopy, RawCommandBuffer, Submit};
 
 /// Command buffer with graphics and transfer functionality.
 pub struct GraphicsCommandBuffer<'a, B: Backend>(pub(crate) &'a mut B::RawCommandBuffer)
-where B::RawCommandBuffer: 'a;
+where
+    B::RawCommandBuffer: 'a;
 
 impl<'a, B: Backend> Capability for GraphicsCommandBuffer<'a, B> {
     type Capability = Graphics;
@@ -46,23 +46,20 @@ where
     }
 
     ///
-    pub fn pipeline_barrier(
-        &mut self,
-        memory_barriers: &[memory::MemoryBarrier],
-        buffer_barriers: &[memory::BufferBarrier],
-        image_barriers: &[memory::ImageBarrier])
-    {
-        self.0.pipeline_barrier(memory_barriers, buffer_barriers, image_barriers)
+    pub fn pipeline_barrier(&mut self, barriers: &[memory::Barrier]) {
+        self.0.pipeline_barrier(barriers)
     }
 
     ///
     pub fn clear_depth_stencil(
         &mut self,
         dsv: &B::DepthStencilView,
+        layout: texture::ImageLayout,
         depth_value: Option<target::Depth>,
-        stencil_value: Option<target::Stencil>)
-    {
-        self.0.clear_depth_stencil(dsv, depth_value, stencil_value)
+        stencil_value: Option<target::Stencil>,
+    ) {
+        self.0
+            .clear_depth_stencil(dsv, layout, depth_value, stencil_value)
     }
 
     /*
@@ -78,17 +75,36 @@ where
     }
 
     ///
-    pub fn copy_image(&mut self, src: &B::Image, dst: &B::Image) {
-        self.0.copy_image(src, dst)
+    pub fn copy_image(
+        &mut self,
+        src: &B::Image,
+        src_layout: texture::ImageLayout,
+        dst: &B::Image,
+        dst_layout: texture::ImageLayout,
+        regions: &[ImageCopy],
+    ) {
+        self.0.copy_image(src, src_layout, dst, dst_layout, regions)
     }
 
     ///
-    pub fn copy_buffer_to_image(&mut self, src: &B::Buffer, dst: &B::Image, layout: texture::ImageLayout, regions: &[BufferImageCopy]) {
+    pub fn copy_buffer_to_image(
+        &mut self,
+        src: &B::Buffer,
+        dst: &B::Image,
+        layout: texture::ImageLayout,
+        regions: &[BufferImageCopy],
+    ) {
         self.0.copy_buffer_to_image(src, dst, layout, regions)
     }
 
     ///
-    pub fn copy_image_to_buffer(&mut self, src: &B::Image, dst: &B::Buffer, layout: texture::ImageLayout, regions: &[BufferImageCopy]) {
+    pub fn copy_image_to_buffer(
+        &mut self,
+        src: &B::Image,
+        dst: &B::Buffer,
+        layout: texture::ImageLayout,
+        regions: &[BufferImageCopy],
+    ) {
         self.0.copy_image_to_buffer(src, dst, layout, regions)
     }
 
@@ -111,17 +127,17 @@ where
     }
 
     ///
-    fn set_viewports(&mut self, viewports: &[target::Rect]) {
+    pub fn set_viewports(&mut self, viewports: &[target::Rect]) {
         self.0.set_viewports(viewports)
     }
 
     ///
-    fn set_scissors(&mut self, scissors: &[target::Rect]) {
+    pub fn set_scissors(&mut self, scissors: &[target::Rect]) {
         self.0.set_scissors(scissors)
     }
 
     ///
-    fn set_ref_values(&mut self, rv: state::RefValues) {
+    pub fn set_ref_values(&mut self, rv: state::RefValues) {
         self.0.set_ref_values(rv)
     }
 }

--- a/src/core/src/command/mod.rs
+++ b/src/core/src/command/mod.rs
@@ -26,7 +26,7 @@ mod raw;
 mod renderpass;
 mod transfer;
 
-pub use self::access::{AccessInfo, AccessGuard};
+pub use self::access::{AccessGuard, AccessInfo};
 pub use self::compute::ComputeCommandBuffer;
 pub use self::general::GeneralCommandBuffer;
 pub use self::graphics::GraphicsCommandBuffer;
@@ -108,6 +108,7 @@ pub enum ClearValue {
 }
 
 ///
+#[derive(Clone, Copy, Debug)]
 pub struct Offset {
     ///
     pub x: i32,
@@ -118,6 +119,7 @@ pub struct Offset {
 }
 
 ///
+#[derive(Clone, Copy, Debug)]
 pub struct Extent {
     ///
     pub width: u32,
@@ -128,6 +130,7 @@ pub struct Extent {
 }
 
 /// Region of two buffers for copying.
+#[derive(Clone, Copy, Debug)]
 pub struct BufferCopy {
     /// Buffer region source offset.
     pub src: u64,
@@ -138,9 +141,8 @@ pub struct BufferCopy {
 }
 
 ///
-pub struct ImageCopy {
-    ///
-    pub extent: Extent,
+#[derive(Clone, Debug)]
+pub struct ImageResolve {
     ///
     pub src_subresource: texture::SubresourceLayers,
     ///
@@ -149,9 +151,29 @@ pub struct ImageCopy {
     pub dst_subresource: texture::SubresourceLayers,
     ///
     pub dst_offset: Offset,
+    ///
+    pub extent: Extent,
 }
 
 ///
+#[derive(Clone, Debug)]
+pub struct ImageCopy {
+    ///
+    pub aspect_mask: texture::ImageAspectFlags,
+    ///
+    pub src_subresource: texture::SubresourceLayers,
+    ///
+    pub src_offset: Offset,
+    ///
+    pub dst_subresource: texture::SubresourceLayers,
+    ///
+    pub dst_offset: Offset,
+    ///
+    pub extent: Extent,
+}
+
+///
+#[derive(Clone, Debug)]
 pub struct BufferImageCopy {
     ///
     pub buffer_offset: u64,
@@ -159,6 +181,8 @@ pub struct BufferImageCopy {
     pub buffer_row_pitch: u32,
     ///
     pub buffer_slice_pitch: u32,
+    ///
+    pub image_aspect: texture::ImageAspectFlags,
     ///
     pub image_subresource: texture::SubresourceLayers,
     ///
@@ -172,7 +196,7 @@ pub type InstanceParams = (InstanceCount, VertexCount);
 
 /// Thread-safe finished command buffer for submission.
 pub struct Submit<B: Backend, C>(B::SubmitInfo, PhantomData<C>);
-unsafe impl<B: Backend, C> Send for Submit<B, C> { }
+unsafe impl<B: Backend, C> Send for Submit<B, C> {}
 
 impl<B: Backend, C> Submit<B, C> {
     ///

--- a/src/core/src/command/transfer.rs
+++ b/src/core/src/command/transfer.rs
@@ -15,11 +15,12 @@
 use Backend;
 use {memory, texture};
 use queue::capability::{Capability, Transfer};
-use super::{BufferCopy, BufferImageCopy, CommandBufferShim, RawCommandBuffer, Submit};
+use super::{BufferCopy, BufferImageCopy, CommandBufferShim, ImageCopy, RawCommandBuffer, Submit};
 
 /// Command buffer with transfer functionality.
 pub struct TransferCommandBuffer<'a, B: Backend>(pub(crate) &'a mut B::RawCommandBuffer)
-where B::RawCommandBuffer: 'a;
+where
+    B::RawCommandBuffer: 'a;
 
 impl<'a, B: Backend> Capability for TransferCommandBuffer<'a, B> {
     type Capability = Transfer;
@@ -41,21 +42,9 @@ impl<'a, B: Backend> TransferCommandBuffer<'a, B> {
     }
 
     ///
-    pub fn pipeline_barrier(
-        &mut self,
-        memory_barriers: &[memory::MemoryBarrier],
-        buffer_barriers: &[memory::BufferBarrier],
-        image_barriers: &[memory::ImageBarrier])
-    {
-        self.0.pipeline_barrier(memory_barriers, buffer_barriers, image_barriers)
+    pub fn pipeline_barrier(&mut self, barriers: &[memory::Barrier]) {
+        self.0.pipeline_barrier(barriers)
     }
-
-    /*
-    ///
-    pub fn update_buffer(&mut self, buffer: &B::Buffer, data: &[u8], offset: usize) {
-        self.0.update_buffer(buffer, data, offset)
-    }
-    */
 
     ///
     pub fn copy_buffer(&mut self, src: &B::Buffer, dst: &B::Buffer, regions: &[BufferCopy]) {
@@ -63,17 +52,36 @@ impl<'a, B: Backend> TransferCommandBuffer<'a, B> {
     }
 
     ///
-    pub fn copy_image(&mut self, src: &B::Image, dst: &B::Image) {
-        self.0.copy_image(src, dst)
+    pub fn copy_image(
+        &mut self,
+        src: &B::Image,
+        src_layout: texture::ImageLayout,
+        dst: &B::Image,
+        dst_layout: texture::ImageLayout,
+        regions: &[ImageCopy],
+    ) {
+        self.0.copy_image(src, src_layout, dst, dst_layout, regions)
     }
 
     ///
-    pub fn copy_buffer_to_image(&mut self, src: &B::Buffer, dst: &B::Image, layout: texture::ImageLayout, regions: &[BufferImageCopy]) {
+    pub fn copy_buffer_to_image(
+        &mut self,
+        src: &B::Buffer,
+        dst: &B::Image,
+        layout: texture::ImageLayout,
+        regions: &[BufferImageCopy],
+    ) {
         self.0.copy_buffer_to_image(src, dst, layout, regions)
     }
 
     ///
-    pub fn copy_image_to_buffer(&mut self, src: &B::Image, dst: &B::Buffer, layout: texture::ImageLayout, regions: &[BufferImageCopy]) {
+    pub fn copy_image_to_buffer(
+        &mut self,
+        src: &B::Image,
+        dst: &B::Buffer,
+        layout: texture::ImageLayout,
+        regions: &[BufferImageCopy],
+    ) {
         self.0.copy_image_to_buffer(src, dst, layout, regions)
     }
 }

--- a/src/core/src/device.rs
+++ b/src/core/src/device.rs
@@ -269,11 +269,11 @@ pub trait Device<B: Backend> {
     fn create_pipeline_layout(&mut self, sets: &[&B::DescriptorSetLayout]) -> handle::PipelineLayout<B>;
 
     /// Create graphics pipelines.
-    fn create_graphics_pipelines(&mut self, &[(B::ShaderLib, B::PipelineLayout, pass::SubPass<B>, &pso::GraphicsPipelineDesc)])
+    fn create_graphics_pipelines(&mut self, &[(&B::ShaderLib, &B::PipelineLayout, pass::SubPass<B>, &pso::GraphicsPipelineDesc)])
             -> Vec<Result<handle::GraphicsPipeline<B>, pso::CreationError>>;
 
     /// Create compute pipelines.
-    fn create_compute_pipelines(&mut self, &[(B::ShaderLib, pso::EntryPoint, B::PipelineLayout)]) -> Vec<Result<handle::ComputePipeline<B>, pso::CreationError>>;
+    fn create_compute_pipelines(&mut self, &[(&B::ShaderLib, pso::EntryPoint, &B::PipelineLayout)]) -> Vec<Result<handle::ComputePipeline<B>, pso::CreationError>>;
 
     ///
     fn create_sampler(&mut self, texture::SamplerInfo) -> handle::Sampler<B>;

--- a/src/core/src/memory.rs
+++ b/src/core/src/memory.rs
@@ -178,12 +178,11 @@ bitflags!(
 
 ///
 #[derive(Clone, Copy, Debug)]
-pub struct MemoryBarrier;
-
-///
-#[derive(Clone, Copy, Debug)]
-pub struct BufferBarrier;
-
-///
-#[derive(Clone, Copy, Debug)]
-pub struct ImageBarrier;
+pub enum Barrier {
+    ///
+    MemoryBarrier,
+    ///
+    BufferBarrier,
+    ///
+    ImageBarrier,
+}

--- a/src/core/src/memory.rs
+++ b/src/core/src/memory.rs
@@ -180,9 +180,9 @@ bitflags!(
 #[derive(Clone, Copy, Debug)]
 pub enum Barrier {
     ///
-    MemoryBarrier,
+    Memory,
     ///
-    BufferBarrier,
+    Buffer,
     ///
-    ImageBarrier,
+    Image,
 }

--- a/src/core/src/texture.rs
+++ b/src/core/src/texture.rs
@@ -610,10 +610,10 @@ bitflags!(
 );
 
 ///
-pub type Subresource = (ImageAspectFlags, Level, Layer);
+pub type Subresource = (Level, Layer);
 
 ///
-pub type SubresourceLayers = (ImageAspectFlags, Level, Range<Layer>);
+pub type SubresourceLayers = (Level, Range<Layer>);
 
 ///
-pub type SubresourceRange = (ImageAspectFlags, Range<Level>, Range<Layer>);
+pub type SubresourceRange = (Range<Level>, Range<Layer>);


### PR DESCRIPTION
* Adjust the core command buffer API for clear/copy/resolve commands to matching the vulkan API
* Implement `clear_depth_stencil`, `copy_*` and `resolve_image` for vulkan
* Smaller cleanup (formating, merge barriers into an enum, ...)

cc #1416 