### PR TITLE
[ll] gl: Add more safety for the command pool memory storage

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -218,12 +218,12 @@ impl RawCommandBuffer {
 
     /// Try to take access of the pool and shared memory.
     pub(crate) fn take_access(&self) -> bool {
-        self.accessible.swap(false, atomic::Ordering::SeqCst)
+        self.accessible.swap(false, atomic::Ordering::Acquire)
     }
 
     /// Release access of the pool and shared memory.
     pub(crate) fn release_access(&self) {
-        self.accessible.store(true, atomic::Ordering::SeqCst)
+        self.accessible.store(true, atomic::Ordering::Release)
     }
 
     // Soft reset only the buffers, but doesn't free any memory or clears memory

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -91,11 +91,11 @@ unsafe impl Send for RawCommandPool {}
 
 impl RawCommandPool {
     fn take_access(&self) -> bool {
-        self.accessible.swap(false, atomic::Ordering::SeqCst)
+        self.accessible.swap(false, atomic::Ordering::Acquire)
     }
 
     fn release_access(&self) {
-        self.accessible.store(true, atomic::Ordering::SeqCst)
+        self.accessible.store(true, atomic::Ordering::Release)
     }
 }
 


### PR DESCRIPTION
* Rework command pool memory storage to work now with a combination of `UnsafeCell` + shared atomic to denote if safe access to the underlying pool and memory is possible. It works similar to a `Mutex` but doesn't block and should be faster. We can revisit the implementation approach on a later stage when we have implemented the rest of the backend imo.

* Fix behavior of `RawCommandBuffer::begin` which should implicitly reset when individual reset flag is set on pool creation
* Emit an error when `reset` is called without the mentioned flag