### PR TITLE
[ll] gl: Implement setting viewports and scissors [42/..]

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -31,3 +31,4 @@ name = "gfx_device_gl"
 log = "0.3"
 gfx_gl = "0.3.1"
 gfx_core = { path = "../../core", version = "0.7" }
+smallvec = "0.4"

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -256,9 +256,12 @@ pub fn get(gl: &gl::Gl) -> (Info, Features, Limits, PrivateCaps) {
     let info = Info::get(gl);
     let tessellation_supported =           info.is_supported(&[Core(4,0),
                                                                Ext("GL_ARB_tessellation_shader")]);
+    let multi_viewports_supported =        info.is_supported(&[Core(4,1)]); // TODO: extension
+
     let limits = Limits {
         max_texture_size: get_usize(gl, gl::MAX_TEXTURE_SIZE),
         max_patch_size: if tessellation_supported { get_usize(gl, gl::MAX_PATCH_VERTICES) as u8 } else {0},
+        max_viewports: if multi_viewports_supported { get_usize(gl, gl::MAX_VIEWPORTS) } else {1},
     };
     let features = Features {
         draw_instanced:                     info.is_supported(&[Core(3,1),

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -22,14 +22,16 @@
 extern crate log;
 extern crate gfx_gl as gl;
 extern crate gfx_core as core;
+extern crate smallvec;
 
 use std::cell::RefCell;
 use std::rc::Rc;
-use core::{self as c, handle, format, texture as t, memory, command as com, buffer};
+use core::{self as c, handle, format, target, texture as t, memory, command as com, buffer, Viewport};
 use core::QueueType;
 use core::target::{Layer, Level};
 use command::{Command, DataBuffer};
 use device::MappingKind;
+use smallvec::SmallVec;
 
 pub use self::device::Device;
 pub use self::info::{Info, PlatformName, Version};
@@ -342,6 +344,10 @@ struct State {
     // Currently bound index/element buffer.
     // None denotes that we don't know what is currently bound.
     index_buffer: Option<gl::types::GLuint>,
+    // Currently set viewports.
+    num_viewports: usize,
+    // Currently set scissor rects.
+    num_scissors: usize,
 }
 
 impl State {
@@ -351,6 +357,8 @@ impl State {
         State {
             vao: false,
             index_buffer: None,
+            num_viewports: 0,
+            num_scissors: 0,
         }
     }
 
@@ -359,6 +367,9 @@ impl State {
     fn flush(&mut self) {
         self.vao = false;
         self.index_buffer = None;
+
+        // TOOD: reset viewports and scissors
+        //       do we need to clear everything from 0..MAX_VIEWPORTS?
     }
 }
 
@@ -486,6 +497,36 @@ impl CommandQueue {
                 self.state.index_buffer = Some(0);
             }
         }
+
+        // Reset viewports
+        if self.state.num_viewports == 1 {
+            unsafe { gl.Viewport(0, 0, 0, 0) };
+            unsafe { gl.DepthRange(0.0, 1.0) };
+        } else if self.state.num_viewports > 1 {
+            // 16 viewports is a common limit set in drivers.
+            let viewports: SmallVec<[[f32; 4]; 16]> =
+                (0..self.state.num_viewports)
+                    .map(|_| [0.0, 0.0, 0.0, 0.0])
+                    .collect();
+            let depth_ranges: SmallVec<[[f64; 2]; 16]> =
+                (0..self.state.num_viewports)
+                    .map(|_| [0.0, 0.0])
+                    .collect();
+            unsafe { gl.ViewportArrayv(0, viewports.len() as i32, viewports.as_ptr() as *const _)};
+            unsafe { gl.DepthRangeArrayv(0, depth_ranges.len() as i32, depth_ranges.as_ptr() as *const _)};
+        }
+
+        // Reset scissors
+        if self.state.num_scissors == 1 {
+            unsafe { gl.Scissor(0, 0, 0, 0) };
+        } else if self.state.num_scissors > 1 {
+            // 16 viewports is a common limit set in drivers.
+            let scissors: SmallVec<[[i32; 4]; 16]> =
+                (0..self.state.num_scissors)
+                    .map(|_| [0, 0, 0, 0])
+                    .collect();
+            unsafe { gl.ScissorArrayv(0, scissors.len() as i32, scissors.as_ptr() as *const _)};
+        }
     }
 
     fn process(&mut self, cmd: &Command, data_buf: &DataBuffer) {
@@ -494,6 +535,9 @@ impl CommandQueue {
                 let gl = &self.share.context;
                 self.state.index_buffer = Some(buffer);
                 unsafe { gl.BindBuffer(gl::ELEMENT_ARRAY_BUFFER, buffer) };
+            }
+            Command::BindVertexBuffers(data_ptr) => {
+                unimplemented!()
             }
             Command::Draw { primitive, start, count, instances } => {
                 let gl = &self.share.context;
@@ -619,6 +663,42 @@ impl CommandQueue {
                     gl.BindBuffer(gl::DRAW_INDIRECT_BUFFER, buffer);
                     // TODO: possible integer conversion issue
                     gl.DispatchComputeIndirect(offset as gl::types::GLintptr);
+                }
+            }
+            Command::SetViewports { viewport_ptr, depth_range_ptr } => {
+                let gl = &self.share.context;
+                let viewports = data_buf.get::<[f32; 4]>(viewport_ptr);
+                let depth_ranges = data_buf.get::<[f64; 2]>(depth_range_ptr);
+
+                let num_viewports = viewports.len();
+                assert_eq!(num_viewports, depth_ranges.len());
+                assert!(0 < num_viewports && num_viewports <= self.share.limits.max_viewports);
+
+                if num_viewports == 1 {
+                    let view = viewports[0];
+                    let depth_range  = depth_ranges[0];
+                    unsafe { gl.Viewport(view[0] as i32, view[1] as i32, view[2] as i32, view[3] as i32) };
+                    unsafe { gl.DepthRange(depth_range[0], depth_range[1]) };
+                } else if num_viewports > 1 {
+                    // Support for these functions is coupled with the support
+                    // of multiple viewports.
+                    unsafe { gl.ViewportArrayv(0, num_viewports as i32, viewports.as_ptr() as *const _) };
+                    unsafe { gl.DepthRangeArrayv(0, num_viewports as i32, depth_ranges.as_ptr() as *const _) };
+                }
+            }
+            Command::SetScissors(data_ptr) => {
+                let gl = &self.share.context;
+                let scissors = data_buf.get::<[i32; 4]>(data_ptr);
+                let num_scissors = scissors.len();
+                assert!(0 < num_scissors && num_scissors <= self.share.limits.max_viewports);
+
+                if num_scissors == 1 {
+                    let scissor = scissors[0];
+                    unsafe { gl.Scissor(scissor[0], scissor[1], scissor[2], scissor[3]) };
+                } else {
+                    // Support for this function is coupled with the support
+                    // of multiple viewports.
+                    unsafe { gl.ScissorArrayv(0, num_scissors as i32, scissors.as_ptr() as *const _) };
                 }
             }
 
@@ -754,12 +834,6 @@ impl CommandQueue {
             },
             Command::SetRasterizer(rast) => {
                 state::bind_rasterizer(&self.share.context, &rast, self.share.info.version.is_embedded);
-            },
-            Command::SetViewports(ref rects) => {
-                state::bind_viewports(&self.share.context, rects);
-            },
-            Command::SetScissors(ref rects) => {
-                state::bind_scissors(&self.share.context, rects);
             },
             Command::SetDepthState(depth) => {
                 state::bind_depth(&self.share.context, &depth);

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -33,6 +33,7 @@ fn create_fbo_internal(gl: &gl::Gl) -> gl::types::GLuint {
 
 pub struct RawCommandPool {
     fbo: n::FrameBuffer,
+    limits: command::Limits,
     command_buffers: Vec<RawCommandBuffer>,
     next_buffer: usize,
 }
@@ -47,7 +48,7 @@ impl core::RawCommandPool<Backend> for RawCommandPool {
 
     fn reserve(&mut self, additional: usize) {
         for _ in 0..additional {
-            self.command_buffers.push(RawCommandBuffer::new(self.fbo));
+            self.command_buffers.push(RawCommandBuffer::new(self.fbo, self.limits));
         }
     }
 
@@ -57,9 +58,11 @@ impl core::RawCommandPool<Backend> for RawCommandPool {
     {
         let queue = queue.as_ref();
         let fbo = create_fbo_internal(&queue.share.context);
-        let buffers = (0..capacity).map(|_| RawCommandBuffer::new(fbo)).collect();
+        let limits = queue.share.limits.into();
+        let buffers = (0..capacity).map(|_| RawCommandBuffer::new(fbo, limits)).collect();
         RawCommandPool {
             fbo,
+            limits,
             command_buffers: buffers,
             next_buffer: 0,
         }

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -97,30 +97,6 @@ pub fn bind_draw_color_buffers(gl: &gl::Gl, mask: usize) {
     unimplemented!()
 }
 
-pub fn bind_viewport(gl: &gl::Gl, rect: Rect) {
-    unsafe { gl.Viewport(
-        rect.x as gl::types::GLint,
-        rect.y as gl::types::GLint,
-        rect.w as gl::types::GLint,
-        rect.h as gl::types::GLint
-    )};
-}
-
-pub fn bind_scissor(gl: &gl::Gl, rect: Option<Rect>) {
-    match rect {
-        Some(r) => { unsafe {
-            gl.Enable(gl::SCISSOR_TEST);
-            gl.Scissor(
-                r.x as gl::types::GLint,
-                r.y as gl::types::GLint,
-                r.w as gl::types::GLint,
-                r.h as gl::types::GLint
-            );
-        }},
-        None => unsafe { gl.Disable(gl::SCISSOR_TEST) },
-    }
-}
-
 pub fn map_comparison(cmp: Comparison) -> gl::types::GLenum {
     match cmp {
         Comparison::Never        => gl::NEVER,

--- a/src/core/src/command/raw.rs
+++ b/src/core/src/command/raw.rs
@@ -54,10 +54,42 @@ pub trait RawCommandBuffer<B: Backend> {
     /// Bind vertex buffers.
     fn bind_vertex_buffers(&mut self, pso::VertexBufferSet<B>);
 
+    /// Set the viewport parameters for the rasterizer.
     ///
+    /// Every other viewport, which is not specified in this call,
+    /// will be disabled.
+    ///
+    /// Ensure that the number of set viewports at draw time is equal
+    /// (or higher) to the number specified in the bound pipeline.
+    ///
+    /// # Errors
+    ///
+    /// This function does not return an error. Invalid usage of this function
+    /// will result in an error on `finish`.
+    ///
+    /// - Number of viewports must be between 1 and `max_viewports`.
+    /// - Only queues with graphics capability support this function.
     fn set_viewports(&mut self, &[Viewport]);
+
+    /// Set the scissor rectangles for the rasterizer.
     ///
+    /// Every other scissor, which is not specified in this call,
+    /// will be disabled.
+    ///
+    /// Each scissor corresponds to the viewport with the same index.
+    ///
+    /// Ensure that the number of set scissors at draw time is equal (or higher)
+    /// to the number of viewports specified in the bound pipeline.
+    ///
+    /// # Errors
+    ///
+    /// This function does not return an error. Invalid usage of this function
+    /// will result in an error on `finish`.
+    ///
+    /// - Number of scissors must be between 1 and `max_viewports`.
+    /// - Only queues with graphics capability support this function.
     fn set_scissors(&mut self, &[target::Rect]);
+
     ///
     fn set_ref_values(&mut self, state::RefValues);
 

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -145,6 +145,8 @@ pub struct Limits {
     pub max_texture_size: usize,
     /// Maximum number of vertices for each patch.
     pub max_patch_size: PatchSize,
+    /// Maximum number of viewports.
+    pub max_viewports: usize,
 }
 
 /// Describes what geometric primitives are created from vertex data.


### PR DESCRIPTION
Implement `set_viewports` and `set_scissors`:
* Our old implementation only allowed one viewport and scissor. To minimize heap allocations we store everything into the `DataBuffer` in the hope to reuse the memory in upcoming frames (we could actually share the internal buffers across all command buffers of a pool!).
* Add validation checks on the command buffer side
* Enabling and Disabling of scissors test will done on when binding the pipeline. Scissor disabling seems to only make sense when rasterization is disabled as vulkan requires at least one viewport/scissor.

### Open Issues
* Disabling (zeroing) all non-active viewports and scissors requires a bit more logic. This is required to be consitent with D3D12. 