### PR TITLE
Fix appveyor for dx12 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,41 +17,40 @@ install:
 build_script:
   # No d3d12 support on GNU windows ATM
   # context: https://github.com/gfx-rs/gfx/pull/1417
-  - if (%COMPILER%==gnu) {
-    - >
-      cargo build --all --features vulkan
+  - if %COMPILER%==gnu (
+      cargo build --all
       --exclude gfx_window_glfw
+      --exclude gfx_window_sdl
       --exclude gfx_device_metal
       --exclude gfx_device_metalll
       --exclude gfx_window_metal
       --exclude gfx_device_dx12ll
-    } else {
-      - >
-        cargo build --all --features vulkan
-        --exclude gfx_window_glfw
-        --exclude gfx_device_metal
-        --exclude gfx_device_metalll
-        --exclude gfx_window_metal
-    }
+      --exclude gfx_device_dx12
+      --exclude gfx_window_dxgi
+    ) else (
+      cargo build --all
+      --exclude gfx_window_glfw
+      --exclude gfx_window_sdl
+      --exclude gfx_device_metal
+      --exclude gfx_device_metalll
+      --exclude gfx_window_metal
+    )
 test_script:
-  # re: gfx is gfx_render
-  - cargo test -p gfx -p gfx_core
-  - if (%COMPILER%==gnu) {
-    - >
-      cargo test --all --features vulkan
+  - if %COMPILER%==gnu (
+      cargo test --all
       --exclude gfx_window_glfw
+      --exclude gfx_window_sdl
       --exclude gfx_device_metal
       --exclude gfx_device_metalll
       --exclude gfx_window_metal
       --exclude gfx_device_dx12ll
-    } else {
-      - >
-        cargo test --all --features vulkan
-        --exclude gfx_window_glfw
-        --exclude gfx_device_metal
-        --exclude gfx_device_metalll
-        --exclude gfx_window_metal
-      - cargo test -p gfx -p gfx_core --features dx11
-      - cargo test -p gfx -p gfx_core --features dx12
-      - cargo test -p gfx -p gfx_core --features dx12ll
-    }
+      --exclude gfx_device_dx12
+      --exclude gfx_window_dxgi
+    ) else (
+      cargo test --all
+      --exclude gfx_window_glfw
+      --exclude gfx_window_sdl
+      --exclude gfx_device_metal
+      --exclude gfx_device_metalll
+      --exclude gfx_window_metal
+    )

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ metal = ["gfx_device_metal", "gfx_window_metal", "gfx_device_metalll"]
 metal_argument_buffer = ["gfx_device_metalll/argument_buffer"]
 gl = ["gfx_device_gl", "gfx_window_glutin"]
 dx11 = ["gfx_device_dx11", "gfx_window_dxgi"]
-dx12 = ["gfx_device_dx12", "gfx_window_dxgi"]
+dx12 = ["gfx_device_dx12", "gfx_device_dx12ll", "gfx_window_dxgi"]
 vulkan = ["gfx_device_vulkan", "gfx_device_vulkanll", "gfx_window_vulkan"]
 sdl = ["gfx_window_sdl"]
 serialize = ["gfx/serialize", "gfx_core/serialize"]
@@ -82,7 +82,7 @@ gfx_window_sdl = { path = "../src/window/sdl", version = "0.7" }
 gfx_device_dx11 = { path = "../src/backend/dx11", version = "0.6", optional = true }
 gfx_device_dx12 = { path = "../src/backend/dx12", version = "0.1", optional = true }
 gfx_window_dxgi = { path = "../src/window/dxgi", version = "0.9", optional = true }
-gfx_device_dx12ll = { path = "../src/backend/dx12ll", version = "0.1" }
+gfx_device_dx12ll = { path = "../src/backend/dx12ll", version = "0.1", optional = true }
 
 # Support examples.
 [[bin]]

--- a/examples/corell/trianglell/main.rs
+++ b/examples/corell/trianglell/main.rs
@@ -14,7 +14,7 @@
 
 extern crate env_logger;
 extern crate gfx_corell;
-#[cfg(all(target_os = "windows", not(feature = "vulkan")))]
+#[cfg(feature = "dx12")]
 extern crate gfx_device_dx12ll as back;
 #[cfg(feature = "vulkan")]
 extern crate gfx_device_vulkanll as back;
@@ -60,7 +60,7 @@ const TRIANGLE: [Vertex; 6] = [
     Vertex { a_Pos: [ -0.5,-0.33 ], a_Uv: [0.0, 0.0] },
 ];
 
-#[cfg(any(feature = "vulkan", target_os = "windows", feature = "metal"))]
+#[cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]
 fn main() {
     env_logger::init().unwrap();
     let mut events_loop = winit::EventsLoop::new();
@@ -93,7 +93,7 @@ fn main() {
 
     // Setup renderpass and pipeline
     // dx12 runtime shader compilation
-    #[cfg(all(target_os = "windows", not(feature = "vulkan")))]
+    #[cfg(feature = "dx12")]
     let shader_lib = factory.create_shader_library_from_source(&[
             (VS, shade::Stage::Vertex, include_bytes!("shader/triangle.hlsl")),
             (PS, shade::Stage::Pixel, include_bytes!("shader/triangle.hlsl")),
@@ -503,7 +503,7 @@ fn main() {
     }
 }
 
-#[cfg(not(any(feature = "vulkan", target_os = "windows", feature = "metal")))]
+#[cfg(not(any(feature = "vulkan", feature = "dx12", feature = "metal")))]
 fn main() {
     println!("You need to enable the native API feature (vulkan/metal) in order to test the LL");
 }


### PR DESCRIPTION
Exclude all the necessary crates for building with appveyor.
`gfx_window_dxgi` is also excluded as it depends on dx12, which we need to feature-gate in the a followup PR but this would block #1437 