### PR TITLE
Dxgi window patches

### DIFF
--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -30,7 +30,7 @@ use device_dx11::{Device, Factory, Resources};
 
 
 pub struct Window {
-    inner: winit::Window,
+    pub inner: winit::Window,
     swap_chain: *mut winapi::IDXGISwapChain,
     driver_type: winapi::D3D_DRIVER_TYPE,
     color_format: format::Format,

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -111,11 +111,18 @@ where Cf: format::RenderFormat
 
 /// Initialize with a given size. Raw format version.
 pub fn init_raw(wb: winit::WindowBuilder, events_loop: &winit::EventsLoop, color_format: format::Format)
-                -> Result<(Window, Device, Factory, h::RawRenderTargetView<Resources>), InitError> {
+                -> Result<(Window, Device, Factory, h::RawRenderTargetView<Resources>), InitError>
+{
     let inner = match wb.build(events_loop) {
         Ok(w) => w,
         Err(_) => return Err(InitError::Window),
     };
+    init_existing_raw(inner, color_format)
+}
+
+pub fn init_existing_raw(inner: winit::Window, color_format: format::Format)
+                         -> Result<(Window, Device, Factory, h::RawRenderTargetView<Resources>), InitError>
+{
     let (width, height) = inner.get_inner_size_pixels().unwrap();
 
     let driver_types = [


### PR DESCRIPTION
@kvark These are the small changes we made and mentioned before.
- An `init_existing_raw` function for dxgi window, to use an already initialized window.
- We added reference counting for the inner (winit window) member of the dxgi window, because we need to use the winit window after `init_existing_raw` is done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/1569)
<!-- Reviewable:end -->
