### PR TITLE
[ll] consistent framebuffer naming

### DIFF
--- a/examples/core/quad/main.rs
+++ b/examples/core/quad/main.rs
@@ -292,7 +292,7 @@ fn main() {
                 .collect();
             (pairs, fbos)
         }
-        Backbuffer::FrameBuffer(fbo) => {
+        Backbuffer::Framebuffer(fbo) => {
             (Vec::new(), vec![fbo])
         }
     };

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -726,7 +726,7 @@ impl d::Device<B> for Device {
         color_attachments: &[&n::RenderTargetView],
         depth_stencil_attachments: &[&n::DepthStencilView],
         _extent: d::Extent,
-    ) -> Result<n::FrameBuffer, d::FrameBufferError> {
+    ) -> Result<n::FrameBuffer, d::FramebufferError> {
         Ok(n::FrameBuffer {
             color: color_attachments.iter().map(|rtv| **rtv).collect(),
             depth_stencil: depth_stencil_attachments.iter().map(|dsv| **dsv).collect(),

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -464,7 +464,7 @@ impl core::Backend for Backend {
 
     type ShaderModule = native::ShaderModule;
     type RenderPass = native::RenderPass;
-    type FrameBuffer = native::FrameBuffer;
+    type Framebuffer = native::FrameBuffer;
 
     type UnboundBuffer = device::UnboundBuffer;
     type Buffer = native::Buffer;

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -27,7 +27,7 @@ impl core::Backend for Backend {
 
     type ShaderModule = ();
     type RenderPass = ();
-    type FrameBuffer = ();
+    type Framebuffer = ();
 
     type UnboundBuffer = ();
     type Buffer = ();
@@ -118,7 +118,7 @@ impl core::Device<Backend> for Device {
         &mut self, _: &(),
         _: &[&()], _: &[&()],
         _: device::Extent,
-    ) -> Result<(), device::FrameBufferError> {
+    ) -> Result<(), device::FramebufferError> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -271,9 +271,9 @@ impl d::Device<B> for Device {
         rtvs: &[&n::TargetView],
         dsvs: &[&n::TargetView],
         _extent: d::Extent,
-    ) -> Result<n::FrameBuffer, d::FrameBufferError> {
+    ) -> Result<n::FrameBuffer, d::FramebufferError> {
         if !self.share.private_caps.framebuffer {
-            return Err(d::FrameBufferError);
+            return Err(d::FramebufferError);
         }
 
         let gl = &self.share.context;

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -51,7 +51,7 @@ impl c::Backend for Backend {
 
     type ShaderModule = native::ShaderModule;
     type RenderPass = native::RenderPass;
-    type FrameBuffer = native::FrameBuffer;
+    type Framebuffer = native::FrameBuffer;
 
     type UnboundBuffer = device::UnboundBuffer;
     type Buffer = native::Buffer;

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -105,7 +105,7 @@ impl core::Surface<B> for Surface {
         let swapchain = Swapchain {
             window: self.window.clone(),
         };
-        let backbuffer = core::Backbuffer::FrameBuffer(0);
+        let backbuffer = core::Backbuffer::Framebuffer(0);
         (swapchain, backbuffer)
     }
 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -10,7 +10,7 @@ use std::{mem, ptr, slice};
 
 use core::{self,
         image, pass, format, mapping, memory, buffer, pso};
-use core::device::{WaitFor, BindError, OutOfMemory, TargetViewError, FrameBufferError, ShaderError, Extent};
+use core::device::{WaitFor, BindError, OutOfMemory, TargetViewError, FramebufferError, ShaderError, Extent};
 use core::pso::{DescriptorSetWrite, DescriptorType, DescriptorSetLayoutBinding, AttributeDesc};
 use core::pass::{Subpass};
 
@@ -410,7 +410,7 @@ impl core::Device<Backend> for Device {
     fn create_framebuffer(&mut self, renderpass: &n::RenderPass,
         color_attachments: &[&n::RenderTargetView], depth_stencil_attachments: &[&n::DepthStencilView],
         extent: Extent,
-    ) -> Result<n::FrameBuffer, FrameBufferError> {
+    ) -> Result<n::FrameBuffer, FramebufferError> {
         let descriptor = unsafe {
             let desc: MTLRenderPassDescriptor = msg_send![renderpass.desc.0, copy]; // Returns retained
             defer_on_unwind! { desc.release() };

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -111,7 +111,7 @@ impl core::Backend for Backend {
 
     type ShaderModule = native::ShaderModule;
     type RenderPass = native::RenderPass;
-    type FrameBuffer = native::FrameBuffer;
+    type Framebuffer = native::FrameBuffer;
 
     type UnboundBuffer = native::UnboundBuffer;
     type Buffer = native::Buffer;

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -594,7 +594,7 @@ impl d::Device<B> for Device {
         color_attachments: &[&n::RenderTargetView],
         depth_stencil_attachments: &[&n::DepthStencilView],
         extent: d::Extent,
-    ) -> Result<n::FrameBuffer, d::FrameBufferError> {
+    ) -> Result<n::FrameBuffer, d::FramebufferError> {
         let attachments = color_attachments
             .iter()
             .map(|attachment| attachment.view)

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -606,7 +606,7 @@ impl core::Backend for Backend {
 
     type ShaderModule = native::ShaderModule;
     type RenderPass = native::RenderPass;
-    type FrameBuffer = native::FrameBuffer;
+    type Framebuffer = native::FrameBuffer;
 
     type UnboundBuffer = device::UnboundBuffer;
     type Buffer = native::Buffer;

--- a/src/core/src/command/graphics.rs
+++ b/src/core/src/command/graphics.rs
@@ -100,7 +100,7 @@ impl<'a, B: Backend, C: Supports<Graphics>> CommandBuffer<'a, B, C> {
     pub fn begin_renderpass_inline(
         &mut self,
         render_pass: &B::RenderPass,
-        frame_buffer: &B::FrameBuffer,
+        frame_buffer: &B::Framebuffer,
         render_area: target::Rect,
         clear_values: &[ClearValue],
     ) -> RenderPassInlineEncoder<B>

--- a/src/core/src/command/raw.rs
+++ b/src/core/src/command/raw.rs
@@ -126,7 +126,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     fn begin_renderpass(
         &mut self,
         render_pass: &B::RenderPass,
-        frame_buffer: &B::FrameBuffer,
+        frame_buffer: &B::Framebuffer,
         render_area: target::Rect,
         clear_values: &[ClearValue],
         first_subpass: SubpassContents,

--- a/src/core/src/command/renderpass.rs
+++ b/src/core/src/command/renderpass.rs
@@ -22,7 +22,7 @@ impl<'a, B: Backend> RenderPassInlineEncoder<'a, B> {
     pub fn new<C>(
         cmd_buffer: &'a mut CommandBuffer<B, C>,
         render_pass: &B::RenderPass,
-        frame_buffer: &B::FrameBuffer,
+        frame_buffer: &B::Framebuffer,
         render_area: target::Rect,
         clear_values: &[ClearValue],
     ) -> Self

--- a/src/core/src/device.rs
+++ b/src/core/src/device.rs
@@ -174,7 +174,7 @@ pub enum ShaderError {
 
 /// An error from creating a framebuffer.
 #[derive(Clone, Debug, PartialEq)]
-pub struct FrameBufferError;
+pub struct FramebufferError;
 
 /// # Overview
 ///
@@ -250,7 +250,7 @@ pub trait Device<B: Backend>: Clone {
         color_attachments: &[&B::RenderTargetView],
         depth_stencil_attachments: &[&B::DepthStencilView],
         extent: Extent,
-    ) -> Result<B::FrameBuffer, FrameBufferError>;
+    ) -> Result<B::Framebuffer, FramebufferError>;
 
     ///
     fn create_shader_module(&mut self, spirv_data: &[u8]) -> Result<B::ShaderModule, ShaderError>;
@@ -430,7 +430,7 @@ pub trait Device<B: Backend>: Clone {
     ///
     /// The framebuffer shouldn't be destroy before any submitted command buffer,
     /// which references the framebuffer, has finished execution.
-    fn destroy_framebuffer(&mut self, B::FrameBuffer);
+    fn destroy_framebuffer(&mut self, B::Framebuffer);
 
     /// Destroys a buffer.
     ///

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -256,7 +256,7 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any {
 
     type ShaderModule:        Debug + Any + Send + Sync;
     type RenderPass:          Debug + Any + Send + Sync;
-    type FrameBuffer:         Debug + Any + Send + Sync;
+    type Framebuffer:         Debug + Any + Send + Sync;
 
     type Memory:              Debug + Any;
     type CommandPool:         RawCommandPool<Self>;

--- a/src/core/src/window.rs
+++ b/src/core/src/window.rs
@@ -244,7 +244,7 @@ pub enum Backbuffer<B: Backend> {
     /// Color image chain
     Images(Vec<B::Image>),
     /// A single opaque framebuffer
-    FrameBuffer(B::FrameBuffer),
+    Framebuffer(B::Framebuffer),
 }
 
 /// The `Swapchain` is the backend representation of the surface.

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -11,7 +11,7 @@ use handle::inner::*;
 use {core, buffer, image, format, mapping, pso};
 use {Backend, Primitive, Extent};
 
-pub use core::device::{TargetViewError, FrameBufferError};
+pub use core::device::{TargetViewError, FramebufferError};
 
 #[derive(Clone)]
 pub struct Device<B: Backend> {
@@ -522,19 +522,19 @@ impl<B: Backend> Device<B> {
         rtvs: &[&handle::raw::RenderTargetView<B>],
         dsvs: &[&handle::raw::DepthStencilView<B>],
         extent: Extent,
-    ) -> Result<handle::raw::FrameBuffer<B>, FrameBufferError>
+    ) -> Result<handle::raw::Framebuffer<B>, FramebufferError>
         where P: pso::GraphicsPipelineMeta<B>
     {
         let rtv_res: Vec<_> = rtvs.iter().map(|&rtv| rtv.resource()).collect();
         let dsv_res: Vec<_> = dsvs.iter().map(|&dsv| dsv.resource()).collect();
         let buffer = self.raw.create_framebuffer(
             pipeline.render_pass(), &rtv_res[..], &dsv_res[..], extent)?;
-        let info = handle::FrameBufferInfo {
+        let info = handle::FramebufferInfo {
             rtvs: rtvs.iter().map(|&rtv| rtv.clone()).collect(),
             dsvs: dsvs.iter().map(|&dsv| dsv.clone()).collect(),
             extent,
         };
-        Ok(FrameBuffer::new(buffer, info, self.garbage.clone()).into())
+        Ok(Framebuffer::new(buffer, info, self.garbage.clone()).into())
     }
 /*
     /// Creates a `ShaderSet` from the supplied vertex and pixel shader source code.

--- a/src/render/src/handle.rs
+++ b/src/render/src/handle.rs
@@ -55,7 +55,7 @@ impl<B: Backend> InnerGarbageCollector<B> {
                 RenderPass(rp) => dev.destroy_renderpass(rp),
                 PipelineLayout(pl) => dev.destroy_pipeline_layout(pl),
                 GraphicsPipeline(pl) => dev.destroy_graphics_pipeline(pl),
-                FrameBuffer(fb) => dev.destroy_framebuffer(fb),
+                Framebuffer(fb) => dev.destroy_framebuffer(fb),
                 Buffer(b) => dev.destroy_buffer(b),
                 Image(i) => dev.destroy_image(i),
                 RenderTargetView(rtv) => dev.destroy_render_target_view(rtv),
@@ -95,7 +95,7 @@ macro_rules! define_resources {
             use std::{cmp, hash};
 
             $(
-            
+
             #[derive(Debug)]
             pub struct $name<B: Backend> {
                 // option for owned drop
@@ -235,7 +235,7 @@ define_resources! {
     PipelineLayout: (),
     GraphicsPipeline: (),
     // ComputePipeline
-    FrameBuffer: ::handle::FrameBufferInfo<B>,
+    Framebuffer: ::handle::FramebufferInfo<B>,
     Buffer: ::buffer::Info,
     Image: ::image::Info,
     RenderTargetView: ::handle::raw::Image<B>,
@@ -261,7 +261,7 @@ pub type UnorderedAccessView<B, T> = Typed<raw::UnorderedAccessView<B>, T>;
 pub use self::raw::Sampler;
 
 #[derive(Debug, Clone)]
-pub struct FrameBufferInfo<B: Backend> {
+pub struct FramebufferInfo<B: Backend> {
     pub rtvs: Vec<raw::RenderTargetView<B>>,
     pub dsvs: Vec<raw::DepthStencilView<B>>,
     pub extent: ::Extent,

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -308,7 +308,7 @@ impl<B: Backend, C> Context<B, C>
 
         let backbuffer_images = match backbuffer {
             core::Backbuffer::Images(images) => images,
-            core::Backbuffer::FrameBuffer(_) => unimplemented!(), //TODO
+            core::Backbuffer::Framebuffer(_) => unimplemented!(), //TODO
         };
 
         let frame_bundles = backbuffer_images

--- a/src/render/src/macros.rs
+++ b/src/render/src/macros.rs
@@ -98,7 +98,7 @@ macro_rules! gfx_descriptors {
                     })*
                     bindings
                 }
-                
+
                 fn layout(&self) -> &B::DescriptorSetLayout { self.layout.resource() }
                 fn set(&self) -> &B::DescriptorSet { self.raw.resource() }
             }
@@ -170,7 +170,7 @@ macro_rules! gfx_graphics_pipeline {
             };
             use $crate::core::{pass as cpass, pso as cpso};
             use $crate::core::command::RenderPassInlineEncoder;
-    
+
             pub struct Meta<B: Backend> {
                 layout: handle::raw::PipelineLayout<B>,
                 render_pass: handle::raw::RenderPass<B>,
@@ -185,7 +185,7 @@ macro_rules! gfx_graphics_pipeline {
                 // TODO:
                 pub viewports: &'a [$crate::core::Viewport],
                 pub scissors: &'a [$crate::core::target::Rect],
-                pub framebuffer: &'a handle::raw::FrameBuffer<B>,
+                pub framebuffer: &'a handle::raw::Framebuffer<B>,
                 $( pub $cmp_name: <$cmp as pso::Component<'a, B>>::Data, )*
             }
 
@@ -225,7 +225,7 @@ macro_rules! gfx_graphics_pipeline {
 
                         device.create_renderpass_raw(&attachments[..], &[subpass], &[])
                     };
-            
+
                     let mut pipeline_desc = cpso::GraphicsPipelineDesc::new(
                         primitive, rasterizer
                     );
@@ -275,7 +275,7 @@ macro_rules! gfx_graphics_pipeline {
                         &buffer_states[..],
                         &image_states[..]
                     );
-                    
+
                     let cmd_buffer = encoder.mut_buffer();
                     cmd_buffer.set_viewports(self.viewports);
                     cmd_buffer.set_scissors(self.scissors);
@@ -301,7 +301,7 @@ macro_rules! gfx_graphics_pipeline {
                     cmd_buffer.begin_renderpass_inline(
                         meta.render_pass.resource(),
                         self.framebuffer.resource(),
-                        render_rect, 
+                        render_rect,
                         &[], // TODO
                     )
                 }


### PR DESCRIPTION
This is to be consistent with Vulkan.
Note: `RenderPass` is like this in Vulkan, so no need to fix it.