### PR TITLE
[ll] dx12: Compute pipelines and cleanup

### DIFF
--- a/examples/core/quad/main.rs
+++ b/examples/core/quad/main.rs
@@ -111,7 +111,7 @@ fn main() {
     #[cfg(feature = "dx12")]
     let vs_module = device
         .create_shader_module_from_source(
-            shade::Stage::Vertex,
+            pso::Stage::Vertex,
             "vs_main",
             "main",
             include_bytes!("shader/quad.hlsl"))
@@ -119,7 +119,7 @@ fn main() {
     #[cfg(feature = "dx12")]
     let fs_module = device
         .create_shader_module_from_source(
-            shade::Stage::Fragment,
+            pso::Stage::Fragment,
             "ps_main",
             "main",
             include_bytes!("shader/quad.hlsl"))

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -556,9 +556,53 @@ impl d::Device<B> for Device {
 
     fn create_compute_pipelines<'a>(
         &mut self,
-        _descs: &[(pso::EntryPoint<'a, B>, &n::PipelineLayout)],
+        descs: &[(pso::EntryPoint<'a, B>, &n::PipelineLayout)],
     ) -> Vec<Result<n::ComputePipeline, pso::CreationError>> {
-        unimplemented!()
+        descs.iter().map(|&(shader, ref signature)| {
+            let cs = {
+                // TODO: better handle case where looking up shader fails
+                match shader.module.shaders.get(shader.entry) {
+                    Some(shader) => {
+                        winapi::D3D12_SHADER_BYTECODE {
+                            pShaderBytecode: unsafe { (**shader).GetBufferPointer() as *const _ },
+                            BytecodeLength: unsafe { (**shader).GetBufferSize() as u64 },
+                        }
+                    }
+                    None => {
+                        winapi::D3D12_SHADER_BYTECODE {
+                            pShaderBytecode: ptr::null(),
+                            BytecodeLength: 0,
+                        }
+                    }
+                }
+            };
+
+            let pso_desc = winapi::D3D12_COMPUTE_PIPELINE_STATE_DESC {
+                pRootSignature: signature.raw,
+                CS: cs,
+                NodeMask: 0,
+                CachedPSO: winapi::D3D12_CACHED_PIPELINE_STATE {
+                    pCachedBlob: ptr::null(),
+                    CachedBlobSizeInBytes: 0,
+                },
+                Flags: winapi::D3D12_PIPELINE_STATE_FLAG_NONE,
+            };
+
+            // Create PSO
+            let mut pipeline = ptr::null_mut();
+            let hr = unsafe {
+                self.device.CreateComputePipelineState(
+                    &pso_desc,
+                    &dxguid::IID_ID3D12PipelineState,
+                    &mut pipeline as *mut *mut _ as *mut *mut _)
+            };
+
+            if winapi::SUCCEEDED(hr) {
+                Ok(n::ComputePipeline { raw: pipeline })
+            } else {
+                Err(pso::CreationError::Other)
+            }
+        }).collect()
     }
 
     fn create_framebuffer(
@@ -574,7 +618,7 @@ impl d::Device<B> for Device {
         }
     }
 
-    fn create_shader_module(&mut self, spirv_data: &[u8]) -> Result<n::ShaderModule, d::ShaderError> {
+    fn create_shader_module(&mut self, _spirv_data: &[u8]) -> Result<n::ShaderModule, d::ShaderError> {
         unimplemented!()
     }
 
@@ -626,8 +670,8 @@ impl d::Device<B> for Device {
         })
     }
 
-    fn get_buffer_requirements(&mut self, _buffer: &UnboundBuffer) -> Requirements {
-        unimplemented!()
+    fn get_buffer_requirements(&mut self, buffer: &UnboundBuffer) -> Requirements {
+        buffer.requirements
     }
 
     fn bind_buffer_memory(
@@ -1079,27 +1123,27 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn destroy_pipeline_layout(&mut self, _pl: n::PipelineLayout) {
-        unimplemented!()
+    fn destroy_pipeline_layout(&mut self, layout: n::PipelineLayout) {
+        unsafe { (*layout.raw).Release(); }
     }
 
-    fn destroy_graphics_pipeline(&mut self, mut pipeline: n::GraphicsPipeline) {
+    fn destroy_graphics_pipeline(&mut self, pipeline: n::GraphicsPipeline) {
         unsafe { (*pipeline.raw).Release(); }
     }
 
-    fn destroy_compute_pipeline(&mut self, _pipeline: n::ComputePipeline) {
-        unimplemented!()
+    fn destroy_compute_pipeline(&mut self, pipeline: n::ComputePipeline) {
+        unsafe { (*pipeline.raw).Release(); }
     }
 
     fn destroy_framebuffer(&mut self, _fb: n::FrameBuffer) {
         unimplemented!()
     }
 
-    fn destroy_buffer(&mut self, mut buffer: n::Buffer) {
+    fn destroy_buffer(&mut self, buffer: n::Buffer) {
         unsafe { (*buffer.resource).Release(); }
     }
 
-    fn destroy_image(&mut self, mut image: n::Image) {
+    fn destroy_image(&mut self, image: n::Image) {
         unsafe { (*image.resource).Release(); }
     }
 
@@ -1132,7 +1176,7 @@ impl d::Device<B> for Device {
     }
 
     fn destroy_descriptor_set_layout(&mut self, _layout: n::DescriptorSetLayout) {
-        unimplemented!()
+        // Just drop
     }
 
     fn destroy_fence(&mut self, _fence: n::Fence) {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -288,7 +288,7 @@ impl d::Device<B> for Device {
         //
         // Each descriptor set layout will be one table entry of the root signature.
         // We have the additional restriction that SRV/CBV/UAV and samplers need to be
-        // separated, so each set layout will actually occupy 2 entries!
+        // separated, so each set layout will actually occupy up to 2 entries!
 
         let total = sets.iter().map(|desc_sec| desc_sec.bindings.len()).sum();
         // guarantees that no re-allocation is done, and our pointers are valid
@@ -369,6 +369,7 @@ impl d::Device<B> for Device {
 
             if !error.is_null() {
                 let error_output = (*error).GetBufferPointer();
+                (*error).Release();
             }
 
             self.device.CreateRootSignature(
@@ -376,9 +377,10 @@ impl d::Device<B> for Device {
                 (*signature_raw).GetBufferPointer(),
                 (*signature_raw).GetBufferSize(),
                 &dxguid::IID_ID3D12RootSignature,
-                &mut signature as *mut *mut _ as *mut *mut _);
+                &mut signature as *mut *mut _ as *mut *mut _,
+            );
+            (*signature_raw).Release();
         }
-        unsafe { (*signature_raw).Release() };
 
         n::PipelineLayout {
             raw: signature,
@@ -478,7 +480,6 @@ impl d::Device<B> for Device {
                                              .zip(pass.color_attachments.iter())
                 {
                     let format = subpass.main_pass.attachments[target.0].format;
-                    println!("{:?}", format);
                     *rtv = conv::map_format(format, true).unwrap_or(winapi::DXGI_FORMAT_UNKNOWN);
                     num_rtvs += 1;
                 }
@@ -516,7 +517,7 @@ impl d::Device<B> for Device {
                     pInputElementDescs: input_element_descs.as_ptr(),
                     NumElements: input_element_descs.len() as u32,
                 },
-                IBStripCutValue: winapi::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_DISABLED,
+                IBStripCutValue: winapi::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_DISABLED, // TODO
                 PrimitiveTopologyType: conv::map_topology_type(desc.input_assembler.primitive),
                 NumRenderTargets: num_rtvs,
                 RTVFormats: rtvs,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -32,8 +32,6 @@ use std::os::windows::ffi::OsStringExt;
 use std::ffi::OsString;
 use std::sync::{Arc, Mutex};
 
-pub type ShaderModel = u16;
-
 #[derive(Clone)]
 pub struct QueueFamily;
 
@@ -299,11 +297,6 @@ impl Device {
             events: Vec::new(),
         }
     }
-
-    /// Return the maximum supported shader model.
-    pub fn get_shader_model(&self) -> ShaderModel {
-        unimplemented!()
-    }
 }
 
 pub struct Instance {
@@ -312,8 +305,9 @@ pub struct Instance {
 
 impl Instance {
     pub fn create(_: &str, _: u32) -> Instance {
-        // Enable debug layer
+        #[cfg(debug_assertions)]
         {
+            // Enable debug layer
             let mut debug_controller: *mut winapi::ID3D12Debug = ptr::null_mut();
             let hr = unsafe {
                 d3d12::D3D12GetDebugInterface(

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -250,7 +250,7 @@ impl Device {
             &mut device,
             winapi::D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
             true,
-            0x10000,
+            1_000_000, // maximum number of CBV/SRV/UAV descriptors in heap for Tier 1
         );
 
         let heap_sampler = Self::create_descriptor_heap_impl(


### PR DESCRIPTION
* Fix build issue in `quad` for dx12 backend
* Improve documentation for root signature layout. Better reflect internal layout.
* Implement compute pipeline creation
* Increase default descriptor heap size for CBV/SRV/UAV heaps to match Tier 1 limit
* Implement a few more destroy functions
* Only enable debug layer for debug builds following Vulkan