### PR TITLE
[ll] updated Readme, Changelog, fixed dx12 nightly build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,64 +1,6 @@
 ## Change Log
 
-### v0.16 (2017-05-11)
-  - `RawGlobal` PSO component ([#1262](https://github.com/gfx-rs/gfx/pull/1262))
-  - run-time configurable instance rate ([#1256](https://github.com/gfx-rs/gfx/pull/1256))
-  - more convenience traits are derived ([#1249](https://github.com/gfx-rs/gfx/pull/1249))
-  - optional cgmath support ([#1242](https://github.com/gfx-rs/gfx/pull/1242))
-
-### v0.15 (2017-04-22)
-  - optional serialization support ([#1234](https://github.com/gfx-rs/gfx/pull/1234))
-  - better GL state caching ([#1221](https://github.com/gfx-rs/gfx/pull/1221))
-  - GL texture staging ([#1202](https://github.com/gfx-rs/gfx/pull/1202))
-  - primitives with adjacency ([#1154](https://github.com/gfx-rs/gfx/pull/1154))
-  - metal backend improvements ([#1165](https://github.com/gfx-rs/gfx/pull/1165), [#1175](https://github.com/gfx-rs/gfx/pull/1175))
-  - resource mapping improvements
-
-### v0.14 (2017-01-16)
-  - fixed `Fence` and `Sync` bounds ([#1095](https://github.com/gfx-rs/gfx/pull/1095))
-  - dx11 buffer mapping support ([#1099](https://github.com/gfx-rs/gfx/pull/1099), [#1105](https://github.com/gfx-rs/gfx/pull/1105))
-  - redesigned resource usage model for next-gen compatibility ([#1123](https://github.com/gfx-rs/gfx/pull/1123))
-  - buffer copy support ([#1129](https://github.com/gfx-rs/gfx/pull/1129))
-  - fixed and improved some errors ([#1137](https://github.com/gfx-rs/gfx/pull/1137), [#1138](https://github.com/gfx-rs/gfx/pull/1138))
-  - application launcher revamp and resize support ([#1121](https://github.com/gfx-rs/gfx/pull/1121))
-
-### v0.13 (2016-12-18)
-  - experimental Metal backend ([#969](https://github.com/gfx-rs/gfx/pull/969), [#1049](https://github.com/gfx-rs/gfx/pull/1049), [#1050](https://github.com/gfx-rs/gfx/pull/1050))
-  - persistent mapping ([#1026](https://github.com/gfx-rs/gfx/pull/1026))
-  - tessellation support ([#1027](https://github.com/gfx-rs/gfx/pull/1027), [#1088](https://github.com/gfx-rs/gfx/pull/1088))
-  - new examples: gamma, particle, terrain_tessellated
-  - better PSO error messages, constant offset checks ([#1004](https://github.com/gfx-rs/gfx/pull/1004))
-  - unified scissor: now Y-reversed on GL ([#1092](https://github.com/gfx-rs/gfx/pull/1092))
-  - `const` resources are now called `immutable`
-  - faster handle clones and cleaner core  API ([#1031](https://github.com/gfx-rs/gfx/pull/1031))
-
-### v0.12 (2016-06-23)
-  - Android / GLES support ([#993](https://github.com/gfx-rs/gfx/pull/993))
-  - GL unsigned int samplers ([#991](https://github.com/gfx-rs/gfx/pull/991))
-  - better errors ([#976](https://github.com/gfx-rs/gfx/pull/976))
-  - better GLSL pre core reflection
-
-### v0.11 (2016-04-30)
-  - modified `Slice` API ([#955](https://github.com/gfx-rs/gfx/pull/955))
-  - fixed GL blending where it's not in the core ([#953](https://github.com/gfx-rs/gfx/pull/953))
-  - raw PSO components for vertex buffers and render targets
-
-### v0.10.2 (2016-04-15)
-  - fixed get_texel_count ([#937](https://github.com/gfx-rs/gfx/pull/937))
-
-### v0.10.1 (2016-03-26)
-  - fixed update_texture ([#912](https://github.com/gfx-rs/gfx/pull/912))
-
-### v0.10 (2016-03-21)
-  - Direct3D 11 backend ([#861](https://github.com/gfx-rs/gfx/pull/861))
-
-### v0.9.2 (2016-02-24)
-  - fixed universal format views ([#886](https://github.com/gfx-rs/gfx/pull/886))
-  - fixed constant buffer binding ([#828](https://github.com/gfx-rs/gfx/pull/828))
-
-### v0.9.1 (2016-02-19)
-  - window resize support ([#879](https://github.com/gfx-rs/gfx/pull/879))
-  - deriving windows attributes from target formats ([#874](https://github.com/gfx-rs/gfx/pull/874))
-
-### v0.9 (2016-01-22)
-  - Pipepeline State Object revolution ([#828](https://github.com/gfx-rs/gfx/pull/828))
+### v0.1 (TBD)
+  - `gfx_hal`: graphics hardware abstraction layer
+  - `gfx_backend_*`: Vulkan, D3D12, Metal
+  - `gfx_render`: safer wrapper at a higher level

--- a/README.md
+++ b/README.md
@@ -22,110 +22,16 @@
 </p>
 
 ## gfx-rs
-`gfx` is a high-performance, bindless graphics API for the Rust programming language. It aims to be the default API for Rust graphics: for one-off applications, or higher level libraries or engines.
 
-### Under Construction
+gfx-rs is a graphics abstraction library in Rust. It consists of the following layers/components:
+- `gfx_hal`: hardware abstraction layer - a Vulkan-ic mostly unsafe API translating to native graphics backends
+- `gfx_backend_*`: graphics backends for various platforms, include the windowing logic.
+- `gfx_render`: higher level wrapper around HAL, providing resources lifetime tracking, synchronization, and more
 
-gfx-rs is undergoing severe changes now with transition to the new [low-level core](http://gfx-rs.github.io/2017/07/24/low-level.html). All the following sections apply to the `pre-ll` branch and will be outdated soon. The new development focus is on zero-cost low-level abstraction of current-gen graphics APIs, such as Vulkan, D3D12, and Metal.
+### Features
 
----
+TODO
 
-## Motivation
+### Usage
 
-- Graphics APIs are mostly designed with C and C++ in mind, and hence are dangerous and error prone, with little static safety guarantees.
-- Providing type safe wrappers around platform-specific APIs is feasible, but only pushes the problem of platform independence to a higher level of abstraction, often to the game or rendering engine.
-- Modern graphics APIs, whilst providing a great degree of flexibility and a high level of performance, often have a much higher barrier to entry than traditional [fixed-function](https://en.wikipedia.org/wiki/Fixed-function) APIs.
-- Graphics APIs like OpenGL still [require the developer to 'bind' and 'unbind' objects](https://www.khronos.org/opengl/wiki/Buffer_Object) in order to perform operations on them. This results in a large amount of boiler plate code, and brings with it the usual problems associated with global state.
-
-## Features
-
-Graphics backends:
-  - [OpenGL 2.1+](src/backend/gl)
-  - [OpenGL ES2+](src/backend/gl) ([works](https://github.com/gfx-rs/gfx/pull/993) on Android)
-  - [Direct3D 11](src/backend/dx11)
-  - [Metal](src/backend/metal) (WIP 75%)
-  - [Vulkan](src/backend/vulkan) (WIP 40%)
-
-Hardware features:
-  - [x] off-screen render targets
-  - [x] multisampling
-  - [x] instancing
-  - [x] geometry shaders
-  - [x] tessellation
-  - [ ] computing
-  - [x] persistent mapping
-
-## Who's using it?
-
-Biggest open-source projects are:
-  - [Amethyst](https://github.com/amethyst/amethyst) engine
-  - [ggez](https://github.com/ggez/ggez) engine
-  - Piston engine - [2d graphics](https://github.com/PistonDevelopers/gfx_graphics)
-  - [LazyBox](https://github.com/lazybox/lazybox) engine
-  - [Vange-rs](https://github.com/kvark/vange-rs) game
-  - [Zemeroth](https://github.com/ozkriff/zemeroth) game
-  - [Rust-quake](https://github.com/Thinkofname/rust-quake) level viewer
-  - [Rust-oids](https://github.com/itadinanta/rust-oids) game
-
-Shiny screens, including some older projects:
-<p align="center">
-  <!--img src="https://raw.githubusercontent.com/csherratt/snowmew/master/.screenshot.jpg" height="160" alt="Snowmew"/-->
-  <img src="https://github.com/PistonDevelopers/hematite/blob/master/screenshot.png" height="160" alt="Hematite"/>
-  <img src="http://image.prntscr.com/image/2f1ec5d477e042dda2c29323c9f49ab4.png" height="160" alt="LazyBox"/>
-  <img src="https://github.com/kvark/vange-rs/blob/master/etc/shots/Road10-debug-shape.png" height="160" alt="Vange-rs"/>
-  <img src="https://github.com/kvark/claymore/raw/master/etc/screens/7-forest.jpg" height="160" alt="Claymore"/>
-  <img src="https://camo.githubusercontent.com/fb8c95650fba27061e58e76f17ff8460a41b3312/687474703a2f2f692e696d6775722e636f6d2f504f68534c77682e706e67" height="160" alt="ZoC"/>
-  <img src="https://camo.githubusercontent.com/0038d5e3c73b280cfa5d01b26ccef12be7237af5/687474703a2f2f692e696d6775722e636f6d2f703163654954352e706e67" height="160" alt="Rust-Quake">
-  <img src="https://github.com/itadinanta/rust-oids/raw/master/img/screenshot_007.png" height="160" alt="Rust-oids">
-  <!--img src="https://raw.githubusercontent.com/csherratt/petri/master/petri.png" height="160" alt="Petri"/-->
-</p>
-
-## Getting started
-
-If you want to build your own stand-alone gfx program, add the following to your new `Cargo.toml`:
-
-	[dependencies]
-	gfx = "0.16"
-
-or, if you want the absolute latest commits to master, you can instead add.
-
-	[dependencies]
-	gfx = { git = "https://github.com/gfx-rs/gfx.git" }
-
-For gfx to work, it needs access to the graphics system of the OS. This is typically provided through some window initialization API.
-gfx can use a couple of those to acquire graphical contexts.
-For example; [glfw](https://github.com/PistonDevelopers/glfw-rs) or [glutin](https://github.com/tomaka/glutin/).
-
-To see how the graphic context is acquired, see the [cube example](https://github.com/gfx-rs/gfx/tree/master/support/examples/cube) or the [triangle example](https://github.com/gfx-rs/gfx/tree/master/render/examples/triangle).
-
-To use `glutin`, for example, your `Cargo.toml` must be extended with the following dependencies:
-
-	[dependencies]
-	...
-	glutin ="*"
-	gfx_window_glutin = "*"
-
-Alternatively, an excellent introduction into gfx and its related crates can be found [here](https://wiki.alopex.li/LearningGfx).
-
-## Running the Examples
-
-The [examples directory](./examples) contains all the examples for GFX, as well as the
-[accompanying documentation](./examples/README.md) for understanding and running those examples.
-
-
-## Structure and current versions
-`gfx` consist of several crates. You can find all of them in this repository.
-
-| Core functionality: | Graphic backends: | Window backends: |
-| :---: | :---: | :---: |
-| [![gfx on crates.io](http://img.shields.io/crates/v/gfx.svg?label=gfx)](http://crates.io/crates/gfx) | [![gfx_device_gl on crates.io](http://img.shields.io/crates/v/gfx_device_gl.svg?label=gfx_device_gl)](http://crates.io/crates/gfx_device_gl) | [![gfx_window_sdl on crates.io](http://img.shields.io/crates/v/gfx_window_sdl.svg?label=gfx_window_sdl)](http://crates.io/crates/gfx_window_sdl) |
-| | [![gfx_device_dx11 on crates.io](http://img.shields.io/crates/v/gfx_device_dx11.svg?label=gfx_device_dx11)](http://crates.io/crates/gfx_device_dx11) | [![gfx_window_dxgi on crates.io](http://img.shields.io/crates/v/gfx_window_dxgi.svg?label=gfx_window_dxgi)](http://crates.io/crates/gfx_window_dxgi) |
-| [![gfx_core on crates.io](http://img.shields.io/crates/v/gfx_core.svg?label=gfx_core)](http://crates.io/crates/gfx_core) | [![gfx_device_metal on crates.io](http://img.shields.io/crates/v/gfx_device_metal.svg?label=gfx_device_metal)](http://crates.io/crates/gfx_device_metal) | [![gfx_window_glfw on crates.io](http://img.shields.io/crates/v/gfx_window_glfw.svg?label=gfx_window_glfw)](http://crates.io/crates/gfx_window_glfw) |
-| [![gfx_macros on crates.io](http://img.shields.io/crates/v/gfx_macros.svg?label=gfx_macros)](http://crates.io/crates/gfx_macros) | [![gfx_device_vulkan on crates.io](http://img.shields.io/crates/v/gfx_device_vulkan.svg?label=gfx_device_vulkan)](http://crates.io/crates/gfx_device_vulkan) | [![gfx_window_metal on crates.io](http://img.shields.io/crates/v/gfx_window_metal.svg?label=gfx_window_metal)](http://crates.io/crates/gfx_window_metal) |
-| | | [![gfx_window_glutin on crates.io](http://img.shields.io/crates/v/gfx_window_glutin.svg?label=gfx_window_glutin)](http://crates.io/crates/gfx_window_glutin) |
-| | | [![gfx_window_vulkan on crates.io](http://img.shields.io/crates/v/gfx_window_vulkan.svg?label=gfx_window_vulkan)](http://crates.io/crates/gfx_window_vulkan) |
-
-## Note
-
-`gfx` is still in development. API may change with new backends/features to be implemented.
-If you are interested in helping out, checkout [contrib.md](info/contrib.md) and do not hesitate to contact the developers on [Gitter](https://gitter.im/gfx-rs/gfx).
+TODO

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1096,10 +1096,10 @@ impl d::Device<B> for Device {
         for desc in descriptor_pools {
             match desc.ty {
                 pso::DescriptorType::Sampler => {
-                    num_samplers += desc.count as _;
+                    num_samplers += desc.count as u64;
                 }
                 _ => {
-                    num_srv_cbv_uav += desc.count as _;
+                    num_srv_cbv_uav += desc.count as u64;
                 }
             }
         }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -5,8 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::os::raw::{c_void, c_long, c_int};
 use std::ptr;
 
-use core::{self, image, pass};
-use core::pso::{DescriptorSetLayoutBinding, DescriptorType};
+use core::{self, image, pass, pso};
 
 use cocoa::foundation::{NSRange, NSUInteger};
 use metal::*;
@@ -137,10 +136,10 @@ impl core::DescriptorPool<Backend> for DescriptorPool {
         layouts.iter().map(|layout| {
             let bindings = layout.bindings.iter().map(|layout| {
                 let binding = match layout.ty {
-                    DescriptorType::Sampler => {
+                    pso::DescriptorType::Sampler => {
                         DescriptorSetBinding::Sampler((0..layout.count).map(|_| MTLSamplerState::nil()).collect())
                     },
-                    DescriptorType::SampledImage => {
+                    pso::DescriptorType::SampledImage => {
                         DescriptorSetBinding::SampledImage((0..layout.count).map(|_| (MTLTexture::nil(), image::ImageLayout::General)).collect())
                     },
                     _ => unimplemented!(),
@@ -167,7 +166,7 @@ impl core::DescriptorPool<Backend> for DescriptorPool {
 #[derive(Debug)]
 pub struct DescriptorSetLayout {
     pub encoder: MTLArgumentEncoder,
-    pub stage_flags: ShaderStageFlags,
+    pub stage_flags: pso::ShaderStageFlags,
 }
 #[cfg(feature = "argument_buffer")]
 unsafe impl Send for DescriptorSetLayout {}
@@ -177,7 +176,7 @@ unsafe impl Sync for DescriptorSetLayout {}
 #[cfg(not(feature = "argument_buffer"))]
 #[derive(Debug)]
 pub struct DescriptorSetLayout {
-    pub bindings: Vec<DescriptorSetLayoutBinding>,
+    pub bindings: Vec<pso::DescriptorSetLayoutBinding>,
 }
 
 #[derive(Clone, Debug)]
@@ -186,7 +185,7 @@ pub struct DescriptorSet {
     pub buffer: MTLBuffer,
     pub offset: NSUInteger,
     pub encoder: MTLArgumentEncoder,
-    pub stage_flags: ShaderStageFlags,
+    pub stage_flags: pso::ShaderStageFlags,
 }
 #[cfg(feature = "argument_buffer")]
 unsafe impl Send for DescriptorSet {}
@@ -202,7 +201,7 @@ pub struct DescriptorSet {
 #[cfg(not(feature = "argument_buffer"))]
 #[derive(Debug)]
 pub struct DescriptorSetInner {
-    pub layout: Vec<DescriptorSetLayoutBinding>, // TODO: maybe don't clone?
+    pub layout: Vec<pso::DescriptorSetLayoutBinding>, // TODO: maybe don't clone?
     pub bindings: HashMap<usize, DescriptorSetBinding>,
 }
 #[cfg(not(feature = "argument_buffer"))]


### PR DESCRIPTION
The old README/CHANGELOG contents make little sense for `ll`. We'll keep them in `pre-ll`, where we'll be forwarding people who needs compatibility stuff.