### PR TITLE
[ll] Add compute descriptor set binding

### DIFF
--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -440,6 +440,15 @@ impl core::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
+    fn bind_compute_descriptor_sets(
+        &mut self,
+        _: &(),
+        _: usize,
+        _: &[&()],
+    ) {
+        unimplemented!()
+    }
+
     fn dispatch(&mut self, _: u32, _: u32, _: u32) {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -471,6 +471,15 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
+    fn bind_compute_descriptor_sets(
+        &mut self,
+        _layout: &n::PipelineLayout,
+        _first_set: usize,
+        _sets: &[&n::DescriptorSet],
+    ) {
+        unimplemented!()
+    }
+
     fn dispatch(&mut self, x: u32, y: u32, z: u32) {
         self.push_cmd(Command::Dispatch(x, y, z));
     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -157,7 +157,7 @@ impl core::RawCommandPool<Backend> for CommandPool {
     unsafe fn from_queue(queue: &CommandQueue, flags: pool::CommandPoolCreateFlags) -> Self {
         CommandPool {
             queue: (queue.0).clone(),
-            managed: if flags.contains(pool::RESET_INDIVIDUAL) { 
+            managed: if flags.contains(pool::RESET_INDIVIDUAL) {
                 None
             } else {
                 Some(Vec::new())
@@ -497,6 +497,15 @@ impl core::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn bind_compute_pipeline(&mut self, pipeline: &native::ComputePipeline) {
+        unimplemented!()
+    }
+
+    fn bind_compute_descriptor_sets(
+        &mut self,
+        _layout: &native::PipelineLayout,
+        _first_set: usize,
+        _sets: &[&native::DescriptorSet],
+    ) {
         unimplemented!()
     }
 

--- a/src/core/src/command/compute.rs
+++ b/src/core/src/command/compute.rs
@@ -10,6 +10,16 @@ impl<'a, B: Backend, C: Supports<Compute>> CommandBuffer<'a, B, C> {
     }
 
     ///
+    pub fn bind_compute_descriptor_sets(
+        &mut self,
+        layout: &B::PipelineLayout,
+        first_set: usize,
+        sets: &[&B::DescriptorSet],
+    ) {
+        self.raw.bind_compute_descriptor_sets(layout, first_set, sets)
+    }
+
+    ///
     pub fn dispatch(&mut self, x: u32, y: u32, z: u32) {
         self.raw.dispatch(x, y, z)
     }

--- a/src/core/src/command/raw.rs
+++ b/src/core/src/command/raw.rs
@@ -173,6 +173,14 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     /// - Only queues with compute capability support this function.
     fn bind_compute_pipeline(&mut self, &B::ComputePipeline);
 
+    ///
+    fn bind_compute_descriptor_sets(
+        &mut self,
+        layout: &B::PipelineLayout,
+        first_set: usize,
+        sets: &[&B::DescriptorSet],
+    );
+
     /// Execute a workgroup in the compute pipeline.
     ///
     /// # Errors


### PR DESCRIPTION
Add `bind_compute_descriptor_sets` command, which is essential for compute support!
Only vulkan and dx12 implementation.