### PR TITLE
[ll] dx12: Start spirv_cross integration

### DIFF
--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -23,7 +23,7 @@ d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch 
 dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 kernel32-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-spirv_cross = "0.1.2"
+spirv_cross = "0.1.4"
 winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 winit = "0.7"
 wio = { git = "https://github.com/msiglreith/wio-rs.git", branch = "stable" }

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -23,6 +23,7 @@ d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch 
 dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 kernel32-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
+spirv_cross = "0.1.2"
 winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 winit = "0.7"
 wio = { git = "https://github.com/msiglreith/wio-rs.git", branch = "stable" }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -361,7 +361,7 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
                 Flags: winapi::D3D12_RESOURCE_BARRIER_FLAG_NONE,
                 u: winapi::D3D12_RESOURCE_TRANSITION_BARRIER {
                     pResource: dst.resource,
-                    Subresource: winapi::D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+                    Subresource: winapi::D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, // TODO: only affected ranges
                     StateBefore: winapi::D3D12_RESOURCE_STATE_COPY_DEST,
                     StateAfter: winapi::D3D12_RESOURCE_STATE_RESOLVE_DEST,
                 },
@@ -391,7 +391,7 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
                 Flags: winapi::D3D12_RESOURCE_BARRIER_FLAG_NONE,
                 u: winapi::D3D12_RESOURCE_TRANSITION_BARRIER {
                     pResource: dst.resource,
-                    Subresource: winapi::D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+                    Subresource: winapi::D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES, // TODO: only affected ranges
                     StateBefore: winapi::D3D12_RESOURCE_STATE_RESOLVE_DEST,
                     StateAfter: winapi::D3D12_RESOURCE_STATE_COPY_DEST,
                 },

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -25,7 +25,7 @@ mod shade;
 mod window;
 
 use core::{memory, Features, Limits, QueueType};
-use spirv_cross::compile;
+use spirv_cross::hlsl;
 use wio::com::ComPtr;
 
 use std::{mem, ptr};
@@ -196,7 +196,7 @@ pub struct Device {
     heap_srv_cbv_uav: Arc<Mutex<native::DescriptorHeap>>,
     heap_sampler: Arc<Mutex<native::DescriptorHeap>>,
     events: Vec<winapi::HANDLE>,
-    hlsl_compiler: compile::HlslCompiler,
+    hlsl_compiler: hlsl::Compiler,
 }
 unsafe impl Send for Device {} //blocked by ComPtr
 
@@ -307,7 +307,7 @@ impl Device {
             heap_srv_cbv_uav: Arc::new(Mutex::new(heap_srv_cbv_uav)),
             heap_sampler: Arc::new(Mutex::new(heap_sampler)),
             events: Vec::new(),
-            hlsl_compiler: compile::HlslCompiler::new(),
+            hlsl_compiler: hlsl::Compiler::new(),
         }
     }
 }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -10,6 +10,7 @@ extern crate kernel32;
 #[macro_use]
 extern crate log;
 extern crate smallvec;
+extern crate spirv_cross;
 extern crate winapi;
 extern crate winit;
 extern crate wio;
@@ -24,6 +25,7 @@ mod shade;
 mod window;
 
 use core::{memory, Features, Limits, QueueType};
+use spirv_cross::compile;
 use wio::com::ComPtr;
 
 use std::{mem, ptr};
@@ -194,6 +196,7 @@ pub struct Device {
     heap_srv_cbv_uav: Arc<Mutex<native::DescriptorHeap>>,
     heap_sampler: Arc<Mutex<native::DescriptorHeap>>,
     events: Vec<winapi::HANDLE>,
+    hlsl_compiler: compile::HlslCompiler,
 }
 unsafe impl Send for Device {} //blocked by ComPtr
 
@@ -304,6 +307,7 @@ impl Device {
             heap_srv_cbv_uav: Arc::new(Mutex::new(heap_srv_cbv_uav)),
             heap_sampler: Arc::new(Mutex::new(heap_sampler)),
             events: Vec::new(),
+            hlsl_compiler: compile::HlslCompiler::new(),
         }
     }
 }


### PR DESCRIPTION
Start integration SPIRV-Cross into gfx-rs for generating HLSL shaders from SPIR-V.

TODO:
- [x] Fix build errors (missing `Clone` for `HlslCompiler`)
- [x] Extract entrypoints from SPIR-V (or HLSL?) and build up the shader module map.

Big Thanks @grovesNL for the `spirv_cross` wrapper 👏 