### PR TITLE
Metal: primitive types, image to buffer copies

### DIFF
--- a/examples/core/quad/main.rs
+++ b/examples/core/quad/main.rs
@@ -73,7 +73,7 @@ fn main() {
     let pixel_height = window_size.1 as u16;
 
     // instantiate backend
-    #[cfg(any(feature = "vulkan", feature = "dx12"))]
+    #[cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]
     let (_instance, adapters, mut surface) = {
         let instance = back::Instance::create("gfx-rs quad", 1);
         let surface = instance.create_surface(&window);
@@ -85,13 +85,6 @@ fn main() {
         let surface = back::Surface::from_window(window);
         let adapters = surface.enumerate_adapters();
         (adapters, surface)
-    };
-    #[cfg(feature = "metal")]
-    let (_instance, adapters, mut surface) = {
-        let instance = back::Instance::create();
-        let surface = instance.create_surface(&window);
-        let adapters = instance.enumerate_adapters();
-        (instance, adapters, surface)
     };
 
     for adapter in &adapters {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -157,6 +157,7 @@ pub struct CommandQueue {
     device: ComPtr<winapi::ID3D12Device>,
     list_type: winapi::D3D12_COMMAND_LIST_TYPE,
 }
+unsafe impl Send for CommandQueue {} //blocked by ComPtr
 
 impl core::RawCommandQueue<Backend> for CommandQueue {
     unsafe fn submit_raw(
@@ -194,6 +195,7 @@ pub struct Device {
     heap_sampler: Arc<Mutex<native::DescriptorHeap>>,
     events: Vec<winapi::HANDLE>,
 }
+unsafe impl Send for Device {} //blocked by ComPtr
 
 impl Device {
     fn new(mut device: ComPtr<winapi::ID3D12Device>) -> Device {

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -1,4 +1,4 @@
-
+use core::device::ResourceHeapType;
 use core::pass::{Attachment, AttachmentRef, SubpassDependency};
 use core::pso::DescriptorSetLayoutBinding;
 use core::{self, image, pso, HeapType};
@@ -134,6 +134,7 @@ pub struct Heap {
     pub raw: ComPtr<winapi::ID3D12Heap>,
     pub ty: HeapType,
     pub size: u64,
+    pub resource_type: ResourceHeapType,
     pub default_state: winapi::D3D12_RESOURCE_STATES,
 }
 #[derive(Debug)]
@@ -256,7 +257,8 @@ pub struct DescriptorPool {
     pub pools: Vec<pso::DescriptorRangeDesc>,
     pub max_size: u64,
 }
-unsafe impl Send for DescriptorPool { }
+unsafe impl Send for DescriptorPool {}
+unsafe impl Sync for DescriptorPool {}
 
 impl core::DescriptorPool<Backend> for DescriptorPool {
     fn allocate_sets(&mut self, layouts: &[&DescriptorSetLayout]) -> Vec<DescriptorSet> {

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -59,6 +59,7 @@ struct CommandBufferInner {
     viewport: Option<MTLViewport>,
     scissors: Option<MTLScissorRect>,
     pipeline_state: Option<MTLRenderPipelineState>, // Unretained
+    primitive_type: MTLPrimitiveType,
     vertex_buffers: Vec<(MTLBuffer, pso::BufferOffset)>, // Unretained
     descriptor_sets: Vec<Option<native::DescriptorSet>>,
 }
@@ -166,6 +167,7 @@ impl core::RawCommandPool<Backend> for CommandPool {
                     viewport: None,
                     scissors: None,
                     pipeline_state: None,
+                    primitive_type: MTLPrimitiveType::Point,
                     vertex_buffers: Vec::new(),
                     descriptor_sets: Vec::new(),
                 })
@@ -437,7 +439,10 @@ impl core::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn bind_graphics_pipeline(&mut self, pipeline: &native::GraphicsPipeline) {
-        self.inner().pipeline_state = Some(pipeline.0);
+        let inner = self.inner();
+        inner.pipeline_state = Some(pipeline.raw);
+        inner.primitive_type = pipeline.primitive_type;
+        //TODO: render_encoder.set_render_pipeline_state(pipeline_state); ?
     }
 
     fn bind_graphics_descriptor_sets(
@@ -446,12 +451,13 @@ impl core::RawCommandBuffer<Backend> for CommandBuffer {
         first_set: usize,
         sets: &[&native::DescriptorSet],
     ) {
-        let descriptor_sets_len = self.inner().descriptor_sets.len();
-        self.inner().descriptor_sets.extend(
+        let inner = self.inner();
+        let descriptor_sets_len = inner.descriptor_sets.len();
+        inner.descriptor_sets.extend(
             (descriptor_sets_len..(first_set + sets.len()))
                 .map(|_| None)
         );
-        for (out, &set) in self.inner().descriptor_sets[first_set ..].iter_mut().zip(sets) {
+        for (out, &set) in inner.descriptor_sets[first_set ..].iter_mut().zip(sets) {
             *out = Some(set.clone());
         }
     }
@@ -571,7 +577,7 @@ impl core::RawCommandBuffer<Backend> for CommandBuffer {
 
         unsafe {
             msg_send![encoder.0,
-                drawPrimitives: MTLPrimitiveType::Triangle
+                drawPrimitives: self.inner().primitive_type
                 vertexStart: vertices.start as NSUInteger
                 vertexCount: (vertices.end - vertices.start) as NSUInteger
                 instanceCount: (instances.end - instances.start) as NSUInteger

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -29,8 +29,8 @@ struct QueueInner {
     queue: MTLCommandQueue,
 }
 
-unsafe impl Send for QueueInner {
-}
+unsafe impl Send for QueueInner {}
+unsafe impl Sync for QueueInner {}
 
 impl Drop for QueueInner {
     fn drop(&mut self) {
@@ -492,7 +492,7 @@ impl core::RawCommandBuffer<Backend> for CommandBuffer {
         &mut self,
         src: &native::Buffer,
         dst: &native::Image,
-        dst_layout: ImageLayout,
+        _dst_layout: ImageLayout,
         regions: &[BufferImageCopy],
     ) {
         let encoder = self.encode_blit();
@@ -528,11 +528,38 @@ impl core::RawCommandBuffer<Backend> for CommandBuffer {
     fn copy_image_to_buffer(
         &mut self,
         src: &native::Image,
-        src_layout: ImageLayout,
+        _src_layout: ImageLayout,
         dst: &native::Buffer,
         regions: &[BufferImageCopy],
     ) {
-        unimplemented!()
+        let encoder = self.encode_blit();
+        let extent = unsafe { MTLSize {
+            width: src.0.width(),
+            height: src.0.height(),
+            depth: src.0.depth(),
+        }};
+        // FIXME: layout
+
+        for region in regions {
+            let image_offset = &region.image_offset;
+
+            for layer in region.image_subresource.1.clone() {
+                let offset = region.buffer_offset + region.buffer_slice_pitch as NSUInteger * (layer - region.image_subresource.1.start) as NSUInteger;
+                unsafe {
+                    msg_send![encoder.0,
+                        copyFromTexture: (src.0).0
+                        sourceSlice: layer as NSUInteger
+                        sourceLevel: region.image_subresource.0 as NSUInteger
+                        sourceOrigin: MTLOrigin { x: image_offset.x as _, y: image_offset.y as _, z: image_offset.z as _ }
+                        sourceSize: extent
+                        toBuffer: (dst.0).0
+                        destinationOffset: offset as NSUInteger
+                        destinationBytesPerRow: region.buffer_row_pitch as NSUInteger
+                        destinationBytesPerImage: region.buffer_slice_pitch as NSUInteger
+                    ]
+                }
+            }
+        }
     }
     
     fn draw(

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -13,6 +13,7 @@ pub fn map_format(format: Format) -> Option<(MTLPixelFormat, bool)> {
         Format(R8_G8_B8_A8, Unorm) => Some((MTLPixelFormat::RGBA8Unorm, false)),
         Format(R8_G8_B8_A8, Srgb) => Some((MTLPixelFormat::RGBA8Unorm_sRGB, false)),
         Format(B8_G8_R8_A8, Unorm) => Some((MTLPixelFormat::BGRA8Unorm, false)),
+        Format(B8_G8_R8_A8, Srgb) => Some((MTLPixelFormat::BGRA8Unorm_sRGB, false)),
         _ => None,
     }
 }
@@ -167,9 +168,9 @@ pub fn resource_options_from_storage_and_cache(storage: MTLStorageMode, cache: M
 }
 
 pub fn map_texture_usage(usage: image::Usage) -> MTLTextureUsage {
-    let mut texture_usage = MTLTextureUsage::empty();
+    let mut texture_usage = MTLTextureUsagePixelFormatView;
     if usage.contains(image::COLOR_ATTACHMENT) || usage.contains(image::DEPTH_STENCIL_ATTACHMENT) {
-        texture_usage |= MTLTextureUsagePixelFormatView;
+        texture_usage |= MTLTextureUsageRenderTarget;
     }
     if usage.contains(image::SAMPLED) {
         texture_usage |= MTLTextureUsageShaderRead;

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -37,6 +37,7 @@ pub struct Device {
     private_caps: PrivateCapabilities,
     limits: Limits,
 }
+unsafe impl Send for Device {}
 
 impl Drop for Device {
     fn drop(&mut self) {
@@ -734,7 +735,8 @@ impl core::Device<Backend> for Device {
         let (storage, cache) = map_heap_properties_to_storage_and_cache(heap_type.properties);
 
         // Heaps cannot be used for CPU coherent resources
-        if self.private_caps.resource_heaps && storage != MTLStorageMode::Shared {
+        //TEMP: MacOS supports Private only, iOS and tvOS can do private/shared
+        if self.private_caps.resource_heaps && storage != MTLStorageMode::Shared && false {
             let descriptor = MTLHeapDescriptor::new();
             descriptor.set_storage_mode(storage);
             descriptor.set_cpu_cache_mode(cache);

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -10,7 +10,6 @@ use std::{mem, ptr, slice};
 
 use core::{self,
         image, pass, format, mapping, memory, buffer, pso};
-use core::{Limits, Features, QueueType, Gpu, HeapType};
 use core::device::{WaitFor, ResourceHeapError, ResourceHeapType, TargetViewError};
 use core::device::{ShaderError, Extent};
 use core::pso::{DescriptorSetWrite, DescriptorType, DescriptorSetLayoutBinding, AttributeDesc};
@@ -23,7 +22,7 @@ use objc::runtime::Object as ObjcObject;
 pub struct Adapter {
     pub(crate) device: MTLDevice,
     pub(crate) adapter_info: core::AdapterInfo,
-    pub(crate) queue_families: [(n::QueueFamily, QueueType); 1],
+    pub(crate) queue_families: [(n::QueueFamily, core::QueueType); 1],
 }
 
 impl Drop for Adapter {
@@ -35,7 +34,7 @@ impl Drop for Adapter {
 pub struct Device {
     device: MTLDevice,
     private_caps: PrivateCapabilities,
-    limits: Limits,
+    limits: core::Limits,
 }
 unsafe impl Send for Device {}
 
@@ -55,7 +54,7 @@ impl Clone for Device {
 }
 
 impl core::Adapter<Backend> for Adapter {
-    fn open(&self, queue_descs: &[(&n::QueueFamily, QueueType, u32)]) -> Gpu<Backend> {
+    fn open(&self, queue_descs: &[(&n::QueueFamily, core::QueueType, u32)]) -> core::Gpu<Backend> {
         let mut general_queues = Vec::new();
         let mut graphics_queues = Vec::new();
         let mut compute_queues = Vec::new();
@@ -63,13 +62,13 @@ impl core::Adapter<Backend> for Adapter {
 
         for &(_, queue_type, count) in queue_descs {
             match queue_type {
-                QueueType::General => general_queues
+                core::QueueType::General => general_queues
                     .push(unsafe { core::CommandQueue::new(command::CommandQueue::new(self.device)) }),
-                QueueType::Graphics => graphics_queues
+                core::QueueType::Graphics => graphics_queues
                     .push(unsafe { core::CommandQueue::new(command::CommandQueue::new(self.device)) }),
-                QueueType::Compute => compute_queues
+                core::QueueType::Compute => compute_queues
                     .push(unsafe { core::CommandQueue::new(command::CommandQueue::new(self.device)) }),
-                QueueType::Transfer => transfer_queues
+                core::QueueType::Transfer => transfer_queues
                     .push(unsafe { core::CommandQueue::new(command::CommandQueue::new(self.device)) }),
             }
         }
@@ -98,7 +97,7 @@ impl core::Adapter<Backend> for Adapter {
                 resource_heaps,
                 indirect_arguments: true, //TEMP
             },
-            limits: Limits {
+            limits: core::Limits {
                 max_texture_size: 4096, // TODO: feature set
                 max_patch_size: 0, // No tesselation
                 max_viewports: 1,
@@ -140,7 +139,7 @@ impl core::Adapter<Backend> for Adapter {
         ];
         let memory_heaps = Vec::new();
 
-        Gpu {
+        core::Gpu {
             device,
             general_queues,
             graphics_queues,
@@ -155,7 +154,7 @@ impl core::Adapter<Backend> for Adapter {
         &self.adapter_info
     }
 
-    fn get_queue_families(&self) -> &[(n::QueueFamily, QueueType)] {
+    fn get_queue_families(&self) -> &[(n::QueueFamily, core::QueueType)] {
         &self.queue_families
     }
 }
@@ -227,11 +226,11 @@ impl Device {
 }
 
 impl core::Device<Backend> for Device {
-    fn get_features(&self) -> &Features {
+    fn get_features(&self) -> &core::Features {
         unimplemented!()
     }
 
-    fn get_limits(&self) -> &Limits {
+    fn get_limits(&self) -> &core::Limits {
         &self.limits
     }
 
@@ -277,6 +276,16 @@ impl core::Device<Backend> for Device {
                 defer! { pipeline.release() };
 
                 // FIXME: lots missing
+
+                let (primitive_class, primitive_type) = match pipeline_desc.input_assembler.primitive {
+                    core::Primitive::PointList => (MTLPrimitiveTopologyClass::Point, MTLPrimitiveType::Point),
+                    core::Primitive::LineList => (MTLPrimitiveTopologyClass::Line, MTLPrimitiveType::Line),
+                    core::Primitive::LineStrip => (MTLPrimitiveTopologyClass::Line, MTLPrimitiveType::LineStrip),
+                    core::Primitive::TriangleList => (MTLPrimitiveTopologyClass::Triangle, MTLPrimitiveType::Triangle),
+                    core::Primitive::TriangleStrip => (MTLPrimitiveTopologyClass::Triangle, MTLPrimitiveType::TriangleStrip),
+                    _ => (MTLPrimitiveTopologyClass::Unspecified, MTLPrimitiveType::Point) //TODO: double-check
+                };
+                pipeline.set_input_primitive_topology(primitive_class);
 
                 // Shaders
                 let mtl_vertex_function = (shader_set.vertex.module.0)
@@ -382,7 +391,10 @@ impl core::Device<Backend> for Device {
                     error!("PSO creation failed: {}", n::objc_err_description(err_ptr));
                     return Err(pso::CreationError::Other);
                 } else {
-                    Ok(n::GraphicsPipeline(pso))
+                    Ok(n::GraphicsPipeline {
+                        raw: pso,
+                        primitive_type,
+                    })
                 }
             }).collect()
         }
@@ -684,7 +696,7 @@ impl core::Device<Backend> for Device {
     }
 
     fn destroy_graphics_pipeline(&mut self, pipeline: n::GraphicsPipeline) {
-        unsafe { pipeline.0.release(); }
+        unsafe { pipeline.raw.release(); }
     }
 
     fn destroy_compute_pipeline(&mut self, pipeline: n::ComputePipeline) {
@@ -731,7 +743,7 @@ impl core::Device<Backend> for Device {
         unsafe { n::dispatch_release(semaphore.0) }
     }
 
-    fn create_heap(&mut self, heap_type: &HeapType, _resource_type: ResourceHeapType, size: u64) -> Result<n::Heap, ResourceHeapError> {
+    fn create_heap(&mut self, heap_type: &core::HeapType, _resource_type: ResourceHeapType, size: u64) -> Result<n::Heap, ResourceHeapError> {
         let (storage, cache) = map_heap_properties_to_storage_and_cache(heap_type.properties);
 
         // Heaps cannot be used for CPU coherent resources

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -1,4 +1,4 @@
-#[macro_use] extern crate gfx_core as core;
+extern crate gfx_core as core;
 extern crate winit;
 extern crate cocoa;
 #[macro_use] extern crate objc;
@@ -57,7 +57,7 @@ impl core::Instance<Backend> for Instance {
 }
 
 impl Instance {
-    pub fn create() -> Self {
+    pub fn create(_: &str, _: u32) -> Self {
         Instance {}
     }
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -132,6 +132,8 @@ pub struct DescriptorPool {
 }
 #[cfg(feature = "argument_buffer")]
 unsafe impl Send for DescriptorPool {}
+#[cfg(feature = "argument_buffer")]
+unsafe impl Sync for DescriptorPool {} //TEMP!
 
 #[cfg(not(feature = "argument_buffer"))]
 #[derive(Debug)]

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -47,7 +47,10 @@ unsafe impl Sync for FrameBuffer {
 pub struct PipelineLayout {}
 
 #[derive(Debug)]
-pub struct GraphicsPipeline(pub MTLRenderPipelineState);
+pub struct GraphicsPipeline {
+    pub(crate) raw: MTLRenderPipelineState,
+    pub(crate) primitive_type: MTLPrimitiveType,
+}
 
 unsafe impl Send for GraphicsPipeline {
 }

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -426,6 +426,9 @@ pub fn map_image_usage(usage: image::Usage) -> vk::ImageUsageFlags {
     if usage.contains(image::DEPTH_STENCIL_ATTACHMENT) {
         flags |= vk::IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     }
+    if usage.contains(image::STORAGE) {
+        flags |= vk::IMAGE_USAGE_STORAGE_BIT;
+    }
     if usage.contains(image::SAMPLED) {
         flags |= vk::IMAGE_USAGE_SAMPLED_BIT;
     }

--- a/src/core/src/image.rs
+++ b/src/core/src/image.rs
@@ -271,15 +271,17 @@ bitflags!(
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub flags Usage: u8 {
         ///
-        const TRANSFER_SRC    = 0x1,
+        const TRANSFER_SRC = 0x1,
         ///
-        const TRANSFER_DST    = 0x2,
+        const TRANSFER_DST = 0x2,
         ///
-        const COLOR_ATTACHMENT  = 0x4,
+        const COLOR_ATTACHMENT = 0x4,
         ///
         const DEPTH_STENCIL_ATTACHMENT = 0x8,
         ///
-        const SAMPLED = 0x10,
+        const STORAGE = 0x10,
+        ///
+        const SAMPLED = 0x20,
         // TODO
     }
 );


### PR DESCRIPTION
This change has a few //TODO items, with an assumption that we need to have a follow-up pass that clarifies Send/Sync usage on resource anyway.

There are still issues with Metal backend: WebGPU prototype crashes while recording an MTL blit encoder, (improper reset/cb re-use most likely), but at least it shows the first frame correctly with a texture now.
The backend also needs to properly implement binding inheritance (e.g. don't require PSO to be set outside of the encoder), but that's for future PRs.