### PR TITLE
[ll] vulkan: Make winit as a default optional feature to support multiple windowing libs (Native X11)

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/gfx_device_vulkan"
 workspace = "../../.."
 
 [features]
-default = []
+default = ["winit"]
 
 [lib]
 name = "gfx_backend_vulkan"
@@ -24,9 +24,13 @@ shared_library = "0.1"
 ash = "0.18.5"
 gfx_core = { path = "../../core", version = "0.10" }
 smallvec = "0.4"
-winit = "0.7"
+winit = { version = "0.7", optional = true }
 glsl-to-spirv = { version = "0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-kernel32-sys = "0.2.2"
+winapi = "0.2"
+kernel32-sys = "0.2"
+user32-sys = "0.2"
 
+[target.'cfg(unix)'.dependencies]
+x11 = { version = "2.15", features = ["xlib"]}

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -5,9 +5,16 @@ extern crate gfx_core as core;
 #[macro_use]
 extern crate lazy_static;
 extern crate smallvec;
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 extern crate kernel32;
+#[cfg(windows)]
+extern crate user32;
+#[cfg(windows)]
+extern crate winapi;
+#[cfg(feature = "winit")]
 extern crate winit;
+#[cfg(unix)]
+extern crate x11;
 #[cfg(feature = "glsl-to-spirv")]
 extern crate glsl_to_spirv;
 
@@ -45,7 +52,7 @@ const SURFACE_EXTENSIONS: &'static [&'static str] = &[
     // Platform-specific WSI extensions
     vk::VK_KHR_XLIB_SURFACE_EXTENSION_NAME,
     vk::VK_KHR_XCB_SURFACE_EXTENSION_NAME,
-    //vk::VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME, //RenderDoc fails with this
+    //vk::VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME,
     vk::VK_KHR_MIR_SURFACE_EXTENSION_NAME,
     vk::VK_KHR_ANDROID_SURFACE_EXTENSION_NAME,
     vk::VK_KHR_WIN32_SURFACE_EXTENSION_NAME,


### PR DESCRIPTION
Similar to PR #1518 

## Additional changes:

- Add dependencies: `x11`, `winapi`, `user32-sys`
- Get window dimensions from native window handle directly

## TODO:

- [X] Create surface from Xlib
- [x] Create surface from Wayland
- [x] Fix Windows build