### PR TITLE
[ll] vk: Fix win32 initialization

### DIFF
--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -41,7 +41,7 @@ impl Instance {
             .expect("Unable to load Vulkan entry points");
 
         let surface = self
-            .surface_extensions
+            .extensions
             .iter()
             .map(|&extension| {
                 match extension {

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use ash::vk;
 use ash::extensions as ext;
+use kernel32;
 
 use {core, winit};
 
@@ -70,7 +71,7 @@ impl Instance {
                     #[cfg(target_os = "windows")]
                     vk::VK_KHR_WIN32_SURFACE_EXTENSION_NAME => {
                         use winit::os::windows::WindowExt;
-                        let win32_loader = ext::Win32Surface::new(entry, &instance.raw.0)
+                        let win32_loader = ext::Win32Surface::new(entry, &self.raw.0)
                             .expect("Unable to load win32 surface functions");
 
                         unsafe {
@@ -82,9 +83,7 @@ impl Instance {
                                 hwnd: window.get_hwnd() as *mut _,
                             };
 
-                            win32_loader
-                                .create_win32_surface_khr(&info, None)
-                                .expect("Error on surface creation")
+                            win32_loader.create_win32_surface_khr(&info, None).ok()
                         }
                     }
                     // TODO: other platforms


### PR DESCRIPTION
* Fix build for surface creation
* Filter request layers to only initialize with available layers, else instance creation can fail (e.g debug layers may not be registered when installing LunarG SDK on windows afaik)