### PR TITLE
[ll] heap creation -> memory allocation

### DIFF
--- a/examples/render/quad_render/Cargo.toml
+++ b/examples/render/quad_render/Cargo.toml
@@ -15,6 +15,6 @@ image = "0.15"
 log = "0.3"
 winit = "0.7"
 gfx_core = { path = "../../../src/core", version = "0.10" }
-gfx = { path = "../../../src/render", version = "0.17" }
+gfx_render = { path = "../../../src/render", version = "0.1" }
 
 gfx_backend_vulkan = { path = "../../../src/backend/vulkan", version = "0.1" }

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -1,5 +1,5 @@
 extern crate env_logger;
-extern crate gfx;
+extern crate gfx_render as gfx;
 extern crate gfx_core as core;
 extern crate gfx_backend_vulkan as back;
 
@@ -194,7 +194,7 @@ fn main() {
     let mut data = Allocator::new(
         gfx::memory::Usage::Data,
         &context.ref_device());
-    println!("Memory types: {:?}", context.ref_device().heap_types());
+    println!("Memory types: {:?}", context.ref_device().memory_types());
     println!("Memory heaps: {:?}", context.ref_device().memory_heaps());
 
     let vertex_count = QUAD.len() as u64;

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use winapi::*;
 
 
-pub fn map_heap_properties(props: memory::HeapProperties) -> D3D12_HEAP_PROPERTIES {
+pub fn map_heap_properties(props: memory::Properties) -> D3D12_HEAP_PROPERTIES {
     //TODO: ensure the flags are valid
     D3D12_HEAP_PROPERTIES {
         Type: if !props.contains(memory::CPU_VISIBLE) {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -768,7 +768,7 @@ impl d::Device<B> for Device {
         let requirements = memory::Requirements {
             size,
             alignment: winapi::D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT as u64,
-            type_mask: if self.features.heterogeneous_resource_heaps { 0x7 } else { 0x7<<4 },
+            type_mask: if self.private_caps.heterogeneous_resource_heaps { 0x7 } else { 0x7<<4 },
         };
 
         Ok(UnboundBuffer {
@@ -879,7 +879,7 @@ impl d::Device<B> for Device {
             requirements: memory::Requirements {
                 size: alloc_info.SizeInBytes,
                 alignment: alloc_info.Alignment,
-                type_mask: if self.features.heterogeneous_resource_heaps { 0x7 }
+                type_mask: if self.private_caps.heterogeneous_resource_heaps { 0x7 }
                     else if usage.can_target() { 0x7<<12 } else { 0x7<<8 },
             },
             kind,

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -1,6 +1,4 @@
-use core::device::ResourceHeapType;
-use core::pso::DescriptorSetLayoutBinding;
-use core::{self, image, pass, pso, HeapType};
+use core::{self, image, pass, pso, MemoryType};
 use free_list;
 use winapi::{self, UINT};
 use wio::com::ComPtr;
@@ -145,7 +143,7 @@ unsafe impl Sync for DepthStencilView { }
 
 #[derive(Debug)]
 pub struct DescriptorSetLayout {
-    pub bindings: Vec<DescriptorSetLayoutBinding>,
+    pub bindings: Vec<pso::DescriptorSetLayoutBinding>,
 }
 
 #[derive(Debug)]
@@ -163,11 +161,10 @@ unsafe impl Send for Semaphore {}
 unsafe impl Sync for Semaphore {}
 
 #[derive(Debug)]
-pub struct Heap {
-    pub raw: ComPtr<winapi::ID3D12Heap>,
-    pub ty: HeapType,
+pub struct Memory {
+    pub heap: ComPtr<winapi::ID3D12Heap>,
+    pub ty: MemoryType,
     pub size: u64,
-    pub resource_type: ResourceHeapType,
     pub default_state: winapi::D3D12_RESOURCE_STATES,
 }
 #[derive(Debug)]

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -21,7 +21,7 @@ impl core::Backend for Backend {
     type SubpassCommandBuffer = SubpassCommandBuffer;
     type QueueFamily = QueueFamily;
 
-    type Heap = ();
+    type Memory = ();
     type CommandPool = RawCommandPool;
     type SubpassCommandPool = SubpassCommandPool;
 
@@ -88,7 +88,7 @@ impl core::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_heap(&mut self, _: &core::HeapType, _: device::ResourceHeapType, _: u64) -> Result<(), device::ResourceHeapError> {
+    fn allocate_memory(&mut self, _: &core::MemoryType, _: u64) -> Result<(), device::OutOfMemory> {
         unimplemented!()
     }
 
@@ -137,20 +137,21 @@ impl core::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn bind_buffer_memory(&mut self, _: &(), _: u64, _: ()) -> Result<(), buffer::CreationError> {
+    fn bind_buffer_memory(&mut self, _: &(), _: u64, _: ()) -> Result<(), device::BindError> {
         unimplemented!()
     }
 
     fn create_image(&mut self, _: image::Kind, _: image::Level, _: format::Format, _: image::Usage)
-         -> Result<(), image::CreationError> {
-            unimplemented!()
-         }
+         -> Result<(), image::CreationError>
+    {
+        unimplemented!()
+    }
 
     fn get_image_requirements(&mut self, _: &()) -> memory::Requirements {
         unimplemented!()
     }
 
-    fn bind_image_memory(&mut self, _: &(), _: u64, _: ()) -> Result<(), image::CreationError> {
+    fn bind_image_memory(&mut self, _: &(), _: u64, _: ()) -> Result<(), device::BindError> {
         unimplemented!()
     }
 
@@ -205,7 +206,7 @@ impl core::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn destroy_heap(&mut self, _: ()) {
+    fn free_memory(&mut self, _: ()) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -592,5 +592,4 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 }
 
 /// A subpass command buffer abstraction for OpenGL
-#[allow(missing_copy_implementations)]
 pub struct SubpassCommandBuffer;

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -57,10 +57,8 @@ pub fn get_program_log(gl: &gl::Gl, name: n::Program) -> String {
 }
 
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct UnboundBuffer;
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct UnboundImage;
 
 /// GL device.
@@ -131,8 +129,8 @@ impl d::Device<B> for Device {
         &self.share.limits
     }
 
-    fn create_heap(&mut self, _: &c::HeapType, _: d::ResourceHeapType, _: u64) -> Result<n::Heap, d::ResourceHeapError> {
-        Ok(n::Heap)
+    fn allocate_memory(&mut self, _: &c::MemoryType, _: u64) -> Result<n::Memory, d::OutOfMemory> {
+        Ok(n::Memory)
     }
 
     fn create_renderpass(
@@ -323,7 +321,7 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn bind_buffer_memory(&mut self, _: &n::Heap, _: u64, _: device::UnboundBuffer) -> Result<n::Buffer, buffer::CreationError> {
+    fn bind_buffer_memory(&mut self, _: &n::Memory, _: u64, _: device::UnboundBuffer) -> Result<n::Buffer, d::BindError> {
         unimplemented!()
     }
 
@@ -336,7 +334,7 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn bind_image_memory(&mut self, _: &n::Heap, _: u64, _: device::UnboundImage) -> Result<n::Image, i::CreationError> {
+    fn bind_image_memory(&mut self, _: &n::Memory, _: u64, _: device::UnboundImage) -> Result<n::Image, d::BindError> {
         unimplemented!()
     }
 
@@ -457,7 +455,7 @@ impl d::Device<B> for Device {
         }
     }
 
-    fn destroy_heap(&mut self, _: n::Heap) {
+    fn free_memory(&mut self, _: n::Memory) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -297,7 +297,6 @@ pub fn get(gl: &gl::Gl) -> (Info, Features, Limits, PrivateCaps) {
                                                                 Ext ("GL_ARB_texture_filter_anisotropic"),
                                                                 Ext ("GL_EXT_texture_filter_anisotropic")]),
         sampler_border_color:               info.is_supported(&[Core(3,3)]), // TODO: extensions
-        heterogeneous_resource_heaps:       true, // TODO
     };
     let private = PrivateCaps {
         array_buffer_supported:             info.is_supported(&[Core(3,0),

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -1,8 +1,7 @@
 //! OpenGL implementation of a device, striving to support OpenGL 2.0 with at
 //! least VAOs, but using newer extensions when available.
 
-#![allow(missing_docs)]
-#![deny(missing_copy_implementations)]
+#![allow(missing_docs, missing_copy_implementations)]
 
 #[macro_use]
 extern crate log;
@@ -48,7 +47,7 @@ impl c::Backend for Backend {
     type SubpassCommandBuffer = command::SubpassCommandBuffer;
     type QueueFamily = QueueFamily;
 
-    type Heap = native::Heap;
+    type Memory = native::Memory;
     type CommandPool = pool::RawCommandPool;
     type SubpassCommandPool = pool::SubpassCommandPool;
 
@@ -221,7 +220,7 @@ impl c::Adapter<Backend> for Adapter {
             graphics_queues: Vec::new(),
             compute_queues: Vec::new(),
             transfer_queues: Vec::new(),
-            heap_types: Vec::new(), // TODO
+            memory_types: Vec::new(), // TODO
             memory_heaps: Vec::new(), // TODO
         };
 
@@ -884,7 +883,6 @@ impl c::RawCommandQueue<Backend> for CommandQueue {
     }
 }
 
-#[allow(missing_copy_implementations)]
 pub struct QueueFamily;
 
 impl c::QueueFamily for QueueFamily {

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -88,7 +88,6 @@ pub struct DescriptorSetLayout;
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct DescriptorSet;
 
-#[allow(missing_copy_implementations)]
 pub struct DescriptorPool {}
 
 impl core::DescriptorPool<Backend> for DescriptorPool {
@@ -107,8 +106,7 @@ pub struct ShaderModule {
 }
 
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
-pub struct Heap;
+pub struct Memory;
 
 #[derive(Debug)]
 pub struct RenderPass {
@@ -122,27 +120,20 @@ pub struct SubpassDesc {
 }
 
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct ConstantBufferView;
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct ShaderResourceView;
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct UnorderedAccessView;
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct RenderTargetView {
     pub view: TargetView,
 }
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct DepthStencilView;
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 pub struct PipelineLayout;
 
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
 // No inter-queue synchronization required for GL.
 pub struct Semaphore;

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -121,7 +121,7 @@ pub fn map_vertex_format(format: Format) -> Option<MTLVertexFormat> {
     })
 }
 
-pub fn map_heap_properties_to_options(properties: memory::HeapProperties) -> MTLResourceOptions {
+pub fn map_memory_properties_to_options(properties: memory::Properties) -> MTLResourceOptions {
     let mut options = MTLResourceOptions::empty();
     if properties.contains(memory::CPU_VISIBLE) {
         if properties.contains(memory::COHERENT) {
@@ -140,7 +140,7 @@ pub fn map_heap_properties_to_options(properties: memory::HeapProperties) -> MTL
     options
 }
 
-pub fn map_heap_properties_to_storage_and_cache(properties: memory::HeapProperties) -> (MTLStorageMode, MTLCPUCacheMode) {
+pub fn map_memory_properties_to_storage_and_cache(properties: memory::Properties) -> (MTLStorageMode, MTLCPUCacheMode) {
     let storage = if properties.contains(memory::CPU_VISIBLE) {
         if properties.contains(memory::COHERENT) {
             MTLStorageMode::Shared

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -100,7 +100,7 @@ impl core::Backend for Backend {
     type SubpassCommandBuffer = command::CommandBuffer;
     type QueueFamily = native::QueueFamily;
 
-    type Heap = native::Heap;
+    type Memory = native::Memory;
     type CommandPool = command::CommandPool;
     type SubpassCommandPool = command::CommandPool;
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1,13 +1,12 @@
 use {Backend};
 
 use std::collections::HashMap;
-use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::os::raw::{c_void, c_long, c_int};
 use std::ptr;
 
-use core::{self, format, memory, image, pass, HeapType};
-use core::pso::{ShaderStageFlags, DescriptorSetLayoutBinding, DescriptorType};
+use core::{self, image, pass};
+use core::pso::{DescriptorSetLayoutBinding, DescriptorType};
 
 use cocoa::foundation::{NSRange, NSUInteger};
 use metal::*;
@@ -19,10 +18,8 @@ pub struct QueueFamily {
 #[derive(Debug)]
 pub struct ShaderModule(pub MTLLibrary);
 
-unsafe impl Send for ShaderModule {
-}
-unsafe impl Sync for ShaderModule {
-}
+unsafe impl Send for ShaderModule {}
+unsafe impl Sync for ShaderModule {}
 
 #[derive(Debug)]
 pub struct RenderPass {
@@ -30,18 +27,14 @@ pub struct RenderPass {
     pub attachments: Vec<pass::Attachment>,
 }
 
-unsafe impl Send for RenderPass {
-}
-unsafe impl Sync for RenderPass {
-}
+unsafe impl Send for RenderPass {}
+unsafe impl Sync for RenderPass {}
 
 #[derive(Debug)]
 pub struct FrameBuffer(pub MTLRenderPassDescriptor);
 
-unsafe impl Send for FrameBuffer {
-}
-unsafe impl Sync for FrameBuffer {
-}
+unsafe impl Send for FrameBuffer {}
+unsafe impl Sync for FrameBuffer {}
 
 #[derive(Debug)]
 pub struct PipelineLayout {}
@@ -49,10 +42,8 @@ pub struct PipelineLayout {}
 #[derive(Debug)]
 pub struct GraphicsPipeline(pub MTLRenderPipelineState);
 
-unsafe impl Send for GraphicsPipeline {
-}
-unsafe impl Sync for GraphicsPipeline {
-}
+unsafe impl Send for GraphicsPipeline {}
+unsafe impl Sync for GraphicsPipeline {}
 
 #[derive(Debug)]
 pub struct ComputePipeline {}
@@ -60,10 +51,8 @@ pub struct ComputePipeline {}
 #[derive(Debug)]
 pub struct Image(pub MTLTexture);
 
-unsafe impl Send for Image {
-}
-unsafe impl Sync for Image {
-}
+unsafe impl Send for Image {}
+unsafe impl Sync for Image {}
 
 #[derive(Debug)]
 pub struct ConstantBufferView {}
@@ -71,10 +60,8 @@ pub struct ConstantBufferView {}
 #[derive(Debug)]
 pub struct ShaderResourceView(pub MTLTexture);
 
-unsafe impl Send for ShaderResourceView {
-}
-unsafe impl Sync for ShaderResourceView {
-}
+unsafe impl Send for ShaderResourceView {}
+unsafe impl Sync for ShaderResourceView {}
 
 #[derive(Debug)]
 pub struct UnorderedAccessView {}
@@ -82,45 +69,32 @@ pub struct UnorderedAccessView {}
 #[derive(Debug)]
 pub struct RenderTargetView(pub MTLTexture);
 
-unsafe impl Send for RenderTargetView {
-}
-unsafe impl Sync for RenderTargetView {
-}
+unsafe impl Send for RenderTargetView {}
+unsafe impl Sync for RenderTargetView {}
 
 #[derive(Debug)]
 pub struct DepthStencilView(pub MTLTexture);
 
-unsafe impl Send for DepthStencilView {
-}
-unsafe impl Sync for DepthStencilView {
-}
+unsafe impl Send for DepthStencilView {}
+unsafe impl Sync for DepthStencilView {}
 
 #[derive(Debug)]
 pub struct Sampler(pub MTLSamplerState);
 
-unsafe impl Send for Sampler {
-}
-unsafe impl Sync for Sampler {
-}
+unsafe impl Send for Sampler {}
+unsafe impl Sync for Sampler {}
 
 #[derive(Debug)]
 pub struct Semaphore(pub *mut c_void);
 
-unsafe impl Send for Semaphore {
-}
-unsafe impl Sync for Semaphore {
-}
+unsafe impl Send for Semaphore {}
+unsafe impl Sync for Semaphore {}
 
 #[derive(Debug)]
 pub struct Buffer(pub MTLBuffer);
 
-unsafe impl Send for Buffer {
-}
-unsafe impl Sync for Buffer {
-}
-
-#[derive(Debug)]
-pub struct DescriptorHeap {}
+unsafe impl Send for Buffer {}
+unsafe impl Sync for Buffer {}
 
 
 #[cfg(feature = "argument_buffer")]
@@ -269,8 +243,8 @@ impl Drop for DescriptorSetBinding {
 }
 
 #[derive(Debug)]
-pub enum Heap {
-    Emulated { heap_type: HeapType, size: u64 },
+pub enum Memory {
+    Emulated { memory_type: core::MemoryType, size: u64 },
     Native(MTLHeap),
 }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -438,9 +438,10 @@ impl core::Adapter<Backend> for Adapter {
         };
 
         let mem_properties =  self.instance.0.get_physical_device_memory_properties(self.handle);
-        let memory_heaps = mem_properties.memory_heaps[..mem_properties.memory_heap_count as usize].iter()
-                                .map(|mem| mem.size).collect::<Vec<_>>();
-        let heap_types = mem_properties.memory_types[..mem_properties.memory_type_count as usize].iter().enumerate().map(|(i, mem)| {
+        let memory_heaps = mem_properties.memory_heaps[..mem_properties.memory_heap_count as usize]
+            .iter()
+            .map(|mem| mem.size).collect();
+        let memory_types = mem_properties.memory_types[..mem_properties.memory_type_count as usize].iter().enumerate().map(|(i, mem)| {
             let mut type_flags = memory::HeapProperties::empty();
 
             if mem.property_flags.intersects(vk::MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
@@ -459,12 +460,12 @@ impl core::Adapter<Backend> for Adapter {
                 type_flags |= memory::LAZILY_ALLOCATED;
             }
 
-            core::HeapType {
+            core::MemoryType {
                 id: i,
                 properties: type_flags,
                 heap_index: mem.heap_index as usize,
             }
-        }).collect::<Vec<_>>();
+        }).collect();
 
         let device_arc = device.raw.clone();
         core::Gpu {
@@ -473,7 +474,7 @@ impl core::Adapter<Backend> for Adapter {
             graphics_queues: collect_queues(queue_descs, &device_arc, QueueType::Graphics),
             compute_queues: collect_queues(queue_descs, &device_arc, QueueType::Compute),
             transfer_queues: collect_queues(queue_descs, &device_arc, QueueType::Transfer),
-            heap_types,
+            memory_types,
             memory_heaps,
         }
     }
@@ -591,7 +592,7 @@ impl core::Backend for Backend {
     type SubpassCommandBuffer = command::SubpassCommandBuffer;
     type QueueFamily = QueueFamily;
 
-    type Heap = native::Heap;
+    type Memory = native::Memory;
     type CommandPool = pool::RawCommandPool;
     type SubpassCommandPool = pool::SubpassCommandPool;
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -425,7 +425,6 @@ impl core::Adapter<Backend> for Adapter {
                 sampler_border_color: false,
                 sampler_lod_bias: false,
                 sampler_objects: false,
-                heterogeneous_resource_heaps: true,
             },
             limits: Limits {
                 max_texture_size: limits.max_image_dimension3d as _,
@@ -442,7 +441,7 @@ impl core::Adapter<Backend> for Adapter {
             .iter()
             .map(|mem| mem.size).collect();
         let memory_types = mem_properties.memory_types[..mem_properties.memory_type_count as usize].iter().enumerate().map(|(i, mem)| {
-            let mut type_flags = memory::HeapProperties::empty();
+            let mut type_flags = memory::Properties::empty();
 
             if mem.property_flags.intersects(vk::MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
                 type_flags |= memory::DEVICE_LOCAL;

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -19,8 +19,8 @@ pub struct GraphicsPipeline(pub vk::Pipeline);
 pub struct ComputePipeline(pub vk::Pipeline);
 
 #[derive(Debug, Hash)]
-pub struct Heap {
-    pub memory: vk::DeviceMemory,
+pub struct Memory {
+    pub inner: vk::DeviceMemory,
     pub ptr: *mut u8,
 }
 

--- a/src/core/src/image.rs
+++ b/src/core/src/image.rs
@@ -31,8 +31,6 @@ pub enum CreationError {
     Data(usize),
     /// The mentioned usage mode is not supported
     Usage(Usage),
-    ///
-    OutOfHeap,
 }
 
 impl fmt::Display for CreationError {
@@ -58,7 +56,6 @@ impl Error for CreationError {
             CreationError::Size(_) => "Unsupported size in one of the dimensions",
             CreationError::Data(_) => "The given data has a different size than the target texture slice",
             CreationError::Usage(_) => "The expected texture usage mode is not supported by a graphic API",
-            CreationError::OutOfHeap => "Not enough space in the heap",
         }
     }
 }

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -142,8 +142,6 @@ pub struct Features {
     pub sampler_anisotropy: bool,
     /// Support setting border texel colors.
     pub sampler_border_color: bool,
-    /// Resource heaps can contain any type of resources, as opposed to be locked to one.
-    pub heterogeneous_resource_heaps: bool,
 }
 
 /// Limits of the device.
@@ -225,10 +223,10 @@ pub enum IndexType {
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct MemoryType {
-    /// Id of the heap type.
+    /// Id of the memory type.
     pub id: usize,
-    /// Properties of the associated heap memory.
-    pub properties: memory::HeapProperties,
+    /// Properties of the associated memory.
+    pub properties: memory::Properties,
     /// Index to the underlying memory heap in `Gpu::memory_heaps`
     pub heap_index: usize,
 }
@@ -327,9 +325,9 @@ pub struct Gpu<B: Backend> {
     pub compute_queues: Vec<CommandQueue<B, Compute>>,
     /// Transfer command queues.
     pub transfer_queues: Vec<CommandQueue<B, Transfer>>,
-    /// Types of memory heaps.
+    /// Types of memory.
     ///
-    /// Each heap type is associated with one heap of `memory_heaps`.
+    /// Each memory type is associated with one heap of `memory_heaps`.
     /// Multiple types can point to the same heap.
     pub memory_types: Vec<MemoryType>,
     /// Memory heaps with their size in bytes.

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -224,12 +224,12 @@ pub enum IndexType {
 ///
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct HeapType {
+pub struct MemoryType {
     /// Id of the heap type.
     pub id: usize,
     /// Properties of the associated heap memory.
     pub properties: memory::HeapProperties,
-    /// Index to the underlying memory heap.
+    /// Index to the underlying memory heap in `Gpu::memory_heaps`
     pub heap_index: usize,
 }
 
@@ -258,7 +258,7 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any {
     type RenderPass:          Debug + Any + Send + Sync;
     type FrameBuffer:         Debug + Any + Send + Sync;
 
-    type Heap:                Debug + Any;
+    type Memory:              Debug + Any;
     type CommandPool:         RawCommandPool<Self>;
     type SubpassCommandPool:  SubpassCommandPool<Self>;
 
@@ -331,7 +331,7 @@ pub struct Gpu<B: Backend> {
     ///
     /// Each heap type is associated with one heap of `memory_heaps`.
     /// Multiple types can point to the same heap.
-    pub heap_types: Vec<HeapType>,
+    pub memory_types: Vec<MemoryType>,
     /// Memory heaps with their size in bytes.
     pub memory_heaps: Vec<u64>,
 }

--- a/src/core/src/memory.rs
+++ b/src/core/src/memory.rs
@@ -38,20 +38,20 @@ pub fn cast_slice<A: Pod, B: Pod>(slice: &[A]) -> &[B] {
 }
 
 bitflags!(
-    /// Heap property flags.
+    /// Memory property flags.
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-    pub flags HeapProperties: u16 {
-        /// Device local heaps are located on the GPU.
+    pub flags Properties: u16 {
+        /// Device local memory on the GPU.
         const DEVICE_LOCAL   = 0x1,
 
         /// CPU-GPU coherent.
         ///
-        /// Non-coherent heaps require explicit flushing.
+        /// Non-coherent memory requires explicit flushing.
         const COHERENT     = 0x2,
 
-        /// Host visible heaps can be accessed by the CPU.
+        /// Host visible memory can be accessed by the CPU.
         ///
-        /// Backends must provide at least one cpu visible heap.
+        /// Backends must provide at least one cpu visible memory.
         const CPU_VISIBLE   = 0x4,
 
         /// Cached memory by the CPU
@@ -60,7 +60,7 @@ bitflags!(
         /// Memory combined writes.
         ///
         /// Buffer writes will be combined for possible larger bus transactions.
-        /// It's not advised to use these heaps for reading back data.
+        /// It's not advised to use these memory allocations for reading back data.
         const WRITE_COMBINED = 0x10,
 
         ///

--- a/src/core/src/memory.rs
+++ b/src/core/src/memory.rs
@@ -89,4 +89,6 @@ pub struct Requirements {
     pub size: u64,
     /// Memory alignment.
     pub alignment: u64,
+    /// Supported memory types.
+    pub type_mask: u64,
 }

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "gfx"
-version = "0.17.0"
+name = "gfx_render"
+version = "0.1.0"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -8,12 +8,12 @@ keywords = ["graphics", "gamedev"]
 license = "Apache-2.0"
 authors = ["The Gfx-rs Developers"]
 readme = "../../README.md"
-documentation = "https://docs.rs/gfx"
+documentation = "https://docs.rs/gfx_render"
 categories = ["rendering::graphics-api"]
 workspace = "../.."
 
 [lib]
-name = "gfx"
+name = "gfx_render"
 path = "src/lib.rs"
 
 [features]

--- a/src/render/src/allocators/boxed.rs
+++ b/src/render/src/allocators/boxed.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
 
 use core::{Device as CoreDevice};
-use core::device::ResourceHeapType;
 use memory::{self, Allocator, Memory};
 use {buffer, image};
 use {Backend, Device};
@@ -19,9 +18,9 @@ impl<B: Backend> BoxedAllocator<B> {
         }
     }
 
-    fn make_memory(&self, mut device: B::Device, heap: B::Heap) -> Memory {
-        let mut heap = Some(heap);
-        let release = Box::new(move || device.destroy_heap(heap.take().unwrap()));
+    fn make_memory(&self, mut device: B::Device, memory: B::Memory) -> Memory {
+        let mut memory = Some(memory);
+        let release = Box::new(move || device.free_memory(memory.take().unwrap()));
         Memory::new(release, self.usage)
     }
 }
@@ -32,36 +31,30 @@ impl<B: Backend> Allocator<B> for BoxedAllocator<B> {
         _: buffer::Usage,
         buffer: B::UnboundBuffer
     ) -> (B::Buffer, Memory) {
-        let heap_type = device.find_usage_heap(self.usage).unwrap();
+        let requirements = device.mut_raw().get_buffer_requirements(&buffer);
+        let mem_type = device.find_usage_memory(self.usage, requirements.type_mask).unwrap();
         let mut device = device.ref_raw().clone();
-        let requirements = device.get_buffer_requirements(&buffer);
-        let resource_type = ResourceHeapType::Buffers;
-        let heap = device.create_heap(&heap_type, resource_type, requirements.size)
+        let memory = device.allocate_memory(&mem_type, requirements.size)
             .unwrap();
-        let buffer = device.bind_buffer_memory(&heap, 0, buffer)
+        let buffer = device.bind_buffer_memory(&memory, 0, buffer)
             .unwrap();
-        
-        (buffer, self.make_memory(device, heap))
+
+        (buffer, self.make_memory(device, memory))
     }
-    
+
     fn allocate_image(&mut self,
         device: &mut Device<B>,
         usage: image::Usage,
         image: B::UnboundImage
     ) -> (B::Image, Memory) {
-        let heap_type = device.find_usage_heap(self.usage).unwrap();
+        let requirements = device.mut_raw().get_image_requirements(&image);
+        let mem_type = device.find_usage_memory(self.usage, requirements.type_mask).unwrap();
         let mut device = device.ref_raw().clone();
-        let requirements = device.get_image_requirements(&image);
-        let resource_type = if usage.can_target() {
-            ResourceHeapType::Targets
-        } else {
-            ResourceHeapType::Images
-        };
-        let heap = device.create_heap(&heap_type, resource_type, requirements.size)
+        let memory = device.allocate_memory(&mem_type, requirements.size)
             .unwrap();
-        let image = device.bind_image_memory(&heap, 0, image)
+        let image = device.bind_image_memory(&memory, 0, image)
             .unwrap();
-        
-        (image, self.make_memory(device, heap))
+
+        (image, self.make_memory(device, memory))
     }
 }

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -239,7 +239,7 @@ impl Capability for core::General {
         let core::Gpu {
             device,
             mut general_queues,
-            heap_types,
+            memory_types,
             memory_heaps,
             ..
         } = adapter.open_with(|ref family, qtype| {
@@ -252,7 +252,7 @@ impl Capability for core::General {
             }
         });
 
-        let (device, garbage) = Device::new(device, heap_types, memory_heaps);
+        let (device, garbage) = Device::new(device, memory_types, memory_heaps);
         let queue = Queue::new(general_queues.remove(0));
         (device, queue, garbage)
     }
@@ -266,7 +266,7 @@ impl Capability for core::Graphics {
         let core::Gpu {
             device,
             mut graphics_queues,
-            heap_types,
+            memory_types,
             memory_heaps,
             ..
         } = adapter.open_with(|ref family, qtype| {
@@ -277,7 +277,7 @@ impl Capability for core::Graphics {
             }
         });
 
-        let (device, garbage) = Device::new(device, heap_types, memory_heaps);
+        let (device, garbage) = Device::new(device, memory_types, memory_heaps);
         let queue = Queue::new(graphics_queues.remove(0));
         (device, queue, garbage)
     }
@@ -436,7 +436,7 @@ impl<B: Backend, C> Context<B, C>
                     None
                 }
             }).collect();
-        
+
         self.device.mut_raw()
             .wait_for_fences(&fences, core::device::WaitFor::All, !0);
     }


### PR DESCRIPTION
This PR renames heaps to memory, which is allocated/freed instead of creation/destruction.
Seeing how we are getting further from DX12 heaps and leaning towards thinner Vk portability layer, naming memory allocations for what they are should make sense.

Also, the DX12 backend update will include splitting the memory types for Resource Heap Tier1 hardware (like NV Vulkan driver does), which is what allows us to get rid of an unsound `ResourceHeapType`.

Todo:
- [x] core + dummy
- [x] render + example
- [x] gl
- [x] vulkan (more work needed for error detection)
- [x] dx12
- [x] metal
- [x] core example
