### PR TITLE
[ll] Working on gl backend (build, fences and samplers)

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -109,27 +109,11 @@ pub enum Command {
     SetDrawColorBuffers(usize),
 }
 
-#[allow(missing_copy_implementations)]
-#[derive(Clone)]
-pub struct SubmitInfo {
-    // Raw pointer optimization:
-    // Command buffers are stored inside the command pools.
-    // We are using raw pointers here to avoid costly clones
-    // and to circumvent the borrow checker. This is safe because
-    // the command buffers are only reused after calling reset.
-    // Reset also resets the command buffers and implies that all
-    // submit infos are either consumed or thrown away.
-    pub(crate) buf: *const Vec<Command>,
-    pub(crate) data: *const DataBuffer,
-}
-
-// See the explanation above why this is safe.
-unsafe impl Send for SubmitInfo {}
-
 pub type FrameBufferTarget = gl::types::GLenum;
 pub type AttachmentPoint = gl::types::GLenum;
 
 // Cache current states of the command buffer
+#[derive(Clone)]
 struct Cache {
     // Active primitive topology, set by the current pipeline.
     primitive: Option<gl::types::GLenum>,
@@ -178,6 +162,7 @@ impl From<c::Limits> for Limits {
 ///
 /// If you want to display your rendered results to a framebuffer created externally, see the
 /// `display_fb` field.
+#[derive(Clone)]
 pub struct RawCommandBuffer {
     pub buf: Vec<Command>,
     pub data: DataBuffer,
@@ -222,11 +207,12 @@ impl RawCommandBuffer {
 }
 
 impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
-    fn finish(&mut self) -> SubmitInfo {
-        SubmitInfo {
-            buf: &self.buf,
-            data: &self.data,
-        }
+    fn begin(&mut self) {
+        // no-op
+    }
+
+    fn finish(&mut self) {
+        // no-op
     }
 
     fn pipeline_barrier(&mut self, barries: &[memory::Barrier<Backend>]) {

--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -26,3 +26,12 @@ pub fn filter_to_gl(f: i::FilterMethod) -> (GLenum, GLenum) {
         i::FilterMethod::Anisotropic(..) => (gl::LINEAR_MIPMAP_LINEAR, gl::LINEAR),
     }
 }
+
+pub fn wrap_to_gl(w: i::WrapMode) -> GLenum {
+    match w {
+        i::WrapMode::Tile   => gl::REPEAT,
+        i::WrapMode::Mirror => gl::MIRRORED_REPEAT,
+        i::WrapMode::Clamp  => gl::CLAMP_TO_EDGE,
+        i::WrapMode::Border => gl::CLAMP_TO_BORDER,
+    }
+}

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -15,14 +15,15 @@
 use std::rc::Rc;
 use std::{slice, ptr};
 
-use {gl};
+use gl;
+use gl::types::{GLenum, GLuint, GLint, GLfloat, GLsizei, GLvoid};
 use core::{self as c, device as d, image as i, pass, pso, buffer, mapping};
 use core::memory::{self, Bind, SHADER_RESOURCE, UNORDERED_ACCESS, Typed};
 use core::format::{ChannelType, Format};
 use core::target::{Layer, Level};
 
 use {Info, Backend as B, Share};
-use {conv, device, native as n, pool};
+use {conv, device, native as n, pool, state};
 
 fn access_to_map_bits(access: memory::Access) -> gl::types::GLenum {
     let mut r = 0;
@@ -90,8 +91,8 @@ impl d::Device<B> for Device {
         &self.share.limits
     }
 
-    fn create_heap(&mut self, _: &c::HeapType, _: d::ResourceHeapType, _: u64) -> Result<n::Heap, d::ResourceHeapError> {
-        unimplemented!()
+    fn create_heap(&mut self, heap_type: &c::HeapType, resource_type: d::ResourceHeapType, size: u64) -> Result<n::Heap, d::ResourceHeapError> {
+        Ok(n::Heap)
     }
 
     fn create_renderpass(&mut self, _: &[pass::Attachment], _: &[pass::SubpassDesc], _: &[pass::SubpassDependency]) -> n::RenderPass {
@@ -102,10 +103,12 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn create_graphics_pipelines<'a>(&mut self, _: &[(&n::ShaderLib, &n::PipelineLayout, pass::SubPass<'a, B>, &pso::GraphicsPipelineDesc)])
-            -> Vec<Result<n::GraphicsPipeline, pso::CreationError>> {
-                unimplemented!()
-            }
+    fn create_graphics_pipelines<'a>(
+        &mut self,
+        descs: &[(&n::ShaderLib, &n::PipelineLayout, pass::SubPass<'a, B>, &pso::GraphicsPipelineDesc)],
+    ) -> Vec<Result<n::GraphicsPipeline, pso::CreationError>> {
+        unimplemented!()
+    }
 
     fn create_compute_pipelines(&mut self, _: &[(&n::ShaderLib, pso::EntryPoint, &n::PipelineLayout)]) -> Vec<Result<n::ComputePipeline, pso::CreationError>> {
         unimplemented!()
@@ -121,9 +124,69 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn create_sampler(&mut self, info: i::SamplerInfo) -> n::Sampler {
-        unimplemented!()
+    fn create_sampler(&mut self, info: i::SamplerInfo) -> n::FatSampler {
+        let object = if self.share.features.sampler_objects {
+            let gl = &self.share.context;
+            let mut name = 0 as n::Sampler;
+
+            let (min, mag) = conv::filter_to_gl(info.filter);
+
+            unsafe {
+                gl.GenSamplers(1, &mut name);
+
+                match info.filter{
+                    i::FilterMethod::Anisotropic(fac) if fac > 1 => {
+                        if self.share.private_caps.sampler_anisotropy_ext {
+                            gl.SamplerParameterf(name, gl::TEXTURE_MAX_ANISOTROPY_EXT, fac as GLfloat);
+                        } else if self.share.features.sampler_anisotropy {
+                            // TODO: Uncomment once `gfx_gl` supports GL 4.6
+                            // gl.SamplerParameterf(name, gl::TEXTURE_MAX_ANISOTROPY, fac as GLfloat);
+                        }
+                    }
+                    _ => ()
+                }
+
+                gl.SamplerParameteri(name, gl::TEXTURE_MIN_FILTER, min as GLint);
+                gl.SamplerParameteri(name, gl::TEXTURE_MAG_FILTER, mag as GLint);
+
+                let (s, t, r) = info.wrap_mode;
+                gl.SamplerParameteri(name, gl::TEXTURE_WRAP_S, conv::wrap_to_gl(s) as GLint);
+                gl.SamplerParameteri(name, gl::TEXTURE_WRAP_T, conv::wrap_to_gl(t) as GLint);
+                gl.SamplerParameteri(name, gl::TEXTURE_WRAP_R, conv::wrap_to_gl(r) as GLint);
+
+                if self.share.features.sampler_lod_bias {
+                    gl.SamplerParameterf(name, gl::TEXTURE_LOD_BIAS, info.lod_bias.into());
+                }
+                if self.share.features.sampler_border_color {
+                    let border: [f32; 4] = info.border.into();
+                    gl.SamplerParameterfv(name, gl::TEXTURE_BORDER_COLOR, &border[0]);
+                }
+
+                let (min, max) = info.lod_range;
+                gl.SamplerParameterf(name, gl::TEXTURE_MIN_LOD, min.into());
+                gl.SamplerParameterf(name, gl::TEXTURE_MAX_LOD, max.into());
+
+                match info.comparison {
+                    None => gl.SamplerParameteri(name, gl::TEXTURE_COMPARE_MODE, gl::NONE as GLint),
+                    Some(cmp) => {
+                        gl.SamplerParameteri(name, gl::TEXTURE_COMPARE_MODE, gl::COMPARE_REF_TO_TEXTURE as GLint);
+                        gl.SamplerParameteri(name, gl::TEXTURE_COMPARE_FUNC, state::map_comparison(cmp) as GLint);
+                    }
+                }
+            }
+
+            name
+        } else {
+            0
+        };
+
+        if let Err(err) = self.share.check() {
+            panic!("Error {:?} creating sampler: {:?}", err, info)
+        }
+
+        n::FatSampler { object, info }
     }
+
     fn create_buffer(&mut self, _: u64, _: u64, _: buffer::Usage) -> Result<device::UnboundBuffer, buffer::CreationError> {
         unimplemented!()
     }
@@ -164,13 +227,14 @@ impl d::Device<B> for Device {
     fn view_image_as_unordered_access(&mut self, _: &n::Image, _: Format) -> Result<n::UnorderedAccessView, d::TargetViewError> {
         unimplemented!()
     }
+
     fn create_descriptor_pool(&mut self, _: usize, _: &[pso::DescriptorRangeDesc]) -> n::DescriptorPool {
         unimplemented!()
     }
+
     fn create_descriptor_set_layout(&mut self, _: &[pso::DescriptorSetLayoutBinding]) -> n::DescriptorSetLayout {
         unimplemented!()
     }
-
 
     fn update_descriptor_sets(&mut self, _: &[pso::DescriptorSetWrite<B>]) {
         unimplemented!()
@@ -189,18 +253,82 @@ impl d::Device<B> for Device {
         }
 
     fn create_semaphore(&mut self) -> n::Semaphore {
-        unimplemented!()
+        n::Semaphore
     }
 
-    fn create_fence(&mut self, _: bool) -> n::Fence {
-        unimplemented!()
+    fn create_fence(&mut self, signalled: bool) -> n::Fence {
+        let sync = if signalled && self.share.private_caps.sync_supported {
+            let gl = &self.share.context;
+            unsafe { gl.FenceSync(gl::SYNC_GPU_COMMANDS_COMPLETE, 0) }
+        } else {
+            ptr::null()
+        };
+        n::Fence::new(sync)
     }
 
-    fn reset_fences(&mut self, _: &[&n::Fence]) {
-        unimplemented!()
+    fn reset_fences(&mut self, fences: &[&n::Fence]) {
+        if !self.share.private_caps.sync_supported {
+            return
+        }
+
+        let gl = &self.share.context;
+        for fence in fences {
+            let sync = fence.0.get();
+            unsafe {
+                if gl.IsSync(sync) == gl::TRUE {
+                    gl.DeleteSync(sync);
+                }
+            }
+            fence.0.set(ptr::null())
+        }
     }
-    fn wait_for_fences(&mut self, _: &[&n::Fence], _: d::WaitFor, _: u32) -> bool {
-        unimplemented!()
+
+    fn wait_for_fences(&mut self, fences: &[&n::Fence], wait: d::WaitFor, timeout_ms: u32) -> bool {
+        if !self.share.private_caps.sync_supported {
+            return true;
+        }
+
+        match wait {
+            d::WaitFor::All => {
+                for fence in fences {
+                    match wait_fence(fence, &self.share.context, timeout_ms) {
+                        gl::TIMEOUT_EXPIRED => return false,
+                        gl::WAIT_FAILED => {
+                            if let Err(err) = self.share.check() {
+                                error!("Error when waiting on fence: {:?}", err);
+                            }
+                            return false
+                        }
+                        _ => (),
+                    }
+                }
+                // All fences have indicated a positive result
+                true
+            },
+            d::WaitFor::Any => {
+                let mut waiting = |timeout_ms: u32| {
+                    for fence in fences {
+                        match wait_fence(fence, &self.share.context, 0) {
+                            gl::ALREADY_SIGNALED | gl::CONDITION_SATISFIED => return true,
+                            gl::WAIT_FAILED => {
+                                if let Err(err) = self.share.check() {
+                                    error!("Error when waiting on fence: {:?}", err);
+                                }
+                                return false
+                            }
+                            _ => (),
+                        }
+                    }
+                    // No fence has indicated a postive result
+                    false
+                };
+
+                // Short-circuit:
+                //   Check current state of all fences first,
+                //   else go trough each fence and wait til at least one has finished
+                waiting(0) || waiting(timeout_ms)
+            },
+        }
     }
 
     fn destroy_heap(&mut self, _: n::Heap) {
@@ -254,7 +382,7 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn destroy_sampler(&mut self, _: n::Sampler) {
+    fn destroy_sampler(&mut self, _: n::FatSampler) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -165,13 +165,13 @@ pub struct PrivateCaps {
     pub array_buffer_supported: bool,
     pub frame_buffer_supported: bool,
     pub immutable_storage_supported: bool,
-    pub sampler_objects_supported: bool,
     pub program_interface_supported: bool,
     pub buffer_storage_supported: bool,
     pub clear_buffer_supported: bool,
     pub frag_data_location_supported: bool,
-    pub sampler_lod_bias_supported: bool,
     pub sync_supported: bool,
+    /// Indicates if we only have support via the EXT.
+    pub sampler_anisotropy_ext: bool,
 }
 
 /// OpenGL implementation information
@@ -301,30 +301,39 @@ pub fn get(gl: &gl::Gl) -> (Info, Features, Limits, PrivateCaps) {
                                                                 Es  (3,0),
                                                                 Ext ("GL_ARB_copy_buffer"),
                                                                 Ext ("GL_NV_copy_buffer")]),
+        sampler_objects:                    info.is_supported(&[Core(3,3),
+                                                                Es  (3,0),
+                                                                Ext ("GL_ARB_sampler_objects")]),
+        sampler_lod_bias:                   info.is_supported(&[Core(3,3)]), // TODO: extension
+        sampler_anisotropy:                 info.is_supported(&[Core(4,6),
+                                                                Ext ("GL_ARB_texture_filter_anisotropic"),
+                                                                Ext ("GL_EXT_texture_filter_anisotropic")]),
+        sampler_border_color:               info.is_supported(&[Core(3,3)]), // TODO: extensions
     };
     let private = PrivateCaps {
-        array_buffer_supported:            info.is_supported(&[Core(3,0),
-                                                               Es  (3,0),
-                                                               Ext ("GL_ARB_vertex_array_object")]),
-        frame_buffer_supported:            info.is_supported(&[Core(3,0),
-                                                               Es  (2,0),
-                                                               Ext ("GL_ARB_framebuffer_object")]),
-        immutable_storage_supported:       info.is_supported(&[Core(3,2),
-                                                               Ext ("GL_ARB_texture_storage")]),
-        sampler_objects_supported:         info.is_supported(&[Core(3,3),
-                                                               Es  (3,0),
-                                                               Ext ("GL_ARB_sampler_objects")]),
-        program_interface_supported:       info.is_supported(&[Core(4,3),
-                                                               Ext ("GL_ARB_program_interface_query")]),
-        buffer_storage_supported:          info.is_supported(&[Core(4,4),
-                                                               Ext ("GL_ARB_buffer_storage")]),
-        clear_buffer_supported:            info.is_supported(&[Core(3,0),
-                                                               Es  (3,0)]),
-        frag_data_location_supported:      !info.version.is_embedded,
-        sampler_lod_bias_supported:        !info.version.is_embedded,
-        sync_supported:                    info.is_supported(&[Core(3,2),
-                                                               Es  (3,0),
-                                                               Ext ("GL_ARB_sync")]),
+        array_buffer_supported:             info.is_supported(&[Core(3,0),
+                                                                Es  (3,0),
+                                                                Ext ("GL_ARB_vertex_array_object")]),
+        frame_buffer_supported:             info.is_supported(&[Core(3,0),
+                                                                Es  (2,0),
+                                                                Ext ("GL_ARB_framebuffer_object")]),
+        immutable_storage_supported:        info.is_supported(&[Core(3,2),
+                                                                Ext ("GL_ARB_texture_storage")]),
+
+        program_interface_supported:        info.is_supported(&[Core(4,3),
+                                                                Ext ("GL_ARB_program_interface_query")]),
+        buffer_storage_supported:           info.is_supported(&[Core(4,4),
+                                                                Ext ("GL_ARB_buffer_storage")]),
+        clear_buffer_supported:             info.is_supported(&[Core(3,0),
+                                                                Es  (3,0)]),
+        frag_data_location_supported:       !info.version.is_embedded,
+
+        sync_supported:                     info.is_supported(&[Core(3,2),
+                                                                Es  (3,0),
+                                                                Ext ("GL_ARB_sync")]),
+        sampler_anisotropy_ext:             !info.is_supported(&[Core(4,6),
+                                                                Ext ("GL_ARB_texture_filter_anisotropic")]) &&
+                                            info.is_supported(&[Ext ("GL_EXT_texture_filter_anisotropic")]),
     };
 
     (info, features, limits, private)

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -50,7 +50,6 @@ impl c::Backend for Backend {
     type CommandQueue = CommandQueue;
     type CommandBuffer = command::RawCommandBuffer;
     type SubpassCommandBuffer = command::SubpassCommandBuffer;
-    type SubmitInfo = command::SubmitInfo;
     type QueueFamily = QueueFamily;
 
     type Heap = native::Heap;
@@ -887,8 +886,8 @@ impl c::RawCommandQueue<Backend> for CommandQueue {
         {
             for cb in submit_info.cmd_buffers {
                 self.reset_state();
-                for com in &*cb.buf {
-                    self.process(com, &*cb.data);
+                for com in &cb.buf {
+                    self.process(com, &cb.data);
                 }
             }
         }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -65,7 +65,7 @@ impl c::Backend for Backend {
     type Buffer = native::Buffer;
     type UnboundImage = device::UnboundImage;
     type Image = native::Image;
-    type Sampler = native::Sampler;
+    type Sampler = native::FatSampler;
 
     type ConstantBufferView = native::ConstantBufferView;
     type ShaderResourceView = native::ShaderResourceView;

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -81,11 +81,11 @@ pub enum Image {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-// Additionally storing the `SamplerInfo` for older OpenGL versions, which
-// don't support separate sampler objects.
-pub struct FatSampler {
-    pub(crate) object: Sampler,
-    pub(crate) info: i::SamplerInfo,
+/// Additionally storing the `SamplerInfo` for older OpenGL versions, which
+/// don't support separate sampler objects.
+pub enum FatSampler {
+    Sampler(Sampler),
+    Info(i::SamplerInfo),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -33,6 +33,12 @@ pub struct Fence(pub Cell<gl::types::GLsync>);
 unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}
 
+impl Fence {
+    pub fn new(sync: gl::types::GLsync) -> Self {
+        Fence(Cell::new(sync))
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct ResourceView {
     pub(crate) object: Texture,
@@ -75,6 +81,8 @@ pub enum Image {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+// Additionally storing the `SamplerInfo` for older OpenGL versions, which
+// don't support separate sampler objects.
 pub struct FatSampler {
     pub(crate) object: Sampler,
     pub(crate) info: i::SamplerInfo,
@@ -135,6 +143,8 @@ pub struct DepthStencilView;
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]
 pub struct PipelineLayout;
+
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]
+// No inter-queue synchronization required for GL.
 pub struct Semaphore;

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -134,6 +134,14 @@ pub struct Features {
     pub separate_blending_slots: bool,
     /// Support accelerated buffer copy.
     pub copy_buffer: bool,
+    /// Support separation of textures and samplers.
+    pub sampler_objects: bool,
+    /// Support sampler LOD bias.
+    pub sampler_lod_bias: bool,
+    /// Support anisotropic filtering.
+    pub sampler_anisotropy: bool,
+    /// Support setting border texel colors.
+    pub sampler_border_color: bool,
 }
 
 /// Limits of the device.


### PR DESCRIPTION
* Fix GL backend build after command pool changes #1457 (pool reset still WIP)
* Implement fence and semaphore handling (ported from the old implementation)
* Implement sampler creation, adding few more features to properly reflect capabilities of the backend