### PR TITLE
[pre-ll] Copy texture to texture

### DIFF
--- a/src/backend/dx11/src/execute.rs
+++ b/src/backend/dx11/src/execute.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{mem, ptr};
+use std::{cmp, mem, ptr};
 use winapi::{self, UINT};
 use core::{self, texture as tex};
 use command;
 use {Buffer, Texture};
+
 
 fn copy_buffer(context: *mut winapi::ID3D11DeviceContext,
                src: &Buffer, dst: &Buffer,
@@ -38,6 +39,32 @@ fn copy_buffer(context: *mut winapi::ID3D11DeviceContext,
     };
 }
 
+fn copy_texture(context: *mut winapi::ID3D11DeviceContext,
+                src: &tex::TextureCopyRegion<Texture>,
+                dst: &tex::TextureCopyRegion<Texture>) {
+    assert_eq!((src.info.width, src.info.height, src.info.depth),
+               (dst.info.width, dst.info.height, dst.info.depth));
+    assert_eq!(src.kind.get_num_slices(), None);
+    assert_eq!(dst.kind.get_num_slices(), None);
+
+    let src_resource = src.texture.as_resource();
+    let dst_resource = dst.texture.as_resource();
+    let src_box = winapi::D3D11_BOX {
+        left: src.info.xoffset as _,
+        right: (src.info.xoffset + src.info.width) as _,
+        top: src.info.yoffset as _,
+        bottom: (src.info.yoffset + src.info.height) as _,
+        front: src.info.zoffset as _,
+        back: (src.info.zoffset + cmp::max(1, src.info.depth)) as _,
+    };
+    unsafe {
+        (*context).CopySubresourceRegion(dst_resource, dst.info.mipmap as _,
+                                         dst.info.xoffset as _, dst.info.yoffset as _, dst.info.zoffset as _,
+                                         src_resource, src.info.mipmap as _, &src_box)
+    };
+
+}
+
 pub fn update_buffer(context: *mut winapi::ID3D11DeviceContext, buffer: &Buffer,
                      data: &[u8], offset_bytes: usize) {
     let dst_resource = (buffer.0).0 as *mut winapi::ID3D11Resource;
@@ -57,30 +84,24 @@ pub fn update_buffer(context: *mut winapi::ID3D11DeviceContext, buffer: &Buffer,
     }
 }
 
-pub fn update_texture(context: *mut winapi::ID3D11DeviceContext, texture: &Texture, kind: tex::Kind,
-                      face: Option<tex::CubeFace>, data: &[u8], image: &tex::RawImageInfo) {
-    let subres = texture_subres(face, image);
-    let dst_resource = texture.as_resource();
-    let (width, height, _, _) = kind.get_level_dimensions(image.mipmap);
-    let stride = image.format.0.get_total_bits() as usize;
-    let row_pitch = width as usize * stride;
-    let depth_pitch = height as usize * row_pitch;
-
-    // DYNAMIC only
-    let offset_bytes = image.xoffset as usize +
-                       image.yoffset as usize * row_pitch +
-                       image.zoffset as usize * depth_pitch;
+pub fn update_texture(context: *mut winapi::ID3D11DeviceContext,
+                      tex: &tex::TextureCopyRegion<Texture>,
+                      data: &[u8]) {
+    let subres = texture_subres(tex.cube_face, &tex.info);
+    let dst_resource = tex.texture.as_resource();
+    // DYNAMIC only; This only works if the whole texture is covered.
+    assert_eq!(tex.info.xoffset + tex.info.yoffset + tex.info.zoffset, 0);
     let map_type = winapi::D3D11_MAP_WRITE_DISCARD;
     let hr = unsafe {
         let mut sub = mem::zeroed();
         let hr = (*context).Map(dst_resource, subres, map_type, 0, &mut sub);
-        let dst = (sub.pData as *mut u8).offset(offset_bytes as isize);
+        let dst = sub.pData as *mut u8;
         ptr::copy_nonoverlapping(data.as_ptr(), dst, data.len());
         (*context).Unmap(dst_resource, 0);
         hr
     };
     if !winapi::SUCCEEDED(hr) {
-        error!("Texture {:?} failed to map, error {:x}", texture, hr);
+        error!("Texture {:?} failed to map, error {:x}", tex.texture, hr);
     }
 }
 
@@ -203,13 +224,16 @@ pub fn process(ctx: *mut winapi::ID3D11DeviceContext, command: &command::Command
         CopyBuffer(ref src, ref dst, src_offset, dst_offset, size) => {
             copy_buffer(ctx, src, dst, src_offset, dst_offset, size);
         },
+        CopyTexture(ref src, ref dst) => {
+            copy_texture(ctx, src, dst);
+        },
         UpdateBuffer(ref buffer, pointer, offset) => {
             let data = data_buf.get(pointer);
             update_buffer(ctx, buffer, data, offset);
         },
-        UpdateTexture(ref tex, kind, face, pointer, ref image) => {
+        UpdateTexture(ref dst, pointer) => {
             let data = data_buf.get(pointer);
-            update_texture(ctx, tex, kind, face, data, image);
+            update_texture(ctx, dst, data);
         },
         GenerateMips(ref srv) => unsafe {
             (*ctx).GenerateMips(srv.0);

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -278,9 +278,9 @@ impl command::Parser for CommandList {
         let ptr = self.1.add(data);
         self.0.push(command::Command::UpdateBuffer(buf, ptr, offset));
     }
-    fn update_texture(&mut self, tex: Texture, kind: tex::Kind, face: Option<tex::CubeFace>, data: &[u8], image: tex::RawImageInfo) {
+    fn update_texture(&mut self, dst: tex::TextureCopyRegion<Texture>, data: &[u8]) {
         let ptr = self.1.add(data);
-        self.0.push(command::Command::UpdateTexture(tex, kind, face, ptr, image));
+        self.0.push(command::Command::UpdateTexture(dst, ptr));
     }
 }
 
@@ -313,8 +313,8 @@ impl command::Parser for DeferredContext {
     fn update_buffer(&mut self, buf: Buffer, data: &[u8], offset: usize) {
         execute::update_buffer(self.0, &buf, data, offset);
     }
-    fn update_texture(&mut self, tex: Texture, kind: tex::Kind, face: Option<tex::CubeFace>, data: &[u8], image: tex::RawImageInfo) {
-        execute::update_texture(self.0, &tex, kind, face, data, &image);
+    fn update_texture(&mut self, dst: tex::TextureCopyRegion<Texture>, data: &[u8]) {
+        execute::update_texture(self.0, &dst, data);
     }
 }
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -596,14 +596,20 @@ impl Device {
                                          size);
                 }
             },
-            Command::CopyBufferToTexture(src, src_offset, dst, kind, face, img) => {
-                match tex::copy_from_buffer(&self.share.context, dst, kind, face, &img, src, src_offset) {
+            Command::CopyBufferToTexture(src, src_offset, ref dst) => {
+                match tex::copy_from_buffer(&self.share.context, dst, src, src_offset) {
                     Ok(_) => (),
                     Err(e) => error!("GL: {:?} failed: {:?}", cmd, e)
                 }
             },
-            Command::CopyTextureToBuffer(src, kind, face, img, dst, dst_offset) => {
-                match tex::copy_to_buffer(&self.share.context, src, kind, face, &img, dst, dst_offset) {
+            Command::CopyTextureToBuffer(ref src, dst, dst_offset, fbo) => {
+                match tex::copy_to_buffer(&self.share.context, src, dst, dst_offset, fbo) {
+                    Ok(_) => (),
+                    Err(e) => error!("GL: {:?} failed: {:?}", cmd, e)
+                }
+            },
+            Command::CopyTextureToTexture(ref src, ref dst, fbo) => {
+                match tex::copy_textures(&self.share.context, src, dst, fbo) {
                     Ok(_) => (),
                     Err(e) => error!("GL: {:?} failed: {:?}", cmd, e)
                 }
@@ -613,11 +619,11 @@ impl Device {
                 factory::update_sub_buffer(&self.share.context, buffer,
                     data.as_ptr(), data.len(), offset, buffer::Role::Vertex);
             },
-            Command::UpdateTexture(texture, kind, face, pointer, ref image) => {
+            Command::UpdateTexture(ref dst, pointer) => {
                 let data = data_buf.get(pointer);
-                match tex::update_texture(&self.share.context, texture, kind, face, image, data) {
+                match tex::update_texture(&self.share.context, dst, data) {
                     Ok(_) => (),
-                    Err(e) => error!("GL: Texture({}) update failed: {:?}", texture, e),
+                    Err(e) => error!("GL: Texture({}) update failed: {:?}", dst.texture, e),
                 }
             },
             Command::GenerateMipmap(view) => {

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -254,8 +254,8 @@ impl command::Buffer<Resources> for CommandBuffer {
                 }
 
                 // It may be the case that we have a stencil clear command for this buffer
-                // queued but a stencil attachment is not requested. In that case, the 
-                // stencil clear must be preserved for future attachments, but the depth 
+                // queued but a stencil attachment is not requested. In that case, the
+                // stencil clear must be preserved for future attachments, but the depth
                 // clear has been processed already and must be removed.
                 if let Some(stencil_value) = clear_entry.get().1 {
                     if let Some(stencil_attachment) = stencil_attachment {
@@ -326,20 +326,21 @@ impl command::Buffer<Resources> for CommandBuffer {
 
     #[allow(unused_variables)]
     fn copy_buffer_to_texture(&mut self, src: Buffer, src_offset_bytes: usize,
-                              dst: Texture,
-                              kind: texture::Kind,
-                              face: Option<texture::CubeFace>,
-                              img: texture::RawImageInfo) {
+                              dst: texture::TextureCopyRegion<Texture>) {
         unimplemented!()
     }
 
     #[allow(unused_variables)]
     fn copy_texture_to_buffer(&mut self,
-                              src: Texture,
-                              kind: texture::Kind,
-                              face: Option<texture::CubeFace>,
-                              img: texture::RawImageInfo,
+                              src: texture::TextureCopyRegion<Texture>,
                               dst: Buffer, dst_offset_bytes: usize) {
+        unimplemented!()
+    }
+
+    #[allow(unused_variables)]
+    fn copy_texture_to_texture(&mut self,
+                               src: texture::TextureCopyRegion<Texture>,
+                               dst: texture::TextureCopyRegion<Texture>) {
         unimplemented!()
     }
 
@@ -397,11 +398,8 @@ impl command::Buffer<Resources> for CommandBuffer {
     }
 
     fn update_texture(&mut self,
-                      tex: Texture,
-                      kind: texture::Kind,
-                      face: Option<texture::CubeFace>,
-                      data: &[u8],
-                      info: texture::RawImageInfo) {
+                      dst: texture::TextureCopyRegion<Texture>,
+                      data: &[u8]) {
         unimplemented!()
     }
 
@@ -422,10 +420,10 @@ impl command::Buffer<Resources> for CommandBuffer {
     fn clear_depth_stencil(&mut self, target: Dsv,
                            depth: Option<target::Depth>, stencil: Option<target::Stencil>) {
         match self.dsv_clear.entry(target) {
-            Entry::Occupied(mut entry) => { 
+            Entry::Occupied(mut entry) => {
                 let new_depth = depth.or(entry.get().0);
                 let new_stencil = stencil.or(entry.get().1);
-                entry.insert((new_depth, new_stencil)); 
+                entry.insert((new_depth, new_stencil));
             },
             Entry::Vacant(entry) => { entry.insert((depth, stencil)); },
         }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -244,26 +244,26 @@ impl command::Buffer<Resources> for Buffer {
 
     #[allow(unused_variables)]
     fn copy_buffer_to_texture(&mut self, src: native::Buffer, src_offset_bytes: usize,
-                              dst: native::Texture,
-                              kind: tex::Kind,
-                              face: Option<tex::CubeFace>,
-                              img: tex::RawImageInfo) {
+                              dst: tex::TextureCopyRegion<native::Texture>) {
         unimplemented!()
     }
 
     #[allow(unused_variables)]
     fn copy_texture_to_buffer(&mut self,
-                              src: native::Texture,
-                              kind: tex::Kind,
-                              face: Option<tex::CubeFace>,
-                              img: tex::RawImageInfo,
+                              src: tex::TextureCopyRegion<native::Texture>,
                               dst: native::Buffer, dst_offset_bytes: usize) {
         unimplemented!()
     }
 
+    #[allow(unused_variables)]
+    fn copy_texture_to_texture(&mut self,
+                               src: tex::TextureCopyRegion<native::Texture>,
+                               dst: tex::TextureCopyRegion<native::Texture>) {
+        unimplemented!()
+    }
+
     fn update_buffer(&mut self, _: native::Buffer, _: &[u8], _: usize) {}
-    fn update_texture(&mut self, _: native::Texture, _: tex::Kind, _: Option<tex::CubeFace>,
-                      _: &[u8], _: tex::RawImageInfo) {}
+    fn update_texture(&mut self, _: tex::TextureCopyRegion<native::Texture>, _: &[u8]) {}
     fn generate_mipmap(&mut self, _: native::TextureView) {}
 
     fn clear_color(&mut self, tv: native::TextureView, color: command::ClearColor) {

--- a/src/core/src/command.rs
+++ b/src/core/src/command.rs
@@ -72,18 +72,19 @@ pub trait Buffer<R: Resources>: 'static + Send {
     /// Copy part of a buffer to a texture
     fn copy_buffer_to_texture(&mut self,
                               src: R::Buffer, src_offset_bytes: usize,
-                              dst: R::Texture, texture::Kind,
-                              Option<texture::CubeFace>, texture::RawImageInfo);
+                              dst: texture::TextureCopyRegion<R::Texture>);
     /// Copy part of a texture to a buffer
     fn copy_texture_to_buffer(&mut self,
-                              src: R::Texture, texture::Kind,
-                              Option<texture::CubeFace>, texture::RawImageInfo,
+                              src: texture::TextureCopyRegion<R::Texture>,
                               dst: R::Buffer, dst_offset_bytes: usize);
+    /// Copy part of one texture into another
+    fn copy_texture_to_texture(&mut self,
+                               src: texture::TextureCopyRegion<R::Texture>,
+                               dst: texture::TextureCopyRegion<R::Texture>);
     /// Update a vertex/index/uniform buffer
     fn update_buffer(&mut self, R::Buffer, data: &[u8], offset: usize);
     /// Update a texture
-    fn update_texture(&mut self, R::Texture, texture::Kind, Option<texture::CubeFace>,
-                      data: &[u8], texture::RawImageInfo);
+    fn update_texture(&mut self, texture::TextureCopyRegion<R::Texture>, data: &[u8]);
     fn generate_mipmap(&mut self, R::ShaderResourceView);
     /// Clear color target
     fn clear_color(&mut self, R::RenderTargetView, ClearColor);

--- a/src/core/src/dummy.rs
+++ b/src/core/src/dummy.rs
@@ -100,17 +100,13 @@ impl command::Buffer<DummyResources> for DummyCommandBuffer {
     fn copy_buffer(&mut self, _: (), _: (),
                    _: usize, _: usize,
                    _: usize) {}
-    fn copy_buffer_to_texture(&mut self,
-                              _: (), _: usize,
-                              _: (), _: texture::Kind,
-                              _: Option<texture::CubeFace>, _: texture::RawImageInfo) {}
-    fn copy_texture_to_buffer(&mut self,
-                              _: (), _: texture::Kind,
-                              _: Option<texture::CubeFace>, _: texture::RawImageInfo,
-                              _: (), _: usize) {}
+    fn copy_buffer_to_texture(&mut self, _: (), _: usize, _: texture::TextureCopyRegion<()>) {}
+    fn copy_texture_to_buffer(&mut self, _: texture::TextureCopyRegion<()>, _: (), _: usize) {}
+    fn copy_texture_to_texture(&mut self,
+                               _: texture::TextureCopyRegion<()>,
+                               _: texture::TextureCopyRegion<()>) {}
     fn update_buffer(&mut self, _: (), _: &[u8], _: usize) {}
-    fn update_texture(&mut self, _: (), _: texture::Kind, _: Option<texture::CubeFace>,
-                      _: &[u8], _: texture::RawImageInfo) {}
+    fn update_texture(&mut self, _: texture::TextureCopyRegion<()>, _: &[u8]) {}
     fn generate_mipmap(&mut self, _: ()) {}
     fn clear_color(&mut self, _: (), _: command::ClearColor) {}
     fn clear_depth_stencil(&mut self, _: (), _: Option<target::Depth>,

--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -425,7 +425,7 @@ pub trait Factory<R: Resources> {
     {
         self.view_texture_as_depth_stencil(tex, 0, None, texture::DepthStencilFlags::empty())
     }
-    
+
     fn create_texture_immutable_u8<T: format::TextureFormat>(&mut self, kind: texture::Kind, mipmap: texture::Mipmap, data: &[&[u8]])
                                    -> Result<(handle::Texture<R, T::Surface>,
                                               handle::ShaderResourceView<R, T::View>),

--- a/src/core/src/texture.rs
+++ b/src/core/src/texture.rs
@@ -396,6 +396,32 @@ impl RawImageInfo {
     }
 }
 
+/// A texture region defined for copy operations
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+pub struct TextureCopyRegion<T> {
+    /// Raw texture
+    pub texture: T,
+    /// Texture kind
+    pub kind: Kind,
+    /// Optional cube face
+    pub cube_face: Option<CubeFace>,
+    /// Dimensions, offsets, and format
+    pub info: RawImageInfo,
+}
+
+impl<T> TextureCopyRegion<T> {
+    /// Change the texture
+    pub fn with_texture<U>(self, texture: U) -> TextureCopyRegion<U> {
+        TextureCopyRegion {
+            texture,
+            kind: self.kind,
+            cube_face: self.cube_face,
+            info: self.info,
+        }
+    }
+}
+
 /// Specifies how texture coordinates outside the range `[0, 1]` are handled.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]


### PR DESCRIPTION
Fixes #1540

Why is there never a case where I can just go in, fix something, and go out. Had to refactor a bunch of API calls and their implementations for the best. Hopefully, it's not going to be thrown away too fast.

Edit:
Note that I've actually verified this to work in a simple test case on GL + D3D11, the modified blend example code can be found at https://github.com/kvark/gfx/commit/c2234e62ca163d2c95dc33805a31fbb9bcfca014
(one needs to hack in TRANSFER_SRC/DST flags into core temporarily to test it on that example).