### PR TITLE
[ll] Surface capability querying

### DIFF
--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -6,7 +6,7 @@ use std::ptr;
 use winit;
 use winapi;
 use wio::com::ComPtr;
-use {conv, native as n, Backend, Instance, QueueFamily};
+use {conv, native as n, Adapter, Backend, Instance, QueueFamily};
 
 use winit::os::windows::WindowExt;
 
@@ -36,6 +36,20 @@ impl core::Surface<Backend> for Surface {
 
         let aa = core::image::AaMode::Single;
         core::image::Kind::D2(self.width as Size, self.height as Size, aa)
+    }
+
+    fn surface_capabilities(&self, _: &Adapter) -> core::SurfaceCapabilities {
+        let extent = core::window::Extent2d {
+            width: self.width,
+            height: self.height,
+        };
+
+        core::SurfaceCapabilities {
+            image_count: 2..16, // we currently use a flip effect which supports 2..16 buffers
+            current_extent: Some(extent),
+            extents: extent..extent,
+            max_image_layers: 1,
+        }
     }
 
     fn build_swapchain<C>(

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -528,6 +528,10 @@ impl core::Surface<Backend> for Surface {
         unimplemented!()
     }
 
+    fn surface_capabilities(&self, _: &Adapter) -> core::SurfaceCapabilities {
+        unimplemented!()
+    }
+
     fn supports_queue(&self, _: &QueueFamily) -> bool {
         unimplemented!()
     }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -106,39 +106,6 @@ impl Error {
 
 type ArrayBuffer = gl::types::GLuint;
 
-/*
-/// Create the proxy target views (RTV and DSV) for the attachments of the
-/// main framebuffer. These have GL names equal to 0.
-/// Not supposed to be used by the users directly.
-pub fn create_main_targets_raw(dim: t::Dimensions, color_format: format::SurfaceType, depth_format: format::SurfaceType)
-                               -> (handle::RawRenderTargetView<Backend>, handle::RawDepthStencilView<Backend>) {
-    use core::handle::Producer;
-    let color_tex =
-        native::Image::Surface(0),
-        t::Info {
-            levels: 1,
-            kind: t::Kind::D2(dim.0, dim.1, dim.3),
-            format: color_format,
-            bind: memory::RENDER_TARGET | memory::TRANSFER_SRC,
-            usage: memory::Usage::Data,
-        },
-    );
-    let depth_tex = temp.make_image(
-        native::Image::Surface(0),
-        t::Info {
-            levels: 1,
-            kind: t::Kind::D2(dim.0, dim.1, dim.3),
-            format: depth_format,
-            bind: memory::DEPTH_STENCIL | memory::TRANSFER_SRC,
-            usage: memory::Usage::Data,
-        },
-    );
-    let m_color = temp.make_rtv(native::TargetView::Surface(0), &color_tex, dim);
-    let m_ds = temp.make_dsv(native::TargetView::Surface(0), &depth_tex, dim);
-    (m_color, m_ds)
-}
-*/
-
 /// Internal struct of shared data between the device and its factories.
 struct Share {
     context: gl::Gl,

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -57,36 +57,6 @@ fn get_window_dimensions(window: &glutin::GlWindow) -> image::Dimensions {
     ((width as f32 * window.hidpi_factor()) as image::Size, (height as f32 * window.hidpi_factor()) as image::Size, 1, aa.into())
 }
 
-/*
-/// Update the internal dimensions of the main framebuffer targets. Generic version over the format.
-pub fn update_views<Cf, Df>(window: &glutin::GlWindow, color_view: &mut handle::RenderTargetView<R, Cf>,
-                    ds_view: &mut handle::DepthStencilView<R, Df>)
-where
-    Cf: format::RenderFormat,
-    Df: format::DepthFormat,
-{
-    let dim = color_view.get_dimensions();
-    assert_eq!(dim, ds_view.get_dimensions());
-    if let Some((cv, dv)) = update_views_raw(window, dim, Cf::get_format(), Df::get_format()) {
-        *color_view = Typed::new(cv);
-        *ds_view = Typed::new(dv);
-    }
-}
-
-/// Return new main target views if the window resolution has changed from the old dimensions.
-pub fn update_views_raw(window: &glutin::GlWindow, old_dimensions: image::Dimensions,
-                        color_format: format::Format, ds_format: format::Format)
-                        -> Option<(handle::RawRenderTargetView<R>, handle::RawDepthStencilView<R>)>
-{
-    let dim = get_window_dimensions(window);
-    if dim != old_dimensions {
-        Some(device_gl::create_main_targets_raw(dim, color_format.0, ds_format.0))
-    }else {
-        None
-    }
-}
-*/
-
 pub struct Swapchain {
     // Underlying window, required for presentation
     window: Rc<glutin::GlWindow>,
@@ -119,6 +89,10 @@ impl core::Surface<B> for Surface {
     fn get_kind(&self) -> core::image::Kind {
         let (w, h, _, a) = get_window_dimensions(&self.window);
         core::image::Kind::D2(w, h, a)
+    }
+
+    fn surface_capabilities(&self, _: &Adapter) -> core::SurfaceCapabilities {
+        unimplemented!()
     }
 
     fn supports_queue(&self, _: &QueueFamily) -> bool { true }

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -1,4 +1,4 @@
-use {Backend};
+use {Adapter, Backend};
 use {native, conversions};
 
 use std::mem;
@@ -50,6 +50,10 @@ const SWAP_CHAIN_IMAGE_COUNT: usize = 3;
 
 impl core::Surface<Backend> for Surface {
     fn get_kind(&self) -> image::Kind {
+        unimplemented!()
+    }
+
+    fn surface_capabilities(&self, _: &Adapter) -> core::SurfaceCapabilities {
         unimplemented!()
     }
 
@@ -107,9 +111,9 @@ impl core::Surface<Backend> for Surface {
 
             // FIXME: depth
             let images = io_surfaces.iter().map(|surface| {
-                let mapped_texture: MTLTexture = msg_send![device.0, 
-                    newTextureWithDescriptor: backbuffer_descriptor.0 
-                    iosurface: surface.obj 
+                let mapped_texture: MTLTexture = msg_send![device.0,
+                    newTextureWithDescriptor: backbuffer_descriptor.0
+                    iosurface: surface.obj
                     plane: 0
                 ]; // Returns retained
                 Backbuffer { color: native::Image(mapped_texture), depth_stencil: None }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -28,7 +28,6 @@ mod native;
 mod pool;
 mod window;
 
-
 const LAYERS: &'static [&'static str] = &[
     #[cfg(debug_assertions)]
     "VK_LAYER_LUNARG_standard_validation",
@@ -88,7 +87,6 @@ fn map_queue_type(flags: vk::QueueFlags) -> QueueType {
         unimplemented!()
     }
 }
-
 
 extern "system" fn callback(
     type_: vk::DebugReportFlagsEXT,
@@ -344,6 +342,12 @@ pub struct Adapter {
     properties: vk::PhysicalDeviceProperties,
     queue_families: Vec<(QueueFamily, QueueType)>,
     info: core::AdapterInfo,
+}
+
+impl Adapter {
+    pub(crate) fn handle(&self) -> vk::PhysicalDevice {
+        self.handle
+    }
 }
 
 impl core::Adapter<Backend> for Adapter {

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -32,7 +32,7 @@ pub use self::queue::{
     General, Graphics, Compute, Transfer,
 };
 pub use self::window::{
-    Backbuffer, Frame, FrameSync, Surface, Swapchain, SwapchainConfig};
+    Backbuffer, Frame, FrameSync, Surface, SurfaceCapabilities, Swapchain, SwapchainConfig};
 pub use draw_state::{state, target};
 
 pub mod adapter;

--- a/src/core/src/window.rs
+++ b/src/core/src/window.rs
@@ -53,6 +53,44 @@ use Backend;
 use image;
 use format::{self, Formatted};
 use queue::CommandQueue;
+use std::ops::Range;
+
+///
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct Extent2d {
+    ///
+    pub width: u32,
+    ///
+    pub height: u32,
+}
+
+///
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct SurfaceCapabilities {
+    /// Number of presentable images supported by the adapter for a swapchain
+    /// created from this surface.
+    ///
+    /// - `image_count.start` must be at least 1.
+    /// - `image_count.end` must be larger of equal to `image_count.start`.
+    pub image_count: Range<u32>,
+
+    /// Current extent of the surface.
+    ///
+    /// `None` if the surface has no explicit size, depending on the swapchain extent.
+    pub current_extent: Option<Extent2d>,
+
+    /// Range of supported extents.
+    ///
+    /// `current_extent` must be inside this range.
+    pub extents: Range<Extent2d>,
+
+    /// Maximum number of layers supported for presentable images.
+    ///
+    /// Must be at least 1.
+    pub max_image_layers: u32,
+}
 
 /// A `Surface` abstracts the surface of a native window, which will be presented
 pub trait Surface<B: Backend> {
@@ -67,6 +105,11 @@ pub trait Surface<B: Backend> {
     ///
     /// ```
     fn supports_queue(&self, queue_family: &B::QueueFamily) -> bool;
+
+    /// Query surface capabilities for this adapter.
+    ///
+    /// Use this function for configuring your swapchain creation.
+    fn surface_capabilities(&self, adapter: &B::Adapter) -> SurfaceCapabilities;
 
     /// Create a new swapchain from a surface and a queue.
     ///


### PR DESCRIPTION
Support querying surface properties to obtain reasonable values for swapchain creation.
Next step are extending swapchain create infos to make use of the queried results.

Metal currently unimplemented