### PR TITLE
[ll][dx12] Subpass Dependencies

### DIFF
--- a/examples/core/quad/main.rs
+++ b/examples/core/quad/main.rs
@@ -189,6 +189,8 @@ fn main() {
 
         let subpass = pass::SubpassDesc {
             color_attachments: &[(0, i::ImageLayout::ColorAttachmentOptimal)],
+            input_attachments: &[],
+            preserve_attachments: &[],
         };
 
         let dependency = pass::SubpassDependency {
@@ -539,11 +541,6 @@ fn main() {
     #[cfg(feature = "metal")]
     device.destroy_shader_module(shader_lib);
 
-    device.destroy_pipeline_layout(pipeline_layout);
-    device.destroy_renderpass(render_pass);
-    device.destroy_heap(heap);
-    device.destroy_heap(image_heap);
-    device.destroy_heap(image_upload_heap);
     device.destroy_buffer(vertex_buffer);
     device.destroy_buffer(image_upload_buffer);
     device.destroy_image(image_logo);
@@ -551,6 +548,11 @@ fn main() {
     device.destroy_sampler(sampler);
     device.destroy_fence(frame_fence);
     device.destroy_semaphore(frame_semaphore);
+    device.destroy_pipeline_layout(pipeline_layout);
+    device.destroy_renderpass(render_pass);
+    device.destroy_heap(heap);
+    device.destroy_heap(image_heap);
+    device.destroy_heap(image_upload_heap);
     for pipeline in pipelines {
         if let Ok(pipeline) = pipeline {
             device.destroy_graphics_pipeline(pipeline);

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -98,6 +98,8 @@ fn main() {
 
         let subpass = pass::SubpassDesc {
             color_attachments: &[(0, i::ImageLayout::ColorAttachmentOptimal)],
+            input_attachments: &[],
+            preserve_attachments: &[],
         };
 
         let dependency = pass::SubpassDependency {

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -524,20 +524,20 @@ pub fn map_buffer_flags(_usage: buffer::Usage) -> D3D12_RESOURCE_FLAGS {
 }
 
 pub fn map_image_flags(usage: image::Usage) -> D3D12_RESOURCE_FLAGS {
-    let mut flags = 0;
+    let mut flags = D3D12_RESOURCE_FLAG_NONE;
 
     if usage.contains(image::COLOR_ATTACHMENT) {
-        flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET.0;
+        flags = flags | D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
     }
     if usage.contains(image::DEPTH_STENCIL_ATTACHMENT) {
-        flags |= D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL.0;
+        flags = flags | D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
     }
     if usage.contains(image::STORAGE) {
-        flags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS.0;
+        flags = flags | D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     }
     if usage.contains(image::DEPTH_STENCIL_ATTACHMENT) && !usage.contains(image::SAMPLED) {
-        flags |= D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE.0;
+        flags = flags | D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE;
     }
 
-    D3D12_RESOURCE_FLAGS(flags) //TODO
+    flags
 }

--- a/src/core/src/format.rs
+++ b/src/core/src/format.rs
@@ -140,6 +140,20 @@ impl_formats! {
     D32_S8          : Vec1<Unorm, Float, Uint> = (f32, u32) {32} [TextureSurface, DepthSurface, StencilSurface],
 }
 
+impl SurfaceType {
+    /// Return true if it's a depth surface type.
+    pub fn is_depth(self) -> bool {
+        match self {
+            SurfaceType::D16 |
+            SurfaceType::D24 |
+            SurfaceType::D24_S8 |
+            SurfaceType::D32 |
+            SurfaceType::D32_S8 => true,
+            _ => false,
+        }
+    }
+}
+
 
 /// Source channel in a swizzle configuration. Some may redirect onto
 /// different physical channels, some may be hardcoded to 0 or 1.

--- a/src/core/src/pass.rs
+++ b/src/core/src/pass.rs
@@ -70,8 +70,10 @@ pub struct Attachment {
     pub layouts: Range<AttachmentLayout>,
 }
 
+/// Index of an attachment within a framebuffer/rebderpass,
+pub type AttachmentId = usize;
 /// Reference to an attachment by index and expected image layout.
-pub type AttachmentRef = (usize, AttachmentLayout);
+pub type AttachmentRef = (AttachmentId, AttachmentLayout);
 
 ///
 #[derive(Copy, Clone, Debug, Hash, PartialEq)]
@@ -99,6 +101,10 @@ pub struct SubpassDependency {
 pub struct SubpassDesc<'a> {
     ///
     pub color_attachments: &'a [AttachmentRef],
+    ///
+    pub input_attachments: &'a [AttachmentRef],
+    ///
+    pub preserve_attachments: &'a [AttachmentId],
 }
 
 /// Index of a subpass.


### PR DESCRIPTION
I'm not yet confident that this is going to be enough, but the implementation is somewhat sound, and it will get us going for the nearest future. Basic logic is the following:

We ignore the access masks and pipeline stages of dependencies, but use the source/dest subpass indexes in order to build an order of subpasses, which fulfills the dependencies (i.e. traversing the graph in this order means that the dependencies of each next subpass are resolved by the time we get to it).

Within the produced order, for each attachment we figure if there is a particular state it needs to be, or preserved, or we don't care. Once we see a required state, we determine where the transition needs to start (at some previous pass, or right here in place), record new barriers, and update the current values for the attachment.

This barrier recording is done in `create_renderpass`, which means we can't store them directly as `D3D12_RESOURCE_STATES`, because we don't know the exact resources yet. Thus, we keep them in `native::BarrierDesc` objects, which get resolved in a simple way during the render pass encoding.