### PR TITLE
[ll] dx12: Implement pipeline barriers

### DIFF
--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -151,29 +151,12 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         stages: Range<pso::PipelineStage>,
         barriers: &[memory::Barrier<Backend>],
     ) {
-        let mut memory_bars: SmallVec<[vk::MemoryBarrier; 4]> = SmallVec::new();
         let mut buffer_bars: SmallVec<[vk::BufferMemoryBarrier; 4]> = SmallVec::new();
         let mut image_bars: SmallVec<[vk::ImageMemoryBarrier; 4]> = SmallVec::new();
 
         for barrier in barriers {
             match *barrier {
-                memory::Barrier::AllBuffers(ref access) => {
-                    memory_bars.push(vk::MemoryBarrier {
-                        s_type: vk::StructureType::MemoryBarrier,
-                        p_next: ptr::null(),
-                        src_access_mask: conv::map_buffer_access(access.start),
-                        dst_access_mask: conv::map_buffer_access(access.end),
-                    });
-                }
-                memory::Barrier::AllImages(ref access) => {
-                    memory_bars.push(vk::MemoryBarrier {
-                        s_type: vk::StructureType::MemoryBarrier,
-                        p_next: ptr::null(),
-                        src_access_mask: conv::map_image_access(access.start),
-                        dst_access_mask: conv::map_image_access(access.end),
-                    });
-                }
-                memory::Barrier::Buffer { ref states, target, ref range } => {
+                memory::Barrier::Buffer { ref states, target} => {
                     buffer_bars.push(vk::BufferMemoryBarrier {
                         s_type: vk::StructureType::BufferMemoryBarrier,
                         p_next: ptr::null(),
@@ -182,8 +165,8 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
                         src_queue_family_index: vk::VK_QUEUE_FAMILY_IGNORED, // TODO
                         dst_queue_family_index: vk::VK_QUEUE_FAMILY_IGNORED, // TODO
                         buffer: target.raw,
-                        offset: range.start,
-                        size: range.end - range.start,
+                        offset: 0,
+                        size: vk::VK_WHOLE_SIZE,
                     });
                 }
                 memory::Barrier::Image { ref states, target, ref range } => {
@@ -210,7 +193,7 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
                 conv::map_pipeline_stage(stages.start),
                 conv::map_pipeline_stage(stages.end),
                 vk::DependencyFlags::empty(), // dependencyFlags // TODO
-                &memory_bars,
+                &[],
                 &buffer_bars,
                 &image_bars,
             );

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -299,6 +299,24 @@ pub fn map_buffer_access(access: buffer::Access) -> vk::AccessFlags {
     if access.contains(buffer::INDIRECT_COMMAND_READ) {
         flags |= vk::ACCESS_INDIRECT_COMMAND_READ_BIT;
     }
+    if access.contains(buffer::SHADER_READ) {
+        flags |= vk::ACCESS_SHADER_READ_BIT;
+    }
+    if access.contains(buffer::SHADER_WRITE) {
+        flags |= vk::ACCESS_SHADER_WRITE_BIT;
+    }
+    if access.contains(buffer::HOST_READ) {
+        flags |= vk::ACCESS_HOST_READ_BIT;
+    }
+    if access.contains(buffer::HOST_WRITE) {
+        flags |= vk::ACCESS_HOST_WRITE_BIT;
+    }
+    if access.contains(buffer::MEMORY_READ) {
+        flags |= vk::ACCESS_MEMORY_READ_BIT;
+    }
+    if access.contains(buffer::MEMORY_WRITE) {
+        flags |= vk::ACCESS_MEMORY_WRITE_BIT;
+    }
 
     flags
 }
@@ -306,15 +324,6 @@ pub fn map_buffer_access(access: buffer::Access) -> vk::AccessFlags {
 pub fn map_image_access(access: image::Access) -> vk::AccessFlags {
     let mut flags = vk::AccessFlags::empty();
 
-    if access.contains(image::RENDER_TARGET_CLEAR) {
-        unimplemented!()
-    }
-    if access.contains(image::RESOLVE_SRC) {
-        unimplemented!()
-    }
-    if access.contains(image::RESOLVE_DST) {
-        unimplemented!()
-    }
     if access.contains(image::COLOR_ATTACHMENT_READ) {
         flags |= vk::ACCESS_COLOR_ATTACHMENT_READ_BIT;
     }
@@ -329,6 +338,30 @@ pub fn map_image_access(access: image::Access) -> vk::AccessFlags {
     }
     if access.contains(image::SHADER_READ) {
         flags |= vk::ACCESS_SHADER_READ_BIT;
+    }
+    if access.contains(image::SHADER_WRITE) {
+        flags |= vk::ACCESS_SHADER_WRITE_BIT;
+    }
+    if access.contains(image::DEPTH_STENCIL_ATTACHMENT_READ) {
+        flags |= vk::ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
+    }
+    if access.contains(image::DEPTH_STENCIL_ATTACHMENT_WRITE) {
+        flags |= vk::ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    }
+    if access.contains(image::HOST_READ) {
+        flags |= vk::ACCESS_HOST_READ_BIT;
+    }
+    if access.contains(image::HOST_WRITE) {
+        flags |= vk::ACCESS_HOST_WRITE_BIT;
+    }
+    if access.contains(image::MEMORY_READ) {
+        flags |= vk::ACCESS_MEMORY_READ_BIT;
+    }
+    if access.contains(image::MEMORY_WRITE) {
+        flags |= vk::ACCESS_MEMORY_WRITE_BIT;
+    }
+    if access.contains(image::INPUT_ATTACHMENT_READ) {
+        flags |= vk::ACCESS_INPUT_ATTACHMENT_READ_BIT;
     }
 
     flags

--- a/src/core/src/buffer.rs
+++ b/src/core/src/buffer.rs
@@ -16,7 +16,7 @@ bitflags!(
         ///
         const TRANSFER_DST = 0x2,
         ///
-        const CONSTANT    = 0x4,
+        const CONSTANT = 0x4,
         ///
         const INDEX = 0x8,
         ///
@@ -49,6 +49,18 @@ bitflags!(
         const CONSTANT_BUFFER_READ   = 0x40,
         ///
         const INDIRECT_COMMAND_READ  = 0x80,
+        ///
+        const SHADER_READ = 0x100,
+        ///
+        const SHADER_WRITE = 0x200,
+        ///
+        const HOST_READ = 0x400,
+        ///
+        const HOST_WRITE = 0x800,
+        ///
+        const MEMORY_READ = 0x1000,
+        ///
+        const MEMORY_WRITE = 0x2000,
     }
 );
 

--- a/src/core/src/image.rs
+++ b/src/core/src/image.rs
@@ -552,22 +552,33 @@ bitflags!(
     ///
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub flags Access: u16 {
-        ///
-        const RENDER_TARGET_CLEAR    = 0x20,
-        ///
-        const RESOLVE_SRC            = 0x100,
-        ///
-        const RESOLVE_DST            = 0x200,
-        ///
-        const COLOR_ATTACHMENT_READ  = 0x1,
-        ///
+        /// Read state but can only be combined with `COLOR_ATTACHMENT_WRITE`.
+        const COLOR_ATTACHMENT_READ = 0x1,
+        /// Write-only state but can be combined with `COLOR_ATTACHMENT_READ`.
         const COLOR_ATTACHMENT_WRITE = 0x2,
         ///
-        const TRANSFER_READ          = 0x4,
+        const TRANSFER_READ = 0x4,
+        /// Write-only state of copy commands.
+        const TRANSFER_WRITE = 0x8,
+        /// Read-only state for SRV access, or combine with `SHADER_WRITE` to have r/w access to UAV.
+        const SHADER_READ = 0x10,
+        /// Write state for UAV access.
+        /// Combine with `SHADER_READ` to have r/w access to UAV.
+        const SHADER_WRITE = 0x20,
         ///
-        const TRANSFER_WRITE         = 0x8,
+        const DEPTH_STENCIL_ATTACHMENT_READ = 0x40,
+        /// Write-only state for depth stencil writes.
+        const DEPTH_STENCIL_ATTACHMENT_WRITE = 0x80,
         ///
-        const SHADER_READ           = 0x10,
+        const HOST_READ = 0x100,
+        ///
+        const HOST_WRITE = 0x200,
+        ///
+        const MEMORY_READ = 0x400,
+        ///
+        const MEMORY_WRITE = 0x800,
+        ///
+        const INPUT_ATTACHMENT_READ = 0x1000,
     }
 );
 

--- a/src/core/src/memory.rs
+++ b/src/core/src/memory.rs
@@ -71,12 +71,9 @@ bitflags!(
 #[allow(missing_docs)] //TODO
 #[derive(Clone, Debug)]
 pub enum Barrier<'a, B: Backend> {
-    AllBuffers(Range<buffer::Access>),
-    AllImages(Range<image::Access>),
     Buffer {
         states: Range<buffer::State>,
         target: &'a B::Buffer,
-        range: Range<u64>,
     },
     Image {
         states: Range<image::State>,


### PR DESCRIPTION
Implement pipeline barriers for dx12 based on vulkan's access model.

Requires a few workarounds and restrictions to make this work:
* We differ between read and read/write states as it's a limitation by dx12. Allowing to only have one write bit set but multiple read bits if no write bit is set.
* `TRANSFER_WRITE` for images is used for all copy commands (including resolve). We add transitions barriers for resolve operations before and afterwards (can be optimized maybe) to have a consistent state accross command list boundaries.
* `SHADER_READ` is limited to SRV reads, which we need to enforce on the shader side for HLSL to get it working. `SHADER_WRITE` is used for write access to UAV and can be combined with `SHADER_READ` to obtain read access to UAV (but not SRV).
* Buffers can only be transistioned as in a whole, not on a range basis. (TODO: image only whole subresources or whole image).
* Global memory barriers currently unsupported (not totally clear if we can support them)
* UAV and aliasing barriers are always inserted atm, needs further investigation on how we can do this smarter.

Imo these are valid restrictions to vulkan's specification.
cc #1498 