### PR TITLE
Metal: primitive types, image to buffer copies

### DIFF
--- a/examples/core/quad/main.rs
+++ b/examples/core/quad/main.rs
@@ -73,7 +73,7 @@ fn main() {
     let pixel_height = window_size.1 as u16;
 
     // instantiate backend
-    #[cfg(any(feature = "vulkan", feature = "dx12"))]
+    #[cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]
     let (_instance, adapters, mut surface) = {
         let instance = back::Instance::create("gfx-rs quad", 1);
         let surface = instance.create_surface(&window);
@@ -85,13 +85,6 @@ fn main() {
         let surface = back::Surface::from_window(window);
         let adapters = surface.enumerate_adapters();
         (adapters, surface)
-    };
-    #[cfg(feature = "metal")]
-    let (_instance, adapters, mut surface) = {
-        let instance = back::Instance::create();
-        let surface = instance.create_surface(&window);
-        let adapters = instance.enumerate_adapters();
-        (instance, adapters, surface)
     };
 
     for adapter in &adapters {

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -13,6 +13,7 @@ pub fn map_format(format: Format) -> Option<(MTLPixelFormat, bool)> {
         Format(R8_G8_B8_A8, Unorm) => Some((MTLPixelFormat::RGBA8Unorm, false)),
         Format(R8_G8_B8_A8, Srgb) => Some((MTLPixelFormat::RGBA8Unorm_sRGB, false)),
         Format(B8_G8_R8_A8, Unorm) => Some((MTLPixelFormat::BGRA8Unorm, false)),
+        Format(B8_G8_R8_A8, Srgb) => Some((MTLPixelFormat::BGRA8Unorm_sRGB, false)),
         _ => None,
     }
 }
@@ -167,9 +168,9 @@ pub fn resource_options_from_storage_and_cache(storage: MTLStorageMode, cache: M
 }
 
 pub fn map_texture_usage(usage: image::Usage) -> MTLTextureUsage {
-    let mut texture_usage = MTLTextureUsage::empty();
+    let mut texture_usage = MTLTextureUsagePixelFormatView;
     if usage.contains(image::COLOR_ATTACHMENT) || usage.contains(image::DEPTH_STENCIL_ATTACHMENT) {
-        texture_usage |= MTLTextureUsagePixelFormatView;
+        texture_usage |= MTLTextureUsageRenderTarget;
     }
     if usage.contains(image::SAMPLED) {
         texture_usage |= MTLTextureUsageShaderRead;

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -37,6 +37,7 @@ pub struct Device {
     private_caps: PrivateCapabilities,
     limits: Limits,
 }
+unsafe impl Send for Device {}
 
 impl Drop for Device {
     fn drop(&mut self) {
@@ -734,7 +735,8 @@ impl core::Device<Backend> for Device {
         let (storage, cache) = map_memory_properties_to_storage_and_cache(memory_type.properties);
 
         // Heaps cannot be used for CPU coherent resources
-        if self.private_caps.resource_heaps && storage != MTLStorageMode::Shared {
+        //TEMP: MacOS supports Private only, iOS and tvOS can do private/shared
+        if self.private_caps.resource_heaps && storage != MTLStorageMode::Shared && false {
             let descriptor = MTLHeapDescriptor::new();
             descriptor.set_storage_mode(storage);
             descriptor.set_cpu_cache_mode(cache);

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -61,7 +61,7 @@ impl core::Instance<Backend> for Instance {
 }
 
 impl Instance {
-    pub fn create() -> Self {
+    pub fn create(_: &str, _: u32) -> Self {
         Instance {}
     }
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -40,7 +40,10 @@ unsafe impl Sync for FrameBuffer {}
 pub struct PipelineLayout {}
 
 #[derive(Debug)]
-pub struct GraphicsPipeline(pub MTLRenderPipelineState);
+pub struct GraphicsPipeline {
+    pub(crate) raw: MTLRenderPipelineState,
+    pub(crate) primitive_type: MTLPrimitiveType,
+}
 
 unsafe impl Send for GraphicsPipeline {}
 unsafe impl Sync for GraphicsPipeline {}

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -106,6 +106,8 @@ pub struct DescriptorPool {
 }
 #[cfg(feature = "argument_buffer")]
 unsafe impl Send for DescriptorPool {}
+#[cfg(feature = "argument_buffer")]
+unsafe impl Sync for DescriptorPool {} //TEMP!
 
 #[cfg(not(feature = "argument_buffer"))]
 #[derive(Debug)]


### PR DESCRIPTION
This change has a few //TODO items, with an assumption that we need to have a follow-up pass that clarifies Send/Sync usage on resource anyway.

There are still issues with Metal backend: WebGPU prototype crashes while recording an MTL blit encoder, (improper reset/cb re-use most likely), but at least it shows the first frame correctly with a texture now.
The backend also needs to properly implement binding inheritance (e.g. don't require PSO to be set outside of the encoder), but that's for future PRs.