### PR TITLE
[ll] Fix garbage leak and implement allocation for render

### DIFF
--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -78,6 +78,7 @@ impl core::RawCommandQueue<Backend> for CommandQueue {
 }
 
 /// Dummy device doing nothing.
+#[derive(Clone)]
 pub struct Device;
 impl core::Device<Backend> for Device {
     fn get_features(&self) -> &core::Features {

--- a/src/core/src/buffer.rs
+++ b/src/core/src/buffer.rs
@@ -1,5 +1,5 @@
 //! Memory buffers
-
+use memory;
 use {IndexType, Backend};
 
 // TODO
@@ -63,4 +63,24 @@ pub struct IndexBufferView<'a, B: Backend> {
     pub offset: u64,
     ///
     pub index_type: IndexType,
+}
+
+/// Retrieve the complete memory requirements for this buffer,
+/// taking usage and device limits into account
+pub fn complete_requirements<B: Backend>(
+    device: &mut B::Device,
+    buffer: &B::UnboundBuffer,
+    usage: Usage,
+) -> memory::Requirements {
+    use std::cmp::max;
+    use device::Device;
+
+    let mut requirements = device.get_buffer_requirements(buffer);
+    if usage.can_transfer() {
+        let limits = device.get_limits();
+        requirements.alignment = max(
+            limits.min_buffer_copy_offset_alignment as u64,
+            requirements.alignment);
+    }
+    requirements
 }

--- a/src/core/src/buffer.rs
+++ b/src/core/src/buffer.rs
@@ -26,6 +26,13 @@ bitflags!(
     }
 );
 
+impl Usage {
+    /// Can this buffer be used in transfer operations ?
+    pub fn can_transfer(&self) -> bool {
+        self.intersects(TRANSFER_SRC | TRANSFER_DST)
+    }
+}
+
 bitflags!(
     /// Buffer state flags.
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]

--- a/src/core/src/device.rs
+++ b/src/core/src/device.rs
@@ -202,7 +202,7 @@ pub struct ShaderError;
 /// - [Device::view_buffer_as_unordered_access](trait.Device.html#method.view_buffer_as_unordered_access).
 ///
 #[allow(missing_docs)]
-pub trait Device<B: Backend> {
+pub trait Device<B: Backend>: Clone {
     /// Returns the features of this `Device`. This usually depends on the graphics API being
     /// used.
     fn get_features(&self) -> &Features;

--- a/src/core/src/image.rs
+++ b/src/core/src/image.rs
@@ -292,7 +292,7 @@ impl Usage {
         self.intersects(COLOR_ATTACHMENT | DEPTH_STENCIL_ATTACHMENT)
     }
 }
-
+/*
 /// Describes a subvolume of a texture, which image data can be uploaded into.
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -356,7 +356,7 @@ impl RawImageInfo {
         self.get_texel_count() * (texel_bytes as usize)
     }
 }
-
+*/
 /// Specifies how texture coordinates outside the range `[0, 1]` are handled.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]

--- a/src/core/src/image.rs
+++ b/src/core/src/image.rs
@@ -281,6 +281,18 @@ bitflags!(
     }
 );
 
+impl Usage {
+    /// Can this image be used in transfer operations ?
+    pub fn can_transfer(&self) -> bool {
+        self.intersects(TRANSFER_SRC | TRANSFER_DST)
+    }
+
+    /// Can this image be used as a target ?
+    pub fn can_target(&self) -> bool {
+        self.intersects(COLOR_ATTACHMENT | DEPTH_STENCIL_ATTACHMENT)
+    }
+}
+
 /// Describes a subvolume of a texture, which image data can be uploaded into.
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/render/src/allocators/boxed.rs
+++ b/src/render/src/allocators/boxed.rs
@@ -29,7 +29,7 @@ impl<B: Backend> BoxedAllocator<B> {
 impl<B: Backend> Allocator<B> for BoxedAllocator<B> {
     fn allocate_buffer(&mut self,
         device: &mut Device<B>,
-        _: &buffer::Usage,
+        _: buffer::Usage,
         buffer: B::UnboundBuffer
     ) -> (B::Buffer, Memory) {
         let heap_type = device.find_usage_heap(self.usage).unwrap();
@@ -46,7 +46,7 @@ impl<B: Backend> Allocator<B> for BoxedAllocator<B> {
     
     fn allocate_image(&mut self,
         device: &mut Device<B>,
-        usage: &image::Usage,
+        usage: image::Usage,
         image: B::UnboundImage
     ) -> (B::Image, Memory) {
         let heap_type = device.find_usage_heap(self.usage).unwrap();

--- a/src/render/src/allocators/boxed.rs
+++ b/src/render/src/allocators/boxed.rs
@@ -1,0 +1,60 @@
+use std::marker::PhantomData;
+
+use core::{Device as CoreDevice};
+use core::device::ResourceHeapType;
+use memory::{self, Allocator, Memory};
+use {Backend, Device};
+
+pub struct BoxedAllocator<B: Backend>(PhantomData<B>);
+
+impl<B: Backend> BoxedAllocator<B> {
+    pub fn new(_: &Device<B>) -> Self {
+        BoxedAllocator(PhantomData)
+    }
+}
+
+impl<B: Backend> Allocator<B> for BoxedAllocator<B> {
+    fn allocate_buffer(&mut self,
+        device: &mut Device<B>,
+        usage: memory::Usage,
+        bind: memory::Bind,
+        buffer: B::UnboundBuffer
+    ) -> (B::Buffer, Memory) {
+        let heap_type = device.find_usage_heap(usage).unwrap();
+        let mut device = device.ref_raw().clone();
+        let requirements = device.get_buffer_requirements(&buffer);
+        let resource_type = ResourceHeapType::Buffers;
+        let heap = device.create_heap(&heap_type, resource_type, requirements.size)
+            .unwrap();
+        let buffer = device.bind_buffer_memory(&heap, 0, buffer)
+            .unwrap();
+        
+        let mut heap = Some(heap);
+        let release = Box::new(move || device.destroy_heap(heap.take().unwrap()));
+        (buffer, Memory::new(release, usage, bind))
+    }
+    
+    fn allocate_image(&mut self,
+        device: &mut Device<B>,
+        usage: memory::Usage,
+        bind: memory::Bind,
+        image: B::UnboundImage
+    ) -> (B::Image, Memory) {
+        let heap_type = device.find_usage_heap(usage).unwrap();
+        let mut device = device.ref_raw().clone();
+        let requirements = device.get_image_requirements(&image);
+        let resource_type = if bind.is_target() {
+            ResourceHeapType::Targets
+        } else {
+            ResourceHeapType::Images
+        };
+        let heap = device.create_heap(&heap_type, resource_type, requirements.size)
+            .unwrap();
+        let image = device.bind_image_memory(&heap, 0, image)
+            .unwrap();
+        
+        let mut heap = Some(heap);
+        let release = Box::new(move || device.destroy_heap(heap.take().unwrap()));
+        (image, Memory::new(release, usage, bind)) 
+    }
+}

--- a/src/render/src/allocators/boxed.rs
+++ b/src/render/src/allocators/boxed.rs
@@ -3,24 +3,36 @@ use std::marker::PhantomData;
 use core::{Device as CoreDevice};
 use core::device::ResourceHeapType;
 use memory::{self, Allocator, Memory};
+use {buffer, image};
 use {Backend, Device};
 
-pub struct BoxedAllocator<B: Backend>(PhantomData<B>);
+pub struct BoxedAllocator<B: Backend> {
+    usage: memory::Usage,
+    phantom: PhantomData<B>
+}
 
 impl<B: Backend> BoxedAllocator<B> {
-    pub fn new(_: &Device<B>) -> Self {
-        BoxedAllocator(PhantomData)
+    pub fn new(usage: memory::Usage, _: &Device<B>) -> Self {
+        BoxedAllocator {
+            usage,
+            phantom: PhantomData
+        }
+    }
+
+    fn make_memory(&self, mut device: B::Device, heap: B::Heap) -> Memory {
+        let mut heap = Some(heap);
+        let release = Box::new(move || device.destroy_heap(heap.take().unwrap()));
+        Memory::new(release, self.usage)
     }
 }
 
 impl<B: Backend> Allocator<B> for BoxedAllocator<B> {
     fn allocate_buffer(&mut self,
         device: &mut Device<B>,
-        usage: memory::Usage,
-        bind: memory::Bind,
+        _: &buffer::Usage,
         buffer: B::UnboundBuffer
     ) -> (B::Buffer, Memory) {
-        let heap_type = device.find_usage_heap(usage).unwrap();
+        let heap_type = device.find_usage_heap(self.usage).unwrap();
         let mut device = device.ref_raw().clone();
         let requirements = device.get_buffer_requirements(&buffer);
         let resource_type = ResourceHeapType::Buffers;
@@ -29,21 +41,18 @@ impl<B: Backend> Allocator<B> for BoxedAllocator<B> {
         let buffer = device.bind_buffer_memory(&heap, 0, buffer)
             .unwrap();
         
-        let mut heap = Some(heap);
-        let release = Box::new(move || device.destroy_heap(heap.take().unwrap()));
-        (buffer, Memory::new(release, usage, bind))
+        (buffer, self.make_memory(device, heap))
     }
     
     fn allocate_image(&mut self,
         device: &mut Device<B>,
-        usage: memory::Usage,
-        bind: memory::Bind,
+        usage: &image::Usage,
         image: B::UnboundImage
     ) -> (B::Image, Memory) {
-        let heap_type = device.find_usage_heap(usage).unwrap();
+        let heap_type = device.find_usage_heap(self.usage).unwrap();
         let mut device = device.ref_raw().clone();
         let requirements = device.get_image_requirements(&image);
-        let resource_type = if bind.is_target() {
+        let resource_type = if usage.can_target() {
             ResourceHeapType::Targets
         } else {
             ResourceHeapType::Images
@@ -53,8 +62,6 @@ impl<B: Backend> Allocator<B> for BoxedAllocator<B> {
         let image = device.bind_image_memory(&heap, 0, image)
             .unwrap();
         
-        let mut heap = Some(heap);
-        let release = Box::new(move || device.destroy_heap(heap.take().unwrap()));
-        (image, Memory::new(release, usage, bind)) 
+        (image, self.make_memory(device, heap))
     }
 }

--- a/src/render/src/allocators/mod.rs
+++ b/src/render/src/allocators/mod.rs
@@ -1,0 +1,7 @@
+mod boxed;
+mod stack;
+
+pub use self::boxed::BoxedAllocator;
+pub use self::stack::StackAllocator;
+
+// TODO: fallbacks when out of memory

--- a/src/render/src/allocators/mod.rs
+++ b/src/render/src/allocators/mod.rs
@@ -3,5 +3,3 @@ mod stack;
 
 pub use self::boxed::BoxedAllocator;
 pub use self::stack::StackAllocator;
-
-// TODO: fallbacks when out of memory

--- a/src/render/src/allocators/stack.rs
+++ b/src/render/src/allocators/stack.rs
@@ -1,0 +1,240 @@
+use std::sync::mpsc;
+use std::collections::HashMap;
+
+use core::{Device as CoreDevice, HeapType};
+use core::device::ResourceHeapType;
+use core::memory::Requirements;
+use memory::{self, Allocator, Memory, ReleaseFn, DropDelayed, DropDelayer};
+use {Backend, Device};
+
+pub struct StackAllocator<B: Backend>(DropDelayed<InnerStackAllocator<B>>);
+
+pub struct InnerStackAllocator<B: Backend> {
+    device: B::Device,
+    heap_chunks: HashMap<memory::Usage, HeapChunks<B>>,
+    chunk_size: u64,
+}
+
+impl<B: Backend> Drop for InnerStackAllocator<B> {
+    fn drop(&mut self) {
+        self.shrink();
+    }
+}
+
+struct HeapChunks<B: Backend> {
+    // TODO: Any support ?
+    buffers: ChunkStack<B>,
+    images: ChunkStack<B>,
+    targets: ChunkStack<B>,
+}
+
+impl<B: Backend> HeapChunks<B> {
+    fn new(heap_type: HeapType) -> Self {
+        HeapChunks {
+            buffers: ChunkStack::new(heap_type, ResourceHeapType::Buffers),
+            images: ChunkStack::new(heap_type, ResourceHeapType::Images),
+            targets: ChunkStack::new(heap_type, ResourceHeapType::Targets),
+        }
+    }
+}
+
+impl<B: Backend> StackAllocator<B> {
+    pub fn new(device: &Device<B>) -> Self {
+        let mega = 1 << 20;
+        Self::with_chunk_size(device, 128 * mega)
+    }
+
+    pub fn with_chunk_size(device: &Device<B>, chunk_size: u64) -> Self {
+        let mut heap_chunks = HashMap::new();
+        if let Some(data_heap) = device.find_data_heap() {
+            heap_chunks.insert(memory::Usage::Data, HeapChunks::new(data_heap));
+        }
+        if let Some(upload_heap) = device.find_upload_heap() {
+            heap_chunks.insert(memory::Usage::Upload, HeapChunks::new(upload_heap));
+        }
+        if let Some(download_heap) = device.find_download_heap() {
+            heap_chunks.insert(memory::Usage::Download, HeapChunks::new(download_heap));
+        }
+        StackAllocator(DropDelayed::new(InnerStackAllocator {
+            device: (*device.ref_raw()).clone(),
+            heap_chunks,
+            chunk_size,
+        }))
+    }
+
+    pub fn shrink(&mut self) {
+        self.0.shrink();
+    }
+}
+
+impl<B: Backend> InnerStackAllocator<B> {
+    fn shrink(&mut self) {
+        let device = &mut self.device;
+        for (_, chunks) in &mut self.heap_chunks {
+            chunks.buffers.shrink(device);
+            chunks.images.shrink(device);
+            chunks.targets.shrink(device);
+        }
+    }
+}
+
+impl<B: Backend> Allocator<B> for StackAllocator<B> {
+    fn allocate_buffer(&mut self,
+        _: &mut Device<B>,
+        usage: memory::Usage,
+        bind: memory::Bind,
+        buffer: B::UnboundBuffer
+    ) -> (B::Buffer, Memory) {
+        let drop_delayer = self.0.drop_delayer();
+        let inner: &mut InnerStackAllocator<B> = &mut self.0;
+        let device = &mut inner.device;
+        let requirements = device.get_buffer_requirements(&buffer);
+        let stack = &mut inner.heap_chunks.get_mut(&usage).unwrap().buffers;
+        let (heap, offset, release) = stack.allocate(
+            device,
+            inner.chunk_size,
+            requirements,
+            drop_delayer,
+        );
+        println!("bind buffer memory to {:?}, offset {:?}", heap, offset);
+        let buffer = device.bind_buffer_memory(heap, offset, buffer)
+            .unwrap();
+        (buffer, Memory::new(release, usage, bind))
+    }
+    
+    fn allocate_image(&mut self,
+        _: &mut Device<B>,
+        usage: memory::Usage,
+        bind: memory::Bind,
+        image: B::UnboundImage
+    ) -> (B::Image, Memory) {
+        let drop_delayer = self.0.drop_delayer();
+        let inner: &mut InnerStackAllocator<B> = &mut self.0;
+        let device = &mut inner.device;
+        let requirements = device.get_image_requirements(&image);
+        let chunks = inner.heap_chunks.get_mut(&usage).unwrap();
+        let stack = if bind.is_target() {
+            &mut chunks.targets
+        } else {
+            &mut chunks.images
+        };
+        let (heap, offset, release) = stack.allocate(
+            device,
+            inner.chunk_size,
+            requirements,
+            drop_delayer,
+        );
+        println!("bind image memory to {:?}, offset {:?}", heap, offset);
+        let image = device.bind_image_memory(heap, offset, image)
+            .unwrap();
+        (image, Memory::new(release, usage, bind))
+    }
+}
+
+struct ChunkStack<B: Backend> {
+    heap_type: HeapType,
+    resource_type: ResourceHeapType,
+    chunks: Vec<B::Heap>,
+    allocs: Vec<StackAlloc>,
+    receiver: mpsc::Receiver<usize>,
+    sender: mpsc::Sender<usize>,
+}
+
+struct StackAlloc {
+    chunk_index: usize,
+    end: u64,
+    released: bool,
+}
+
+impl<B: Backend> ChunkStack<B> {
+    fn new(heap_type: HeapType, resource_type: ResourceHeapType) -> Self {
+        let (sender, receiver) = mpsc::channel();
+
+        ChunkStack {
+            heap_type,
+            resource_type,
+            chunks: Vec::new(),
+            allocs: Vec::new(),
+            receiver,
+            sender,
+        }
+    }
+
+    fn allocate(&mut self,
+        device: &mut B::Device,
+        chunk_size: u64,
+        req: Requirements,
+        drop_delayer: DropDelayer<InnerStackAllocator<B>>,
+    ) -> (&B::Heap, u64, ReleaseFn)
+    {
+        self.update_allocs();
+        assert!(req.size <= chunk_size);
+
+        let (chunk_index, beg, end) =
+            if let Some(tail) = self.allocs.last() {
+                let rem = tail.end % req.alignment;
+                let beg = if rem == 0 {
+                    tail.end
+                } else {
+                    tail.end - rem + req.alignment
+                };
+                let end = beg + req.size;
+                if end <= chunk_size {
+                    (tail.chunk_index, beg, end)
+                } else {
+                    (tail.chunk_index + 1, 0, req.size)
+                }
+            } else {
+                (0, 0, req.size)
+            };
+
+        if chunk_index == self.chunks.len() {
+            self.grow(device, chunk_size);
+        }
+
+        let alloc_index = self.allocs.len();
+        self.allocs.push(StackAlloc {
+            chunk_index,
+            end,
+            released: false,
+        });
+
+        println!("allocated #{:?} {:?}..{:?}) from chunk {:?}", alloc_index, beg, end, chunk_index);
+        let sender = self.sender.clone();
+        (&self.chunks[chunk_index], beg, Box::new(move || {
+            let _ = drop_delayer;
+            sender.send(alloc_index).unwrap_or_else(|_| {
+                error!("could not release StackAllocator's memory")
+            });
+        }))
+    }
+
+    fn grow(&mut self, device: &mut B::Device, chunk_size: u64) {
+        println!("create chunk of {} bytes on {:?} ({:?})", chunk_size, self.heap_type, self.resource_type);
+        let heap = device.create_heap(&self.heap_type, self.resource_type, chunk_size)
+            .unwrap();
+        self.chunks.push(heap);
+    }
+
+    fn shrink(&mut self, device: &mut B::Device) {
+        self.update_allocs();
+
+        let drain_beg = self.allocs.last()
+            .map(|a| a.chunk_index + 1)
+            .unwrap_or(0);
+
+        for heap in self.chunks.drain(drain_beg..) {
+            println!("destroy chunk on {:?} ({:?})", self.heap_type, self.resource_type);
+            device.destroy_heap(heap);
+        }
+    }
+    
+    fn update_allocs(&mut self) {
+        for alloc_index in self.receiver.try_iter() {
+            self.allocs[alloc_index].released = true;
+        }
+        while self.allocs.last().map(|a| a.released).unwrap_or(false) {
+            self.allocs.pop();
+        }
+    }
+}

--- a/src/render/src/buffer.rs
+++ b/src/render/src/buffer.rs
@@ -1,6 +1,10 @@
 use memory::Memory;
 
-pub use core::buffer::CreationError;
+pub use core::buffer::{CreationError};
+pub use core::buffer::{Usage,
+    TRANSFER_SRC, TRANSFER_DST, CONSTANT, INDEX, INDIRECT, VERTEX
+};
+
 /* TODO
 /// Error creating a buffer.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -38,8 +42,8 @@ impl Error for CreationError {
 /// An information block that is immutable and associated to each buffer.
 #[derive(Debug)]
 pub struct Info {
-    /// Role
-    pub role: Role,
+    /// Usage
+    pub usage: Usage,
     /// Memory
     pub memory: Memory,
     /// Size in bytes
@@ -47,21 +51,5 @@ pub struct Info {
     /// Stride of a single element, in bytes. Only used for structured buffers
     /// that you use via shader resource / unordered access views.
     pub stride: u64,
-    // TODO: do we need things from buffer::Usage ?
     // TODO: mapping stuff
-}
-
-/// Role of the memory buffer.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-#[repr(u8)]
-pub enum Role {
-    /// Generic vertex buffer
-    Vertex,
-    /// Index buffer
-    Index,
-    /// Constant buffer
-    Constant,
-    /// Staging buffer
-    Staging,
 }

--- a/src/render/src/buffer.rs
+++ b/src/render/src/buffer.rs
@@ -1,8 +1,7 @@
-use std::fmt;
-use std::error::Error;
+use memory::Memory;
 
-use memory;
-
+pub use core::buffer::CreationError;
+/* TODO
 /// Error creating a buffer.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum CreationError {
@@ -34,22 +33,20 @@ impl Error for CreationError {
         }
     }
 }
+*/
 
 /// An information block that is immutable and associated to each buffer.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Debug)]
 pub struct Info {
     /// Role
     pub role: Role,
-    /// Usage
-    pub usage: memory::Usage,
-    /// Bind flags
-    pub bind: memory::Bind,
+    /// Memory
+    pub memory: Memory,
     /// Size in bytes
-    pub size: usize,
+    pub size: u64,
     /// Stride of a single element, in bytes. Only used for structured buffers
     /// that you use via shader resource / unordered access views.
-    pub stride: usize,
+    pub stride: u64,
     // TODO: do we need things from buffer::Usage ?
     // TODO: mapping stuff
 }

--- a/src/render/src/buffer.rs
+++ b/src/render/src/buffer.rs
@@ -5,40 +5,6 @@ pub use core::buffer::{Usage,
     TRANSFER_SRC, TRANSFER_DST, CONSTANT, INDEX, INDIRECT, VERTEX
 };
 
-/* TODO
-/// Error creating a buffer.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum CreationError {
-    /// Some of the bind flags are not supported.
-    UnsupportedBind(memory::Bind),
-    /// Unknown other error.
-    Other,
-    /// Usage mode is not supported
-    UnsupportedUsage(memory::Usage),
-    // TODO: unsupported role
-}
-
-impl fmt::Display for CreationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            CreationError::UnsupportedBind(ref bind) => write!(f, "{}: {:?}", self.description(), bind),
-            CreationError::UnsupportedUsage(usage) => write!(f, "{}: {:?}", self.description(), usage),
-            _ => write!(f, "{}", self.description()),
-        }
-    }
-}
-
-impl Error for CreationError {
-    fn description(&self) -> &str {
-        match *self {
-            CreationError::UnsupportedBind(_) => "Bind flags are not supported",
-            CreationError::Other => "An unknown error occurred",
-            CreationError::UnsupportedUsage(_) => "Requested memory usage mode is not supported",
-        }
-    }
-}
-*/
-
 /// An information block that is immutable and associated to each buffer.
 #[derive(Debug)]
 pub struct Info {

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -204,7 +204,7 @@ impl<B: Backend> Device<B> {
         where A: Allocator<B>
     {
         let buffer = self.raw.create_buffer(size, stride, usage)?;
-        let (buffer, memory) = allocator.allocate_buffer(self, &usage, buffer);
+        let (buffer, memory) = allocator.allocate_buffer(self, usage, buffer);
         let info = buffer::Info { usage, memory, size, stride };
         Ok(Buffer::new(buffer, info, self.garbage.clone()).into())
     }
@@ -235,7 +235,7 @@ impl<B: Backend> Device<B> {
         where A: Allocator<B>
     {
         let image = self.raw.create_image(kind, mip_levels, format, usage)?;
-        let (image, memory) = allocator.allocate_image(self, &usage, image);
+        let (image, memory) = allocator.allocate_image(self, usage, image);
         let info = image::Info { usage, kind, mip_levels, format, memory };
         Ok(Image::new(image, info, self.garbage.clone()).into())
     }

--- a/src/render/src/image.rs
+++ b/src/render/src/image.rs
@@ -1,5 +1,5 @@
 use core;
-use memory;
+use memory::Memory;
 
 pub use core::image::{
     CreationError, Kind, AaMode, Size, Level, Layer, Usage, Dimensions,
@@ -9,14 +9,12 @@ pub use core::image::{
 
 /// Texture storage descriptor.
 #[allow(missing_docs)]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Debug)]
 pub struct Info {
     pub kind: Kind,
-    pub levels: Level,
-    pub format: core::format::SurfaceType,
-    pub bind: memory::Bind,
-    pub usage: memory::Usage,
+    pub mip_levels: Level,
+    pub format: core::format::Format,
+    pub memory: Memory,
     // TODO: do we need things from image::Usage ?
 }
 
@@ -36,9 +34,8 @@ impl Info {
         }
     }
 
-    /// Get the raw image info for a given mip and a channel type.
-    pub fn to_raw_image_info(&self, cty: core::format::ChannelType, mip: Level) -> RawImageInfo {
-        let format = core::format::Format(self.format, cty.into());
-        self.to_image_info(mip).convert(format)
+    /// Get the raw image info for a given mip.
+    pub fn to_raw_image_info(&self, mip: Level) -> RawImageInfo {
+        self.to_image_info(mip).convert(self.format)
     }
 }

--- a/src/render/src/image.rs
+++ b/src/render/src/image.rs
@@ -3,7 +3,6 @@ use memory::Memory;
 
 pub use core::image::{
     CreationError, Kind, AaMode, Size, Level, Layer, Dimensions,
-    ImageInfoCommon, RawImageInfo, NewImageInfo,
     SamplerInfo, SubresourceRange
 };
 pub use core::image::{Usage,
@@ -22,7 +21,7 @@ pub struct Info {
     pub format: core::format::Format,
     pub memory: Memory,
 }
-
+/*
 impl Info {
     /// Get image info for a given mip.
     pub fn to_image_info(&self, mip: Level) -> NewImageInfo {
@@ -44,3 +43,4 @@ impl Info {
         self.to_image_info(mip).convert(self.format)
     }
 }
+*/

--- a/src/render/src/image.rs
+++ b/src/render/src/image.rs
@@ -2,20 +2,25 @@ use core;
 use memory::Memory;
 
 pub use core::image::{
-    CreationError, Kind, AaMode, Size, Level, Layer, Usage, Dimensions,
+    CreationError, Kind, AaMode, Size, Level, Layer, Dimensions,
     ImageInfoCommon, RawImageInfo, NewImageInfo,
     SamplerInfo, SubresourceRange
+};
+pub use core::image::{Usage,
+    TRANSFER_SRC, TRANSFER_DST,
+    COLOR_ATTACHMENT, DEPTH_STENCIL_ATTACHMENT,
+    SAMPLED
 };
 
 /// Texture storage descriptor.
 #[allow(missing_docs)]
 #[derive(Debug)]
 pub struct Info {
+    pub usage: Usage,
     pub kind: Kind,
     pub mip_levels: Level,
     pub format: core::format::Format,
     pub memory: Memory,
-    // TODO: do we need things from image::Usage ?
 }
 
 impl Info {

--- a/src/render/src/memory.rs
+++ b/src/render/src/memory.rs
@@ -184,37 +184,37 @@ impl<I, T> ops::DerefMut for Typed<I, T> {
 
 /// This is the unique owner of the inner struct.
 #[derive(Debug)]
-pub struct DropDelayed<T>(Arc<UnsafeCell<T>>);
+pub struct Provider<T>(Arc<UnsafeCell<T>>);
 /// Keep-alive without any access (only Drop if last one).
-pub struct DropDelayer<T>(Arc<UnsafeCell<T>>);
+pub struct Dependency<T>(Arc<UnsafeCell<T>>);
 
-impl<T> DropDelayed<T> {
+impl<T> Provider<T> {
     pub fn new(inner: T) -> Self {
-        DropDelayed(Arc::new(UnsafeCell::new(inner)))
+        Provider(Arc::new(UnsafeCell::new(inner)))
     }
 
-    pub fn drop_delayer(&self) -> DropDelayer<T> {
-        DropDelayer(self.0.clone())
+    pub fn dependency(&self) -> Dependency<T> {
+        Dependency(self.0.clone())
     }
 }
 
-impl<T> ops::Deref for DropDelayed<T> {
+impl<T> ops::Deref for Provider<T> {
     type Target = T;
     fn deref(&self) -> &T { unsafe { &*self.0.get() } }
 }
 
-impl<T> ops::DerefMut for DropDelayed<T> {
+impl<T> ops::DerefMut for Provider<T> {
     fn deref_mut(&mut self) -> &mut T { unsafe { &mut *self.0.get() } }
 }
 
-impl<T> Clone for DropDelayer<T> {
+impl<T> Clone for Dependency<T> {
     fn clone(&self) -> Self {
-        DropDelayer(self.0.clone())
+        Dependency(self.0.clone())
     }
 }
 
-impl<T> fmt::Debug for DropDelayer<T> {
+impl<T> fmt::Debug for Dependency<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "DropDelayer")
+        write!(f, "Dependency")
     }
 }

--- a/src/render/src/memory.rs
+++ b/src/render/src/memory.rs
@@ -116,13 +116,13 @@ impl fmt::Debug for Memory {
 pub trait Allocator<B: Backend> {
     fn allocate_buffer(&mut self,
         device: &mut Device<B>,
-        usage: &buffer::Usage,
+        usage: buffer::Usage,
         buffer: B::UnboundBuffer
     ) -> (B::Buffer, Memory);
     
     fn allocate_image(&mut self,
         device: &mut Device<B>,
-        usage: &image::Usage,
+        usage: image::Usage,
         image: B::UnboundImage
     ) -> (B::Image, Memory);
 }

--- a/src/render/src/memory.rs
+++ b/src/render/src/memory.rs
@@ -5,6 +5,7 @@ use std::{ops, cmp, fmt, hash};
 use std::sync::Arc;
 use std::cell::UnsafeCell;
 
+use {buffer, image};
 use {Backend, Device};
 
 /// How this memory will be used regarding GPU-CPU data flow.
@@ -91,16 +92,11 @@ pub type ReleaseFn = Box<FnMut()>; // TODO?: FnOnce
 pub struct Memory {
     release: ReleaseFn,
     pub usage: Usage,
-    pub bind: Bind,
 }
 
 impl Memory {
-    pub fn new(
-        release: ReleaseFn,
-        usage: Usage,
-        bind: Bind
-    ) -> Self {
-        Memory { release, usage, bind }
+    pub fn new(release: ReleaseFn, usage: Usage) -> Self {
+        Memory { release, usage }
     }
 }
 
@@ -112,7 +108,7 @@ impl Drop for Memory {
 
 impl fmt::Debug for Memory {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "Memory {{ usage: {:?}, bind: {:?}, .. }}", self.usage, self.bind)
+        write!(f, "Memory({:?})", self.usage)
     }
 }
 
@@ -120,15 +116,13 @@ impl fmt::Debug for Memory {
 pub trait Allocator<B: Backend> {
     fn allocate_buffer(&mut self,
         device: &mut Device<B>,
-        usage: Usage,
-        bind: Bind,
+        usage: &buffer::Usage,
         buffer: B::UnboundBuffer
     ) -> (B::Buffer, Memory);
     
     fn allocate_image(&mut self,
         device: &mut Device<B>,
-        usage: Usage,
-        bind: Bind,
+        usage: &image::Usage,
         image: B::UnboundImage
     ) -> (B::Image, Memory);
 }

--- a/src/render/src/memory.rs
+++ b/src/render/src/memory.rs
@@ -26,47 +26,6 @@ pub enum Usage {
 }
 
 bitflags!(
-    /// Flags providing information about the usage of a resource.
-    ///
-    /// A `Bind` value can be a combination of the following bit patterns:
-    ///
-    /// - [`RENDER_TARGET`](constant.RENDER_TARGET.html)
-    /// - [`DEPTH_STENCIL`](constant.DEPTH_STENCIL.html)
-    /// - [`SHADER_RESOURCE`](constant.SHADER_RESOURCE.html)
-    /// - [`UNORDERED_ACCESS`](constant.UNORDERED_ACCESS.html)
-    /// - [`TRANSFER_SRC`](constant.TRANSFER_SRC.html)
-    /// - [`TRANSFER_DST`](constant.TRANSFER_DST.html)
-    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-    pub flags Bind: u8 {
-        /// Can be rendered into.
-        const RENDER_TARGET    = 0x1,
-        /// Can serve as a depth/stencil target.
-        const DEPTH_STENCIL    = 0x2,
-        /// Can be bound to the shader for reading.
-        const SHADER_RESOURCE  = 0x4,
-        /// Can be bound to the shader for writing.
-        const UNORDERED_ACCESS = 0x8,
-        /// Can be transfered from.
-        const TRANSFER_SRC     = 0x10,
-        /// Can be transfered into.
-        const TRANSFER_DST     = 0x20,
-    }
-);
-
-impl Bind {
-    /// Is this memory bound to be a target ?
-    pub fn is_target(&self) -> bool {
-        self.intersects(RENDER_TARGET | DEPTH_STENCIL)
-    }
-
-    /// Is this memory bound to be mutated ?
-    pub fn is_mutable(&self) -> bool {
-        let mutable = TRANSFER_DST | UNORDERED_ACCESS | RENDER_TARGET | DEPTH_STENCIL;
-        self.intersects(mutable)
-    }
-}
-
-bitflags!(
     /// Flags providing information about the type of memory access to a resource.
     ///
     /// An `Access` value can be a combination of the the following bit patterns:


### PR DESCRIPTION
Working on #1484.
With the simplest `BoxedAllocator` (allocates an heap for each resource) the example looks fine.
With the `StackAllocator` the logo is not displayed, do I need to use the heap offsets when doing mapping, copies, .. ?
@kvark I hope that's simple enough ;)