### PR TITLE
[ll] core: Refactor command pools

### DIFF
--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -14,14 +14,13 @@ impl core::Backend for Backend {
     type Device = Device;
 
     type CommandQueue = CommandQueue;
-    type RawCommandBuffer = RawCommandBuffer;
+    type CommandBuffer = RawCommandBuffer;
     type SubpassCommandBuffer = SubpassCommandBuffer;
-    type SubmitInfo = SubmitInfo;
     type QueueFamily = QueueFamily;
 
     type Heap = ();
     type Mapping = ();
-    type RawCommandPool = RawCommandPool;
+    type CommandPool = RawCommandPool;
     type SubpassCommandPool = SubpassCommandPool;
 
     type ShaderLib = ();
@@ -276,10 +275,6 @@ impl core::QueueFamily for QueueFamily {
     }
 }
 
-/// Dummy submit info containing nothing.
-#[derive(Clone)]
-pub struct SubmitInfo;
-
 /// Dummy subpass command buffer.
 pub struct SubpassCommandBuffer;
 
@@ -290,19 +285,15 @@ impl core::RawCommandPool<Backend> for RawCommandPool {
         unimplemented!()
     }
 
-    fn reserve(&mut self, _: usize) {
+    unsafe fn from_queue(_: &CommandQueue) -> Self {
         unimplemented!()
     }
 
-    unsafe fn from_queue(_: &CommandQueue, _: usize) -> Self {
+    fn allocate(&mut self, _: usize) -> Vec<RawCommandBuffer> {
         unimplemented!()
     }
 
-    unsafe fn acquire_command_buffer(&mut self) -> RawCommandBuffer {
-        unimplemented!()
-    }
-
-    unsafe fn return_command_buffer(&mut self, _: RawCommandBuffer) {
+    unsafe fn free(&mut self, _: Vec<RawCommandBuffer>) {
         unimplemented!()
     }
 }
@@ -314,10 +305,14 @@ impl core::SubpassCommandPool<Backend> for SubpassCommandPool {
 }
 
 /// Dummy command buffer, which ignores all the calls.
+#[derive(Clone)]
 pub struct RawCommandBuffer;
 impl core::RawCommandBuffer<Backend> for RawCommandBuffer {
+    fn begin(&mut self) {
+        unimplemented!()
+    }
 
-    fn finish(&mut self) -> SubmitInfo {
+    fn finish(&mut self) {
         unimplemented!()
     }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -436,7 +436,7 @@ impl core::RawCommandQueue<Backend> for CommandQueue {
     ){
         let buffers = submission.cmd_buffers
             .iter()
-            .map(|cmd| cmd.command_buffer)
+            .map(|cmd| cmd.raw)
             .collect::<Vec<_>>();
         let waits = submission.wait_semaphores
             .iter()
@@ -488,7 +488,6 @@ impl core::Backend for Backend {
     type CommandQueue = CommandQueue;
     type CommandBuffer = command::CommandBuffer;
     type SubpassCommandBuffer = command::SubpassCommandBuffer;
-    type SubmitInfo = command::SubmitInfo;
     type QueueFamily = QueueFamily;
 
     type Heap = native::Heap;

--- a/src/core/src/command/mod.rs
+++ b/src/core/src/command/mod.rs
@@ -58,10 +58,13 @@ impl<'a, B: Backend, C> CommandBuffer<'a, B, C> {
     ///
     /// The command buffer will be consumed and can't be modified further.
     /// The command pool must be reset to able to re-record commands.
-    pub fn finish(mut self) -> Submit<B, C> {
+    pub fn finish(self) -> Submit<B, C> {
+        unsafe { Submit::new(self) }
+    }
+}
+
+impl<'a, B: Backend, C> Drop for CommandBuffer<'a, B, C> {
+    fn drop(&mut self) {
         self.raw.finish();
-        unsafe {
-            Submit::new(self)
-        }
     }
 }

--- a/src/core/src/command/mod.rs
+++ b/src/core/src/command/mod.rs
@@ -15,7 +15,6 @@
 //!
 
 use Backend;
-use pool::{RawCommandPool};
 use std::marker::PhantomData;
 
 mod compute;
@@ -29,42 +28,28 @@ pub use self::raw::RawCommandBuffer;
 pub use self::renderpass::*;
 pub use self::transfer::*;
 
-
 /// Thread-safe finished command buffer for submission.
-pub struct Submit<B: Backend, C>(B::SubmitInfo, PhantomData<C>);
+pub struct Submit<B: Backend, C>(pub(crate) B::CommandBuffer, PhantomData<C>);
 unsafe impl<B: Backend, C> Send for Submit<B, C> {}
 
 impl<B: Backend, C> Submit<B, C> {
     ///
-    pub unsafe fn new(info: B::SubmitInfo) -> Self {
-        Submit(info, PhantomData)
-    }
-
-    // Unsafe because we could try to submit a command buffer multiple times.
-    #[doc(hidden)]
-    pub unsafe fn get_info(&self) -> &B::SubmitInfo {
-        &self.0
-    }
-
-    /// Unsafe because we could try to submit a command buffer multiple times by cloning.
-    pub unsafe fn into_info(self) -> B::SubmitInfo {
-        self.0
+    pub unsafe fn new(buffer: CommandBuffer<B, C>) -> Self {
+        Submit(buffer.raw.clone(), PhantomData)
     }
 }
 
 /// Command buffer with compute, graphics and transfer functionality.
-pub struct CommandBuffer<'a, B: 'a + Backend, C> {
-    pub(crate) raw: B::CommandBuffer,
-    pool: &'a mut B::CommandPool,
+pub struct CommandBuffer<'a, B: Backend, C> {
+    pub(crate) raw: &'a mut B::CommandBuffer,
     _capability: PhantomData<C>,
 }
 
 impl<'a, B: Backend, C> CommandBuffer<'a, B, C> {
     /// Create a new typed command buffer from a raw command pool.
-    pub unsafe fn new(pool: &'a mut B::CommandPool) -> Self {
+    pub unsafe fn new(raw: &'a mut B::CommandBuffer) -> Self {
         CommandBuffer {
-            raw: pool.acquire_command_buffer(),
-            pool,
+            raw,
             _capability: PhantomData,
         }
     }
@@ -74,10 +59,9 @@ impl<'a, B: Backend, C> CommandBuffer<'a, B, C> {
     /// The command buffer will be consumed and can't be modified further.
     /// The command pool must be reset to able to re-record commands.
     pub fn finish(mut self) -> Submit<B, C> {
-        let submit = self.raw.finish();
+        self.raw.finish();
         unsafe {
-            self.pool.return_command_buffer(self.raw);
-            Submit::new(submit)
+            Submit::new(self)
         }
     }
 }

--- a/src/core/src/command/raw.rs
+++ b/src/core/src/command/raw.rs
@@ -21,9 +21,12 @@ use super::{BufferCopy, BufferImageCopy, ClearColor, ClearValue, ImageCopy, Imag
             InstanceParams, SubpassContents};
 
 ///
-pub trait RawCommandBuffer<B: Backend> {
+pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     ///
-    fn finish(&mut self) -> B::SubmitInfo;
+    fn begin(&mut self);
+
+    ///
+    fn finish(&mut self);
 
     ///
     fn pipeline_barrier(&mut self, &[Barrier<B>]);

--- a/src/core/src/command/renderpass.rs
+++ b/src/core/src/command/renderpass.rs
@@ -48,7 +48,7 @@ impl<'a, B: Backend> RenderPassInlineEncoder<'a, B> {
             render_area,
             clear_values,
             SubpassContents::Inline);
-        RenderPassInlineEncoder(&mut cmd_buffer.raw)
+        RenderPassInlineEncoder(cmd_buffer.raw)
     }
 
     ///

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -223,14 +223,13 @@ pub struct HeapType {
 /// Different types of a specific API.
 #[allow(missing_docs)]
 pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any {
-    type Adapter:            Adapter<Self>;
-    type Device:             Device<Self>;
+    type Adapter:             Adapter<Self>;
+    type Device:              Device<Self>;
 
-    type CommandQueue:       RawCommandQueue<Self>;
-    type CommandBuffer:      RawCommandBuffer<Self>;
+    type CommandQueue:        RawCommandQueue<Self>;
+    type CommandBuffer:       RawCommandBuffer<Self>;
     type SubpassCommandBuffer;
-    type QueueFamily:        QueueFamily;
-    type SubmitInfo:         Clone + Send;
+    type QueueFamily:         QueueFamily;
 
     type ShaderLib:           Debug + Any + Send + Sync;
     type RenderPass:          Debug + Any + Send + Sync;

--- a/src/core/src/pool.rs
+++ b/src/core/src/pool.rs
@@ -15,12 +15,11 @@
 //! Command pools
 
 use {Backend};
-use command::CommandBuffer;
+use command::{CommandBuffer, RawCommandBuffer};
 use queue::CommandQueue;
 use queue::capability::Supports;
 use std::marker::PhantomData;
 
-/// `CommandPool` can allocate command buffers of a specific type only.
 /// The allocated command buffers are associated with the creating command queue.
 pub trait RawCommandPool<B: Backend>: Send {
     /// Reset the command pool and the corresponding command buffers.
@@ -28,21 +27,28 @@ pub trait RawCommandPool<B: Backend>: Send {
     /// # Synchronization: You may _not_ free the pool if a command buffer is still in use (pool memory still in use)
     fn reset(&mut self);
 
-    /// Reserve an additional amount of command buffers.
-    fn reserve(&mut self, additional: usize);
-
     #[doc(hidden)]
     unsafe fn from_queue(queue: &B::CommandQueue, capacity: usize) -> Self;
 
-    #[doc(hidden)]
-    unsafe fn acquire_command_buffer(&mut self) -> B::CommandBuffer;
+    /// Allocate new command buffers from the pool.
+    fn allocate(&mut self, num: usize) -> Vec<B::CommandBuffer>;
 
-    #[doc(hidden)]
-    unsafe fn return_command_buffer(&mut self, B::CommandBuffer);
+    /// Free command buffers which are allocated from this pool.
+    unsafe fn free(&mut self, buffers: Vec<B::CommandBuffer>);
 }
 
+/// Strong-typed command pool.
 ///
-pub struct CommandPool<B: Backend, C>(B::CommandPool, PhantomData<C>);
+/// This a safer wrapper around `RawCommandPool` which ensures that only **one**
+/// command buffer is recorded at the same time from the current queue.
+/// Command buffers are stored internally and can only be obtained via a strong-typed
+/// `CommandBuffer` wrapper for encoding.
+pub struct CommandPool<B: Backend, C> {
+    buffers: Vec<B::CommandBuffer>,
+    pool: B::CommandPool,
+    next_buffer: usize,
+    _capability: PhantomData<C>,
+}
 
 impl<B: Backend, C> CommandPool<B, C> {
     /// Create a pool for a specific command queue
@@ -54,24 +60,44 @@ impl<B: Backend, C> CommandPool<B, C> {
         let raw = unsafe {
             B::CommandPool::from_queue(queue.as_raw(), capacity)
         };
-        CommandPool(raw, PhantomData)
+        CommandPool {
+            buffers: Vec::new(),
+            pool: raw,
+            next_buffer: 0,
+            _capability: PhantomData,
+        }
     }
 
     /// Reset the command pool and the corresponding command buffers.
     ///
     /// # Synchronization: You may _not_ free the pool if a command buffer is still in use (pool memory still in use)
-    pub fn reset(&mut self) { self.0.reset() }
+    pub fn reset(&mut self) {
+        self.pool.reset();
+        self.next_buffer = 0;
+    }
 
     /// Reserve an additional amount of command buffers.
-    pub fn reserve(&mut self, additional: usize) { self.0.reserve(additional) }
+    pub fn reserve(&mut self, additional: usize) {
+        let buffers = self.pool.allocate(additional);
+        self.buffers.extend(buffers);
+    }
 
     /// Get a command buffer for recording.
     ///
     /// You can only record to one command buffer per pool at the same time.
     /// If more command buffers are requested than allocated, new buffers will be reserved.
     /// The command buffer will be returned in 'recording' state.
-    pub fn acquire_command_buffer(&mut self) -> CommandBuffer<B, C> {
-        unsafe { CommandBuffer::new(&mut self.0) }
+    pub fn acquire_command_buffer<'a>(&'a mut self) -> CommandBuffer<'a, B, C> {
+        if self.buffers.len() <= self.next_buffer {
+            self.reserve(1);
+        }
+
+        let buffer = &mut self.buffers[self.next_buffer];
+        self.next_buffer += 1;
+        unsafe {
+            buffer.begin();
+            CommandBuffer::new(buffer)
+        }
     }
 }
 

--- a/src/core/src/queue/submission.rs
+++ b/src/core/src/queue/submission.rs
@@ -25,7 +25,7 @@ use smallvec::SmallVec;
 /// Raw submission information for a command queue.
 pub struct RawSubmission<'a, B: Backend + 'a> {
     /// Command buffers to submit.
-    pub cmd_buffers: &'a [B::SubmitInfo],
+    pub cmd_buffers: &'a [B::CommandBuffer],
     /// Semaphores to wait being signalled before submission.
     pub wait_semaphores: &'a [(&'a B::Semaphore, pso::PipelineStage)],
     /// Semaphores which get signalled after submission.
@@ -34,7 +34,7 @@ pub struct RawSubmission<'a, B: Backend + 'a> {
 
 /// Submission information for a command queue.
 pub struct Submission<'a, B: Backend, C> {
-    cmd_buffers: SmallVec<[B::SubmitInfo; 16]>,
+    cmd_buffers: SmallVec<[B::CommandBuffer; 16]>,
     wait_semaphores: SmallVec<[(&'a B::Semaphore, pso::PipelineStage); 16]>,
     signal_semaphores: SmallVec<[&'a B::Semaphore; 16]>,
     marker: PhantomData<C>,
@@ -88,7 +88,7 @@ where
     where
         (C, S): Upper
     {
-        self.cmd_buffers.extend(submits.iter().map(|submit| unsafe { submit.get_info().clone() }));
+        self.cmd_buffers.extend(submits.iter().map(|submit| submit.0.clone()));
         Submission {
             cmd_buffers: self.cmd_buffers,
             wait_semaphores: self.wait_semaphores,


### PR DESCRIPTION
Refactor the current command pool implementation and remove `SubmitInfo`.
Motivated by providing a lower level design which is more vulkan flavored.

We basically follow the (internal) paradigm of providing `Raw` objects (close to the metal, zero overhead, C-ish) and having safe wrappers on top of them which enforce some constraints at compile time and come with minimal overhead.

### Lower layer
* The `RawCommandBuffer` isn't supposed to store the command buffers internally and moves that task onto the library user.
* `SubmitInfo` was a safe object to pass over thread boundaries to prevent users from recording multiple command buffers at the same time. We now move towards sending (+ cloning) `RawCommandBuffers` which requires the users to take care of not recording multiple buffers from one pool at the same time.

### Higher layer
* `CommandPool` fullfills the part of a higher wrapper around `RawCommandPool` to ensure capabilities for the underlying buffers and prevent multiple buffer encoding. Stores command buffers internally in a `Vec` queue.
* `Submit` internally uses now `RawCommandBuffers` instead of `SubmitInfo`.

## TODO
- [x] ~~Ensure that `CommandBuffer` is `!Send` (how?)~~ edit: Can be `Send`..
- [x] Update the Vulkan backend