### PR TITLE
[ll] gl: Command pool resetting

### DIFF
--- a/examples/core/quad/main.rs
+++ b/examples/core/quad/main.rs
@@ -26,7 +26,7 @@ extern crate gfx_device_metal as back;
 extern crate winit;
 extern crate image;
 
-use core::{buffer, command, device as d, image as i, memory as m, pass, pso, state};
+use core::{buffer, command, device as d, image as i, memory as m, pass, pso, pool, state};
 use core::{Adapter, Device, QueueFamily, SwapChain, WindowExt};
 use core::{DescriptorPool, Gpu, FrameSync, Primitive, Surface, SwapchainConfig};
 use core::format::{Formatted, Srgba8 as ColorFormat, Vec2};
@@ -337,7 +337,7 @@ fn main() {
 
     let mut frame_semaphore = device.create_semaphore();
     let mut frame_fence = device.create_fence(false); // TODO: remove
-    let mut graphics_pool = queue.create_graphics_pool(16);
+    let mut graphics_pool = queue.create_graphics_pool(16, pool::CommandPoolCreateFlags::empty());
 
     // copy buffer to texture
     {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -3,7 +3,7 @@
 
 extern crate gfx_core as core;
 
-use core::{buffer, command, device, format, image, target, mapping, memory, pass, pso};
+use core::{buffer, command, device, format, image, target, mapping, memory, pass, pool, pso};
 use core::device::{TargetViewError};
 
 /// Dummy backend.
@@ -285,7 +285,7 @@ impl core::RawCommandPool<Backend> for RawCommandPool {
         unimplemented!()
     }
 
-    unsafe fn from_queue(_: &CommandQueue) -> Self {
+    unsafe fn from_queue(_: &CommandQueue, _: pool::CommandPoolCreateFlags) -> Self {
         unimplemented!()
     }
 
@@ -316,6 +316,9 @@ impl core::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
+    fn reset(&mut self, _: bool) {
+        unimplemented!()
+    }
 
     fn pipeline_barrier(&mut self, _: &[memory::Barrier<Backend>]) {
         unimplemented!()

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -155,7 +155,6 @@ impl From<c::Limits> for Limits {
 pub struct RawCommandBuffer {
     pub(crate) memory: Arc<RefCell<pool::OwnedBuffer>>,
     pub(crate) buf: BufferSlice,
-    pub(crate) data: BufferSlice,
     // Buffer id for the owning command pool.
     // Only relevant if individual resets are allowed.
     pub(crate) id: u64,
@@ -201,7 +200,6 @@ impl RawCommandBuffer {
         RawCommandBuffer {
             memory,
             buf: BufferSlice::new(),
-            data: BufferSlice::new(),
             id,
             fbo,
             display_fb: 0 as n::FrameBuffer,
@@ -215,7 +213,6 @@ impl RawCommandBuffer {
     // of the owning pool.
     pub(crate) fn soft_reset(&mut self) {
         self.buf = BufferSlice::new();
-        self.data = BufferSlice::new();
         self.cache = Cache::new();
     }
 
@@ -236,15 +233,11 @@ impl RawCommandBuffer {
     /// Copy a given u8 slice into the data buffer.
     fn add_raw(&mut self, data: &[u8]) -> BufferSlice {
         let mut data_buffer = &mut self.memory.borrow_mut().data;
-        let slice = {
-            data_buffer.extend_from_slice(data);
-            BufferSlice {
-                offset: (data_buffer.len() - data.len()) as u32,
-                size: data.len() as u32,
-            }
-        };
-        self.data.append(slice);
-        slice
+        data_buffer.extend_from_slice(data);
+        BufferSlice {
+            offset: (data_buffer.len() - data.len()) as u32,
+            size: data.len() as u32,
+        }
     }
 
     fn is_main_target(&self, tv: n::TargetView) -> bool {

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -15,15 +15,16 @@
 #![allow(missing_docs)]
 
 use gl;
-use core::{self as c, command, image, memory, state as s, target, Viewport};
+use core::{self as c, command, image, memory, target, Viewport};
 use core::buffer::IndexBufferView;
 use core::command::{BufferCopy, BufferImageCopy, ClearValue, ImageCopy, ImageResolve,
                     InstanceParams, SubpassContents};
 use core::target::{ColorValue, Stencil};
 use {native as n, Backend};
-use pool::BufferMemory;
+use pool::{self, BufferMemory};
+use std::cell::RefCell;
 use std::mem;
-use std::slice::Iter;
+use std::sync::Arc;
 
 // Command buffer implementation details:
 //
@@ -38,11 +39,18 @@ use std::slice::Iter;
 /// The place of some data in a buffer.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct BufferSlice {
-    offset: u32,
-    size: u32,
+    pub offset: u32,
+    pub size: u32,
 }
 
 impl BufferSlice {
+    fn new() -> Self {
+        BufferSlice {
+            offset: 0,
+            size: 0,
+        }
+    }
+
     // Append a data pointer, resulting in one data pointer
     // covering the whole memory region.
     fn append(&mut self, other: BufferSlice) {
@@ -53,103 +61,6 @@ impl BufferSlice {
         } else {
             assert_eq!(self.offset + self.size, other.offset);
             self.size += other.size;
-        }
-    }
-
-    fn contains(&self, other: BufferSlice) -> bool {
-        self.offset <= other.offset &&
-        self.offset + self.size >= other.offset + other.size
-    }
-}
-
-#[derive(Clone)]
-#[allow(missing_copy_implementations)]
-// Owned slice of a (growable) vector owned by a pool.
-pub struct Buffer<T> {
-    buffer: *mut Vec<T>,
-    slice: BufferSlice,
-}
-
-unsafe impl<T> Send for Buffer<T> where T: Send {}
-
-impl<T> Buffer<T> {
-    /// Create a new empty buffer.
-    pub fn new(buffer: &mut Vec<T>) -> Self {
-        Buffer {
-            buffer: buffer as *mut _,
-            slice: BufferSlice { offset: 0, size: 0 },
-        }
-    }
-
-    // Only set the reserved slice length to 0.
-    // Doesn't clear the actual data.
-    fn soft_reset(&mut self) {
-        self.slice = BufferSlice { offset: 0, size: 0 };
-    }
-
-    // Soft resets the buffer and additionally clears the _whole_ internal buffer.
-    fn reset(&mut self) {
-        self.soft_reset();
-        unsafe { (*self.buffer).clear(); }
-    }
-}
-
-pub type CommandBuffer = Buffer<Command>;
-pub type DataBuffer = Buffer<u8>;
-
-impl CommandBuffer {
-    fn push(&mut self, cmd: Command) {
-        unsafe {
-            (*self.buffer).push(cmd);
-            self.slice.append(
-                BufferSlice {
-                    offset: (*self.buffer).len() as u32 - 1,
-                    size: 1,
-                });
-        }
-    }
-}
-
-impl<'a> IntoIterator for &'a CommandBuffer {
-    type Item = &'a Command;
-    type IntoIter = Iter<'a, Command>;
-    fn into_iter(self) -> Self::IntoIter {
-        unsafe {
-            assert!((*self.buffer).len() >= (self.slice.offset+self.slice.size) as usize);
-            (*self.buffer)[self.slice.offset as usize..(self.slice.offset+self.slice.size) as usize].into_iter()
-        }
-    }
-}
-
-impl DataBuffer {
-    /// Copy a given vector slice into the buffer.
-    fn add<T>(&mut self, data: &[T]) -> BufferSlice {
-        self.add_raw(unsafe { mem::transmute(data) })
-    }
-    /// Copy a given u8 slice into the buffer.
-    fn add_raw(&mut self, data: &[u8]) -> BufferSlice {
-        let slice = unsafe {
-            (*self.buffer).extend_from_slice(data);
-            BufferSlice {
-                offset: ((*self.buffer).len() - data.len()) as u32,
-                size: data.len() as u32,
-            }
-        };
-        self.slice.append(slice);
-        slice
-    }
-    /// Return a reference to a stored data object.
-    pub fn get<T>(&self, ptr: BufferSlice) -> &[T] {
-        assert_eq!(ptr.size % mem::size_of::<T>() as u32, 0);
-        let raw_data = self.get_raw(ptr);
-        unsafe { mem::transmute(raw_data) }
-    }
-    /// Return a reference to a stored data object.
-    pub fn get_raw(&self, ptr: BufferSlice) -> &[u8] {
-        assert!(self.slice.contains(ptr));
-        unsafe {
-            assert!((*self.buffer).len() >= (ptr.offset + ptr.size) as usize);
-            &(*self.buffer)[ptr.offset as usize..(ptr.offset + ptr.size) as usize]
         }
     }
 }
@@ -242,8 +153,9 @@ impl From<c::Limits> for Limits {
 /// `display_fb` field.
 #[derive(Clone)]
 pub struct RawCommandBuffer {
-    pub(crate) buf: CommandBuffer,
-    pub(crate) data: DataBuffer,
+    pub(crate) memory: Arc<RefCell<pool::OwnedBuffer>>,
+    pub(crate) buf: BufferSlice,
+    pub(crate) data: BufferSlice,
     // Buffer id for the owning command pool.
     // Only relevant if individual resets are allowed.
     pub(crate) id: u64,
@@ -264,30 +176,32 @@ pub struct RawCommandBuffer {
     active_attribs: usize,
 }
 
+unsafe impl Send for RawCommandBuffer { }
+
 impl RawCommandBuffer {
     pub(crate) fn new(
         fbo: n::FrameBuffer,
         limits: Limits,
         memory: &mut BufferMemory,
     ) -> Self {
-        let (buf, data, id) = match *memory {
-            BufferMemory::Linear { ref mut commands, ref mut data } => {
-                (CommandBuffer::new(commands), DataBuffer::new(data), 0)
+        let (memory, id) = match *memory {
+            BufferMemory::Linear(ref buffer) => {
+                (buffer.clone(), 0)
             }
             BufferMemory::Individual { ref mut storage, ref mut next_buffer_id } => {
                 // Add a new pair of buffers
-                storage.insert(*next_buffer_id, (Vec::new(), Vec::new()));
+                let buffer = Arc::new(RefCell::new(pool::OwnedBuffer::new()));
+                storage.insert(*next_buffer_id, buffer.clone());
                 let id = *next_buffer_id;
                 *next_buffer_id += 1;
-
-                let &mut (ref mut commands, ref mut data) = storage.get_mut(&id).unwrap();
-                (CommandBuffer::new(commands), DataBuffer::new(data), id)
+                (buffer, id)
             }
         };
 
         RawCommandBuffer {
-            buf,
-            data,
+            memory,
+            buf: BufferSlice::new(),
+            data: BufferSlice::new(),
             id,
             fbo,
             display_fb: 0 as n::FrameBuffer,
@@ -300,9 +214,37 @@ impl RawCommandBuffer {
     // Soft reset only the buffers, but doesn't free any memory or clears memory
     // of the owning pool.
     pub(crate) fn soft_reset(&mut self) {
-        self.buf.soft_reset();
-        self.data.soft_reset();
+        self.buf = BufferSlice::new();
+        self.data = BufferSlice::new();
         self.cache = Cache::new();
+    }
+
+    fn push_cmd(&mut self, cmd: Command) {
+        let mut cmd_buffer = &mut self.memory.borrow_mut().commands;
+        cmd_buffer.push(cmd);
+        self.buf.append(
+            BufferSlice {
+                offset: cmd_buffer.len() as u32 - 1,
+                size: 1,
+            });
+    }
+
+    /// Copy a given vector slice into the data buffer.
+    fn add<T>(&mut self, data: &[T]) -> BufferSlice {
+        self.add_raw(unsafe { mem::transmute(data) })
+    }
+    /// Copy a given u8 slice into the data buffer.
+    fn add_raw(&mut self, data: &[u8]) -> BufferSlice {
+        let mut data_buffer = &mut self.memory.borrow_mut().data;
+        let slice = {
+            data_buffer.extend_from_slice(data);
+            BufferSlice {
+                offset: (data_buffer.len() - data.len()) as u32,
+                size: data.len() as u32,
+            }
+        };
+        self.data.append(slice);
+        slice
     }
 
     fn is_main_target(&self, tv: n::TargetView) -> bool {
@@ -324,9 +266,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         //       Currently works under the assumption that the user
         //       calls this function API conform.
         // TODO: should use the `release_resources` and shrink the buffers?
-        self.buf.reset();
-        self.data.reset();
-        self.cache = Cache::new();
+        self.soft_reset();
+        let mut buffer = self.memory.borrow_mut();
+        buffer.commands.clear();
+        buffer.data.clear();
     }
 
     fn pipeline_barrier(&mut self, barries: &[memory::Barrier<Backend>]) {
@@ -359,14 +302,16 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         value: command::ClearColor,
     ) {
         if self.is_main_target(rtv.view) {
-            self.buf.push(Command::BindFrameBuffer(gl::DRAW_FRAMEBUFFER, self.display_fb));
+            let fbo = self.display_fb;
+            self.push_cmd(Command::BindFrameBuffer(gl::DRAW_FRAMEBUFFER, fbo));
         } else {
-            self.buf.push(Command::BindFrameBuffer(gl::DRAW_FRAMEBUFFER, self.fbo));
-            self.buf.push(Command::BindTargetView(gl::DRAW_FRAMEBUFFER, gl::COLOR_ATTACHMENT0, rtv.view));
-            self.buf.push(Command::SetDrawColorBuffers(1));
+            let fbo = self.fbo;
+            self.push_cmd(Command::BindFrameBuffer(gl::DRAW_FRAMEBUFFER, fbo));
+            self.push_cmd(Command::BindTargetView(gl::DRAW_FRAMEBUFFER, gl::COLOR_ATTACHMENT0, rtv.view));
+            self.push_cmd(Command::SetDrawColorBuffers(1));
         }
 
-        self.buf.push(Command::ClearColor(rtv.view, value));
+        self.push_cmd(Command::ClearColor(rtv.view, value));
     }
 
     fn clear_depth_stencil(
@@ -397,7 +342,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         }
 
         self.cache.index_type = Some(ibv.index_type);
-        self.buf.push(Command::BindIndexBuffer(*ibv.buffer));
+        self.push_cmd(Command::BindIndexBuffer(*ibv.buffer));
     }
 
     fn bind_vertex_buffers(&mut self, vbs: c::pso::VertexBufferSet<Backend>) {
@@ -421,13 +366,13 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
                 for viewport in viewports {
                     let viewport = &[viewport.x as f32, viewport.y as f32, viewport.w as f32, viewport.h as f32];
-                    viewport_ptr.append(self.data.add::<f32>(viewport));
+                    viewport_ptr.append(self.add::<f32>(viewport));
                 }
                 for viewport in viewports {
                     let depth_range = &[viewport.near as f64, viewport.far as f64];
-                    depth_range_ptr.append(self.data.add::<f64>(depth_range));
+                    depth_range_ptr.append(self.add::<f64>(depth_range));
                 }
-                self.buf.push(Command::SetViewports { viewport_ptr, depth_range_ptr });
+                self.push_cmd(Command::SetViewports { viewport_ptr, depth_range_ptr });
             }
             _ => {
                 error!("Number of viewports exceeds the number of maximum viewports");
@@ -446,9 +391,9 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
                 let mut scissors_ptr = BufferSlice { offset: 0, size: 0 };
                 for scissor in scissors {
                     let scissor = &[scissor.x as i32, scissor.y as i32, scissor.w as i32, scissor.h as i32];
-                    scissors_ptr.append(self.data.add::<i32>(scissor));
+                    scissors_ptr.append(self.add::<i32>(scissor));
                 }
-                self.buf.push(Command::SetScissors(scissors_ptr));
+                self.push_cmd(Command::SetScissors(scissors_ptr));
             }
             _ => {
                 error!("Number of scissors exceeds the number of maximum viewports");
@@ -467,7 +412,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     fn set_blend_constants(&mut self, cv: target::ColorValue) {
         if self.cache.blend_color != Some(cv) {
             self.cache.blend_color = Some(cv);
-            self.buf.push(Command::SetBlendColor(cv));
+            self.push_cmd(Command::SetBlendColor(cv));
         }
     }
 
@@ -489,11 +434,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
     fn dispatch(&mut self, x: u32, y: u32, z: u32) {
-        self.buf.push(Command::Dispatch(x, y, z));
+        self.push_cmd(Command::Dispatch(x, y, z));
     }
 
     fn dispatch_indirect(&mut self, buffer: &n::Buffer, offset: u64) {
-        self.buf.push(Command::DispatchIndirect(*buffer, offset));
+        self.push_cmd(Command::DispatchIndirect(*buffer, offset));
     }
 
     fn copy_buffer(&mut self, src: &n::Buffer, dst: &n::Buffer, regions: &[BufferCopy]) {
@@ -539,7 +484,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     ) {
         match self.cache.primitive {
             Some(primitive) => {
-                self.buf.push(
+                self.push_cmd(
                     Command::Draw {
                         primitive,
                         start,
@@ -573,7 +518,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         };
         match self.cache.primitive {
             Some(primitive) => {
-                self.buf.push(
+                self.push_cmd(
                     Command::DrawIndexed {
                         primitive,
                         index_type,

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -21,19 +21,31 @@ use core::command::{BufferCopy, BufferImageCopy, ClearValue, ImageCopy, ImageRes
                     InstanceParams, SubpassContents};
 use core::target::{ColorValue, Stencil};
 use {native as n, Backend};
-use std::{mem};
+use pool::BufferMemory;
+use std::mem;
+use std::slice::Iter;
 
-/// The place of some data in the data buffer.
+// Command buffer implementation details:
+//
+// The underlying commands and data are stored inside the associated command pool.
+// See the comments for further safety requirements.
+// Each command buffer holds a (growable) slice of the buffers (`CommandBuffer`
+// and `DataBuffer`) in the pool.
+//
+// Command buffers are recorded one-after-another for each command pool.
+// Actual storage depends on the resetting behavior of the pool.
+
+/// The place of some data in a buffer.
 #[derive(Clone, Copy, PartialEq, Debug)]
-pub struct DataPointer {
+pub struct BufferSlice {
     offset: u32,
     size: u32,
 }
 
-impl DataPointer {
+impl BufferSlice {
     // Append a data pointer, resulting in one data pointer
     // covering the whole memory region.
-    fn append(&mut self, other: DataPointer) {
+    fn append(&mut self, other: BufferSlice) {
         if self.size == 0 {
             // Empty or dummy pointer
             self.offset = other.offset;
@@ -43,36 +55,102 @@ impl DataPointer {
             self.size += other.size;
         }
     }
+
+    fn contains(&self, other: BufferSlice) -> bool {
+        self.offset <= other.offset &&
+        self.offset + self.size >= other.offset + other.size
+    }
 }
 
 #[derive(Clone)]
-pub struct DataBuffer(Vec<u8>);
-impl DataBuffer {
-    /// Create a new empty data buffer.
-    pub fn new() -> DataBuffer {
-        DataBuffer(Vec::new())
+#[allow(missing_copy_implementations)]
+// Owned slice of a (growable) vector owned by a pool.
+pub struct Buffer<T> {
+    buffer: *mut Vec<T>,
+    slice: BufferSlice,
+}
+
+unsafe impl<T> Send for Buffer<T> where T: Send {}
+
+impl<T> Buffer<T> {
+    /// Create a new empty buffer.
+    pub fn new(buffer: &mut Vec<T>) -> Self {
+        Buffer {
+            buffer: buffer as *mut _,
+            slice: BufferSlice { offset: 0, size: 0 },
+        }
     }
+
+    // Only set the reserved slice length to 0.
+    // Doesn't clear the actual data.
+    fn soft_reset(&mut self) {
+        self.slice = BufferSlice { offset: 0, size: 0 };
+    }
+
+    // Soft resets the buffer and additionally clears the _whole_ internal buffer.
+    fn reset(&mut self) {
+        self.soft_reset();
+        unsafe { (*self.buffer).clear(); }
+    }
+}
+
+pub type CommandBuffer = Buffer<Command>;
+pub type DataBuffer = Buffer<u8>;
+
+impl CommandBuffer {
+    fn push(&mut self, cmd: Command) {
+        unsafe {
+            (*self.buffer).push(cmd);
+            self.slice.append(
+                BufferSlice {
+                    offset: (*self.buffer).len() as u32 - 1,
+                    size: 1,
+                });
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a CommandBuffer {
+    type Item = &'a Command;
+    type IntoIter = Iter<'a, Command>;
+    fn into_iter(self) -> Self::IntoIter {
+        unsafe {
+            assert!((*self.buffer).len() >= (self.slice.offset+self.slice.size) as usize);
+            (*self.buffer)[self.slice.offset as usize..(self.slice.offset+self.slice.size) as usize].into_iter()
+        }
+    }
+}
+
+impl DataBuffer {
     /// Copy a given vector slice into the buffer.
-    fn add<T>(&mut self, data: &[T]) -> DataPointer {
+    fn add<T>(&mut self, data: &[T]) -> BufferSlice {
         self.add_raw(unsafe { mem::transmute(data) })
     }
     /// Copy a given u8 slice into the buffer.
-    fn add_raw(&mut self, data: &[u8]) -> DataPointer {
-        self.0.extend_from_slice(data);
-        DataPointer {
-            offset: (self.0.len() - data.len()) as u32,
-            size: data.len() as u32,
-        }
+    fn add_raw(&mut self, data: &[u8]) -> BufferSlice {
+        let slice = unsafe {
+            (*self.buffer).extend_from_slice(data);
+            BufferSlice {
+                offset: ((*self.buffer).len() - data.len()) as u32,
+                size: data.len() as u32,
+            }
+        };
+        self.slice.append(slice);
+        slice
     }
     /// Return a reference to a stored data object.
-    pub fn get<T>(&self, ptr: DataPointer) -> &[T] {
+    pub fn get<T>(&self, ptr: BufferSlice) -> &[T] {
         assert_eq!(ptr.size % mem::size_of::<T>() as u32, 0);
         let raw_data = self.get_raw(ptr);
         unsafe { mem::transmute(raw_data) }
     }
     /// Return a reference to a stored data object.
-    pub fn get_raw(&self, ptr: DataPointer) -> &[u8] {
-        &self.0[ptr.offset as usize..(ptr.offset + ptr.size) as usize]
+    pub fn get_raw(&self, ptr: BufferSlice) -> &[u8] {
+        assert!(self.slice.contains(ptr));
+        unsafe {
+            assert!((*self.buffer).len() >= (ptr.offset + ptr.size) as usize);
+            &(*self.buffer)[ptr.offset as usize..(ptr.offset + ptr.size) as usize]
+        }
     }
 }
 
@@ -96,12 +174,12 @@ pub enum Command {
         instances: Option<InstanceParams>,
     },
     BindIndexBuffer(gl::types::GLuint),
-    BindVertexBuffers(DataPointer),
+    BindVertexBuffers(BufferSlice),
     SetViewports {
-        viewport_ptr: DataPointer,
-        depth_range_ptr: DataPointer,
+        viewport_ptr: BufferSlice,
+        depth_range_ptr: BufferSlice,
     },
-    SetScissors(DataPointer),
+    SetScissors(BufferSlice),
     SetBlendColor(ColorValue),
     ClearColor(n::TargetView, command::ClearColor),
     BindFrameBuffer(FrameBufferTarget, n::FrameBuffer),
@@ -164,8 +242,12 @@ impl From<c::Limits> for Limits {
 /// `display_fb` field.
 #[derive(Clone)]
 pub struct RawCommandBuffer {
-    pub buf: Vec<Command>,
-    pub data: DataBuffer,
+    pub(crate) buf: CommandBuffer,
+    pub(crate) data: DataBuffer,
+    // Buffer id for the owning command pool.
+    // Only relevant if individual resets are allowed.
+    pub(crate) id: u64,
+
     fbo: n::FrameBuffer,
     /// The framebuffer to use for rendering to the main targets (0 by default).
     ///
@@ -183,10 +265,30 @@ pub struct RawCommandBuffer {
 }
 
 impl RawCommandBuffer {
-    pub(crate) fn new(fbo: n::FrameBuffer, limits: Limits) -> Self {
+    pub(crate) fn new(
+        fbo: n::FrameBuffer,
+        limits: Limits,
+        memory: &mut BufferMemory,
+    ) -> Self {
+        let (buf, data, id) = match *memory {
+            BufferMemory::Linear { ref mut commands, ref mut data } => {
+                (CommandBuffer::new(commands), DataBuffer::new(data), 0)
+            }
+            BufferMemory::Individual { ref mut storage, ref mut next_buffer_id } => {
+                // Add a new pair of buffers
+                storage.insert(*next_buffer_id, (Vec::new(), Vec::new()));
+                let id = *next_buffer_id;
+                *next_buffer_id += 1;
+
+                let &mut (ref mut commands, ref mut data) = storage.get_mut(&id).unwrap();
+                (CommandBuffer::new(commands), DataBuffer::new(data), id)
+            }
+        };
+
         RawCommandBuffer {
-            buf: Vec::new(),
-            data: DataBuffer::new(),
+            buf,
+            data,
+            id,
             fbo,
             display_fb: 0 as n::FrameBuffer,
             cache: Cache::new(),
@@ -195,9 +297,11 @@ impl RawCommandBuffer {
         }
     }
 
-    pub(crate) fn reset(&mut self) {
-        self.buf.clear();
-        self.data.0.clear();
+    // Soft reset only the buffers, but doesn't free any memory or clears memory
+    // of the owning pool.
+    pub(crate) fn soft_reset(&mut self) {
+        self.buf.soft_reset();
+        self.data.soft_reset();
         self.cache = Cache::new();
     }
 
@@ -213,6 +317,16 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
     fn finish(&mut self) {
         // no-op
+    }
+
+    fn reset(&mut self, _release_resources: bool) {
+        // TODO: error when calling this for linear memory storage
+        //       Currently works under the assumption that the user
+        //       calls this function API conform.
+        // TODO: should use the `release_resources` and shrink the buffers?
+        self.buf.reset();
+        self.data.reset();
+        self.cache = Cache::new();
     }
 
     fn pipeline_barrier(&mut self, barries: &[memory::Barrier<Backend>]) {
@@ -302,8 +416,8 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
                 //
                 // We try to store everything into a contiguous block of memory,
                 // which allows us to avoid memory allocations when executing the commands.
-                let mut viewport_ptr = DataPointer { offset: 0, size: 0 };
-                let mut depth_range_ptr = DataPointer { offset: 0, size: 0 };
+                let mut viewport_ptr = BufferSlice { offset: 0, size: 0 };
+                let mut depth_range_ptr = BufferSlice { offset: 0, size: 0 };
 
                 for viewport in viewports {
                     let viewport = &[viewport.x as f32, viewport.y as f32, viewport.w as f32, viewport.h as f32];
@@ -329,7 +443,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
                 self.cache.error_state = true;
             }
             n if n <= self.limits.max_viewports => {
-                let mut scissors_ptr = DataPointer { offset: 0, size: 0 };
+                let mut scissors_ptr = BufferSlice { offset: 0, size: 0 };
                 for scissor in scissors {
                     let scissor = &[scissor.x as i32, scissor.y as i32, scissor.w as i32, scissor.h as i32];
                     scissors_ptr.append(self.data.add::<i32>(scissor));
@@ -493,16 +607,5 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 }
 
 /// A subpass command buffer abstraction for OpenGL
-pub struct SubpassCommandBuffer {
-    pub buf: Vec<Command>,
-    pub data: DataBuffer,
-}
-
-impl SubpassCommandBuffer {
-    pub fn new() -> Self {
-        SubpassCommandBuffer {
-            buf: Vec::new(),
-            data: DataBuffer::new(),
-        }
-    }
-}
+#[allow(missing_copy_implementations)]
+pub struct SubpassCommandBuffer;

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use core::{self, pool};
-use command::{self, RawCommandBuffer, SubpassCommandBuffer};
+use command::{self, Command, RawCommandBuffer, SubpassCommandBuffer};
 use native as n;
 use {Backend, CommandQueue, Share};
 use gl;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 fn create_fbo_internal(gl: &gl::Gl) -> gl::types::GLuint {
@@ -28,32 +29,99 @@ fn create_fbo_internal(gl: &gl::Gl) -> gl::types::GLuint {
     name
 }
 
-#[allow(missing_copy_implementations)]
+// Storage of command buffer memory.
+// Depends on the reset model chosen when creating the command pool.
+pub enum BufferMemory {
+    // Storing all recorded commands and data in the pool in a linear
+    // piece of memory shared by all associated command buffers.
+    //
+    // # Safety!
+    //
+    // This implementation heavily relays on the fact that the user **must**
+    // ensure that only **one** associated command buffer from each pool
+    // is recorded at the same time. Additionally, we only allow to reset the
+    // whole command pool. This allows us to avoid fragmentation of the memory
+    // and saves us additional bookkeeping overhead for keeping track of all
+    // allocated buffers.
+    //
+    // Reseting the pool will free all data and commands recorded. Therefore it's
+    // crucial that all submits have been finished **before** calling `reset`.
+    Linear {
+        commands: Vec<Command>,
+        data: Vec<u8>,
+    },
+    // Storing the memory for each command buffer separately to allow individual
+    // command buffer resets.
+    Individual {
+        storage: HashMap<u64, (Vec<Command>, Vec<u8>)>,
+        next_buffer_id: u64,
+    },
+}
+
 pub struct RawCommandPool {
     fbo: n::FrameBuffer,
     limits: command::Limits,
+    memory: BufferMemory,
 }
 
 impl core::RawCommandPool<Backend> for RawCommandPool {
     fn reset(&mut self) {
-        unimplemented!()
+        match self.memory {
+            BufferMemory::Linear { ref mut commands, ref mut data } => {
+                commands.clear();
+                data.clear();
+            }
+            BufferMemory::Individual { ref mut storage, .. } => {
+                for (_, &mut (ref mut commands, ref mut data)) in storage {
+                    commands.clear();
+                    data.clear();
+                }
+            }
+        }
     }
 
-    unsafe fn from_queue(mut queue: &CommandQueue) -> Self {
+    unsafe fn from_queue(mut queue: &CommandQueue, flags: pool::CommandPoolCreateFlags) -> Self {
         let fbo = create_fbo_internal(&queue.share.context);
         let limits = queue.share.limits.into();
+        let memory = if flags.contains(pool::RESET_INDIVIDUAL) {
+            BufferMemory::Individual {
+                storage: HashMap::new(),
+                next_buffer_id: 0,
+            }
+        } else {
+            BufferMemory::Linear {
+                commands: Vec::new(),
+                data: Vec::new(),
+            }
+        };
+
+        // Ignoring `TRANSIENT` hint, unsure how to make use of this.
+
         RawCommandPool {
             fbo,
             limits,
+            memory,
         }
     }
 
     fn allocate(&mut self, num: usize) -> Vec<RawCommandBuffer> {
-        (0..num).map(|_| RawCommandBuffer::new(self.fbo, self.limits)).collect()
+        (0..num).map(|_|
+                    RawCommandBuffer::new(
+                        self.fbo,
+                        self.limits,
+                        &mut self.memory))
+                .collect()
     }
 
-    unsafe fn free(&mut self, buffer: Vec<RawCommandBuffer>) {
-        // no-op
+    unsafe fn free(&mut self, buffers: Vec<RawCommandBuffer>) {
+        if let BufferMemory::Individual { ref mut storage, .. } = self.memory {
+            // Expecting that the buffers actually are allocated from this pool.
+            for buffer in buffers {
+                storage.remove(&buffer.id);
+            }
+        }
+        // Linear: Freeing doesn't really matter here as everything is backed by
+        //         only one Vec.
     }
 }
 

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -56,10 +56,22 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         );
     }
 
-    fn finish(&mut self)  {
+    fn finish(&mut self) {
         assert_eq!(Ok(()), unsafe {
             self.device.0.end_command_buffer(self.raw)
         });
+    }
+
+    fn reset(&mut self, release_resources: bool) {
+        let flags = if release_resources {
+            vk::COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT
+        } else {
+            vk::CommandBufferResetFlags ::empty()
+        };
+
+        assert_eq!(Ok(()),
+            unsafe { self.device.0.reset_command_buffer(self.raw, flags) }
+        );
     }
 
     fn begin_renderpass(

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -330,6 +330,10 @@ impl core::Adapter<Backend> for Adapter {
                 unordered_access_view: false,
                 separate_blending_slots: false,
                 copy_buffer: false,
+                sampler_anisotropy: false,
+                sampler_border_color: false,
+                sampler_lod_bias: false,
+                sampler_objects: false,
             },
             limits: Limits {
                 max_texture_size: limits.max_image_dimension3d as usize,

--- a/src/core/src/command/raw.rs
+++ b/src/core/src/command/raw.rs
@@ -29,6 +29,9 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     fn finish(&mut self);
 
     ///
+    fn reset(&mut self, release_resources: bool);
+
+    ///
     fn pipeline_barrier(&mut self, &[Barrier<B>]);
 
     ///

--- a/src/core/src/queue/mod.rs
+++ b/src/core/src/queue/mod.rs
@@ -25,7 +25,7 @@ pub mod capability;
 pub mod submission;
 
 use Backend;
-use pool::CommandPool;
+use pool::{CommandPool, CommandPoolCreateFlags};
 use std::marker::PhantomData;
 
 pub use self::capability::{Compute, Graphics, General, Transfer, Supports};
@@ -117,42 +117,50 @@ impl<B: Backend, C> CommandQueue<B, C> {
     }
 
     ///
-    pub fn create_general_pool(&self,
+    pub fn create_general_pool(
+        &self,
         capacity: usize,
+        flags: CommandPoolCreateFlags,
     ) -> CommandPool<B, General>
     where
         C: Supports<General>
     {
-        CommandPool::from_queue(self, capacity)
+        CommandPool::from_queue(self, capacity, flags)
     }
 
     ///
-    pub fn create_graphics_pool(&self,
+    pub fn create_graphics_pool(
+        &self,
         capacity: usize,
+        flags: CommandPoolCreateFlags,
     ) -> CommandPool<B, Graphics>
     where
         C: Supports<Graphics>
     {
-        CommandPool::from_queue(self, capacity)
+        CommandPool::from_queue(self, capacity, flags)
     }
 
     ///
-    pub fn create_compute_pool(&self,
+    pub fn create_compute_pool(
+        &self,
         capacity: usize,
+        flags: CommandPoolCreateFlags,
     ) -> CommandPool<B, Compute>
     where
         C: Supports<Compute>
     {
-        CommandPool::from_queue(self, capacity)
+        CommandPool::from_queue(self, capacity, flags)
     }
 
     ///
-    pub fn create_transfer_pool(&self,
+    pub fn create_transfer_pool(
+        &self,
         capacity: usize,
+        flags: CommandPoolCreateFlags,
     ) -> CommandPool<B, Transfer>
     where
         C: Supports<Transfer>
     {
-        CommandPool::from_queue(self, capacity)
+        CommandPool::from_queue(self, capacity, flags)
     }
 }


### PR DESCRIPTION
* core: Add possiblity to select reset behavior on pool creation (as exposed in vulkan)
* gl/vk: Implement new reset mechaniccs

The OpenGL implementation is a bit more tricky as we need to internally keep book of the buffer memory at the command pool side to be able to `CommandPool::reset`. We differ between two cases: pool reset only (linear) and allow individual pool resets (individual).

* `Linear` stores all buffer memory inside one (actually two..) large Vec, which is possible as we only allow (not enforced) one buffer to be recorded at the same time for each pool.
* `Individual` requires a bit more bookkeeping (`HashMap`) by splitting the memory storage up into one Vec for each command buffer.

Internally using `Arc<RefCell<_>>` for storing buffers. It's a consensus on the safety side: `*mut Vec<_>` would be more performant but could result in access of already freed memory if the application isn't API conform (undefined behavior for vulkan!). `Arc<Mutex<_>>` would add extra safety if the user tries to record multiple buffers in the `Linear` case but locks would be quite costly.