### PR TITLE
Implement update_descriptor_sets with the new view system on Vulkan, plus corollary changes.

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1024,6 +1024,7 @@ impl d::Device<B> for Device {
     fn create_buffer_view(
         &mut self,
         _buffer: &n::Buffer,
+        _format: format::Format,
         _range: Range<u64>,
     ) -> Result<n::BufferView, buffer::ViewError> {
         unimplemented!()

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -137,7 +137,7 @@ impl core::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_buffer_view(&mut self, _: &(), _: Range<u64>) -> Result<(), buffer::ViewError> {
+    fn create_buffer_view(&mut self, _: &(), _: format::Format, _: Range<u64>) -> Result<(), buffer::ViewError> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -35,8 +35,8 @@ pub fn wrap_to_gl(w: i::WrapMode) -> t::GLenum {
 }
 
 pub fn buffer_usage_to_gl_target(usage: buffer::Usage) -> Option<t::GLenum> {
-    match usage & (buffer::CONSTANT | buffer::INDEX | buffer::VERTEX | buffer::INDIRECT) {
-        buffer::CONSTANT => Some(gl::UNIFORM_BUFFER),
+    match usage & (buffer::UNIFORM | buffer::INDEX | buffer::VERTEX | buffer::INDIRECT) {
+        buffer::UNIFORM => Some(gl::UNIFORM_BUFFER),
         buffer::INDEX => Some(gl::ELEMENT_ARRAY_BUFFER),
         buffer::VERTEX => Some(gl::ARRAY_BUFFER),
         buffer::INDIRECT => unimplemented!(),

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -373,7 +373,7 @@ impl d::Device<B> for Device {
     fn create_buffer(
         &mut self, size: u64, stride: u64, usage: buffer::Usage,
     ) -> Result<UnboundBuffer, buffer::CreationError> {
-        if !self.share.features.constant_buffer && usage.contains(buffer::CONSTANT) {
+        if !self.share.features.constant_buffer && usage.contains(buffer::UNIFORM) {
             error!("Constant buffers are not supported by this GL version");
             return Err(buffer::CreationError::Other);
         }
@@ -472,7 +472,7 @@ impl d::Device<B> for Device {
     }
 
     fn create_buffer_view(
-        &mut self, _: &n::Buffer, _: Range<u64>
+        &mut self, _: &n::Buffer, _: Format, _: Range<u64>
     ) -> Result<n::BufferView, buffer::ViewError> {
         unimplemented!()
     }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -766,7 +766,7 @@ impl core::Device<Backend> for Device {
     }
 
     fn create_buffer_view(
-        &mut self, _buffer: &n::Buffer, _range: Range<u64>
+        &mut self, _buffer: &n::Buffer, _format: format::Format, _range: Range<u64>
     ) -> Result<n::BufferView, buffer::ViewError> {
         unimplemented!()
     }

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -450,8 +450,17 @@ pub fn map_buffer_usage(usage: buffer::Usage) -> vk::BufferUsageFlags {
     if usage.contains(buffer::TRANSFER_DST) {
         flags |= vk::BUFFER_USAGE_TRANSFER_DST_BIT;
     }
-    if usage.contains(buffer::CONSTANT) {
+    if usage.contains(buffer::UNIFORM) {
         flags |= vk::BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+    }
+    if usage.contains(buffer::STORAGE) {
+        flags |= vk::BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    }
+    if usage.contains(buffer::UNIFORM_TEXEL) {
+        flags |= vk::BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
+    }
+    if usage.contains(buffer::STORAGE_TEXEL) {
+        flags |= vk::BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
     }
     if usage.contains(buffer::INDEX) {
         flags |= vk::BUFFER_USAGE_INDEX_BUFFER_BIT;

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -712,14 +712,22 @@ impl d::Device<B> for Device {
 
         Ok(buffer)
     }
-
+    
     fn create_buffer_view(
-        &mut self, buffer: &n::Buffer, range: Range<u64>,
+        &mut self, buffer: &n::Buffer, format: format::Format, range: Range<u64>
     ) -> Result<n::BufferView, buffer::ViewError> {
-        Ok(n::BufferView {
-            buffer: buffer.raw,
-            range,
-        })
+        unimplemented!() // The implementation is below, but ash is currently missing create_buffer_view.
+        /* Ok(n::BufferView { raw: 
+            self.raw.0.create_buffer_view(vk::BufferViewCreateInfo {
+                s_type: vk::StructureType::BufferViewCreateInfo,
+                p_next: ptr::null(),
+                flags: vk::BufferViewCreateFlags::empty(),
+                buffer: buffer.raw,
+                format: conv::map_format(format.0, format.1).unwrap(),
+                offset: range.start,
+                range: range.end - range.start,
+            }, None).expect("Error on buffer view creation") //TODO: Proper error handling
+        }) */
     }
 
     fn create_image(&mut self, kind: image::Kind, mip_levels: image::Level, format: format::Format, usage: image::Usage)
@@ -932,7 +940,7 @@ impl d::Device<B> for Device {
     fn update_descriptor_sets(&mut self, writes: &[pso::DescriptorSetWrite<B>]) {
         let mut image_infos = Vec::new();
         let mut buffer_infos = Vec::new();
-        // let mut texel_buffer_views = Vec::new();
+        let mut texel_buffer_views = Vec::new();
 
         for write in writes {
             match write.write {
@@ -949,7 +957,7 @@ impl d::Device<B> for Device {
                 pso::DescriptorWrite::SampledImage(ref images) |
                 pso::DescriptorWrite::StorageImage(ref images) |
                 pso::DescriptorWrite::InputAttachment(ref images) => {
-                    for &(ref view, layout) in images {
+                    for &(view, layout) in images {
                         image_infos.push(vk::DescriptorImageInfo {
                             sampler: vk::Sampler::null(),
                             image_view: view.view,
@@ -958,13 +966,21 @@ impl d::Device<B> for Device {
                     }
                 }
 
-                pso::DescriptorWrite::ConstantBuffer(ref cbvs) => {
-                    for &(ref buffer, ref range) in cbvs {
+                pso::DescriptorWrite::UniformBuffer(ref buffers) |
+                pso::DescriptorWrite::StorageBuffer(ref buffers) => {
+                    for &(buffer, ref range) in buffers {
                         buffer_infos.push(vk::DescriptorBufferInfo {
                             buffer: buffer.raw,
                             offset: range.start,
                             range: range.end - range.start,
                         });
+                    }
+                }
+
+                pso::DescriptorWrite::UniformTexelBuffer(ref views) |
+                pso::DescriptorWrite::StorageTexelBuffer(ref views) => {
+                    for view in views {
+                        texel_buffer_views.push(view.raw)
                     }
                 }
 
@@ -975,44 +991,53 @@ impl d::Device<B> for Device {
         // Track current subslice for each write
         let mut cur_image_index = 0;
         let mut cur_buffer_index = 0;
+        let mut cur_view_index = 0;
 
         let writes = writes.iter().map(|write| {
-            let (ty, count, image_info, buffer_info, texel_buffer_view) = match write.write {
+            let ty = match write.write {
+                pso::DescriptorWrite::Sampler(_) => vk::DescriptorType::Sampler,
+                pso::DescriptorWrite::SampledImage(_) => vk::DescriptorType::SampledImage,
+                pso::DescriptorWrite::StorageImage(_) => vk::DescriptorType::StorageImage,
+                pso::DescriptorWrite::InputAttachment(_) => vk::DescriptorType::InputAttachment,
+                pso::DescriptorWrite::UniformBuffer(_) => vk::DescriptorType::UniformBuffer,
+                pso::DescriptorWrite::StorageBuffer(_) => vk::DescriptorType::StorageBuffer,
+                pso::DescriptorWrite::UniformTexelBuffer(_) => vk::DescriptorType::UniformTexelBuffer,
+                pso::DescriptorWrite::StorageTexelBuffer(_) => vk::DescriptorType::StorageTexelBuffer,
+            };
+
+            let (count, image_info, buffer_info, texel_buffer_view) = match write.write {
                 pso::DescriptorWrite::Sampler(ref samplers) => {
                     let info_ptr = &image_infos[cur_image_index] as *const _;
                     cur_image_index += samplers.len();
-
-                    (vk::DescriptorType::Sampler, samplers.len(),
-                        info_ptr, ptr::null(), ptr::null())
+                    
+                    (samplers.len(), info_ptr, ptr::null(), ptr::null())
                 }
-                pso::DescriptorWrite::SampledImage(ref images) => {
-                    let info_ptr = &image_infos[cur_image_index] as *const _;
-                    cur_image_index += images.len();
-
-                    (vk::DescriptorType::SampledImage, images.len(),
-                        info_ptr, ptr::null(), ptr::null())
-                }
-                pso::DescriptorWrite::StorageImage(ref images) => {
-                    let info_ptr = &image_infos[cur_image_index] as *const _;
-                    cur_image_index += images.len();
-
-                    (vk::DescriptorType::StorageImage, images.len(),
-                        info_ptr, ptr::null(), ptr::null())
-                }
-                pso::DescriptorWrite::ConstantBuffer(ref cbvs) => {
-                    let info_ptr = &buffer_infos[cur_buffer_index] as *const _;
-                    cur_buffer_index += cbvs.len();
-
-                    (vk::DescriptorType::UniformBuffer, cbvs.len(),
-                        ptr::null(), info_ptr, ptr::null())
-                }
+                
+                pso::DescriptorWrite::SampledImage(ref images) |
+                pso::DescriptorWrite::StorageImage(ref images) |
                 pso::DescriptorWrite::InputAttachment(ref images) => {
                     let info_ptr = &image_infos[cur_image_index] as *const _;
                     cur_image_index += images.len();
 
-                    (vk::DescriptorType::InputAttachment, images.len(),
-                        info_ptr, ptr::null(), ptr::null())
+                    (images.len(), info_ptr, ptr::null(), ptr::null())
                 }
+                
+                pso::DescriptorWrite::UniformBuffer(ref buffers) |
+                pso::DescriptorWrite::StorageBuffer(ref buffers) => {
+                    let info_ptr = &buffer_infos[cur_buffer_index] as *const _;
+                    cur_buffer_index += buffers.len();
+
+                    (buffers.len(), ptr::null(), info_ptr, ptr::null())
+                }
+
+                pso::DescriptorWrite::UniformTexelBuffer(ref views) |
+                pso::DescriptorWrite::StorageTexelBuffer(ref views) => {
+                    let info_ptr = &texel_buffer_views[cur_view_index] as *const _;
+                    cur_view_index += views.len();
+
+                    (views.len(), ptr::null(), ptr::null(), info_ptr)
+                }
+                
                 _ => unimplemented!(), // TODO
             };
 

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -37,9 +37,7 @@ unsafe impl Send for Buffer {}
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct BufferView {
-    //TODO: `VkBufferView`
-    pub(crate) buffer: vk::Buffer,
-    pub(crate) range: Range<u64>,
+    pub(crate) raw: vk::BufferView,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]

--- a/src/core/src/buffer.rs
+++ b/src/core/src/buffer.rs
@@ -54,13 +54,19 @@ bitflags!(
         ///
         const TRANSFER_DST = 0x2,
         ///
-        const CONSTANT = 0x4,
+        const UNIFORM = 0x4,
         ///
-        const INDEX = 0x8,
+        const STORAGE = 0x8,
         ///
-        const INDIRECT = 0x10,
+        const UNIFORM_TEXEL = 0x10,
         ///
-        const VERTEX = 0x20,
+        const STORAGE_TEXEL = 0x20,
+        ///
+        const INDEX = 0x40,
+        ///
+        const INDIRECT = 0x80,
+        ///
+        const VERTEX = 0x100,
     }
 );
 

--- a/src/core/src/device.rs
+++ b/src/core/src/device.rs
@@ -183,7 +183,7 @@ pub trait Device<B: Backend>: Clone {
 
     ///
     fn create_buffer_view(
-        &mut self, &B::Buffer, Range<u64>
+        &mut self, &B::Buffer, format::Format, Range<u64>
     ) -> Result<B::BufferView, buffer::ViewError>;
 
     ///

--- a/src/core/src/pso/descriptor.rs
+++ b/src/core/src/pso/descriptor.rs
@@ -94,9 +94,9 @@ pub enum DescriptorWrite<'a, B: Backend> {
     Sampler(Vec<&'a B::Sampler>),
     SampledImage(Vec<(&'a B::ImageView, ImageLayout)>),
     StorageImage(Vec<(&'a B::ImageView, ImageLayout)>),
+    InputAttachment(Vec<(&'a B::ImageView, ImageLayout)>),
+    UniformBuffer(Vec<(&'a B::Buffer, Range<u64>)>),
+    StorageBuffer(Vec<(&'a B::Buffer, Range<u64>)>),
     UniformTexelBuffer(Vec<&'a B::BufferView>),
     StorageTexelBuffer(Vec<&'a B::BufferView>),
-    ConstantBuffer(Vec<(&'a B::Buffer, Range<u64>)>),
-    StorageBuffer, //TODO
-    InputAttachment(Vec<(&'a B::ImageView, ImageLayout)>),
 }

--- a/src/render/src/buffer.rs
+++ b/src/render/src/buffer.rs
@@ -6,7 +6,7 @@ use Backend;
 
 pub use core::buffer::{CreationError, ViewError};
 pub use core::buffer::{Usage,
-    TRANSFER_SRC, TRANSFER_DST, CONSTANT, INDEX, INDIRECT, VERTEX
+    TRANSFER_SRC, TRANSFER_DST, UNIFORM, INDEX, INDIRECT, VERTEX
 };
 
 /// An information block that is immutable and associated to each buffer.

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -139,11 +139,12 @@ impl<B: Backend> Device<B> {
     pub fn create_buffer_view_raw(
         &mut self,
         buffer: &handle::raw::Buffer<B>,
+        format: format::Format,
         range: Range<u64>,
     ) -> Result<handle::raw::BufferView<B>, buffer::ViewError> {
-        self.raw.create_buffer_view(buffer.resource(), range)
-            .map(|cbv| BufferView::new(
-                cbv,
+        self.raw.create_buffer_view(buffer.resource(), format, range)
+            .map(|view| BufferView::new(
+                view,
                 buffer.clone(),
                 self.garbage.clone()
             ).into())
@@ -152,9 +153,10 @@ impl<B: Backend> Device<B> {
     pub fn create_buffer_view<T>(
         &mut self,
         buffer: &handle::Buffer<B, T>,
+        format: format::Format,
         range: Range<u64>,
     ) -> Result<handle::BufferView<B, T>, buffer::ViewError> {
-        self.create_buffer_view_raw(buffer.as_ref(), range)
+        self.create_buffer_view_raw(buffer.as_ref(), format, range)
             .map(Typed::new)
     }
 


### PR DESCRIPTION
This PR updates `Device::update_descriptor_sets` to use the new system of views, and implements all currently supported descriptor types. 

Some related bits of code (match statements, enums) related to the changes have been reordered/renamed to be consistent. This can be undone if it's an inconvenience. 