### PR TITLE
[ll] Extend pso functionality and work on gl backend [43/..]

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -102,6 +102,7 @@ pub enum Command {
         depth_range_ptr: DataPointer,
     },
     SetScissors(DataPointer),
+    SetBlendColor(ColorValue),
 }
 
 #[allow(missing_copy_implementations)]
@@ -127,6 +128,10 @@ struct Cache {
     primitive: Option<gl::types::GLenum>,
     // Active index type, set by the current index buffer.
     index_type: Option<c::IndexType>,
+    // Stencil reference values (front, back).
+    stencil_ref: Option<(Stencil, Stencil)>,
+    // Blend color.
+    blend_color: Option<ColorValue>,
     // Indicates that invalid commands have been recorded.
     error_state: bool,
 }
@@ -136,6 +141,8 @@ impl Cache {
         Cache {
             primitive: None,
             index_type: None,
+            stencil_ref: None,
+            blend_color: None,
             error_state: false,
         }
     }
@@ -325,8 +332,18 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         }
     }
 
-    fn set_ref_values(&mut self, rv: s::RefValues) {
-        unimplemented!()
+    fn set_stencil_reference(&mut self, front: target::Stencil, back: target::Stencil) {
+        // Only cache the stencil references values until
+        // we assembled all the pieces to set the stencil state
+        // from the pipeline.
+        self.cache.stencil_ref = Some((front, back));
+    }
+
+    fn set_blend_constants(&mut self, cv: target::ColorValue) {
+        if self.cache.blend_color != Some(cv) {
+            self.cache.blend_color = Some(cv);
+            self.buf.push(Command::SetBlendColor(cv));
+        }
     }
 
     fn bind_descriptor_heap(&mut self, _: &n::DescriptorHeap) {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -489,6 +489,9 @@ impl CommandQueue {
             self.state.vao = true
         }
 
+        // Reset indirect draw buffer
+        unsafe { gl.BindBuffer(gl::DRAW_INDIRECT_BUFFER, 0) };
+
         // Unbind index buffers
         match self.state.index_buffer {
             Some(0) => (), // Nothing to do
@@ -852,9 +855,6 @@ impl CommandQueue {
                 }else if false {
                     error!("Separate blending slots are not supported");
                 }
-            },
-            Command::SetBlendColor(color) => {
-                state::set_blend_color(&self.share.context, color);
             },
             Command::SetPatches(num) => {
                 let gl = &self.share.context;

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -39,7 +39,7 @@ pub use self::info::{Info, PlatformName, Version};
 mod command;
 mod device;
 mod info;
-mod native;
+pub mod native;
 mod pool;
 mod state;
 mod texture;
@@ -70,8 +70,8 @@ impl c::Backend for Backend {
     type Semaphore           = (); // TODO
     type Mapping             = device::MappingGate;
     type Image               = native::Image;
-    type ComputePipeline     = native::PipelineState;
-    type GraphicsPipeline    = native::PipelineState;
+    type ComputePipeline     = native::ComputePipeline;
+    type GraphicsPipeline    = native::GraphicsPipeline;
     type PipelineLayout = ();
     type DescriptorSet       = native::DescriptorSet;
     type ShaderLib = ();
@@ -80,22 +80,6 @@ impl c::Backend for Backend {
     type FrameBuffer = ();
     type DescriptorHeap      = native::DescriptorHeap;
 }
-
-/*
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub struct BufferElement {
-    pub desc: c::pso::VertexBufferDesc,
-    pub elem: c::pso::Element<format::Format>,
-}
-
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct OutputMerger {
-    pub draw_mask: u32,
-    pub stencil: Option<s::Stencil>,
-    pub depth: Option<s::Depth>,
-    pub colors: Vec<s::Color>,
-}
-*/
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Error {
@@ -707,72 +691,53 @@ impl CommandQueue {
             Command::SetBlendColor(color) => {
                 state::set_blend_color(&self.share.context, color);
             }
-            /*
-            Command::Clear(color, depth, stencil) => {
+            Command::ClearColor(texture, c) => {
                 let gl = &self.share.context;
+                state::unlock_color_mask(gl);
                 if self.share.private_caps.clear_buffer_supported {
-                    if let Some(c) = color {
-                        let slot = 0; //TODO?
-                        state::unlock_color_mask(gl);
+                    // Render target view bound to the framebuffer at attachment slot 0.
+                    unsafe {
                         match c {
-                            com::ClearColor::Float(v) => unsafe {
-                                gl.ClearBufferfv(gl::COLOR, slot, &v[0]);
-                            },
-                            com::ClearColor::Int(v) => unsafe {
-                                gl.ClearBufferiv(gl::COLOR, slot, &v[0]);
-                            },
-                            com::ClearColor::Uint(v) => unsafe {
-                                gl.ClearBufferuiv(gl::COLOR, slot, &v[0]);
-                            },
-                        }
-                    }
-                    if let Some(ref d) = depth {
-                        unsafe {
-                            gl.DepthMask(gl::TRUE);
-                            gl.ClearBufferfv(gl::DEPTH, 0, d);
-                        }
-                    }
-                    if let Some(s) = stencil {
-                        let v = s as gl::types::GLint;
-                        unsafe {
-                            gl.StencilMask(gl::types::GLuint::max_value());
-                            gl.ClearBufferiv(gl::STENCIL, 0, &v);
+                            com::ClearColor::Float(v) => {
+                                gl.ClearBufferfv(gl::COLOR, 0, &v[0]);
+                            }
+                            com::ClearColor::Int(v) => {
+                                gl.ClearBufferiv(gl::COLOR, 0, &v[0]);
+                            }
+                            com::ClearColor::Uint(v) => {
+                                gl.ClearBufferuiv(gl::COLOR, 0, &v[0]);
+                            }
                         }
                     }
                 } else {
-                    let mut flags = 0;
-                    if let Some(col) = color {
-                        flags |= gl::COLOR_BUFFER_BIT;
-                        let v = if let com::ClearColor::Float(v) = col {
-                            v
-                        } else {
-                            warn!("Integer clears are not supported on GL2");
-                            [0.0, 0.0, 0.0, 0.0]
-                        };
-                        state::unlock_color_mask(gl);
-                        unsafe {
-                            gl.ClearColor(v[0], v[1], v[2], v[3]);
-                        }
-                    }
-                    if let Some(d) = depth {
-                        flags |= gl::DEPTH_BUFFER_BIT;
-                        unsafe  {
-                            gl.DepthMask(gl::TRUE);
-                            gl.ClearDepth(d as gl::types::GLdouble);
-                        }
-                    }
-                    if let Some(s) = stencil {
-                        flags |= gl::STENCIL_BUFFER_BIT;
-                        unsafe  {
-                            gl.StencilMask(gl::types::GLuint::max_value());
-                            gl.ClearStencil(s as gl::types::GLint);
-                        }
-                    }
+                    let v = if let com::ClearColor::Float(v) = c {
+                        v
+                    } else {
+                        warn!("Integer clears are not supported on GL2");
+                        [0.0, 0.0, 0.0, 0.0]
+                    };
+
                     unsafe {
-                        gl.Clear(flags);
+                        gl.ClearColor(v[0], v[1], v[2], v[3]);
+                        gl.Clear(gl::COLOR_BUFFER_BIT);
                     }
                 }
-            },
+            }
+            Command::BindFrameBuffer(point, frame_buffer) => {
+                if self.share.private_caps.frame_buffer_supported {
+                    let gl = &self.share.context;
+                    unsafe { gl.BindFramebuffer(point, frame_buffer) };
+                } else if frame_buffer != 0 {
+                    error!("Tried to bind FBO {} without FBO support!", frame_buffer);
+                }
+            }
+            Command::BindTargetView(point, attachment, view) => {
+                self.bind_target(point, attachment, &view)
+            }
+            Command::SetDrawColorBuffers(num) => {
+                state::bind_draw_color_buffers(&self.share.context, num);
+            }
+            /*
             Command::BindProgram(program) => unsafe {
                 self.share.context.UseProgram(program);
             },
@@ -821,21 +786,9 @@ impl CommandQueue {
             Command::UnbindAttribute(slot) => unsafe {
                 self.share.context.DisableVertexAttribArray(slot as gl::types::GLuint);
             },
-            Command::BindFrameBuffer(point, frame_buffer) => {
-                if self.share.private_caps.frame_buffer_supported {
-                    let gl = &self.share.context;
-                    unsafe { gl.BindFramebuffer(point, frame_buffer) };
-                } else if frame_buffer != 0 {
-                    error!("Tried to bind FBO {} without FBO support!", frame_buffer);
-                }
-            },
             Command::BindUniform(loc, uniform) => {
                 let gl = &self.share.context;
                 shade::bind_uniform(gl, loc as gl::types::GLint, uniform);
-            },
-            Command::SetDrawColorBuffers(num) => {
-                let mask = (1 << (num as usize)) - 1;
-                state::bind_draw_color_buffers(&self.share.context, mask);
             },
             Command::SetRasterizer(rast) => {
                 state::bind_rasterizer(&self.share.context, &rast, self.share.info.version.is_embedded);

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -701,7 +701,9 @@ impl CommandQueue {
                     unsafe { gl.ScissorArrayv(0, num_scissors as i32, scissors.as_ptr() as *const _) };
                 }
             }
-
+            Command::SetBlendColor(color) => {
+                state::set_blend_color(&self.share.context, color);
+            }
             /*
             Command::Clear(color, depth, stencil) => {
                 let gl = &self.share.context;

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -55,16 +55,14 @@ impl ResourceView {
 }
 
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub struct PipelineState {
-    /*
+#[derive(Clone, Debug, Copy)]
+pub struct GraphicsPipeline {
     program: Program,
-    primitive: c::Primitive,
-    input: Vec<Option<BufferElement>>,
-    scissor: bool,
-    rasterizer: s::Rasterizer,
-    output: OutputMerger,
-    */
+}
+
+#[derive(Clone, Debug, Copy)]
+pub struct ComputePipeline {
+    program: Program,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -18,7 +18,7 @@ use core::state::{BlendValue, Comparison, CullFace, Equation,
                   Offset, RasterMethod, StencilOp, FrontFace};
 use core::target::{ColorValue, Rect, Stencil};
 use gl;
-
+use smallvec::SmallVec;
 
 pub fn bind_raster_method(gl: &gl::Gl, method: s::RasterMethod, offset: Option<s::Offset>) {
     let (gl_draw, gl_offset) = match method {
@@ -73,28 +73,10 @@ pub fn bind_rasterizer(gl: &gl::Gl, r: &s::Rasterizer, is_embedded: bool) {
     }
 }
 
-pub fn bind_draw_color_buffers(gl: &gl::Gl, mask: usize) {
-    /*
-    let attachments = [
-        gl::COLOR_ATTACHMENT0,  gl::COLOR_ATTACHMENT1,  gl::COLOR_ATTACHMENT2,
-        gl::COLOR_ATTACHMENT3,  gl::COLOR_ATTACHMENT4,  gl::COLOR_ATTACHMENT5,
-        gl::COLOR_ATTACHMENT6,  gl::COLOR_ATTACHMENT7,  gl::COLOR_ATTACHMENT8,
-        gl::COLOR_ATTACHMENT9,  gl::COLOR_ATTACHMENT10, gl::COLOR_ATTACHMENT11,
-        gl::COLOR_ATTACHMENT12, gl::COLOR_ATTACHMENT13, gl::COLOR_ATTACHMENT14,
-        gl::COLOR_ATTACHMENT15];
-    let mut targets = [0; MAX_COLOR_TARGETS];
-    let mut count = 0;
-    let mut i = 0;
-    while mask >> i != 0 {
-        if mask & (1<<i) != 0 {
-            targets[count] = attachments[i];
-            count += 1;
-        }
-        i += 1;
-    }
-    unsafe { gl.DrawBuffers(count as gl::types::GLint, targets.as_ptr()) };
-    */
-    unimplemented!()
+pub fn bind_draw_color_buffers(gl: &gl::Gl, num: usize) {
+    let attachments: SmallVec<[gl::types::GLenum; 16]> =
+        (0..num).map(|x| gl::COLOR_ATTACHMENT0 + x as u32).collect();
+    unsafe { gl.DrawBuffers(num as gl::types::GLint, attachments.as_ptr()) };
 }
 
 pub fn map_comparison(cmp: Comparison) -> gl::types::GLenum {

--- a/src/core/src/command/general.rs
+++ b/src/core/src/command/general.rs
@@ -86,8 +86,13 @@ impl<'a, B: Backend> GeneralCommandBuffer<'a, B> {
     }
 
     ///
-    pub fn set_ref_values(&mut self, rv: state::RefValues) {
-        self.0.set_ref_values(rv)
+    pub fn set_stencil_reference(&mut self, front: target::Stencil, back: target::Stencil) {
+        self.0.set_stencil_reference(front, back)
+    }
+
+    ///
+    pub fn set_blend_constants(&mut self, cv: target::ColorValue) {
+        self.0.set_blend_constants(cv)
     }
 
     ///

--- a/src/core/src/command/graphics.rs
+++ b/src/core/src/command/graphics.rs
@@ -16,7 +16,7 @@ use {Backend, Viewport};
 use {memory, pso, state, target, texture};
 use buffer::IndexBufferView;
 use queue::capability::{Capability, Graphics};
-use super::{BufferCopy, BufferImageCopy, CommandBufferShim, ImageCopy, RawCommandBuffer, Submit};
+use super::{BufferCopy, BufferImageCopy, ClearColor, CommandBufferShim, ImageCopy, RawCommandBuffer, Submit};
 
 /// Command buffer with graphics and transfer functionality.
 pub struct GraphicsCommandBuffer<'a, B: Backend>(pub(crate) &'a mut B::RawCommandBuffer)
@@ -48,6 +48,11 @@ where
     ///
     pub fn pipeline_barrier(&mut self, barriers: &[memory::Barrier]) {
         self.0.pipeline_barrier(barriers)
+    }
+
+    ///
+    pub fn clear_color(&mut self, rtv: &B::RenderTargetView, layout: texture::ImageLayout, clear_value: ClearColor) {
+        self.0.clear_color(rtv, layout, clear_value)
     }
 
     ///

--- a/src/core/src/command/graphics.rs
+++ b/src/core/src/command/graphics.rs
@@ -137,7 +137,12 @@ where
     }
 
     ///
-    pub fn set_ref_values(&mut self, rv: state::RefValues) {
-        self.0.set_ref_values(rv)
+    pub fn set_stencil_reference(&mut self, front: target::Stencil, back: target::Stencil) {
+        self.0.set_stencil_reference(front, back)
+    }
+
+    ///
+    pub fn set_blend_constants(&mut self, cv: target::ColorValue) {
+        self.0.set_blend_constants(cv)
     }
 }

--- a/src/core/src/command/raw.rs
+++ b/src/core/src/command/raw.rs
@@ -91,7 +91,10 @@ pub trait RawCommandBuffer<B: Backend> {
     fn set_scissors(&mut self, &[target::Rect]);
 
     ///
-    fn set_ref_values(&mut self, state::RefValues);
+    fn set_stencil_reference(&mut self, front: target::Stencil, back: target::Stencil);
+
+    ///
+    fn set_blend_constants(&mut self, target::ColorValue);
 
     ///
     fn begin_renderpass(

--- a/src/core/src/pso/input_assembler.rs
+++ b/src/core/src/pso/input_assembler.rs
@@ -56,11 +56,31 @@ pub struct VertexBufferDesc {
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct AttributeDesc {
     /// Attribute binding location in the shader.
-    location: Location,
+    pub location: Location,
     /// Index of the associated vertex buffer descriptor.
-    binding: BufferIndex,
+    pub binding: BufferIndex,
     /// Attribute element description.
-    element: Element<format::Format>,
+    pub element: Element<format::Format>,
+}
+
+///
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub enum PrimitiveRestart {
+    ///
+    Disabled,
+    ///
+    U16,
+    ///
+    U32,
+}
+
+///
+pub struct InputAssemblerDesc {
+    /// Type of the primitive
+    pub primitive: Primitive,
+    ///
+    pub primitive_restart: PrimitiveRestart,
 }
 
 /// A complete set of vertex buffers to be used for vertex import in PSO.

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -23,7 +23,7 @@ pub use headless::Headless;
 
 use core::{format, handle, texture};
 use core::memory;
-use device_gl::Resources as R;
+use device_gl::{native as n, Backend as B};
 use glutin::GlContext;
 use std::rc::Rc;
 
@@ -71,20 +71,20 @@ pub struct SwapChain {
     // Underlying window, required for presentation
     window: Rc<glutin::GlWindow>,
     // Single element backbuffer
-    backbuffer: [core::Backbuffer<device_gl::Backend>; 1],
+    backbuffer: [core::Backbuffer<B>; 1],
 }
 
-impl core::SwapChain<device_gl::Backend> for SwapChain {
-    fn get_backbuffers(&mut self) -> &[core::Backbuffer<device_gl::Backend>] {
+impl core::SwapChain<B> for SwapChain {
+    fn get_backbuffers(&mut self) -> &[core::Backbuffer<B>] {
         &self.backbuffer
     }
 
-    fn acquire_frame(&mut self, sync: core::FrameSync<device_gl::Resources>) -> core::Frame {
+    fn acquire_frame(&mut self, sync: core::FrameSync<B>) -> core::Frame {
         // TODO: sync
         core::Frame::new(0)
     }
 
-    fn present<Q>(&mut self, _: &mut Q, _: &[&handle::Semaphore<device_gl::Resources>])
+    fn present<Q>(&mut self, _: &mut Q, _: &[&handle::Semaphore<B>])
         where Q: AsMut<device_gl::CommandQueue>
     {
         self.window.swap_buffers();
@@ -93,10 +93,10 @@ impl core::SwapChain<device_gl::Backend> for SwapChain {
 
 pub struct Surface {
     window: Rc<glutin::GlWindow>,
-    manager: handle::Manager<R>,
+    manager: handle::Manager<B>,
 }
 
-impl core::Surface<device_gl::Backend> for Surface {
+impl core::Surface<B> for Surface {
     type SwapChain = SwapChain;
 
     fn supports_queue(&self, _: &device_gl::QueueFamily) -> bool { true }
@@ -105,8 +105,8 @@ impl core::Surface<device_gl::Backend> for Surface {
     {
         use core::handle::Producer;
         let dim = get_window_dimensions(&self.window);
-        let color = self.manager.make_texture(
-            device_gl::NewTexture::Surface(0),
+        let color = self.manager.make_image(
+            n::Image::Surface(0),
             texture::Info {
                 levels: 1,
                 kind: texture::Kind::D2(dim.0, dim.1, dim.3),
@@ -117,8 +117,8 @@ impl core::Surface<device_gl::Backend> for Surface {
         );
 
         let ds = config.depth_stencil_format.map(|ds_format| {
-            self.manager.make_texture(
-                device_gl::NewTexture::Surface(0),
+            self.manager.make_image(
+                n::Image::Surface(0),
                 texture::Info {
                     levels: 1,
                     kind: texture::Kind::D2(dim.0, dim.1, dim.3),
@@ -164,7 +164,7 @@ impl Window {
         &self.0
     }
 }
-impl core::WindowExt<device_gl::Backend> for Window {
+impl core::WindowExt<B> for Window {
     type Surface = Surface;
     type Adapter = device_gl::Adapter;
 


### PR DESCRIPTION
* core: Add further configuration possibilities for graphics pipelines (still not finished so far: multisampling, depth-stencil state and dynamic states)
* core: Split the setting of reference values (blend constants and stencil ref) into two commands
* glutin: Fix window backend after the merge of `Resources` and `Backend`
* gl: Implement color clearing based on the old implementation
