### PR TITLE
[ll] Copy implementations for most of the resource types

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,4 +43,6 @@ test_script:
       --exclude gfx_window_glfw
       --exclude gfx_window_sdl
       --exclude gfx_backend_metal
+      &&
+      (cd src/backend/dx12 && cargo test --features copy)
     )

--- a/scripts/travis-script.sh
+++ b/scripts/travis-script.sh
@@ -30,6 +30,8 @@ elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   FEATURES+="metal"
   GLUTIN_HEADLESS_FEATURE="--features headless"
 
+  # Test the `copy` feature on metal
+  (cd backend/src/metal && cargo test --features copy)
   # Test the indirect argument buffer path on OSX
   (cd examples/core/quad && cargo build --features metal,metal_argument_buffer)
 fi

--- a/scripts/travis-script.sh
+++ b/scripts/travis-script.sh
@@ -20,12 +20,17 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   EXCLUDES+=" --exclude gfx_backend_metal"
 
   FEATURES+="vulkan"
+
+  # Test the `copy` feature on vulkan
+  (cd backend/src/vulkan && cargo test --features copy)
+
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   EXCLUDES+=" --exclude gfx_backend_vulkan"
 
   FEATURES+="metal"
   GLUTIN_HEADLESS_FEATURE="--features headless"
 
+  # Test the indirect argument buffer path on OSX
   (cd examples/core/quad && cargo build --features metal,metal_argument_buffer)
 fi
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -14,6 +14,9 @@ workspace = "../../.."
 [lib]
 name = "gfx_backend_dx12"
 
+[features]
+copy = ["gfx_core/copy"]
+
 [dependencies]
 bitflags = "0.8"
 log = "0.3"

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -315,8 +315,8 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
                     } else {
                         // Generate barrier for each layer/level combination.
                         let (levels, layers) = range.clone();
-                        for level in levels {
-                            for layer in layers.clone() {
+                        for level in levels.start .. levels.end {
+                            for layer in layers.start .. layers.end {
                                 barrier.u.Subresource = target.calc_subresource(level as _, layer as _);
                                 raw_barriers.push(barrier);
                             }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1,11 +1,10 @@
-use wio::com::ComPtr;
 use core::{command, image, memory, pass, pso, target};
 use core::{IndexCount, IndexType, InstanceCount, VertexCount, VertexOffset, Viewport};
 use core::buffer::IndexBufferView;
 use core::command::{AttachmentClear, BufferCopy, BufferImageCopy, ClearColor,
                     ClearValue, ImageCopy, ImageResolve, SubpassContents};
 use winapi::{self, UINT64, UINT};
-use {conv, native as n, Backend};
+use {conv, native as n, Backend, ComPtr};
 use smallvec::SmallVec;
 use std::{cmp, mem, ptr};
 use std::ops::Range;
@@ -736,8 +735,8 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         let (width, height, depth, _) = image.kind.get_dimensions();
         for region in regions {
             // Copy each layer in the region
-            let layers = region.image_subresource.1.clone();
-            for layer in layers {
+            let layers = &region.image_subresource.1;
+            for layer in layers.start .. layers.end {
                 assert_eq!(region.buffer_offset % winapi::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as u64, 0);
                 assert_eq!(region.buffer_row_pitch % winapi::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as u32, 0);
                 assert!(region.buffer_row_pitch >= width as u32 * image.bits_per_texel as u32 / 8);
@@ -800,8 +799,8 @@ impl command::RawCommandBuffer<Backend> for CommandBuffer {
         let (width, height, depth, _) = image.kind.get_dimensions();
         for region in regions {
             // Copy each layer in the region
-            let layers = region.image_subresource.1.clone();
-            for layer in layers {
+            let layers = &region.image_subresource.1;
+            for layer in layers.start .. layers.end {
                 assert_eq!(region.buffer_offset % winapi::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as u64, 0);
                 assert_eq!(region.buffer_row_pitch % winapi::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as u32, 0);
                 assert!(region.buffer_row_pitch >= width as u32 * image.bits_per_texel as u32 / 8);

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -11,12 +11,12 @@ use std::cmp;
 use std::collections::BTreeMap;
 use std::ops::Range;
 use std::{ffi, mem, ptr, slice};
-use {free_list, native as n, shade, Backend as B, Device};
+use {free_list, native as n, shade, Backend as B, ComPtr, Device};
 use winapi;
-use wio::com::ComPtr;
 
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct UnboundBuffer {
     requirements: memory::Requirements,
     stride: u64,
@@ -24,6 +24,7 @@ pub struct UnboundBuffer {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct UnboundImage {
     desc: winapi::D3D12_RESOURCE_DESC,
     requirements: memory::Requirements,
@@ -710,8 +711,8 @@ impl d::Device<B> for Device {
         _extent: d::Extent,
     ) -> n::FrameBuffer {
         n::FrameBuffer {
-            color: color_attachments.iter().map(|rtv| **rtv).collect(),
-            depth_stencil: depth_stencil_attachments.iter().map(|dsv| **dsv).collect(),
+            color: color_attachments.iter().map(|rtv| (*rtv).clone()).collect(),
+            depth_stencil: depth_stencil_attachments.iter().map(|dsv| (*dsv).clone()).collect(),
         }
     }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -28,54 +28,15 @@ use core::{memory, Features, Limits, QueueType};
 use spirv_cross::hlsl;
 
 #[cfg(not(feature = "copy"))]
-pub use wio::com::ComPtr;
+use wio::com::ComPtr;
 #[cfg(feature = "copy")]
-use copy_ptr::CopyPtr as ComPtr;
+use core::copy::Pointer as ComPtr;
 
 use std::{mem, ptr};
 use std::os::raw::c_void;
 use std::os::windows::ffi::OsStringExt;
 use std::ffi::OsString;
 use std::sync::{Arc, Mutex};
-
-#[cfg(feature = "copy")]
-mod copy_ptr {
-    use std::{fmt, ops};
-
-    pub struct CopyPtr<T>(*mut T);
-    impl<T> CopyPtr<T> {
-        pub(crate) unsafe fn new(ptr: *mut T) -> Self {
-            CopyPtr(ptr)
-        }
-    }
-    impl<T> CopyPtr<T> {
-        pub(crate) unsafe fn as_mut(&self) -> &mut T {
-            &mut *self.0
-        }
-    }
-    impl<T> Clone for CopyPtr<T> {
-        fn clone(&self) -> Self {
-            CopyPtr(self.0)
-        }
-    }
-    impl<T> Copy for CopyPtr<T> {}
-    impl<T> ops::Deref for CopyPtr<T> {
-        type Target = T;
-        fn deref(&self) -> &T {
-            unsafe { &*self.0 }
-        }
-    }
-    impl<T> ops::DerefMut for CopyPtr<T> {
-        fn deref_mut(&mut self) -> &mut T {
-            unsafe { &mut *self.0 }
-        }
-    }
-    impl<T> fmt::Debug for CopyPtr<T> {
-        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            write!(formatter, "ComPtr({:p})", self.0)
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct QueueFamily;

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -1,8 +1,7 @@
 use core::{self, image, pass, pso, MemoryType};
 use free_list;
 use winapi::{self, UINT};
-use wio::com::ComPtr;
-use Backend;
+use {Backend, ComPtr};
 
 use std::collections::BTreeMap;
 use std::ops::Range;
@@ -61,6 +60,7 @@ pub struct RenderPass {
 }
 
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct GraphicsPipeline {
     pub raw: *mut winapi::ID3D12PipelineState,
     pub topology: winapi::D3D12_PRIMITIVE_TOPOLOGY,
@@ -69,6 +69,7 @@ unsafe impl Send for GraphicsPipeline { }
 unsafe impl Sync for GraphicsPipeline { }
 
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct ComputePipeline {
     pub raw: *mut winapi::ID3D12PipelineState,
 }
@@ -93,13 +94,14 @@ pub struct PipelineLayout {
 unsafe impl Send for PipelineLayout { }
 unsafe impl Sync for PipelineLayout { }
 
-#[derive(Debug, Hash, Clone)]
+#[derive(Clone, Debug, Hash)]
 pub struct FrameBuffer {
     pub color: Vec<RenderTargetView>,
     pub depth_stencil: Vec<DepthStencilView>,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Buffer {
     pub resource: *mut winapi::ID3D12Resource,
     pub size_in_bytes: u32,
@@ -108,7 +110,8 @@ pub struct Buffer {
 unsafe impl Send for Buffer { }
 unsafe impl Sync for Buffer { }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Image {
     pub resource: *mut winapi::ID3D12Resource,
     pub kind: image::Kind,
@@ -131,7 +134,8 @@ impl Image {
     }
 }
 
-#[derive(Copy, Debug, Hash, Clone)]
+#[derive(Clone, Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Copy))]
 pub struct RenderTargetView {
     pub resource: *mut winapi::ID3D12Resource,
     pub handle: winapi::D3D12_CPU_DESCRIPTOR_HANDLE,
@@ -139,7 +143,8 @@ pub struct RenderTargetView {
 unsafe impl Send for RenderTargetView { }
 unsafe impl Sync for RenderTargetView { }
 
-#[derive(Copy, Debug, Hash, Clone)]
+#[derive(Debug, Hash, Clone)]
+#[cfg_attr(feature = "copy", derive(Copy))]
 pub struct DepthStencilView {
     pub resource: *mut winapi::ID3D12Resource,
     pub handle: winapi::D3D12_CPU_DESCRIPTOR_HANDLE,
@@ -153,6 +158,7 @@ pub struct DescriptorSetLayout {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Fence {
     pub raw: ComPtr<winapi::ID3D12Fence>,
 }
@@ -160,6 +166,7 @@ unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Semaphore {
     pub raw: ComPtr<winapi::ID3D12Fence>,
 }
@@ -167,6 +174,7 @@ unsafe impl Send for Semaphore {}
 unsafe impl Sync for Semaphore {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Memory {
     pub heap: ComPtr<winapi::ID3D12Heap>,
     pub ty: MemoryType,
@@ -174,12 +182,15 @@ pub struct Memory {
     pub default_state: winapi::D3D12_RESOURCE_STATES,
 }
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct ConstantBufferView;
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct ShaderResourceView {
     pub handle: winapi::D3D12_CPU_DESCRIPTOR_HANDLE,
 }
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct UnorderedAccessView;
 
 #[derive(Debug)]
@@ -356,6 +367,7 @@ impl core::DescriptorPool<Backend> for DescriptorPool {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Sampler {
     pub handle: winapi::D3D12_CPU_DESCRIPTOR_HANDLE,
 }

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -126,7 +126,7 @@ unsafe impl Sync for Image { }
 impl Image {
     /// Get the SubresourceRange for the whole image.
     pub fn as_subresource_range(&self) -> image::SubresourceRange {
-        (0..self.levels, 0..self.layers)
+        ((0..self.levels).into(), (0..self.layers).into())
     }
 
     pub fn calc_subresource(&self, mip_level: UINT, layer: UINT) -> UINT {

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -1,4 +1,3 @@
-use wio::com::ComPtr;
 use dxguid;
 use std::ptr;
 use std::os::raw::c_void;
@@ -6,7 +5,7 @@ use winapi;
 
 use core::pool;
 use command::CommandBuffer;
-use {Backend, CommandQueue};
+use {Backend, CommandQueue, ComPtr};
 
 pub struct RawCommandPool {
     inner: ComPtr<winapi::ID3D12CommandAllocator>,

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -5,8 +5,7 @@ use std::collections::VecDeque;
 use std::ptr;
 use winit;
 use winapi;
-use wio::com::ComPtr;
-use {conv, native as n, Adapter, Backend, Instance, QueueFamily};
+use {conv, native as n, Adapter, Backend, ComPtr, Instance, QueueFamily};
 
 use winit::os::windows::WindowExt;
 

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -14,6 +14,7 @@ workspace = "../../.."
 [features]
 default = ["winit"]
 argument_buffer = []
+copy = ["gfx_core/copy"]
 
 [lib]
 name = "gfx_backend_metal"

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -513,8 +513,9 @@ impl core::RawCommandBuffer<Backend> for CommandBuffer {
 
         for region in regions {
             let image_offset = &region.image_offset;
+            let layers = &region.image_subresource.1;
 
-            for layer in region.image_subresource.1.clone() {
+            for layer in layers.start .. layers.end {
                 let offset = region.buffer_offset + region.buffer_slice_pitch as NSUInteger * (layer - region.image_subresource.1.start) as NSUInteger;
                 unsafe {
                     msg_send![encoder.0,

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -16,6 +16,7 @@ pub struct QueueFamily {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct ShaderModule(pub MTLLibrary);
 
 unsafe impl Send for ShaderModule {}
@@ -31,66 +32,79 @@ unsafe impl Send for RenderPass {}
 unsafe impl Sync for RenderPass {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct FrameBuffer(pub MTLRenderPassDescriptor);
 
 unsafe impl Send for FrameBuffer {}
 unsafe impl Sync for FrameBuffer {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct PipelineLayout {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct GraphicsPipeline(pub MTLRenderPipelineState);
 
 unsafe impl Send for GraphicsPipeline {}
 unsafe impl Sync for GraphicsPipeline {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct ComputePipeline {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Image(pub MTLTexture);
 
 unsafe impl Send for Image {}
 unsafe impl Sync for Image {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct ConstantBufferView {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct ShaderResourceView(pub MTLTexture);
 
 unsafe impl Send for ShaderResourceView {}
 unsafe impl Sync for ShaderResourceView {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct UnorderedAccessView {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct RenderTargetView(pub MTLTexture);
 
 unsafe impl Send for RenderTargetView {}
 unsafe impl Sync for RenderTargetView {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct DepthStencilView(pub MTLTexture);
 
 unsafe impl Send for DepthStencilView {}
 unsafe impl Sync for DepthStencilView {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Sampler(pub MTLSamplerState);
 
 unsafe impl Send for Sampler {}
 unsafe impl Sync for Sampler {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Semaphore(pub *mut c_void);
 
 unsafe impl Send for Semaphore {}
 unsafe impl Sync for Semaphore {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Buffer(pub MTLBuffer);
 
 unsafe impl Send for Buffer {}
@@ -177,6 +191,7 @@ pub struct DescriptorSetLayout {
 
 #[derive(Clone, Debug)]
 #[cfg(feature = "argument_buffer")]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct DescriptorSet {
     pub buffer: MTLBuffer,
     pub offset: NSUInteger,
@@ -243,30 +258,30 @@ impl Drop for DescriptorSetBinding {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub enum Memory {
     Emulated { memory_type: core::MemoryType, size: u64 },
     Native(MTLHeap),
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct UnboundBuffer {
     pub size: u64,
 }
 
-unsafe impl Send for UnboundBuffer {
-}
-unsafe impl Sync for UnboundBuffer {
-}
+unsafe impl Send for UnboundBuffer {}
+unsafe impl Sync for UnboundBuffer {}
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct UnboundImage(pub MTLTextureDescriptor);
 
-unsafe impl Send for UnboundImage {
-}
-unsafe impl Sync for UnboundImage {
-}
+unsafe impl Send for UnboundImage {}
+unsafe impl Sync for UnboundImage {}
 
 #[derive(Debug)]
+//#[cfg_attr(feature = "copy", derive(Clone, Copy))] //TODO
 pub struct Fence(pub Arc<Mutex<bool>>);
 
 impl core::QueueFamily for QueueFamily {

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -13,6 +13,7 @@ workspace = "../../.."
 
 [features]
 default = []
+copy = ["gfx_core/copy"]
 
 [lib]
 name = "gfx_backend_vulkan"
@@ -21,7 +22,7 @@ name = "gfx_backend_vulkan"
 log = "0.3"
 lazy_static = "0.2"
 shared_library = "0.1"
-ash = "0.18.5"
+ash = "0.18.6"
 gfx_core = { path = "../../core", version = "0.10" }
 smallvec = "0.4"
 winit = "0.7"

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -53,7 +53,7 @@ fn map_buffer_image_regions(
                     y: region.image_offset.y,
                     z: region.image_offset.z,
                 },
-                image_extent: image.extent.into(),
+                image_extent: image.extent.clone().into(),
             }
         })
         .collect()

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -1,6 +1,5 @@
 use std::{cmp, ptr};
 use std::ops::Range;
-use std::sync::Arc;
 use smallvec::SmallVec;
 use ash::vk;
 use ash::version::DeviceV1_0;
@@ -14,12 +13,13 @@ use core::command::{
 };
 use core::image::ImageLayout;
 use {conv, native as n};
-use {Backend, RawDevice};
+use {Backend, DeviceRef};
 
 #[derive(Clone)]
+#[cfg_attr(feature = "copy", derive(Copy))]
 pub struct CommandBuffer {
-    pub raw: vk::CommandBuffer,
-    pub device: Arc<RawDevice>,
+    pub(crate) raw: vk::CommandBuffer,
+    pub(crate) device: DeviceRef,
 }
 
 fn map_subpass_contents(contents: SubpassContents) -> vk::SubpassContents {
@@ -53,7 +53,7 @@ fn map_buffer_image_regions(
                     y: region.image_offset.y,
                     z: region.image_offset.z,
                 },
-                image_extent: image.extent.clone(),
+                image_extent: image.extent.into(),
             }
         })
         .collect()

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -248,7 +248,8 @@ pub fn map_subresource_with_layers(
     layers: image::Layer,
 ) -> vk::ImageSubresourceLayers
 {
-    map_subresource_layers(aspect_mask, &(mip_level, base_layer..base_layer+layers))
+    let range = (base_layer..base_layer+layers).into();
+    map_subresource_layers(aspect_mask, &(mip_level, range))
 }
 
 pub fn map_subresource_range(

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -8,7 +8,7 @@ use std::{mem, ptr};
 use std::ffi::CString;
 use std::ops::Range;
 
-use {Backend as B, Device};
+use {Backend as B, Device, DeviceRef};
 use {conv, memory};
 
 
@@ -21,6 +21,15 @@ pub struct UnboundBuffer(n::Buffer);
 pub struct UnboundImage(n::Image);
 
 impl Device {
+    #[cfg(feature = "copy")]
+    pub(crate) fn get_ref(&self) -> DeviceRef {
+        unsafe { DeviceRef::new(&self.raw as *const _ as *mut _) }
+    }
+    #[cfg(not(feature = "copy"))]
+    pub(crate) fn get_ref(&self) -> DeviceRef {
+        self.raw.clone()
+    }
+
     fn create_image_view(&mut self, image: &n::Image, format: format::Format) -> vk::ImageView {
         // TODO
         let components = vk::ComponentMapping {
@@ -915,7 +924,7 @@ impl d::Device<B> for Device {
 
         n::DescriptorPool {
             raw: pool,
-            device: self.raw.clone().into(),
+            device: self.get_ref(),
         }
     }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -13,9 +13,11 @@ use {conv, memory};
 
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct UnboundBuffer(n::Buffer);
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct UnboundImage(n::Image);
 
 impl Device {
@@ -821,10 +823,10 @@ impl d::Device<B> for Device {
 
         let raw = unsafe {
             self.raw.0.create_image(&info, None)
-                      .expect("Error on image creation") // TODO: error handling
+                .expect("Error on image creation") // TODO: error handling
         };
 
-        Ok(UnboundImage(n::Image{ raw, bytes_per_texel, extent }))
+        Ok(UnboundImage(n::Image{ raw, bytes_per_texel, extent: extent.into() }))
     }
 
     ///
@@ -852,7 +854,7 @@ impl d::Device<B> for Device {
     fn view_buffer_as_constant(&mut self, buffer: &n::Buffer, range: Range<u64>) -> Result<n::ConstantBufferView, d::TargetViewError> {
         Ok(n::ConstantBufferView {
             buffer: buffer.raw,
-            range,
+            range: range.into(),
         })
     }
 
@@ -865,7 +867,7 @@ impl d::Device<B> for Device {
         let rtv = n::RenderTargetView {
             image: image.raw,
             view: self.create_image_view(image, format),
-            range,
+            range: range.into(),
         };
 
         Ok(rtv)
@@ -913,7 +915,7 @@ impl d::Device<B> for Device {
 
         n::DescriptorPool {
             raw: pool,
-            device: self.raw.clone(),
+            device: self.raw.clone().into(),
         }
     }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -466,7 +466,7 @@ impl core::Adapter<Backend> for Adapter {
             }
         }).collect();
 
-        let device_ref = DeviceRef::from(device.raw.clone());
+        let device_ref = device.get_ref();
         core::Gpu {
             device,
             general_queues: collect_queues(queue_descs, &device_ref, QueueType::General),
@@ -577,43 +577,7 @@ impl core::RawCommandQueue<Backend> for CommandQueue {
 }
 
 #[cfg(feature = "copy")]
-mod device_ref {
-    use std::{fmt, ops, sync};
-    use RawDevice;
-
-    pub struct DeviceRef(*mut RawDevice);
-    unsafe impl Send for DeviceRef {}
-    unsafe impl Sync for DeviceRef {}
-    impl From<sync::Arc<RawDevice>> for DeviceRef {
-        fn from(arc: sync::Arc<RawDevice>) -> Self {
-            DeviceRef(&arc.0 as *const _ as *mut _)
-        }
-    }
-    impl Clone for DeviceRef {
-        fn clone(&self) -> Self {
-            DeviceRef(self. 0)
-        }
-    }
-    impl Copy for DeviceRef {}
-    impl fmt::Debug for DeviceRef {
-        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            write!(formatter, "DeviceRef({:p})", self.0)
-        }
-    }
-    impl ops::Deref for DeviceRef {
-        type Target = RawDevice;
-        fn deref(&self) -> &RawDevice {
-            unsafe { &*self.0 }
-        }
-    }
-    impl ops::DerefMut for DeviceRef {
-        fn deref_mut(&mut self) -> &mut RawDevice {
-            unsafe { &mut *self.0 }
-        }
-    }
-}
-#[cfg(feature = "copy")]
-use device_ref::DeviceRef;
+type DeviceRef = core::copy::Pointer<RawDevice>;
 #[cfg(not(feature = "copy"))]
 type DeviceRef = Arc<RawDevice>;
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -18,8 +18,6 @@ use ash::vk;
 use core::memory;
 use core::{Features, Limits, PatchSize, QueueType};
 use std::{fmt, mem, ptr};
-#[cfg(feature = "copy")]
-use std::ops;
 use std::ffi::{CStr, CString};
 use std::sync::Arc;
 
@@ -506,19 +504,24 @@ impl fmt::Debug for RawDevice {
 #[cfg(not(feature = "copy"))]
 pub type CommandQueueRef = Arc<vk::Queue>;
 #[cfg(feature = "copy")]
-#[derive(Clone, Copy)]
-pub struct CommandQueueRef(vk::Queue);
+pub use queue_ref::CommandQueueRef;
 #[cfg(feature = "copy")]
-impl CommandQueueRef {
-    fn new(queue: vk::Queue) -> Self {
-        CommandQueueRef(queue)
+mod queue_ref {
+    use vk;
+    use std::ops;
+
+    #[derive(Clone, Copy)]
+    pub struct CommandQueueRef(vk::Queue);
+    impl CommandQueueRef {
+        pub(crate) fn new(queue: vk::Queue) -> Self {
+            CommandQueueRef(queue)
+        }
     }
-}
-#[cfg(feature = "copy")]
-impl ops::Deref for CommandQueueRef {
-    type Target = vk::Queue;
-    fn deref(&self) -> &vk::Queue {
-        &self.0
+    impl ops::Deref for CommandQueueRef {
+        type Target = vk::Queue;
+        fn deref(&self) -> &vk::Queue {
+            &self.0
+        }
     }
 }
 

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -3,7 +3,7 @@ use ash::version::DeviceV1_0;
 use core;
 use core::image::SubresourceRange;
 #[cfg(feature = "copy")]
-use core::CopyRange as Range;
+use core::copy::Range as Range;
 #[cfg(not(feature = "copy"))]
 use std::ops::Range;
 use {Backend, DeviceRef};

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -2,29 +2,37 @@ use ash::vk;
 use ash::version::DeviceV1_0;
 use core;
 use core::image::SubresourceRange;
+#[cfg(feature = "copy")]
+use core::CopyRange as Range;
+#[cfg(not(feature = "copy"))]
 use std::ops::Range;
-use std::sync::Arc;
-use {Backend, RawDevice};
+use {Backend, DeviceRef};
 
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Semaphore(pub vk::Semaphore);
 
 #[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Fence(pub vk::Fence);
 
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct GraphicsPipeline(pub vk::Pipeline);
 
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct ComputePipeline(pub vk::Pipeline);
 
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Memory {
     pub inner: vk::DeviceMemory,
     pub ptr: *mut u8,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Buffer {
     pub raw: vk::Buffer,
     pub memory: vk::DeviceMemory,
@@ -36,65 +44,76 @@ unsafe impl Sync for Buffer {}
 unsafe impl Send for Buffer {}
 
 #[derive(Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Image {
     pub raw: vk::Image,
     pub bytes_per_texel: u8,
     pub extent: vk::Extent3D,
 }
 
-
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct Sampler(pub vk::Sampler);
 
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct RenderPass {
     pub raw: vk::RenderPass,
 }
 
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct FrameBuffer {
     pub raw: vk::Framebuffer,
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct DescriptorSetLayout {
     pub raw: vk::DescriptorSetLayout,
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct DescriptorSet {
     pub raw: vk::DescriptorSet,
 }
 
 #[derive(Debug, Hash)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct PipelineLayout {
     pub raw: vk::PipelineLayout,
 }
 
 #[derive(Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct ShaderModule {
     pub raw: vk::ShaderModule,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "copy", derive(Copy))]
 pub struct ConstantBufferView {
     pub buffer: vk::Buffer,
     pub range: Range<u64>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "copy", derive(Copy))]
 pub enum ShaderResourceView {
     Buffer,
     Image(vk::ImageView),
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "copy", derive(Copy))]
 pub enum UnorderedAccessView {
     Buffer,
     Image(vk::ImageView),
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "copy", derive(Copy))]
 pub struct RenderTargetView {
     pub image: vk::Image,
     pub view: vk::ImageView,
@@ -102,6 +121,7 @@ pub struct RenderTargetView {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "copy", derive(Copy))]
 pub struct DepthStencilView {
     pub image: vk::Image,
     pub view: vk::ImageView,
@@ -109,9 +129,10 @@ pub struct DepthStencilView {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "copy", derive(Clone, Copy))]
 pub struct DescriptorPool {
     pub(crate) raw: vk::DescriptorPool,
-    pub(crate) device: Arc<RawDevice>,
+    pub(crate) device: DeviceRef,
 }
 
 impl core::DescriptorPool<Backend> for DescriptorPool {

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -1,17 +1,16 @@
 use std::ptr;
-use std::sync::Arc;
 use ash::vk;
 use ash::version::DeviceV1_0;
 use smallvec::SmallVec;
 
 use command::{CommandBuffer, SubpassCommandBuffer};
 use core::pool;
-use {Backend, CommandQueue, RawDevice};
+use {Backend, CommandQueue, DeviceRef};
 
 
 pub struct RawCommandPool {
     pool: vk::CommandPool,
-    device: Arc<RawDevice>,
+    device: DeviceRef,
 }
 
 impl pool::RawCommandPool<Backend> for RawCommandPool {
@@ -88,7 +87,7 @@ pub struct SubpassCommandPool {
     _pool: vk::CommandPool,
     _command_buffers: Vec<SubpassCommandBuffer>,
     _next_buffer: usize,
-    _device: Arc<RawDevice>,
+    _device: DeviceRef,
 }
 
 impl pool::SubpassCommandPool<Backend> for SubpassCommandPool { }

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -171,7 +171,7 @@ impl core::Surface<Backend> for Surface {
         config: core::SwapchainConfig,
         present_queue: &core::CommandQueue<Backend, C>,
     ) -> (Swapchain, Vec<core::Backbuffer<Backend>>) {
-        let functor = ext::Swapchain::new(&self.raw.instance.0, &present_queue.as_raw().device().0)
+        let functor = ext::Swapchain::new(&self.raw.instance.0, &present_queue.as_raw().device.0)
             .expect("Unable to query swapchain function");
 
         // TODO: check for better ones if available
@@ -285,7 +285,7 @@ impl core::Swapchain<Backend> for Swapchain {
 
         assert_eq!(Ok(()), unsafe {
             self.functor
-                .queue_present_khr(*present_queue.as_raw().raw(), &info)
+                .queue_present_khr(*present_queue.as_raw().raw, &info)
         });
         // TODO: handle result and return code
     }

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -13,6 +13,7 @@ workspace = "../.."
 [features]
 #TODO: switch to pure `serde` feature once `draw_state` is no longer used
 serialize = ["serde", "serde_derive", "draw_state/serialize"]
+copy = []
 unstable = []
 
 [lib]

--- a/src/core/src/copy.rs
+++ b/src/core/src/copy.rs
@@ -1,0 +1,62 @@
+//! # Copy routines
+//!
+//! This module provides reusable primitives for resources that need to
+//! implement `Copy` for Vulkan portability.
+
+use std::{fmt, ops};
+
+/// A copyable range replacement for `std::ops::Range`
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Range<T> {
+    ///
+    pub start: T,
+    ///
+    pub end: T,
+}
+
+impl<T> From<ops::Range<T>> for Range<T> {
+    fn from(other: ops::Range<T>) -> Self {
+        Range {
+            start: other.start,
+            end: other.end,
+        }
+    }
+}
+
+
+/// A horribly unsafe copyable mutable pointer.
+pub struct Pointer<T>(*mut T);
+unsafe impl<T> Send for Pointer<T> {}
+unsafe impl<T> Sync for Pointer<T> {}
+impl<T> Pointer<T> {
+    #[doc(hidden)]
+    pub unsafe fn new(ptr: *mut T) -> Self {
+        Pointer(ptr)
+    }
+    #[doc(hidden)]
+    pub unsafe fn as_mut(&self) -> &mut T {
+        &mut *self.0
+    }
+}
+impl<T> Clone for Pointer<T> {
+    fn clone(&self) -> Self {
+        Pointer(self.0)
+    }
+}
+impl<T> Copy for Pointer<T> {}
+impl<T> ops::Deref for Pointer<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { &*self.0 }
+    }
+}
+impl<T> ops::DerefMut for Pointer<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.0 }
+    }
+}
+impl<T> fmt::Debug for Pointer<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "Pointer({:p})", self.0)
+    }
+}

--- a/src/core/src/image.rs
+++ b/src/core/src/image.rs
@@ -10,7 +10,7 @@
 use std::error::Error;
 use std::fmt;
 #[cfg(feature = "copy")]
-use CopyRange as Range;
+use copy::Range as Range;
 #[cfg(not(feature = "copy"))]
 use std::ops::Range;
 use {format, state, target};

--- a/src/core/src/image.rs
+++ b/src/core/src/image.rs
@@ -9,6 +9,9 @@
 
 use std::error::Error;
 use std::fmt;
+#[cfg(feature = "copy")]
+use CopyRange as Range;
+#[cfg(not(feature = "copy"))]
 use std::ops::Range;
 use {format, state, target};
 pub use target::{Layer, Level};
@@ -457,7 +460,7 @@ impl SamplerInfo {
             filter: filter,
             wrap_mode: (wrap, wrap, wrap),
             lod_bias: Lod(0),
-            lod_range: Lod(-8000)..Lod(8000),
+            lod_range: (Lod(-8000)..Lod(8000)).into(),
             comparison: None,
             border: PackedColor(0),
         }

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -21,8 +21,6 @@ use std::any::Any;
 use std::error::Error;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
-#[cfg(feature = "copy")]
-use std::ops::Range;
 
 pub use self::adapter::{Adapter, AdapterInfo};
 pub use self::command::{RawCommandBuffer};
@@ -40,6 +38,8 @@ pub use draw_state::{state, target};
 pub mod adapter;
 pub mod buffer;
 pub mod command;
+#[cfg(feature = "copy")]
+pub mod copy;
 pub mod device;
 pub mod format;
 pub mod image;
@@ -75,25 +75,6 @@ pub type UnorderedViewSlot = u8;
 pub type ColorSlot = u8;
 /// Slot for a sampler.
 pub type SamplerSlot = u8;
-
-/// A copyable range replacement for `std::ops::Range`
-#[cfg(feature = "copy")]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct CopyRange<T> {
-    ///
-    pub start: T,
-    ///
-    pub end: T,
-}
-#[cfg(feature = "copy")]
-impl<T> From<Range<T>> for CopyRange<T> {
-    fn from(other: Range<T>) -> Self {
-        CopyRange {
-            start: other.start,
-            end: other.end,
-        }
-    }
-}
 
 ///
 #[allow(missing_docs)]

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -21,6 +21,8 @@ use std::any::Any;
 use std::error::Error;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
+#[cfg(feature = "copy")]
+use std::ops::Range;
 
 pub use self::adapter::{Adapter, AdapterInfo};
 pub use self::command::{RawCommandBuffer};
@@ -73,6 +75,25 @@ pub type UnorderedViewSlot = u8;
 pub type ColorSlot = u8;
 /// Slot for a sampler.
 pub type SamplerSlot = u8;
+
+/// A copyable range replacement for `std::ops::Range`
+#[cfg(feature = "copy")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CopyRange<T> {
+    ///
+    pub start: T,
+    ///
+    pub end: T,
+}
+#[cfg(feature = "copy")]
+impl<T> From<Range<T>> for CopyRange<T> {
+    fn from(other: Range<T>) -> Self {
+        CopyRange {
+            start: other.start,
+            end: other.end,
+        }
+    }
+}
 
 ///
 #[allow(missing_docs)]


### PR DESCRIPTION
~~requires https://github.com/MaikKlein/ash/pull/31~~

Needed for #1226, so that we can expose most of the types as copyable things without boxing them.
I'm going to implement the `copy` feature on other backends too, but still not sure if `gfx_core` needs to force `Copy` on some of the `Backend` associated types, or just having them in the backends is enough.