### PR TITLE
[ll] More mapping

### DIFF
--- a/examples/core/quad/main.rs
+++ b/examples/core/quad/main.rs
@@ -288,13 +288,11 @@ fn main() {
     };
 
     // TODO: check transitions: read/write mapping and vertex buffer read
-    {
-        let mut vertices = device
-            .acquire_mapping_writer::<Vertex>(&vertex_buffer, 0..buffer_len)
-            .unwrap();
-        vertices.copy_from_slice(&QUAD);
-        device.release_mapping_writer(vertices);
-    }
+    let mut vertices = device
+        .acquire_mapping_writer::<Vertex>(&vertex_buffer, 0..buffer_len)
+        .unwrap();
+    vertices.copy_from_slice(&QUAD);
+    device.release_mapping_writer(vertices);
 
     // Image
     let img_data = include_bytes!("data/logo.png");
@@ -315,17 +313,15 @@ fn main() {
     };
 
     // copy image data into staging buffer
-    {
-        let mut data = device
-            .acquire_mapping_writer::<u8>(&image_upload_buffer, 0..upload_size)
-            .unwrap();
-        for y in 0 .. height as usize {
-            let row = &(*img)[y*(width as usize)*image_stride .. (y+1)*(width as usize)*image_stride];
-            let dest_base = y * row_pitch as usize;
-            data[dest_base .. dest_base + row.len()].copy_from_slice(row);
-        }
-        device.release_mapping_writer(data);
+    let mut data = device
+        .acquire_mapping_writer::<u8>(&image_upload_buffer, 0..upload_size)
+        .unwrap();
+    for y in 0 .. height as usize {
+        let row = &(*img)[y*(width as usize)*image_stride .. (y+1)*(width as usize)*image_stride];
+        let dest_base = y * row_pitch as usize;
+        data[dest_base .. dest_base + row.len()].copy_from_slice(row);
     }
+    device.release_mapping_writer(data);
 
     let image = device.create_image(kind, 1, ColorFormat::get_format(), i::TRANSFER_DST | i::SAMPLED).unwrap(); // TODO: usage
     println!("{:?}", image);

--- a/examples/render/quad_render/Cargo.toml
+++ b/examples/render/quad_render/Cargo.toml
@@ -4,15 +4,6 @@ version = "0.1.0"
 publish = false
 workspace = "../../.."
 
-[features]
-default = ["vulkan"]
-#metal = ["gfx_device_metal", "gfx_window_metal"]
-gl = ["glutin", "gfx_backend_gl"]
-#dx11 = ["gfx_device_dx11", "gfx_window_dxgi"]
-#dx12 = ["gfx_device_dx12", "gfx_window_dxgi"]
-vulkan = ["gfx_backend_vulkan"]
-unstable = []
-
 [[bin]]
 name = "quad_render"
 path = "main.rs"
@@ -26,28 +17,4 @@ winit = "0.7"
 gfx_core = { path = "../../../src/core", version = "0.10" }
 gfx = { path = "../../../src/render", version = "0.17" }
 
-[dependencies.gfx_backend_gl]
-path = "../../../src/backend/gl"
-version = "0.1"
-optional = true
-
-[dependencies.gfx_backend_vulkan]
-path = "../../../src/backend/vulkan"
-version = "0.1"
-optional = true
-
-#[dependencies.gfx_device_metal]
-#path = "../../../src/backend/metal"
-#version = "0.3"
-#optional = true
-
-#[dependencies.gfx_window_metal]
-#path = "../../../src/window/metal"
-#version = "0.4"
-#optional = true
-
-#[target.'cfg(windows)'.dependencies]
-#gfx_device_dx11 = { path = "../../../src/backend/dx11", version = "0.6", optional = true }
-#gfx_device_dx12 = { path = "../../../src/backend/dx12", version = "0.1", optional = true }
-#gfx_window_dxgi = { path = "../../../src/window/dxgi", version = "0.9", optional = true }
-
+gfx_backend_vulkan = { path = "../../../src/backend/vulkan", version = "0.1" }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -966,16 +966,15 @@ impl d::Device<B> for Device {
     fn acquire_mapping_raw(&mut self, buf: &n::Buffer, read: Option<Range<u64>>)
         -> Result<*mut u8, mapping::Error>
     {
-        let read_range = if let Some(read) = read {
-            winapi::D3D12_RANGE {
-                Begin: read.start,
-                End: read.end,
-            }
-        } else {
-            winapi::D3D12_RANGE {
+        let read_range = match read {
+            Some(r) => winapi::D3D12_RANGE {
+                Begin: r.start,
+                End: r.end,
+            },
+            None => winapi::D3D12_RANGE {
                 Begin: 0,
                 End: 0,
-            }
+            },
         };
         
         let mut ptr = ptr::null_mut();
@@ -987,16 +986,15 @@ impl d::Device<B> for Device {
     }
 
     fn release_mapping_raw(&mut self, buf: &n::Buffer, wrote: Option<Range<u64>>) {
-        let written_range = if let Some(wrote) = wrote {
-            winapi::D3D12_RANGE {
-                Begin: wrote.start,
-                End: wrote.end,
-            }
-        } else {
-            winapi::D3D12_RANGE {
+        let written_range = match wrote {
+            Some(w) => winapi::D3D12_RANGE {
+                Begin: w.start,
+                End: w.end,
+            },
+            None => winapi::D3D12_RANGE {
                 Begin: 0,
                 End: 0,
-            }
+            },
         };
 
         unsafe { (*buf.resource).Unmap(0, &written_range) };

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -427,7 +427,6 @@ impl core::Backend for Backend {
     type QueueFamily = QueueFamily;
 
     type Heap = native::Heap;
-    type Mapping = device::Mapping;
     type CommandPool = pool::RawCommandPool;
     type SubpassCommandPool = pool::SubpassCommandPool;
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -22,7 +22,6 @@ impl core::Backend for Backend {
     type QueueFamily = QueueFamily;
 
     type Heap = ();
-    type Mapping = ();
     type CommandPool = RawCommandPool;
     type SubpassCommandPool = SubpassCommandPool;
 
@@ -181,19 +180,13 @@ impl core::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn read_mapping_raw(&mut self, _: &(), _: Range<u64>)
-        -> Result<(*const u8, ()), mapping::Error>
+    fn acquire_mapping_raw(&mut self, _: &(), _: Option<Range<u64>>)
+        -> Result<*mut u8, mapping::Error>
     {
         unimplemented!()
     }
 
-    fn write_mapping_raw(&mut self, _: &(), _: Range<u64>)
-        -> Result<(*mut u8, ()), mapping::Error>
-    {
-        unimplemented!()
-    }
-
-    fn unmap_mapping_raw(&mut self, _: ()) {
+    fn release_mapping_raw(&mut self, _: &(), _: Option<Range<u64>>) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -83,19 +83,6 @@ impl Device {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-pub enum MappingKind {}
-
-#[derive(Debug)]
-#[allow(missing_copy_implementations)]
-pub struct Mapping {
-    pub kind: MappingKind,
-    pub pointer: *mut ::std::os::raw::c_void,
-}
-
-unsafe impl Send for Mapping {}
-unsafe impl Sync for Mapping {}
-
 impl Device {
     pub fn create_shader_module_from_source(
         &mut self,
@@ -381,19 +368,13 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn read_mapping_raw(&mut self, _: &n::Buffer, _: Range<u64>)
-        -> Result<(*const u8, Mapping), mapping::Error>
+    fn acquire_mapping_raw(&mut self, buf: &n::Buffer, read: Option<Range<u64>>)
+        -> Result<*mut u8, mapping::Error>
     {
         unimplemented!()
     }
 
-    fn write_mapping_raw(&mut self, _: &n::Buffer, _: Range<u64>)
-        -> Result<(*mut u8, Mapping), mapping::Error>
-    {
-        unimplemented!()
-    }
-
-    fn unmap_mapping_raw(&mut self, _: Mapping) {
+    fn release_mapping_raw(&mut self, buf: &n::Buffer, wrote: Option<Range<u64>>) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -49,7 +49,6 @@ impl c::Backend for Backend {
     type QueueFamily = QueueFamily;
 
     type Heap = native::Heap;
-    type Mapping = device::Mapping;
     type CommandPool = pool::RawCommandPool;
     type SubpassCommandPool = pool::SubpassCommandPool;
 

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -18,8 +18,7 @@ name = "gfx_backend_vulkan"
 log = "0.3"
 lazy_static = "0.2"
 shared_library = "0.1"
-#ash = "0.18.5"
-ash = { git = "https://github.com/MaikKlein/ash/", revision="5b5ecf115440fef37fdf75ca3e29f1ff2aa4eb87" }
+ash = "0.18.5"
 gfx_core = { path = "../../core", version = "0.10" }
 smallvec = "0.4"
 winit = "0.7"

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -18,7 +18,8 @@ name = "gfx_backend_vulkan"
 log = "0.3"
 lazy_static = "0.2"
 shared_library = "0.1"
-ash = "0.18.4"
+#ash = "0.18.5"
+ash = { git = "https://github.com/MaikKlein/ash/", revision="5b5ecf115440fef37fdf75ca3e29f1ff2aa4eb87" }
 gfx_core = { path = "../../core", version = "0.10" }
 smallvec = "0.4"
 winit = "0.7"

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -584,7 +584,6 @@ impl core::Backend for Backend {
     type QueueFamily = QueueFamily;
 
     type Heap = native::Heap;
-    type Mapping = device::Mapping;
     type CommandPool = pool::RawCommandPool;
     type SubpassCommandPool = pool::SubpassCommandPool;
 

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -19,13 +19,21 @@ pub struct GraphicsPipeline(pub vk::Pipeline);
 pub struct ComputePipeline(pub vk::Pipeline);
 
 #[derive(Debug, Hash)]
-pub struct Heap(pub vk::DeviceMemory);
+pub struct Heap {
+    pub memory: vk::DeviceMemory,
+    pub ptr: *mut u8,
+}
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Buffer {
     pub raw: vk::Buffer,
     pub memory: vk::DeviceMemory,
+    pub offset: u64,
+    pub ptr: *mut u8,
 }
+
+unsafe impl Sync for Buffer {}
+unsafe impl Send for Buffer {}
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct Image {

--- a/src/core/src/device.rs
+++ b/src/core/src/device.rs
@@ -337,10 +337,10 @@ pub trait Device<B: Backend>: Clone {
     {
         let count = (range.end - range.start) as usize / mem::size_of::<T>();
         self.acquire_mapping_raw(buffer, Some(range.clone()))
-            .map(|ptr| {
-                let start_ptr = unsafe { ptr.offset(range.start as isize) } as *const _;
+            .map(|ptr| unsafe {
+                let start_ptr = ptr.offset(range.start as isize) as *const _;
                 mapping::Reader {
-                    slice: unsafe { slice::from_raw_parts(start_ptr, count) },
+                    slice: slice::from_raw_parts(start_ptr, count),
                     buffer,
                     released: false,
                 }
@@ -350,9 +350,7 @@ pub trait Device<B: Backend>: Clone {
     /// Release a mapping Reader
     ///
     /// See `acquire_mapping_raw` for more information.
-    fn release_mapping_reader<'a, T>(&mut self, mut reader: mapping::Reader<'a, B, T>)
-        where T: Copy
-    {
+    fn release_mapping_reader<'a, T>(&mut self, mut reader: mapping::Reader<'a, B, T>) {
         reader.released = true;
         self.release_mapping_raw(reader.buffer, None);
     }
@@ -368,10 +366,10 @@ pub trait Device<B: Backend>: Clone {
     {
         let count = (range.end - range.start) as usize / mem::size_of::<T>();
         self.acquire_mapping_raw(buffer, None)
-            .map(|ptr| {
-                let start_ptr = unsafe { ptr.offset(range.start as isize) } as *mut _;
+            .map(|ptr| unsafe {
+                let start_ptr = ptr.offset(range.start as isize) as *mut _;
                 mapping::Writer {
-                    slice: unsafe { slice::from_raw_parts_mut(start_ptr, count) },
+                    slice: slice::from_raw_parts_mut(start_ptr, count),
                     buffer,
                     range,
                     released: false,
@@ -379,9 +377,7 @@ pub trait Device<B: Backend>: Clone {
             })
     }
 
-    fn release_mapping_writer<'a, T>(&mut self, mut writer: mapping::Writer<'a, B, T>)
-        where T: Copy
-    {
+    fn release_mapping_writer<'a, T>(&mut self, mut writer: mapping::Writer<'a, B, T>) {
         writer.released = true;
         self.release_mapping_raw(writer.buffer, Some(writer.range.clone()));
     }

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -257,7 +257,6 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any {
     type FrameBuffer:         Debug + Any + Send + Sync;
 
     type Heap:                Debug + Any;
-    type Mapping:             Debug + Any + Send + Sync;
     type CommandPool:         RawCommandPool<Self>;
     type SubpassCommandPool:  SubpassCommandPool<Self>;
 

--- a/src/core/src/mapping.rs
+++ b/src/core/src/mapping.rs
@@ -1,7 +1,6 @@
 #![deny(missing_docs, missing_copy_implementations)]
 
 //! Memory mapping
-use std::{fmt, ops};
 use std::error::Error as StdError;
 use std::fmt;
 use std::ops::{self, Range};
@@ -40,47 +39,44 @@ impl StdError for Error {
 }
 
 /// Mapping reader
-pub struct Reader<'a, B: Backend, T: 'a + Copy> {
+pub struct Reader<'a, B: Backend, T: 'a> {
     pub(crate) slice: &'a [T],
     pub(crate) buffer: &'a B::Buffer,
     pub(crate) released: bool,
 }
 
-impl<'a, B: Backend, T: 'a + Copy> Drop for Reader<'a, B, T> {
+impl<'a, B: Backend, T: 'a> Drop for Reader<'a, B, T> {
     fn drop(&mut self) {
-        if !self.released { panic!("a mapping reader was not released"); }
+        assert!(self.released, "a mapping reader was not released");
     }
 }
 
-impl<'a, B: Backend, T: 'a + Copy> ops::Deref for Reader<'a, B, T> {
+impl<'a, B: Backend, T: 'a> ops::Deref for Reader<'a, B, T> {
     type Target = [T];
-
     fn deref(&self) -> &[T] { self.slice }
 }
 
 /// Mapping writer.
 /// Currently is not possible to make write-only slice so while it is technically possible
 /// to read from Writer, it will lead to an undefined behavior. Please do not read from it.
-pub struct Writer<'a, B: Backend, T: 'a + Copy> {
+pub struct Writer<'a, B: Backend, T: 'a> {
     pub(crate) slice: &'a mut [T],
     pub(crate) buffer: &'a B::Buffer,
     pub(crate) range: Range<u64>,
     pub(crate) released: bool,
 }
 
-impl<'a, B: Backend, T: 'a + Copy> Drop for Writer<'a, B, T> {
+impl<'a, B: Backend, T: 'a> Drop for Writer<'a, B, T> {
     fn drop(&mut self) {
-        if !self.released { panic!("a mapping writer was not released"); }
+        assert!(self.released, "a mapping writer was not released");
     }
 }
 
-impl<'a, B: Backend, T: 'a + Copy> ops::Deref for Writer<'a, B, T> {
+impl<'a, B: Backend, T: 'a> ops::Deref for Writer<'a, B, T> {
     type Target = [T];
-
     fn deref(&self) -> &[T] { self.slice }
 }
 
-impl<'a, B: Backend, T: 'a + Copy> ops::DerefMut for Writer<'a, B, T> {
+impl<'a, B: Backend, T: 'a> ops::DerefMut for Writer<'a, B, T> {
     fn deref_mut(&mut self) -> &mut [T] { self.slice }
 }
-

--- a/src/core/src/mapping.rs
+++ b/src/core/src/mapping.rs
@@ -3,6 +3,8 @@
 //! Memory mapping
 use std::{fmt, ops};
 use std::error::Error as StdError;
+use std::fmt;
+use std::ops::{self, Range};
 use Backend;
 
 // TODO
@@ -40,7 +42,14 @@ impl StdError for Error {
 /// Mapping reader
 pub struct Reader<'a, B: Backend, T: 'a + Copy> {
     pub(crate) slice: &'a [T],
-    pub(crate) _mapping: B::Mapping,
+    pub(crate) buffer: &'a B::Buffer,
+    pub(crate) released: bool,
+}
+
+impl<'a, B: Backend, T: 'a + Copy> Drop for Reader<'a, B, T> {
+    fn drop(&mut self) {
+        if !self.released { panic!("a mapping reader was not released"); }
+    }
 }
 
 impl<'a, B: Backend, T: 'a + Copy> ops::Deref for Reader<'a, B, T> {
@@ -54,7 +63,15 @@ impl<'a, B: Backend, T: 'a + Copy> ops::Deref for Reader<'a, B, T> {
 /// to read from Writer, it will lead to an undefined behavior. Please do not read from it.
 pub struct Writer<'a, B: Backend, T: 'a + Copy> {
     pub(crate) slice: &'a mut [T],
-    pub(crate) _mapping: B::Mapping,
+    pub(crate) buffer: &'a B::Buffer,
+    pub(crate) range: Range<u64>,
+    pub(crate) released: bool,
+}
+
+impl<'a, B: Backend, T: 'a + Copy> Drop for Writer<'a, B, T> {
+    fn drop(&mut self) {
+        if !self.released { panic!("a mapping writer was not released"); }
+    }
 }
 
 impl<'a, B: Backend, T: 'a + Copy> ops::Deref for Writer<'a, B, T> {

--- a/src/render/src/allocators/stack.rs
+++ b/src/render/src/allocators/stack.rs
@@ -76,7 +76,6 @@ impl<B: Backend> Allocator<B> for StackAllocator<B> {
             requirements,
             dependency,
         );
-        println!("bind buffer memory to {:?}, offset {:?}", heap, offset);
         let buffer = device.mut_raw().bind_buffer_memory(heap, offset, buffer)
             .unwrap();
         (buffer, Memory::new(release, inner.usage))
@@ -102,7 +101,6 @@ impl<B: Backend> Allocator<B> for StackAllocator<B> {
             requirements,
             dependency,
         );
-        println!("bind image memory to {:?}, offset {:?}", heap, offset);
         let image = device.mut_raw().bind_image_memory(heap, offset, image)
             .unwrap();
         (image, Memory::new(release, inner.usage))
@@ -176,7 +174,6 @@ impl<B: Backend> ChunkStack<B> {
             released: false,
         });
 
-        println!("allocated #{:?} {:?}..{:?}) from chunk {:?}", alloc_index, beg, end, chunk_index);
         let sender = self.sender.clone();
         (&self.chunks[chunk_index], beg, Box::new(move || {
             let _ = dependency;
@@ -192,7 +189,6 @@ impl<B: Backend> ChunkStack<B> {
         chunk_size: u64
     ) {
         let heap_type = device.find_usage_heap(usage).unwrap();
-        println!("create chunk of {} bytes on {:?} ({:?})", chunk_size, heap_type, self.resource_type);
         let heap = device.mut_raw()
             .create_heap(&heap_type, self.resource_type, chunk_size)
             .unwrap();
@@ -207,7 +203,6 @@ impl<B: Backend> ChunkStack<B> {
             .unwrap_or(0);
 
         for heap in self.chunks.drain(drain_beg..) {
-            println!("destroy chunk of {:?}", self.resource_type);
             device.destroy_heap(heap);
         }
     }

--- a/src/render/src/buffer.rs
+++ b/src/render/src/buffer.rs
@@ -1,5 +1,6 @@
+use std::sync::atomic::{self, AtomicBool};
+
 use memory::Memory;
-use mapping;
 
 pub use core::buffer::{CreationError};
 pub use core::buffer::{Usage,
@@ -18,6 +19,27 @@ pub struct Info {
     /// Stride of a single element, in bytes. Only used for structured buffers
     /// that you use via shader resource / unordered access views.
     pub stride: u64,
-    /// Mapping informations
-    pub mapping: Option<mapping::Info>,
+    /// Exclusive access
+    pub(crate) access: AtomicBool,
+}
+
+impl Info {
+    pub(crate) fn new(usage: Usage, memory: Memory, size: u64, stride: u64)
+        -> Self
+    {
+        let access = AtomicBool::new(false);
+        Info { usage, memory, size, stride, access }
+    }
+
+    pub(crate) fn acquire_access(&self) -> bool {
+        !self.access.swap(true, atomic::Ordering::Acquire)
+    }
+
+    pub(crate) fn release_access(&self) {
+        if cfg!(debug) {
+            assert!(self.access.swap(false, atomic::Ordering::Release));
+        } else {
+            self.access.store(false, atomic::Ordering::Release);
+        }
+    }
 }

--- a/src/render/src/buffer.rs
+++ b/src/render/src/buffer.rs
@@ -1,4 +1,5 @@
 use memory::Memory;
+use mapping;
 
 pub use core::buffer::{CreationError};
 pub use core::buffer::{Usage,
@@ -17,5 +18,6 @@ pub struct Info {
     /// Stride of a single element, in bytes. Only used for structured buffers
     /// that you use via shader resource / unordered access views.
     pub stride: u64,
-    // TODO: mapping stuff
+    /// Mapping informations
+    pub mapping: Option<mapping::Info>,
 }

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -205,7 +205,7 @@ impl<B: Backend> Device<B> {
         where MTB: MaybeTypedBuffer<B>
     {
         let (resource, info) = buffer.as_raw().resource_info();
-        if !info.acquire_access() {
+        if !info.access.acquire_exclusive() {
             return Err(mapping::Error::AccessOverlap);
         }
         Ok(mapping::Reader {
@@ -226,7 +226,7 @@ impl<B: Backend> Device<B> {
         where T: Copy
     {
         self.raw.release_mapping_reader(reader.inner);
-        reader.info.release_access();
+        reader.info.access.release_exclusive();
     }
 
     /// Acquire a mapping Writer.
@@ -245,7 +245,7 @@ impl<B: Backend> Device<B> {
         where MTB: MaybeTypedBuffer<B>
     {
         let (resource, info) = buffer.as_raw().resource_info();
-        if !info.acquire_access() {
+        if !info.access.acquire_exclusive() {
             return Err(mapping::Error::AccessOverlap);
         }
         Ok(mapping::Writer {
@@ -266,7 +266,7 @@ impl<B: Backend> Device<B> {
         where T: Copy
     {
         self.raw.release_mapping_writer(writer.inner);
-        writer.info.release_access();
+        writer.info.access.release_exclusive();
     }
 
     pub fn create_image_raw<A>(&mut self,

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -164,7 +164,8 @@ impl<B: Backend> Device<B> {
         }))
     }
 
-    pub fn create_buffer_raw<A>(&mut self,
+    pub fn create_buffer_raw<A>(
+        &mut self,
         allocator: &mut A,
         usage: buffer::Usage,
         size: u64,
@@ -178,7 +179,8 @@ impl<B: Backend> Device<B> {
         Ok(Buffer::new(buffer, info, self.garbage.clone()).into())
     }
 
-    pub fn create_buffer<T, A>(&mut self,
+    pub fn create_buffer<T, A>(
+        &mut self,
         allocator: &mut A,
         usage: buffer::Usage,
         size: u64
@@ -198,7 +200,8 @@ impl<B: Backend> Device<B> {
     ///
     /// The accessible slice will correspond to the specified range (in elements).
     /// See `acquire_mapping_writer` for more information.
-    pub fn acquire_mapping_reader<'a, MTB>(&mut self,
+    pub fn acquire_mapping_reader<'a, MTB>(
+        &mut self,
         buffer: &'a MTB,
         range: Range<u64>,
     ) -> Result<mapping::Reader<'a, B, MTB::Data>, mapping::Error>
@@ -220,11 +223,10 @@ impl<B: Backend> Device<B> {
     /// Release a mapping Reader.
     ///
     /// See `acquire_mapping_writer` for more information.
-    pub fn release_mapping_reader<'a, T>(&mut self,
+    pub fn release_mapping_reader<'a, T>(
+        &mut self,
         reader: mapping::Reader<'a, B, T>
-    )
-        where T: Copy
-    {
+    ) {
         self.raw.release_mapping_reader(reader.inner);
         reader.info.access.release_exclusive();
     }
@@ -238,7 +240,8 @@ impl<B: Backend> Device<B> {
     /// Submitting commands involving this buffer to the device
     /// implicitly requires exclusive access until frame synchronisation
     /// on `acquire_frame`.
-    pub fn acquire_mapping_writer<'a, MTB>(&mut self,
+    pub fn acquire_mapping_writer<'a, MTB>(
+        &mut self,
         buffer: &'a MTB,
         range: Range<u64>,
     ) -> Result<mapping::Writer<'a, B, MTB::Data>, mapping::Error>
@@ -260,16 +263,46 @@ impl<B: Backend> Device<B> {
     /// Release a mapping Writer.
     ///
     /// See `acquire_mapping_writer` for more information.
-    pub fn release_mapping_writer<'a, T>(&mut self,
+    pub fn release_mapping_writer<'a, T>(
+        &mut self,
         writer: mapping::Writer<'a, B, T>
-    )
-        where T: Copy
-    {
+    ) {
         self.raw.release_mapping_writer(writer.inner);
         writer.info.access.release_exclusive();
     }
 
-    pub fn create_image_raw<A>(&mut self,
+    /// Sugar to acquire and release a mapping reader.
+    pub fn read_mapping<'a, MTB>(
+        &'a mut self,
+        buffer: &'a MTB,
+        range: Range<u64>
+    ) -> Result<mapping::ReadScope<'a, B, MTB::Data>, mapping::Error>
+        where MTB: MaybeTypedBuffer<B>
+    {
+        let reader = self.acquire_mapping_reader(buffer, range)?;
+        Ok(mapping::ReadScope {
+            reader: Some(reader),
+            device: self,
+        })
+    }
+
+    /// Sugar to acquire and release a mapping writer.
+    pub fn write_mapping<'a, MTB>(
+        &'a mut self,
+        buffer: &'a MTB,
+        range: Range<u64>
+    ) -> Result<mapping::WriteScope<'a, B, MTB::Data>, mapping::Error>
+        where MTB: MaybeTypedBuffer<B>
+    {
+        let writer = self.acquire_mapping_writer(buffer, range)?;
+        Ok(mapping::WriteScope {
+            writer: Some(writer),
+            device: self,
+        })
+    }
+
+    pub fn create_image_raw<A>(
+        &mut self,
         allocator: &mut A,
         usage: image::Usage,
         kind: image::Kind,
@@ -284,7 +317,8 @@ impl<B: Backend> Device<B> {
         Ok(Image::new(image, info, self.garbage.clone()).into())
     }
 
-    pub fn create_image<F, A>(&mut self,
+    pub fn create_image<F, A>(
+        &mut self,
         allocator: &mut A,
         usage: image::Usage,
         kind: image::Kind,
@@ -309,7 +343,8 @@ impl<B: Backend> Device<B> {
         ).into()
     }
 
-    pub fn view_buffer_as_constant_raw(&mut self,
+    pub fn view_buffer_as_constant_raw(
+        &mut self,
         buffer: &handle::raw::Buffer<B>,
         range: Range<u64>,
     ) -> Result<handle::raw::ConstantBufferView<B>, TargetViewError>
@@ -322,7 +357,8 @@ impl<B: Backend> Device<B> {
             ).into())
     }
 
-    pub fn view_buffer_as_constant<T>(&mut self,
+    pub fn view_buffer_as_constant<T>(
+        &mut self,
         buffer: &handle::Buffer<B, T>,
         range: Range<u64>,
     ) -> Result<handle::ConstantBufferView<B, T>, TargetViewError>
@@ -331,7 +367,8 @@ impl<B: Backend> Device<B> {
             .map(Typed::new)
     }
 
-    pub(crate) fn view_backbuffer_as_render_target_raw(&mut self,
+    pub(crate) fn view_backbuffer_as_render_target_raw(
+        &mut self,
         image: B::Image,
         kind: image::Kind,
         format: format::Format,
@@ -350,7 +387,8 @@ impl<B: Backend> Device<B> {
     // pub fn view_image_as_depth_stencil_raw
     // pub fn view_image_as_depth_stencil
 
-    pub fn view_image_as_render_target_raw(&mut self,
+    pub fn view_image_as_render_target_raw(
+        &mut self,
         image: &handle::raw::Image<B>,
         format: format::Format,
         range: image::SubresourceRange
@@ -364,7 +402,8 @@ impl<B: Backend> Device<B> {
             ).into())
     }
 
-    pub fn view_image_as_render_target<F>(&mut self,
+    pub fn view_image_as_render_target<F>(
+        &mut self,
         image: &handle::Image<B, F>,
         range: image::SubresourceRange
     ) -> Result<handle::RenderTargetView<B, F>, TargetViewError>
@@ -374,7 +413,8 @@ impl<B: Backend> Device<B> {
             .map(Typed::new)
     }
     
-    pub fn view_image_as_shader_resource_raw(&mut self,
+    pub fn view_image_as_shader_resource_raw(
+        &mut self,
         image: &handle::raw::Image<B>,
         format: format::Format
     ) -> Result<handle::raw::ShaderResourceView<B>, TargetViewError>
@@ -396,7 +436,8 @@ impl<B: Backend> Device<B> {
             .map(Typed::new)
     }
 
-    pub fn view_image_as_unordered_access_raw(&mut self,
+    pub fn view_image_as_unordered_access_raw(
+        &mut self,
         image: &handle::raw::Image<B>,
         format: format::Format
     ) -> Result<handle::raw::UnorderedAccessView<B>, TargetViewError>

--- a/src/render/src/handle.rs
+++ b/src/render/src/handle.rs
@@ -111,11 +111,16 @@ macro_rules! define_resources {
                 }
 
                 pub fn resource(&self) -> &B::$name {
-                    self.resource.as_ref().unwrap()
+                    self.resource_info().0
                 }
 
                 pub fn info(&self) -> &$info {
-                    &self.info
+                    self.resource_info().1
+                }
+
+                pub fn resource_info(&self) -> (&B::$name, &$info) {
+                    (self.resource.as_ref().unwrap(),
+                     &self.info)
                 }
             }
 

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -371,7 +371,7 @@ impl<B: Backend, C> Context<B, C>
         bundle.signal_fence.signal = Reached;
 
         bundle.handles.clear();
-        bundle.access_info.release_accesses();
+        bundle.access_info.end_gpu_access();
         bundle.access_info.clear();
         bundle.encoder_pools.clear();
 
@@ -396,11 +396,12 @@ impl<B: Backend, C> Context<B, C>
         let inner_submits: Vec<_> = submits.into_iter()
             .map(|mut submit| {
                 bundle.handles.append(&mut submit.handles);
-                submit.access_info.acquire_accesses();
                 bundle.access_info.append(&mut submit.access_info);
                 bundle.encoder_pools.push(submit.pool);
                 submit.inner
             }).collect();
+
+        assert!(bundle.access_info.start_gpu_access()); // TODO: recovery
 
         {
             let submission = core::Submission::new()

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -132,6 +132,7 @@ pub mod memory;
 pub mod allocators;
 pub mod buffer;
 pub mod image;
+pub mod mapping;
 /*
 // Pipeline states
 pub mod pso;

--- a/src/render/src/mapping.rs
+++ b/src/render/src/mapping.rs
@@ -1,0 +1,79 @@
+use std::{fmt, ops};
+use std::error::Error as StdError;
+
+use {core, memory, buffer};
+use Backend;
+
+/// Error accessing a mapping.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Error {
+    /// The requested mapping access did not match the expected usage.
+    InvalidAccess(memory::Access, memory::Usage),
+    /// The requested mapping access overlaps with another.
+    AccessOverlap,
+    /// Another error reported by GFX's core
+    Core(core::mapping::Error)
+}
+
+impl From<core::mapping::Error> for Error {
+    fn from(c: core::mapping::Error) -> Self {
+        Error::Core(c)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+        match *self {
+            InvalidAccess(ref access, ref usage) => {
+                write!(f, "{}: access = {:?}, usage = {:?}", self.description(), access, usage)
+            }
+            AccessOverlap => write!(f, "{}", self.description()),
+            Core(ref c) => c.fmt(f),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        use self::Error::*;
+        match *self {
+            InvalidAccess(..) => "The requested access did not match the expected usage",
+            AccessOverlap => "The requested access overlaps with another",
+            Core(ref c) => c.description(),
+        }
+    }
+}
+
+pub struct Reader<'a, B: Backend, T: 'a + Copy> {
+    pub(crate) inner: core::mapping::Reader<'a, B, T>,
+    pub(crate) info: &'a buffer::Info,
+}
+
+impl<'a, B: Backend, T: 'a + Copy> ops::Deref for Reader<'a, B, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] { &self.inner }
+}
+
+pub struct Writer<'a, B: Backend, T: 'a + Copy> {
+    pub(crate) inner: core::mapping::Writer<'a, B, T>,
+    pub(crate) info: &'a buffer::Info,
+}
+
+impl<'a, B: Backend, T: 'a + Copy> ops::Deref for Writer<'a, B, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] { &self.inner }
+}
+
+impl<'a, B: Backend, T: 'a + Copy> ops::DerefMut for Writer<'a, B, T> {
+    fn deref_mut(&mut self) -> &mut [T] { &mut self.inner }
+}
+
+// TODO
+#[derive(Debug)]
+pub struct Info {
+    // cpu_access: AtomicBool,
+    // gpu_access: AtomicBool,
+}

--- a/src/render/src/mapping.rs
+++ b/src/render/src/mapping.rs
@@ -2,7 +2,7 @@ use std::{fmt, ops};
 use std::error::Error as StdError;
 
 use {core, memory, buffer};
-use Backend;
+use {Backend, Device};
 
 /// Error accessing a mapping.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -45,28 +45,65 @@ impl StdError for Error {
     }
 }
 
-pub struct Reader<'a, B: Backend, T: 'a + Copy> {
+pub struct Reader<'a, B: Backend, T: 'a> {
     pub(crate) inner: core::mapping::Reader<'a, B, T>,
     pub(crate) info: &'a buffer::Info,
 }
 
-impl<'a, B: Backend, T: 'a + Copy> ops::Deref for Reader<'a, B, T> {
+impl<'a, B: Backend, T: 'a> ops::Deref for Reader<'a, B, T> {
     type Target = [T];
 
     fn deref(&self) -> &[T] { &self.inner }
 }
 
-pub struct Writer<'a, B: Backend, T: 'a + Copy> {
+pub struct Writer<'a, B: Backend, T: 'a> {
     pub(crate) inner: core::mapping::Writer<'a, B, T>,
     pub(crate) info: &'a buffer::Info,
 }
 
-impl<'a, B: Backend, T: 'a + Copy> ops::Deref for Writer<'a, B, T> {
+impl<'a, B: Backend, T: 'a> ops::Deref for Writer<'a, B, T> {
     type Target = [T];
 
     fn deref(&self) -> &[T] { &self.inner }
 }
 
-impl<'a, B: Backend, T: 'a + Copy> ops::DerefMut for Writer<'a, B, T> {
+impl<'a, B: Backend, T: 'a> ops::DerefMut for Writer<'a, B, T> {
     fn deref_mut(&mut self) -> &mut [T] { &mut self.inner }
+}
+
+
+pub struct ReadScope<'a, B: Backend, T: 'a> {
+    pub(crate) reader: Option<Reader<'a, B, T>>,
+    pub(crate) device: &'a mut Device<B>,
+}
+
+impl<'a, B: Backend, T: 'a> ops::Deref for ReadScope<'a, B, T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] { self.reader.as_ref().unwrap() }
+}
+
+impl<'a, B: Backend, T: 'a> Drop for ReadScope<'a, B, T> {
+    fn drop(&mut self) {
+        self.device.release_mapping_reader(self.reader.take().unwrap());
+    }
+}
+
+pub struct WriteScope<'a, B: Backend, T: 'a> {
+    pub(crate) writer: Option<Writer<'a, B, T>>,
+    pub(crate) device: &'a mut Device<B>,
+}
+
+impl<'a, B: Backend, T: 'a> ops::Deref for WriteScope<'a, B, T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] { self.writer.as_ref().unwrap() }
+}
+
+impl<'a, B: Backend, T: 'a> ops::DerefMut for WriteScope<'a, B, T> {
+    fn deref_mut(&mut self) -> &mut [T] { self.writer.as_mut().unwrap() }
+}
+
+impl<'a, B: Backend, T: 'a> Drop for WriteScope<'a, B, T> {
+    fn drop(&mut self) {
+        self.device.release_mapping_writer(self.writer.take().unwrap());
+    }
 }

--- a/src/render/src/mapping.rs
+++ b/src/render/src/mapping.rs
@@ -70,10 +70,3 @@ impl<'a, B: Backend, T: 'a + Copy> ops::Deref for Writer<'a, B, T> {
 impl<'a, B: Backend, T: 'a + Copy> ops::DerefMut for Writer<'a, B, T> {
     fn deref_mut(&mut self) -> &mut [T] { &mut self.inner }
 }
-
-// TODO
-#[derive(Debug)]
-pub struct Info {
-    // cpu_access: AtomicBool,
-    // gpu_access: AtomicBool,
-}


### PR DESCRIPTION
Modifies the mapping API for `core` as we discussed.
~~Tracking is not yet implemented for `render`.~~
~~Currently using an unpublished version of `ash` for the Vulkan backend.~~
A nice side effect is that the render example now works with `StackAllocator` :)