### PR TITLE
[ll] Further work on the gl backend [41/..]

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -69,6 +69,7 @@ pub enum Command {
         base: c::VertexOffset,
         instances: Option<InstanceParams>,
     },
+    BindIndexBuffer(gl::types::GLuint),
 }
 
 #[allow(missing_copy_implementations)]
@@ -208,7 +209,13 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
     fn bind_index_buffer(&mut self, ibv: IndexBufferView<Backend>) {
-        unimplemented!()
+        // TODO: how can we incoporate the buffer offset?
+        if ibv.offset > 0 {
+            warn!("Non-zero index buffer offset currently not handled.");
+        }
+
+        self.cache.index_type = Some(ibv.index_type);
+        self.buf.push(Command::BindIndexBuffer(*ibv.buffer));
     }
 
     fn bind_vertex_buffers(&mut self, vbs: c::pso::VertexBufferSet<Backend>) {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -290,7 +290,7 @@ impl d::Device<B> for Device {
     }
 
     fn create_buffer_raw(&mut self, info: buffer::Info) -> Result<handle::RawBuffer<B>, buffer::CreationError> {
-        if !self.share.capabilities.constant_buffer_supported && info.role == buffer::Role::Constant {
+        if !self.share.capabilities.features.constant_buffer && info.role == buffer::Role::Constant {
             error!("Constant buffers are not supported by this GL version");
             return Err(buffer::CreationError::Other);
         }
@@ -422,7 +422,7 @@ impl d::Device<B> for Device {
             return Err(CreationError::Size(0))
         }
         let dim = desc.kind.get_dimensions();
-        let max_size = self.share.capabilities.max_texture_size;
+        let max_size = self.share.capabilities.limits.max_texture_size;
         if dim.0 as usize > max_size {
             return Err(CreationError::Size(dim.0));
         }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -285,12 +285,16 @@ pub fn temporary_ensure_unmapped(pointer: &mut *mut ::std::os::raw::c_void,
 }
 
 impl d::Device<B> for Device {
-    fn get_capabilities(&self) -> &c::Capabilities {
-        &self.share.capabilities
+    fn get_features(&self) -> &c::Features {
+        &self.share.features
+    }
+
+    fn get_limits(&self) -> &c::Limits {
+        &self.share.limits
     }
 
     fn create_buffer_raw(&mut self, info: buffer::Info) -> Result<handle::RawBuffer<B>, buffer::CreationError> {
-        if !self.share.capabilities.features.constant_buffer && info.role == buffer::Role::Constant {
+        if !self.share.features.constant_buffer && info.role == buffer::Role::Constant {
             error!("Constant buffers are not supported by this GL version");
             return Err(buffer::CreationError::Other);
         }
@@ -422,7 +426,7 @@ impl d::Device<B> for Device {
             return Err(CreationError::Size(0))
         }
         let dim = desc.kind.get_dimensions();
-        let max_size = self.share.capabilities.limits.max_texture_size;
+        let max_size = self.share.limits.max_texture_size;
         if dim.0 as usize > max_size {
             return Err(CreationError::Size(dim.0));
         }

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 use std::{ffi, fmt, mem, str};
 use gl;
-use core::{Capabilities, Features, IndexCount, Limits, VertexCount};
+use core::{Features, IndexCount, Limits, VertexCount};
 
 /// A version number for a specific component of an OpenGL implementation
 #[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]
@@ -251,7 +251,7 @@ impl Info {
 
 /// Load the information pertaining to the driver and the corresponding device
 /// capabilities.
-pub fn get(gl: &gl::Gl) -> (Info, Capabilities, PrivateCaps) {
+pub fn get(gl: &gl::Gl) -> (Info, Features, Limits, PrivateCaps) {
     use self::Requirement::*;
     let info = Info::get(gl);
     let tessellation_supported =           info.is_supported(&[Core(4,0),
@@ -293,10 +293,6 @@ pub fn get(gl: &gl::Gl) -> (Info, Capabilities, PrivateCaps) {
                                                                 Ext ("GL_ARB_copy_buffer"),
                                                                 Ext ("GL_NV_copy_buffer")]),
     };
-    let caps = Capabilities {
-        features,
-        limits,
-    };
     let private = PrivateCaps {
         array_buffer_supported:            info.is_supported(&[Core(3,0),
                                                                Es  (3,0),
@@ -322,7 +318,7 @@ pub fn get(gl: &gl::Gl) -> (Info, Capabilities, PrivateCaps) {
                                                                Ext ("GL_ARB_sync")]),
     };
 
-    (info, caps, private)
+    (info, features, limits, private)
 }
 
 #[cfg(test)]

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -188,7 +188,7 @@ pub struct Info {
 }
 
 #[derive(Copy, Clone)]
-enum Requirement {
+pub enum Requirement {
     Core(u32,u32),
     Es(u32, u32),
     Ext(&'static str),
@@ -237,7 +237,7 @@ impl Info {
         exts.iter().any(|e| self.extensions.contains(e))
     }
 
-    fn is_supported(&self, requirements: &[Requirement]) -> bool {
+    pub fn is_supported(&self, requirements: &[Requirement]) -> bool {
         use self::Requirement::*;
         requirements.iter().any(|r| {
             match *r {

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 use std::{ffi, fmt, mem, str};
 use gl;
-use core::{Capabilities, IndexCount, VertexCount};
+use core::{Capabilities, Features, IndexCount, Limits, VertexCount};
 
 /// A version number for a specific component of an OpenGL implementation
 #[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]
@@ -256,41 +256,46 @@ pub fn get(gl: &gl::Gl) -> (Info, Capabilities, PrivateCaps) {
     let info = Info::get(gl);
     let tessellation_supported =           info.is_supported(&[Core(4,0),
                                                                Ext("GL_ARB_tessellation_shader")]);
-    let caps = Capabilities {
+    let limits = Limits {
         max_texture_size: get_usize(gl, gl::MAX_TEXTURE_SIZE),
         max_patch_size: if tessellation_supported { get_usize(gl, gl::MAX_PATCH_VERTICES) as u8 } else {0},
+    };
+    let features = Features {
+        draw_instanced:                     info.is_supported(&[Core(3,1),
+                                                                Es  (3,0),
+                                                                Ext ("GL_ARB_draw_instanced")]),
+        draw_instanced_base:                info.is_supported(&[Core(4,2),
+                                                                Ext ("GL_ARB_base_instance")]),
+        draw_indexed_base:                  info.is_supported(&[Core(3, 2)]), // TODO: extension
+        draw_indexed_instanced:             info.is_supported(&[Core(3, 1),
+                                                                Es  (3, 0)]), // TODO: extension
 
-        draw_instanced_supported:           info.is_supported(&[Core(3,1),
-                                                               Es  (3,0),
-                                                               Ext ("GL_ARB_draw_instanced")]),
-        draw_instanced_base_supported:      info.is_supported(&[Core(4,2),
-                                                               Ext ("GL_ARB_base_instance")]),
-        draw_indexed_base_supported:        info.is_supported(&[Core(3, 2)]), // TODO: extension
-        draw_indexed_instanced_supported:   info.is_supported(&[Core(3, 1),
-                                                               Es  (3, 0)]), // TODO: extension
+        draw_indexed_instanced_base_vertex: info.is_supported(&[Core(3, 2)]), // TODO: extension
+        draw_indexed_instanced_base:        info.is_supported(&[Core(4, 2)]) , // TODO: extension
 
-        draw_indexed_instanced_base_vertex_supported: info.is_supported(&[Core(3, 2)]), // TODO: extension
-        draw_indexed_instanced_base_supported:        info.is_supported(&[Core(4, 2)]) , // TODO: extension
-
-        instance_rate_supported:           info.is_supported(&[Core(3,3),
-                                                               Es  (3,0),
-                                                               Ext ("GL_ARB_instanced_arrays")]),
-        vertex_base_supported:             info.is_supported(&[Core(3,2),
-                                                               Es  (3,2),
-                                                               Ext ("GL_ARB_draw_elements_base_vertex")]),
-        srgb_color_supported:              info.is_supported(&[Core(3,2),
-                                                               Ext ("GL_ARB_framebuffer_sRGB")]),
-        constant_buffer_supported:         info.is_supported(&[Core(3,1),
-                                                               Es  (3,0),
-                                                               Ext ("GL_ARB_uniform_buffer_object")]),
-        unordered_access_view_supported:   info.is_supported(&[Core(4,0)]), // TODO: extension
-        separate_blending_slots_supported: info.is_supported(&[Core(4,0),
-                                                               Es  (3,0),
-                                                               Ext ("GL_ARB_draw_buffers_blend")]),
-        copy_buffer_supported:             info.is_supported(&[Core(3,1),
-                                                               Es  (3,0),
-                                                               Ext ("GL_ARB_copy_buffer"),
-                                                               Ext ("GL_NV_copy_buffer")]),
+        instance_rate:                      info.is_supported(&[Core(3,3),
+                                                                Es  (3,0),
+                                                                Ext ("GL_ARB_instanced_arrays")]),
+        vertex_base:                        info.is_supported(&[Core(3,2),
+                                                                Es  (3,2),
+                                                                Ext ("GL_ARB_draw_elements_base_vertex")]),
+        srgb_color:                         info.is_supported(&[Core(3,2),
+                                                                Ext ("GL_ARB_framebuffer_sRGB")]),
+        constant_buffer:                    info.is_supported(&[Core(3,1),
+                                                                Es  (3,0),
+                                                                Ext ("GL_ARB_uniform_buffer_object")]),
+        unordered_access_view:              info.is_supported(&[Core(4,0)]), // TODO: extension
+        separate_blending_slots:            info.is_supported(&[Core(4,0),
+                                                                Es  (3,0),
+                                                                Ext ("GL_ARB_draw_buffers_blend")]),
+        copy_buffer:                        info.is_supported(&[Core(3,1),
+                                                                Es  (3,0),
+                                                                Ext ("GL_ARB_copy_buffer"),
+                                                                Ext ("GL_NV_copy_buffer")]),
+    };
+    let caps = Capabilities {
+        features,
+        limits,
     };
     let private = PrivateCaps {
         array_buffer_supported:            info.is_supported(&[Core(3,0),
@@ -316,6 +321,7 @@ pub fn get(gl: &gl::Gl) -> (Info, Capabilities, PrivateCaps) {
                                                                Es  (3,0),
                                                                Ext ("GL_ARB_sync")]),
     };
+
     (info, caps, private)
 }
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -473,6 +473,10 @@ impl CommandQueue {
 
     fn process(&mut self, cmd: &Command, data_buf: &DataBuffer) {
         match *cmd {
+            Command::BindIndexBuffer(buffer) => {
+                let gl = &self.share.context;
+                unsafe { gl.BindBuffer(gl::ELEMENT_ARRAY_BUFFER, buffer) };
+            }
             Command::Draw { primitive, start, count, instances } => {
                 let gl = &self.share.context;
                 match instances {
@@ -712,10 +716,6 @@ impl CommandQueue {
             },
             Command::UnbindAttribute(slot) => unsafe {
                 self.share.context.DisableVertexAttribArray(slot as gl::types::GLuint);
-            },
-            Command::BindIndex(buffer) => {
-                let gl = &self.share.context;
-                unsafe { gl.BindBuffer(gl::ELEMENT_ARRAY_BUFFER, buffer) };
             },
             Command::BindFrameBuffer(point, frame_buffer) => {
                 if self.share.private_caps.frame_buffer_supported {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -208,6 +208,16 @@ impl Adapter {
             software_rendering: false, // not always true ..
         };
 
+        let queue_type = {
+            use info::Requirement::{Core, Es};
+            let compute_supported = info.is_supported(&[Core(4,3), Es(3, 1)]); // TODO: extension
+            if compute_supported {
+                QueueType::General
+            } else {
+                QueueType::Graphics
+            }
+        };
+
         // create the shared context
         let handles = handle::Manager::new();
         let share = Share {
@@ -221,7 +231,7 @@ impl Adapter {
         Adapter {
             share: Rc::new(share),
             adapter_info: adapter_info,
-            queue_family: [(QueueFamily, QueueType::Graphics)],
+            queue_family: [(QueueFamily, queue_type)],
         }
     }
 }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -244,7 +244,7 @@ impl c::Adapter<Backend> for Adapter {
 
         // initialize permanent states
         let gl = &self.share.context;
-        if self.share.capabilities.srgb_color_supported {
+        if self.share.capabilities.features.srgb_color {
             unsafe {
                 gl.Enable(gl::FRAMEBUFFER_SRGB);
             }
@@ -495,10 +495,11 @@ impl CommandQueue {
             }
             Command::Draw { primitive, start, count, instances } => {
                 let gl = &self.share.context;
+                let features = &self.share.capabilities.features;
                 match instances {
                     Some((num, base)) => unsafe {
-                        if self.share.capabilities.draw_instanced_supported {
-                            if self.share.capabilities.draw_instanced_base_supported {
+                        if features.draw_instanced {
+                            if features.draw_instanced_base {
                                 gl.DrawArraysInstancedBaseInstance(
                                     primitive,
                                     start as gl::types::GLsizei,
@@ -531,12 +532,12 @@ impl CommandQueue {
             }
             Command::DrawIndexed { primitive, index_type, start, count, base: base_vertex, instances } => {
                 let gl = &self.share.context;
-                let caps = &self.share.capabilities;
+                let features = &self.share.capabilities.features;
                 let offset = start as *const gl::types::GLvoid;
 
                 match instances {
                     Some((num, base_instance)) => unsafe {
-                        if caps.draw_indexed_instanced_base_supported {
+                        if features.draw_indexed_instanced_base {
                             // fully compatible
                             gl.DrawElementsInstancedBaseVertexBaseInstance(
                                 primitive,
@@ -551,7 +552,7 @@ impl CommandQueue {
                             error!("Instance bases with instanced indexed drawing is not supported")
                         } else {
                             // No base instance
-                            if caps.draw_indexed_instanced_base_vertex_supported {
+                            if features.draw_indexed_instanced_base_vertex {
                                 gl.DrawElementsInstancedBaseVertex(
                                     primitive,
                                     count as gl::types::GLsizei,
@@ -564,7 +565,7 @@ impl CommandQueue {
                                 error!("Base vertex with instanced indexed drawing is not supported")
                             } else {
                                 // No base instance and base vertex
-                                if caps.draw_indexed_instanced_supported {
+                                if features.draw_indexed_instanced {
                                     gl.DrawElementsInstanced(
                                         primitive,
                                         count as gl::types::GLsizei,
@@ -579,7 +580,7 @@ impl CommandQueue {
                         }
                     },
                     None => unsafe {
-                        if caps.draw_indexed_base_supported {
+                        if features.draw_indexed_base {
                             gl.DrawElementsBaseVertex(
                                 primitive,
                                 count as gl::types::GLsizei,

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -336,7 +336,10 @@ pub struct CommandQueue {
 struct State {
     // Indicate if the vertex array object is bound.
     // If VAOs are not supported, this will be also set to true.
-    vao: bool
+    vao: bool,
+    // Currently bound index/element buffer.
+    // None denotes that we don't know what is currently bound.
+    index_buffer: Option<gl::types::GLuint>,
 }
 
 impl State {
@@ -345,6 +348,7 @@ impl State {
     fn new() -> Self {
         State {
             vao: false,
+            index_buffer: None,
         }
     }
 
@@ -352,6 +356,7 @@ impl State {
     // Required if we allow users to manually inject OpenGL calls.
     fn flush(&mut self) {
         self.vao = false;
+        self.index_buffer = None;
     }
 }
 
@@ -463,11 +468,21 @@ impl CommandQueue {
         let gl = &self.share.context;
         let priv_caps = &self.share.private_caps;
 
+        // Bind default VAO
         if !self.state.vao {
             if priv_caps.array_buffer_supported {
                 unsafe { gl.BindVertexArray(self.vao) };
             }
             self.state.vao = true
+        }
+
+        // Unbind index buffers
+        match self.state.index_buffer {
+            Some(0) => (), // Nothing to do
+            Some(_) | None => {
+                unsafe { gl.BindBuffer(gl::ELEMENT_ARRAY_BUFFER, 0) };
+                self.state.index_buffer = Some(0);
+            }
         }
     }
 
@@ -475,6 +490,7 @@ impl CommandQueue {
         match *cmd {
             Command::BindIndexBuffer(buffer) => {
                 let gl = &self.share.context;
+                self.state.index_buffer = Some(buffer);
                 unsafe { gl.BindBuffer(gl::ELEMENT_ARRAY_BUFFER, buffer) };
             }
             Command::Draw { primitive, start, count, instances } => {

--- a/src/core/src/device.rs
+++ b/src/core/src/device.rs
@@ -20,7 +20,7 @@
 use std::error::Error;
 use std::{mem, fmt};
 use {buffer, handle, format, mapping, pass, pso, shade, target, texture};
-use {Capabilities, Backend};
+use {Backend, Features, Limits};
 use memory::{Usage, Typed, Pod, cast_slice};
 use memory::{Bind, RENDER_TARGET, DEPTH_STENCIL, SHADER_RESOURCE, UNORDERED_ACCESS};
 
@@ -231,9 +231,12 @@ pub enum WaitFor {
 ///
 #[allow(missing_docs)]
 pub trait Device<B: Backend> {
-    /// Returns the capabilities of this `Device`. This usually depends on the graphics API being
+    /// Returns the features of this `Device`. This usually depends on the graphics API being
     /// used.
-    fn get_capabilities(&self) -> &Capabilities;
+    fn get_features(&self) -> &Features;
+
+    /// Returns the limits of this `Device`.
+    fn get_limits(&self) -> &Limits;
 
     // resource creation
     fn create_buffer_raw(&mut self, buffer::Info) -> Result<handle::RawBuffer<B>, buffer::CreationError>;

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -105,41 +105,57 @@ pub struct Viewport {
 }
 
 
-/// Features that the device supports.
+/// Capabilities of the device and backend.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Capabilities {
+    /// Device features of the core interface.
+    pub features: Features,
+    /// Limits of the device.
+    pub limits: Limits,
+}
+
+/// Features that the device supports.
+/// These only include features of the core interface and not API extensions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct Features {
+    /// Support instanced drawing.
+    pub draw_instanced: bool,
+    /// Support offsets for instanced drawing with base instance.
+    pub draw_instanced_base: bool,
+    /// Support indexed drawing with base vertex.
+    pub draw_indexed_base: bool,
+    /// Support indexed, instanced drawing.
+    pub draw_indexed_instanced: bool,
+    /// Support indexed, instanced drawing with base vertex only.
+    pub draw_indexed_instanced_base_vertex: bool,
+    /// Support indexed, instanced drawing with base vertex and instance.
+    pub draw_indexed_instanced_base: bool,
+    /// Support manually specified vertex attribute rates (divisors).
+    pub instance_rate: bool,
+    /// Support base vertex offset for indexed drawing.
+    pub vertex_base: bool,
+    /// Support sRGB textures and rendertargets.
+    pub srgb_color: bool,
+    /// Support constant buffers.
+    pub constant_buffer: bool,
+    /// Support unordered-access views.
+    pub unordered_access_view: bool,
+    /// Support specifying the blend function and equation for each color target.
+    pub separate_blending_slots: bool,
+    /// Support accelerated buffer copy.
+    pub copy_buffer: bool,
+}
+
+/// Limits of the device.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct Limits {
     /// Maximum supported texture size.
     pub max_texture_size: usize,
     /// Maximum number of vertices for each patch.
     pub max_patch_size: PatchSize,
-
-    /// Support instanced drawing.
-    pub draw_instanced_supported: bool,
-    /// Support offsets for instanced drawing with base instance.
-    pub draw_instanced_base_supported: bool,
-    /// Support indexed drawing with base vertex.
-    pub draw_indexed_base_supported: bool,
-    /// Support indexed, instanced drawing.
-    pub draw_indexed_instanced_supported: bool,
-    /// Support indexed, instanced drawing with base vertex only.
-    pub draw_indexed_instanced_base_vertex_supported: bool,
-    /// Support indexed, instanced drawing with base vertex and instance.
-    pub draw_indexed_instanced_base_supported: bool,
-    /// Support manually specified vertex attribute rates (divisors).
-    pub instance_rate_supported: bool,
-    /// Support base vertex offset for indexed drawing.
-    pub vertex_base_supported: bool,
-    /// Support sRGB textures and rendertargets.
-    pub srgb_color_supported: bool,
-    /// Support constant buffers.
-    pub constant_buffer_supported: bool,
-    /// Support unordered-access views.
-    pub unordered_access_view_supported: bool,
-    /// Support specifying the blend function and equation for each color target.
-    pub separate_blending_slots_supported: bool,
-    /// Support accelerated buffer copy.
-    pub copy_buffer_supported: bool,
 }
 
 /// Describes what geometric primitives are created from vertex data.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -104,17 +104,6 @@ pub struct Viewport {
     pub far: f32,
 }
 
-
-/// Capabilities of the device and backend.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct Capabilities {
-    /// Device features of the core interface.
-    pub features: Features,
-    /// Limits of the device.
-    pub limits: Limits,
-}
-
 /// Features that the device supports.
 /// These only include features of the core interface and not API extensions.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
* gl: Implement index buffer binding command
* gl: Create a `GeneralQueue` if we have compute support, else fall back to `GraphicsQueue`
* core: Split `Capabilities` into `Features` (specify which aspects of the our API are supported) and `Limits` (numerical limits like max_texture_size, max_viewports, ..)