### PR TITLE
[ll] Metal Backend: Support multiple windowing libs

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/gfx_backend_metal"
 workspace = "../../.."
 
 [features]
-default = []
+default = ["winit"]
 argument_buffer = []
 
 [lib]
@@ -21,7 +21,7 @@ name = "gfx_backend_metal"
 [dependencies]
 gfx_core = { path = "../../core", version = "0.10" }
 log = "0.3"
-winit = "0.7"
+winit = { version = "0.7", optional = true }
 scopeguard = "0.3"
 metal-rs = "0.4"
 objc = "0.2"

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -87,6 +87,7 @@ impl Instance {
         }
     }
 
+    #[cfg(feature = "winit")]
     pub fn create_surface(&self, window: &winit::Window) -> Surface {
         use winit::os::macos::WindowExt;
         self.create_surface_from_nsview(window.get_nsview())

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -41,18 +41,6 @@ use core_graphics::geometry::CGRect;
 pub struct Instance {
 }
 
-pub trait NativeWindow {
-    fn get_nsview(&self) -> *mut c_void;
-}
-
-#[cfg(feature = "winit")]
-impl NativeWindow for winit::Window {
-    fn get_nsview(&self) -> *mut c_void {
-        use winit::os::macos::WindowExt;
-        WindowExt::get_nsview(self)
-    }
-}
-
 impl core::Instance<Backend> for Instance {
     fn enumerate_adapters(&self) -> Vec<Adapter> {
         // TODO: enumerate all devices
@@ -77,9 +65,9 @@ impl Instance {
         Instance {}
     }
 
-    pub fn create_surface(&self, window: &NativeWindow) -> Surface {
+    pub fn create_surface_from_nsview(&self, nsview: *mut c_void) -> Surface {
         unsafe {
-            let view: cocoa::base::id = mem::transmute(window.get_nsview());
+            let view: cocoa::base::id = mem::transmute(nsview);
             if view.is_null() {
                 panic!("window does not have a valid contentView");
             }
@@ -97,6 +85,11 @@ impl Instance {
                 render_layer: RefCell::new(render_layer),
             }))
         }
+    }
+
+    pub fn create_surface(&self, window: &winit::Window) -> Surface {
+        use winit::os::macos::WindowExt;
+        self.create_surface_from_nsview(window.get_nsview())
     }
 }
 

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -13,7 +13,6 @@ use core::format::ChannelType;
 use core::CommandQueue;
 
 use metal::*;
-use winit::os::macos::WindowExt;
 use objc::runtime::{Object, Class};
 use core_foundation::base::TCFType;
 use core_foundation::string::{CFString, CFStringRef};


### PR DESCRIPTION
Metal backend in `ll` branch needed winit object to create surface. However, it was inconvenient for users with sdl2, glew3 windowing library instead of winit library. Thus I made a trait NativeWindow to bridge window objects and the metal Instance in gfx-rs.