### PR TITLE
[ll] Pixel to Fragment rename

### DIFF
--- a/examples/core/quad/main.rs
+++ b/examples/core/quad/main.rs
@@ -84,7 +84,7 @@ fn main() {
     #[cfg(feature = "dx12")]
     let shader_lib = device.create_shader_library_from_source(&[
             (VS, shade::Stage::Vertex, include_bytes!("shader/quad.hlsl")),
-            (PS, shade::Stage::Pixel, include_bytes!("shader/quad.hlsl")),
+            (PS, shade::Stage::Fragment, include_bytes!("shader/quad.hlsl")),
         ]).expect("Error on creating shader lib");
     #[cfg(feature = "vulkan")]
     let vs_module = device.create_shader_module(include_bytes!("data/vs_main.spv")).unwrap();
@@ -103,7 +103,7 @@ fn main() {
     #[cfg(feature = "gl")]
     let shader_lib = device.create_shader_library_from_source(&[
             (VS, pso::Stage::Vertex, include_bytes!("shader/quad_450.glslv")),
-            (PS, pso::Stage::Pixel, include_bytes!("shader/quad_450.glslf")),
+            (PS, pso::Stage::Fragment, include_bytes!("shader/quad_450.glslf")),
         ]).expect("Error on creating shader lib");
 
     let set0_layout = device.create_descriptor_set_layout(&[
@@ -111,7 +111,7 @@ fn main() {
                 binding: 0,
                 ty: pso::DescriptorType::SampledImage,
                 count: 1,
-                stage_flags: pso::STAGE_PIXEL,
+                stage_flags: pso::STAGE_FRAGMENT,
             }
         ],
     );
@@ -121,7 +121,7 @@ fn main() {
                 binding: 0,
                 ty: pso::DescriptorType::Sampler,
                 count: 1,
-                stage_flags: pso::STAGE_PIXEL,
+                stage_flags: pso::STAGE_FRAGMENT,
             }
         ],
     );
@@ -196,7 +196,7 @@ fn main() {
             hull: None,
             domain: None,
             geometry: None,
-            pixel: Some(pso::EntryPoint { entry: "main", module: &fs_module },),
+            fragment: Some(pso::EntryPoint { entry: "main", module: &fs_module },),
         };
         let subpass = Subpass { index: 0, main_pass: &render_pass };
         device.create_graphics_pipelines(&[
@@ -409,7 +409,7 @@ fn main() {
                     target: rtv,
                     range: (0..1, 0..1),
                 };
-                cmd_buffer.pipeline_barrier(pso::TRANSFER .. pso::PIXEL_SHADER, &[rtv_target_barrier]);
+                cmd_buffer.pipeline_barrier(pso::TRANSFER .. pso::FRAGMENT_SHADER, &[rtv_target_barrier]);
             }
 
             cmd_buffer.set_viewports(&[viewport]);
@@ -435,7 +435,7 @@ fn main() {
                     target: rtv,
                     range: (0..1, 0..1),
                 };
-                cmd_buffer.pipeline_barrier(pso::PIXEL_SHADER .. pso::TRANSFER, &[rtv_present_barrier]);
+                cmd_buffer.pipeline_barrier(pso::FRAGMENT_SHADER .. pso::TRANSFER, &[rtv_present_barrier]);
             }
 
             cmd_buffer.finish()

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -75,7 +75,7 @@ fn main() {
     #[cfg(feature = "dx12")]
     let shader_lib = device.create_shader_library_from_source(&[
             (VS, shade::Stage::Vertex, include_bytes!("../../core/quad/shader/quad.hlsl")),
-            (PS, shade::Stage::Pixel, include_bytes!("../../core/quad/shader/quad.hlsl")),
+            (PS, shade::Stage::Fragment, include_bytes!("../../core/quad/shader/quad.hlsl")),
         ]).expect("Error on creating shader lib");
     #[cfg(feature = "vulkan")]
     let vs_module = device.create_shader_module(include_bytes!("../../core/quad/data/vs_main.spv")).unwrap();
@@ -94,7 +94,7 @@ fn main() {
     #[cfg(feature = "gl")]
     let shader_lib = device.create_shader_library_from_source(&[
             (VS, pso::Stage::Vertex, include_bytes!("../../core/quad/shader/quad_450.glslv")),
-            (PS, pso::Stage::Pixel, include_bytes!("../../core/quad/shader/quad_450.glslf")),
+            (PS, pso::Stage::Fragment, include_bytes!("../../core/quad/shader/quad_450.glslf")),
         ]).expect("Error on creating shader lib");
 
     let set0_layout = device.create_descriptor_set_layout(&[
@@ -102,7 +102,7 @@ fn main() {
                 binding: 0,
                 ty: pso::DescriptorType::SampledImage,
                 count: 1,
-                stage_flags: pso::STAGE_PIXEL,
+                stage_flags: pso::STAGE_FRAGMENT,
             }
         ],
     );
@@ -112,7 +112,7 @@ fn main() {
                 binding: 0,
                 ty: pso::DescriptorType::Sampler,
                 count: 1,
-                stage_flags: pso::STAGE_PIXEL,
+                stage_flags: pso::STAGE_FRAGMENT,
             }
         ],
     );
@@ -187,7 +187,7 @@ fn main() {
             hull: None,
             domain: None,
             geometry: None,
-            pixel: Some(pso::EntryPoint { entry: "main", module: &fs_module },),
+            fragment: Some(pso::EntryPoint { entry: "main", module: &fs_module },),
         };
         let subpass = Subpass { index: 0, main_pass: &render_pass };
         device.create_graphics_pipelines(&[

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -109,7 +109,7 @@ impl Device {
             pso::Stage::Hull     => gl::TESS_CONTROL_SHADER,
             pso::Stage::Domain   => gl::TESS_EVALUATION_SHADER,
             pso::Stage::Geometry => gl::GEOMETRY_SHADER,
-            pso::Stage::Pixel    => gl::FRAGMENT_SHADER,
+            pso::Stage::Fragment => gl::FRAGMENT_SHADER,
             pso::Stage::Compute  => gl::COMPUTE_SHADER,
         };
 
@@ -209,7 +209,7 @@ impl d::Device<B> for Device {
                     attach_shader(shaders.hull);
                     attach_shader(shaders.domain);
                     attach_shader(shaders.geometry);
-                    attach_shader(shaders.pixel);
+                    attach_shader(shaders.fragment);
 
                     if !priv_caps.program_interface_supported && priv_caps.frag_data_location_supported {
                         for i in 0..subpass.color_attachments.len() {

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -358,7 +358,7 @@ pub fn map_pipeline_stage(stage: pso::PipelineStage) -> vk::PipelineStageFlags {
     if stage.contains(pso::GEOMETRY_SHADER) {
         flags |= vk::PIPELINE_STAGE_GEOMETRY_SHADER_BIT;
     }
-    if stage.contains(pso::PIXEL_SHADER) {
+    if stage.contains(pso::FRAGMENT_SHADER) {
         flags |= vk::PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
     }
     if stage.contains(pso::EARLY_FRAGMENT_TESTS) {
@@ -466,7 +466,7 @@ pub fn map_stage_flags(stages: pso::ShaderStageFlags) -> vk::ShaderStageFlags {
         flags |= vk::SHADER_STAGE_GEOMETRY_BIT;
     }
 
-    if stages.contains(pso::STAGE_PIXEL) {
+    if stages.contains(pso::STAGE_FRAGMENT) {
         flags |= vk::SHADER_STAGE_FRAGMENT_BIT;
     }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -268,7 +268,7 @@ impl d::Device<B> for Device {
                 stages.push(make_stage(vk::SHADER_STAGE_VERTEX_BIT, shaders.vertex));
             }
             // Pixel stage
-            if let Some(entry) = shaders.pixel {
+            if let Some(entry) = shaders.fragment {
                 stages.push(make_stage(vk::SHADER_STAGE_FRAGMENT_BIT, entry));
             }
             // Geometry stage
@@ -340,8 +340,8 @@ impl d::Device<B> for Device {
                 s_type: vk::StructureType::PipelineRasterizationStateCreateInfo,
                 p_next: ptr::null(),
                 flags: vk::PipelineRasterizationStateCreateFlags::empty(),
-                depth_clamp_enable: vk::VK_TRUE, // TODO
-                rasterizer_discard_enable: vk::VK_FALSE, // TODO
+                depth_clamp_enable: if desc.rasterizer.depth_clamping { vk::VK_TRUE } else { vk::VK_FALSE },
+                rasterizer_discard_enable: if shaders.fragment.is_none() { vk::VK_TRUE } else { vk::VK_FALSE },
                 polygon_mode: polygon_mode,
                 cull_mode: conv::map_cull_mode(desc.rasterizer.cull_mode),
                 front_face: conv::map_front_face(desc.rasterizer.front_face),

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -87,6 +87,20 @@ pub struct Viewport {
     pub far: f32,
 }
 
+impl Viewport {
+    /// Construct a viewport from rectangle.
+    pub fn from_rect(rect: target::Rect, near: f32, far: f32) -> Self {
+        Viewport {
+            x: rect.x,
+            y: rect.y,
+            w: rect.w,
+            h: rect.h,
+            near,
+            far,
+        }
+    }
+}
+
 /// Features that the device supports.
 /// These only include features of the core interface and not API extensions.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/core/src/pso/graphics.rs
+++ b/src/core/src/pso/graphics.rs
@@ -30,6 +30,8 @@ pub struct GraphicsShaderSet<'a, B: Backend> {
 }
 
 ///
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
 pub struct GraphicsPipelineDesc {
     /// Rasterizer setup
     pub rasterizer: Rasterizer,
@@ -62,7 +64,7 @@ impl GraphicsPipelineDesc {
 }
 
 ///
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
 pub struct DepthBias {
     ///
@@ -74,7 +76,7 @@ pub struct DepthBias {
 }
 
 /// Rasterization state.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
 pub struct Rasterizer {
     /// How to rasterize this primitive.
@@ -109,6 +111,8 @@ impl Rasterizer {
 }
 
 ///
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
 pub struct BlendDesc {
     ///
     pub alpha_coverage: bool,
@@ -130,6 +134,8 @@ impl BlendDesc {
 }
 
 ///
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
 pub enum LogicOp {
     ///
     Clear,

--- a/src/core/src/pso/graphics.rs
+++ b/src/core/src/pso/graphics.rs
@@ -26,7 +26,7 @@ pub struct GraphicsShaderSet<'a, B: Backend> {
     ///
     pub geometry: Option<EntryPoint<'a, B>>,
     ///
-    pub pixel: Option<EntryPoint<'a, B>>,
+    pub fragment: Option<EntryPoint<'a, B>>,
 }
 
 ///
@@ -90,9 +90,7 @@ pub struct Rasterizer {
     ///
     pub depth_bias: Option<DepthBias>,
     ///
-    pub conservative_rasterization: bool,
-    /// Discard primitives before the rasterizer.
-    pub rasterizer_discard: bool,
+    pub conservative: bool,
 }
 
 impl Rasterizer {
@@ -104,8 +102,7 @@ impl Rasterizer {
             front_face: s::FrontFace::CounterClockwise,
             depth_clamping: true,
             depth_bias: None,
-            conservative_rasterization: false,
-            rasterizer_discard: false,
+            conservative: false,
         }
     }
 }

--- a/src/core/src/pso/input_assembler.rs
+++ b/src/core/src/pso/input_assembler.rs
@@ -62,6 +62,8 @@ pub enum PrimitiveRestart {
 }
 
 ///
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
 pub struct InputAssemblerDesc {
     /// Type of the primitive
     pub primitive: Primitive,

--- a/src/core/src/pso/mod.rs
+++ b/src/core/src/pso/mod.rs
@@ -68,8 +68,8 @@ bitflags!(
         const DOMAIN_SHADER = 0x20,
         /// Geometry shader execution.
         const GEOMETRY_SHADER = 0x40,
-        /// Pixel shader execution.
-        const PIXEL_SHADER = 0x80,
+        /// Fragment shader execution.
+        const FRAGMENT_SHADER = 0x80,
         /// Stage of early depth and stencil test.
         const EARLY_FRAGMENT_TESTS = 0x100,
         /// Stage of late depth and stencil test.
@@ -100,13 +100,13 @@ bitflags!(
         const STAGE_DOMAIN   = 0x4,
         /// Geometry shader stage.
         const STAGE_GEOMETRY = 0x8,
-        /// Pixel shader stage.
-        const STAGE_PIXEL    = 0x10,
+        /// Fragment shader stage.
+        const STAGE_FRAGMENT = 0x10,
         /// Compute shader stage.
         const STAGE_COMPUTE  = 0x20,
         /// All graphics pipeline shader stages.
         const STAGE_GRAPHICS = STAGE_VERTEX.bits | STAGE_HULL.bits |
-            STAGE_DOMAIN.bits | STAGE_GEOMETRY.bits | STAGE_PIXEL.bits,
+            STAGE_DOMAIN.bits | STAGE_GEOMETRY.bits | STAGE_FRAGMENT.bits,
         /// All shader stages.
         const STAGE_ALL      = STAGE_GRAPHICS.bits | STAGE_COMPUTE.bits,
     }
@@ -122,7 +122,7 @@ pub enum Stage {
     Hull,
     Domain,
     Geometry,
-    Pixel,
+    Fragment,
     Compute
 }
 


### PR DESCRIPTION
I believe `fragment` is a better term (it's not always pixels being processed) and more consistent with Vulkan. Sorry for bikeshedding!
Also removed explicit rasterizer discard, we'll instead just check for the fragment shader presence.