### PR TITLE
[pre-ll] Cherry picks from v0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ name = "gfx_app"
 [dependencies]
 log = "0.3"
 env_logger = "0.4"
-glutin = "0.9"
-winit = "0.7"
+glutin = "0.10"
+winit = "0.8"
 gfx_core = { path = "src/core", version = "0.7.1" }
 gfx_corell = { path = "src/corell", version = "0.1" }
 gfx = { path = "src/render", version = "0.16" }
 gfx_macros = { path = "src/macros", version = "0.2" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.14" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.17" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.18" }
 
 [dependencies.gfx_device_vulkan]
 path = "src/backend/vulkan"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,19 @@
 environment:
+  RUST_BACKTRACE: full
   matrix:
-    - TARGET: 1.20.0-x86_64-pc-windows
-      COMPILER: gnu
-    - TARGET: 1.20.0-x86_64-pc-windows
-      COMPILER: msvc
-    - TARGET: nightly-x86_64-pc-windows
-      COMPILER: msvc
+  - channel: stable
+    target: x86_64-pc-windows-msvc
+  - channel: stable
+    target: x86_64-pc-windows-gnu
+  - channel: nightly
+    target: x86_64-pc-windows-msvc
 install:
-  - if %COMPILER%==gnu choco install -y mingw
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}-${env:COMPILER}.exe" -FileName "rust-install.exe"
-  - ps: .\rust-install.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null
-  - ps: $env:PATH="$env:PATH;C:\rust\bin;C:\tools\mingw64\bin"
-  - if %COMPILER%==gnu gcc -v
-  - rustc -vV
-  - cargo -vV
-build_script:
-  - cargo build --features vulkan
+- appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+- rustup-init -yv --default-toolchain %channel% --default-host %target%
+- set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+- rustc -vV
+- cargo -vV
+build: false
 test_script:
-  - cargo test --all --features vulkan
-  - cargo test -p gfx -p gfx_core --features "mint serialize"
+- cargo test --all --features vulkan
+- cargo test -p gfx -p gfx_core --features "mint serialize"

--- a/src/backend/dx12ll/Cargo.toml
+++ b/src/backend/dx12ll/Cargo.toml
@@ -36,4 +36,4 @@ dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gf
 kernel32-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
 winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-winit = "0.7"
+winit = "0.8"

--- a/src/backend/metalll/Cargo.toml
+++ b/src/backend/metalll/Cargo.toml
@@ -14,7 +14,7 @@ argument_buffer = []
 [dependencies]
 log = "0.3"
 gfx_corell = { path = "../../corell", version = "0.1.0" }
-winit = "0.7"
+winit = "0.8"
 cocoa = "0.9"
 objc = "0.2"
 metal-rs = "0.4.2"

--- a/src/backend/vulkanll/Cargo.toml
+++ b/src/backend/vulkanll/Cargo.toml
@@ -32,7 +32,7 @@ shared_library = "0.1"
 gfx_corell = { path = "../../corell", version = "0.1.0" }
 ash = "0.15.7"
 spirv-utils = { git = "https://github.com/msiglreith/spirv-utils.git", branch = "gfx" }
-winit = "0.7"
+winit = "0.8"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.2"

--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -231,6 +231,7 @@ macro_rules! gfx_pipeline_base {
         pub mod $module {
             #[allow(unused_imports)]
             use super::*;
+            #[allow(unused_imports)]
             use super::gfx;
             gfx_pipeline_inner!{ $(
                 $field: $ty,
@@ -248,6 +249,7 @@ macro_rules! gfx_pipeline {
         pub mod $module {
             #[allow(unused_imports)]
             use super::*;
+            #[allow(unused_imports)]
             use super::gfx;
             gfx_pipeline_inner!{ $(
                 $field: $ty,

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -32,6 +32,6 @@ kernel32-sys = "0.2"
 user32-sys = "0.2"
 dxguid-sys = "0.2"
 winapi = "0.2"
-winit = "0.7"
+winit = "0.8"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.6" }

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.17.0"
+version = "0.18.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,7 +28,7 @@ documentation = "https://docs.rs/gfx_window_glutin"
 name = "gfx_window_glutin"
 
 [dependencies]
-glutin = "0.9"
+glutin = "0.10"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.14" }
 

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -30,7 +30,7 @@ name = "gfx_window_metal"
 log = "0.3"
 cocoa = "0.9"
 objc = "0.2"
-winit = "0.7"
+winit = "0.8"
 metal-rs = "0.4"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.3" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/gfx_window_vulkan"
 name = "gfx_window_vulkan"
 
 [dependencies]
-winit = "0.7"
+winit = "0.8"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.2" }


### PR DESCRIPTION
v0.16 improvements for the pre-ll branch.

* Fix: Updating appveyor 1.n -> 1.n+1 isn't fun
* Add: Latest glutin/winit is nice to have
* Fix: Unused warnings in out-of-crate macros is a bore