### PR TITLE
Metal: individual command buffer reset

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -33,7 +33,6 @@ use std::os::raw::c_void;
 use core::{QueueType};
 use objc::runtime::{Object, Class};
 use cocoa::base::YES;
-use cocoa::appkit::NSWindow;
 use core_graphics::geometry::CGRect;
 
 pub struct Instance {


### PR DESCRIPTION
In short:
Pools with individual reset have `managed == None`, their command buffers have `queue == Some`, and they use it to reset themselves.
