### PR TITLE
[ll] implement `Default` for `WrapMmode`

### DIFF
--- a/src/corell/src/image.rs
+++ b/src/corell/src/image.rs
@@ -217,6 +217,12 @@ pub enum WrapMode {
     Border,
 }
 
+impl Default for WrapMode {
+    fn default() -> Self {
+        WrapMode::Tile
+    }
+}
+
 /// A wrapper for the LOD level of a texture.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
 pub struct Lod(i16);


### PR DESCRIPTION
From the doc comments:

```rust
pub enum WrapMode {
    /// Tile the texture. That is, sample the coordinate modulo `1.0`. This is
    /// the default.
    Tile,
``` 