### PR TITLE
[0.16] Add allow unused super::gfx import for pso macro

### DIFF
--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -231,6 +231,7 @@ macro_rules! gfx_pipeline_base {
         pub mod $module {
             #[allow(unused_imports)]
             use super::*;
+            #[allow(unused_imports)]
             use super::gfx;
             gfx_pipeline_inner!{ $(
                 $field: $ty,
@@ -248,6 +249,7 @@ macro_rules! gfx_pipeline {
         pub mod $module {
             #[allow(unused_imports)]
             use super::*;
+            #[allow(unused_imports)]
             use super::gfx;
             gfx_pipeline_inner!{ $(
                 $field: $ty,


### PR DESCRIPTION
Can produce 
```
warning: unused import: `super::gfx`
```