### PR TITLE
[ll] Fix build for CI, rewriting headless test as doc example

### DIFF
--- a/scripts/travis-script.sh
+++ b/scripts/travis-script.sh
@@ -8,9 +8,6 @@ fi
 export RUST_BACKTRACE=1
 
 EXCLUDES=""
-EXCLUDSE+=" --exclude gfx_window_glfw"
-EXCLUDES+=" --exclude gfx_window_dxgi"
-
 EXCLUDES+=" --exclude gfx_device_dx11"
 EXCLUDES+=" --exclude gfx_device_dx12ll"
 EXCLUDES+=" --exclude gfx_device_dx12"
@@ -23,13 +20,10 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 
   EXCLUDES+=" --exclude gfx_device_metal"
   EXCLUDES+=" --exclude gfx_device_metalll"
-  EXCLUDES+=" --exclude gfx_window_metal"
 
   FEATURES+="vulkan"
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  EXCLUDES+=" --exclude gfx_window_vulkan"
-  EXCLUDES+=" --exclude gfx_device_vulkan"
-  EXCLUDES+=" --exclude gfx_device_vulkanll"
+  EXCLUDES+=" --exclude gfx_backend_vulkan"
 
   FEATURES+="metal metal_argument_buffer"
   GLUTIN_HEADLESS_FEATURE="--features headless"
@@ -39,4 +33,3 @@ cargo build --all --features "$FEATURES" $EXCLUDES
 
 cargo test --all --features $FEATURES $EXCLUDES
 cargo test --all --features "$FEATURES mint serialize" $EXCLUDES
-cargo test -p gfx_window_glutin $GLUTIN_HEADLESS_FEATURE

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -1,6 +1,7 @@
 //! Window creation using glutin for gfx.
 //!
 //! # Examples
+//!
 //! The following code creates a `gfx::Surface` using glutin.
 //!
 //! ```no_run
@@ -19,6 +20,26 @@
 //!
 //!     // Then use the glutin window to create a gfx surface.
 //!     let surface = Surface::from_window(glutin_window);
+//! }
+//! ```
+//!
+//! Headless initialization without a window.
+//!
+//! ```no_run
+//! extern crate glutin;
+//! extern crate gfx_backend_gl;
+//! extern crate gfx_core as core;
+//!
+//! use core::Instance;
+//! use gfx_backend_gl::Headless;
+//! use glutin::{HeadlessRendererBuilder};
+//!
+//! fn main() {
+//!     let context = HeadlessRendererBuilder::new(256, 256)
+//!         .build()
+//!         .expect("Failed to build headless context");
+//!     let headless = Headless(context);
+//!     let _adapters = headless.enumerate_adapters();
 //! }
 //! ```
 
@@ -151,22 +172,5 @@ impl core::Instance<B> for Headless {
         unsafe { self.0.make_current().unwrap() };
         let adapter = Adapter::new(|s| self.0.get_proc_address(s) as *const _);
         vec![adapter]
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_headless() {
-        use core::Instance;
-        use glutin::{HeadlessRendererBuilder};
-        let context = HeadlessRendererBuilder::new(256, 256)
-            .build()
-            .expect("Failed to build headless context");
-
-        let headless = Headless(context);
-        let _adapters = headless.enumerate_adapters();
     }
 }


### PR DESCRIPTION
This should allow us to use bors for the `ll` branch.

Changed the headless test to a doc example because it fails on appveyor (and maybe travis also) with `NonAvailablePixelFormat`. Glutin doesn't allow to configure the pixel format settings at the moment afaik.