### PR TITLE
Make the dx12 backend ocean ready 🌊 

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -313,16 +313,8 @@ fn main() {
     let upload_type =
         memory_types.iter().find(|mem_type| {
             buffer_req.type_mask & (1 << mem_type.id) != 0 &&
-            mem_type.properties.contains(m::CPU_VISIBLE) &&
-            mem_type.properties.contains(m::WRITE_COMBINED)
-        })
-        .unwrap_or_else(||
-            memory_types.iter().find(|mem_type| {
-                buffer_req.type_mask & (1 << mem_type.id) != 0 &&
-                mem_type.properties.contains(m::CPU_VISIBLE)
-            })
-            .unwrap()
-        );
+            mem_type.properties.contains(m::CPU_VISIBLE)
+        }).unwrap();
 
     let buffer_memory = device.allocate_memory(upload_type, 1024).unwrap();
     let vertex_buffer = device.bind_buffer_memory(&buffer_memory, 0, buffer_unbound).unwrap();

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -9,18 +9,22 @@ use winapi::*;
 
 pub fn map_heap_properties(props: memory::Properties) -> D3D12_HEAP_PROPERTIES {
     //TODO: ensure the flags are valid
-    D3D12_HEAP_PROPERTIES {
-        Type: if !props.contains(memory::CPU_VISIBLE) {
-            D3D12_HEAP_TYPE_DEFAULT
-        } else if props.contains(memory::WRITE_COMBINED) {
-            D3D12_HEAP_TYPE_UPLOAD
-        } else {
-            D3D12_HEAP_TYPE_READBACK
-        },
-        CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
-        MemoryPoolPreference: D3D12_MEMORY_POOL_UNKNOWN,
-        CreationNodeMask: 0,
-        VisibleNodeMask: 0,
+    if !props.contains(memory::CPU_VISIBLE) {
+        D3D12_HEAP_PROPERTIES {
+            Type: D3D12_HEAP_TYPE_DEFAULT,
+            CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
+            MemoryPoolPreference: D3D12_MEMORY_POOL_UNKNOWN,
+            CreationNodeMask: 0,
+            VisibleNodeMask: 0,
+        }
+    } else {
+        D3D12_HEAP_PROPERTIES {
+            Type:  D3D12_HEAP_TYPE_CUSTOM,
+            CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_WRITE_BACK,
+            MemoryPoolPreference: D3D12_MEMORY_POOL_L0,
+            CreationNodeMask: 0,
+            VisibleNodeMask: 0,
+        }
     }
 }
 
@@ -525,8 +529,14 @@ pub fn map_descriptor_range(bind: &DescriptorSetLayoutBinding, register_space: u
     }
 }
 
-pub fn map_buffer_flags(_usage: buffer::Usage) -> D3D12_RESOURCE_FLAGS {
-    D3D12_RESOURCE_FLAG_NONE
+pub fn map_buffer_flags(usage: buffer::Usage) -> D3D12_RESOURCE_FLAGS {
+    let mut flags = D3D12_RESOURCE_FLAG_NONE;
+
+    if usage.contains(buffer::STORAGE) {
+        flags = flags | D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+    }
+
+    flags
 }
 
 pub fn map_image_flags(usage: image::Usage) -> D3D12_RESOURCE_FLAGS {

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -1,32 +1,10 @@
 use core::format::{Format, SurfaceType};
-use core::{buffer, memory, state, pso, Primitive};
+use core::{buffer, state, pso, Primitive};
 use core::image::{self, FilterMethod, WrapMode};
 use core::pso::DescriptorSetLayoutBinding;
 use core::state::Comparison;
 use std::fmt;
 use winapi::*;
-
-
-pub fn map_heap_properties(props: memory::Properties) -> D3D12_HEAP_PROPERTIES {
-    //TODO: ensure the flags are valid
-    if !props.contains(memory::CPU_VISIBLE) {
-        D3D12_HEAP_PROPERTIES {
-            Type: D3D12_HEAP_TYPE_DEFAULT,
-            CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
-            MemoryPoolPreference: D3D12_MEMORY_POOL_UNKNOWN,
-            CreationNodeMask: 0,
-            VisibleNodeMask: 0,
-        }
-    } else {
-        D3D12_HEAP_PROPERTIES {
-            Type:  D3D12_HEAP_TYPE_CUSTOM,
-            CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_WRITE_BACK,
-            MemoryPoolPreference: D3D12_MEMORY_POOL_L0,
-            CreationNodeMask: 0,
-            VisibleNodeMask: 0,
-        }
-    }
-}
 
 pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
     use core::format::SurfaceType::*;

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -217,6 +217,7 @@ pub struct Device {
     rtv_pool: Arc<Mutex<native::DescriptorCpuPool>>,
     dsv_pool: Arc<Mutex<native::DescriptorCpuPool>>,
     srv_pool: Arc<Mutex<native::DescriptorCpuPool>>,
+    uav_pool: Arc<Mutex<native::DescriptorCpuPool>>,
     sampler_pool: Arc<Mutex<native::DescriptorCpuPool>>,
     // CPU/GPU descriptor heaps
     heap_srv_cbv_uav: Arc<Mutex<native::DescriptorHeap>>,
@@ -272,6 +273,19 @@ impl Device {
             offset: 0,
             size: 0,
             max_size: max_srvs as _,
+        };
+
+        let max_uavs = 0x1000; // TODO
+        let uav_pool = native::DescriptorCpuPool {
+            heap: Self::create_descriptor_heap_impl(
+                &mut device,
+                winapi::D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
+                false,
+                max_uavs,
+            ),
+            offset: 0,
+            size: 0,
+            max_size: max_uavs as _,
         };
 
         let max_samplers = 2048; // D3D12 doesn't allow more samplers for one heap.
@@ -346,6 +360,7 @@ impl Device {
             rtv_pool: Arc::new(Mutex::new(rtv_pool)),
             dsv_pool: Arc::new(Mutex::new(dsv_pool)),
             srv_pool: Arc::new(Mutex::new(srv_pool)),
+            uav_pool: Arc::new(Mutex::new(uav_pool)),
             sampler_pool: Arc::new(Mutex::new(sampler_pool)),
             heap_srv_cbv_uav: Arc::new(Mutex::new(heap_srv_cbv_uav)),
             heap_sampler: Arc::new(Mutex::new(heap_sampler)),

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -353,6 +353,7 @@ impl Device {
                 ],
                 min_buffer_copy_offset_alignment: winapi::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as _,
                 min_buffer_copy_pitch_alignment: winapi::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as _,
+                min_uniform_buffer_offset_alignment: 256, // Required alignment for CBVs
             },
             private_caps: Capabilities {
                 heterogeneous_resource_heaps: features.ResourceHeapTier != winapi::D3D12_RESOURCE_HEAP_TIER_1,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -34,6 +34,67 @@ use std::os::windows::ffi::OsStringExt;
 use std::ffi::OsString;
 use std::sync::{Arc, Mutex};
 
+pub(crate) struct HeapProperties {
+    pub page_property: winapi::D3D12_CPU_PAGE_PROPERTY,
+    pub memory_pool: winapi::D3D12_MEMORY_POOL,
+}
+
+// https://msdn.microsoft.com/de-de/library/windows/desktop/dn788678(v=vs.85).aspx
+static HEAPS_NUMA: &'static [HeapProperties] = &[
+    // DEFAULT
+    HeapProperties {
+        page_property: winapi::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE,
+        memory_pool: winapi::D3D12_MEMORY_POOL_L1,
+    },
+    // UPLOAD
+    HeapProperties {
+        page_property: winapi::D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE,
+        memory_pool: winapi::D3D12_MEMORY_POOL_L0,
+
+    },
+    // READBACK
+    HeapProperties {
+        page_property: winapi::D3D12_CPU_PAGE_PROPERTY_WRITE_BACK,
+        memory_pool: winapi::D3D12_MEMORY_POOL_L0,
+    },
+];
+
+static HEAPS_UMA: &'static [HeapProperties] = &[
+    // DEFAULT
+    HeapProperties {
+        page_property: winapi::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE,
+        memory_pool: winapi::D3D12_MEMORY_POOL_L0,
+    },
+    // UPLOAD
+    HeapProperties {
+        page_property: winapi::D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE,
+        memory_pool: winapi::D3D12_MEMORY_POOL_L0,
+    },
+    // READBACK
+    HeapProperties {
+        page_property: winapi::D3D12_CPU_PAGE_PROPERTY_WRITE_BACK,
+        memory_pool: winapi::D3D12_MEMORY_POOL_L0,
+    },
+];
+
+static HEAPS_CCUMA: &'static [HeapProperties] = &[
+    // DEFAULT
+    HeapProperties {
+        page_property: winapi::D3D12_CPU_PAGE_PROPERTY_NOT_AVAILABLE,
+        memory_pool: winapi::D3D12_MEMORY_POOL_L0,
+    },
+    // UPLOAD
+    HeapProperties {
+        page_property: winapi::D3D12_CPU_PAGE_PROPERTY_WRITE_BACK,
+        memory_pool: winapi::D3D12_MEMORY_POOL_L0,
+    },
+    //READBACK
+    HeapProperties {
+        page_property: winapi::D3D12_CPU_PAGE_PROPERTY_WRITE_BACK,
+        memory_pool: winapi::D3D12_MEMORY_POOL_L0,
+    },
+];
+
 #[derive(Clone)]
 pub struct QueueFamily;
 
@@ -94,6 +155,7 @@ fn collect_queues<C>(
 #[derive(Clone)]
 pub struct Adapter {
     adapter: ComPtr<winapi::IDXGIAdapter2>,
+    factory: ComPtr<winapi::IDXGIFactory4>,
     info: core::AdapterInfo,
     queue_families: Vec<(QueueFamily, QueueType)>,
 }
@@ -113,26 +175,88 @@ impl core::Adapter<Backend> for Adapter {
         if !winapi::SUCCEEDED(hr) {
             error!("error on device creation: {:x}", hr);
         }
-        let device = Device::new(unsafe { ComPtr::new(device_raw) });
+        let mut device = Device::new(unsafe { ComPtr::new(device_raw) });
+
+        // Get the IDXGIAdapter3 from the created device to query video memory information.
+        let mut adapter_id = unsafe { mem::uninitialized() };
+        unsafe { device.raw.GetAdapterLuid(&mut adapter_id); }
+
+        let mut adapter = {
+            let mut adapter: *mut winapi::IDXGIAdapter3 = ptr::null_mut();
+            unsafe {
+                assert_eq!(winapi::S_OK, self.factory.as_mut().EnumAdapterByLuid(
+                    adapter_id,
+                    &dxguid::IID_IDXGIAdapter3,
+                    &mut adapter as *mut *mut _ as *mut *mut _,
+                ));
+                ComPtr::new(adapter)
+            }
+        };
 
         // https://msdn.microsoft.com/en-us/library/windows/desktop/dn788678(v=vs.85).aspx
-        let base_memory_types = [
-            core::MemoryType {
-                id: 0,
-                properties: memory::DEVICE_LOCAL,
-                heap_index: 1,
-            },
-            core::MemoryType {
-                id: 1,
-                properties: memory::CPU_VISIBLE | memory::CPU_CACHED,
-                heap_index: 0,
-            },
-            core::MemoryType {
-                id: 2,
-                properties: memory::CPU_VISIBLE | memory::WRITE_COMBINED,
-                heap_index: 0,
-            },
-        ];
+        let base_memory_types = match device.private_caps.memory_architecture {
+            MemoryArchitecture::NUMA => [
+                // DEFAULT
+                core::MemoryType {
+                    id: 0,
+                    properties: memory::DEVICE_LOCAL,
+                    heap_index: 0,
+                },
+                // UPLOAD
+                core::MemoryType {
+                    id: 1,
+                    properties: memory::CPU_VISIBLE | memory::COHERENT,
+                    heap_index: 1,
+                },
+                // READBACK
+                core::MemoryType {
+                    id: 2,
+                    properties: memory::CPU_VISIBLE | memory::COHERENT | memory::CPU_CACHED,
+                    heap_index: 1,
+                },
+            ],
+            MemoryArchitecture::UMA => [
+                // DEFAULT
+                core::MemoryType {
+                    id: 0,
+                    properties: memory::DEVICE_LOCAL,
+                    heap_index: 0,
+                },
+                // UPLOAD
+                core::MemoryType {
+                    id: 1,
+                    properties: memory::DEVICE_LOCAL | memory::CPU_VISIBLE | memory::COHERENT,
+                    heap_index: 0,
+                },
+                // READBACK
+                core::MemoryType {
+                    id: 2,
+                    properties: memory::DEVICE_LOCAL | memory::CPU_VISIBLE | memory::COHERENT | memory::CPU_CACHED,
+                    heap_index: 0,
+                },
+            ],
+            MemoryArchitecture::CacheCoherentUMA => [
+                // DEFAULT
+                core::MemoryType {
+                    id: 0,
+                    properties: memory::DEVICE_LOCAL,
+                    heap_index: 0,
+                },
+                // UPLOAD
+                core::MemoryType {
+                    id: 1,
+                    properties: memory::DEVICE_LOCAL | memory::CPU_VISIBLE | memory::COHERENT | memory::CPU_CACHED,
+                    heap_index: 0,
+                },
+                // READBACK
+                core::MemoryType {
+                    id: 2,
+                    properties: memory::DEVICE_LOCAL | memory::CPU_VISIBLE | memory::COHERENT | memory::CPU_CACHED,
+                    heap_index: 0,
+                },
+            ],
+        };
+
         let memory_types = if device.private_caps.heterogeneous_resource_heaps {
             base_memory_types.to_vec()
         } else {
@@ -153,13 +277,34 @@ impl core::Adapter<Backend> for Adapter {
             types
         };
 
+        let memory_heaps = {
+            let mut query_memory = |segment: winapi::DXGI_MEMORY_SEGMENT_GROUP| unsafe {
+                let mut mem_info: winapi::DXGI_QUERY_VIDEO_MEMORY_INFO = mem::uninitialized();
+                assert_eq!(winapi::S_OK, adapter.QueryVideoMemoryInfo(
+                    0,
+                    segment,
+                    &mut mem_info,
+                ));
+                mem_info.Budget
+            };
+
+            let local = query_memory(winapi::DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
+            match device.private_caps.memory_architecture {
+                MemoryArchitecture::NUMA => {
+                    let non_local = query_memory(winapi::DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
+                    vec![local, non_local]
+                },
+                _ => vec![local],
+            }
+        };
+
         core::Gpu {
             general_queues: collect_queues(queue_descs, &device, QueueType::General),
             graphics_queues: collect_queues(queue_descs, &device, QueueType::Graphics),
             compute_queues: collect_queues(queue_descs, &device, QueueType::Compute),
             transfer_queues: collect_queues(queue_descs, &device, QueueType::Transfer),
             memory_types,
-            memory_heaps: vec![!0, !0], // TODO: VRAM sizes
+            memory_heaps,
             device,
         }
     }
@@ -202,9 +347,17 @@ impl core::RawCommandQueue<Backend> for CommandQueue {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+enum MemoryArchitecture {
+    NUMA,
+    UMA,
+    CacheCoherentUMA,
+}
+
 #[derive(Clone)]
 pub struct Capabilities {
     heterogeneous_resource_heaps: bool,
+    memory_architecture: MemoryArchitecture,
 }
 
 #[derive(Clone)]
@@ -213,6 +366,7 @@ pub struct Device {
     features: core::Features,
     limits: core::Limits,
     private_caps: Capabilities,
+    heap_properties: &'static [HeapProperties],
     // CPU only pools
     rtv_pool: Arc<Mutex<native::DescriptorCpuPool>>,
     dsv_pool: Arc<Mutex<native::DescriptorCpuPool>>,
@@ -233,6 +387,13 @@ impl Device {
             device.CheckFeatureSupport(winapi::D3D12_FEATURE_D3D12_OPTIONS,
                 &mut features as *mut _ as *mut _,
                 mem::size_of::<winapi::D3D12_FEATURE_DATA_D3D12_OPTIONS>() as _)
+        });
+
+        let mut features_architecture: winapi::D3D12_FEATURE_DATA_ARCHITECTURE = unsafe { mem::zeroed() };
+        assert_eq!(winapi::S_OK, unsafe {
+            device.CheckFeatureSupport(winapi::D3D12_FEATURE_ARCHITECTURE,
+                &mut features_architecture as *mut _ as *mut _,
+                mem::size_of::<winapi::D3D12_FEATURE_DATA_ARCHITECTURE>() as _)
         });
 
         // Allocate descriptor heaps
@@ -315,6 +476,15 @@ impl Device {
             max_samplers,
         );
 
+        let uma = features_architecture.UMA == winapi::TRUE;
+        let cc_uma = features_architecture.CacheCoherentUMA == winapi::TRUE;
+
+        let (memory_architecture, heap_properties) = match (uma, cc_uma) {
+            (true, true)  => (MemoryArchitecture::CacheCoherentUMA, HEAPS_CCUMA),
+            (true, false) => (MemoryArchitecture::UMA, HEAPS_UMA),
+            (false, _)            => (MemoryArchitecture::NUMA, HEAPS_NUMA),
+        };
+
         Device {
             raw: device,
             features: Features { // TODO
@@ -357,7 +527,9 @@ impl Device {
             },
             private_caps: Capabilities {
                 heterogeneous_resource_heaps: features.ResourceHeapTier != winapi::D3D12_RESOURCE_HEAP_TIER_1,
+                memory_architecture,
             },
+            heap_properties,
             rtv_pool: Arc::new(Mutex::new(rtv_pool)),
             dsv_pool: Arc::new(Mutex::new(dsv_pool)),
             srv_pool: Arc::new(Mutex::new(srv_pool)),
@@ -466,6 +638,7 @@ impl core::Instance<Backend> for Instance {
                 devices.push(
                     Adapter {
                         adapter: adapter,
+                        factory: self.factory.clone(),
                         info: info,
                         queue_families: vec![(QueueFamily, QueueType::General)], // TODO:
                     });

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -197,7 +197,6 @@ pub struct Memory {
     pub(crate) heap: ComPtr<winapi::ID3D12Heap>,
     pub(crate) ty: MemoryType,
     pub(crate) size: u64,
-    pub(crate) default_state: winapi::D3D12_RESOURCE_STATES,
 }
 
 #[derive(Debug)]

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -279,6 +279,7 @@ pub fn query_all(gl: &gl::Gl) -> (Info, Features, Limits, PrivateCaps) {
 
         min_buffer_copy_offset_alignment: 1,
         min_buffer_copy_pitch_alignment: 1,
+        min_uniform_buffer_offset_alignment: 1, // TODO
 
     };
     let features = Features {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -208,22 +208,23 @@ impl c::Adapter<Backend> for Adapter {
             panic!("Error opening adapter: {:?}", err);
         }
 
+        // COHERENT flags require that the backend does flushing and invaldation
+        // by itself. If we move towards persistent mapping we need to re-evaluate it.
         let memory_types = if self.share.private_caps.map {
             vec![
-                //TODO: expose `COHERENT` types as well
                 c::MemoryType {
                     id: 0,
                     properties: c::memory::DEVICE_LOCAL,
                     heap_index: 1,
                 },
-                c::MemoryType { //download
+                c::MemoryType { // upload
                     id: 1,
-                    properties: c::memory::CPU_VISIBLE | c::memory::CPU_CACHED,
+                    properties: c::memory::CPU_VISIBLE | c::memory::COHERENT,
                     heap_index: 0,
                 },
-                c::MemoryType { // upload
+                c::MemoryType { // download
                     id: 2,
-                    properties: c::memory::CPU_VISIBLE | c::memory::WRITE_COMBINED,
+                    properties: c::memory::CPU_VISIBLE | c::memory::COHERENT | c::memory::CPU_CACHED,
                     heap_index: 0,
                 },
             ]

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -97,7 +97,7 @@ pub struct Memory {
 
 impl Memory {
     pub fn can_upload(&self) -> bool {
-        self.properties.contains(mem::CPU_VISIBLE | mem::WRITE_COMBINED)
+        self.properties.contains(mem::CPU_VISIBLE)
     }
     pub fn can_download(&self) -> bool {
         self.properties.contains(mem::CPU_VISIBLE | mem::CPU_CACHED)

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -112,7 +112,7 @@ pub fn map_blend_factor(factor: core::state::Factor, scalar: bool) -> MTLBlendFa
 pub fn map_vertex_format(format: Format) -> Option<MTLVertexFormat> {
     use core::format::SurfaceType::*;
     use core::format::ChannelType::*;
-   
+
     // TODO: more formats
     Some(match format {
         Format(R32_G32_B32_A32, Float) => MTLVertexFormat::Float4,
@@ -135,8 +135,8 @@ pub fn map_memory_properties_to_options(properties: memory::Properties) -> MTLRe
     } else {
         panic!("invalid heap properties");
     }
-    if properties.contains(memory::WRITE_COMBINED) {
-        options |= MTLResourceOptionCPUCacheModeWriteCombined;
+    if !properties.contains(memory::CPU_CACHED) {
+        options |= MTLResourceCPUCacheModeWriteCombined;
     }
     options
 }
@@ -153,10 +153,10 @@ pub fn map_memory_properties_to_storage_and_cache(properties: memory::Properties
     } else {
         panic!("invalid heap properties");
     };
-    let cpu = if properties.contains(memory::WRITE_COMBINED) {
-        MTLCPUCacheMode::WriteCombined
-    } else {
+    let cpu = if properties.contains(memory::CPU_CACHED) {
         MTLCPUCacheMode::DefaultCache
+    } else {
+        MTLCPUCacheMode::WriteCombined
     };
     (storage, cpu)
 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -103,6 +103,7 @@ impl core::Adapter<Backend> for Adapter {
 
                 min_buffer_copy_offset_alignment: 4, // TODO: Lower on iOS
                 min_buffer_copy_pitch_alignment: 4, // TODO: made this up
+                min_uniform_buffer_offset_alignment: 1, // TODO
 
                 max_compute_group_count: [0; 3], // TODO
                 max_compute_group_size: [0; 3], // TODO

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -118,7 +118,7 @@ impl core::Adapter<Backend> for Adapter {
             },
             core::MemoryType {
                 id: 1,
-                properties: memory::CPU_VISIBLE | memory::CPU_CACHED | memory::WRITE_COMBINED,
+                properties: memory::CPU_VISIBLE | memory::CPU_CACHED,
                 heap_index: 0,
             },
             core::MemoryType {
@@ -128,12 +128,6 @@ impl core::Adapter<Backend> for Adapter {
             },
             core::MemoryType {
                 id: 3,
-                properties: memory::CPU_VISIBLE | memory::COHERENT
-                    | memory::CPU_CACHED | memory::WRITE_COMBINED,
-                heap_index: 0,
-            },
-            core::MemoryType {
-                id: 4,
                 properties: memory::DEVICE_LOCAL,
                 heap_index: 1,
             },

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -443,6 +443,7 @@ impl core::Adapter<Backend> for Adapter {
                 max_compute_group_size: [max_group_size[0] as _, max_group_size[1] as _, max_group_size[2] as _],
                 min_buffer_copy_offset_alignment: limits.optimal_buffer_copy_offset_alignment as _,
                 min_buffer_copy_pitch_alignment: limits.optimal_buffer_copy_row_pitch_alignment as _,
+                min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment as _,
             },
         };
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -164,6 +164,8 @@ pub struct Limits {
     /// The alignment of the row pitch of the texture data stored in a buffer that is
     /// used in a GPU copy operation, in bytes, non-zero.
     pub min_buffer_copy_pitch_alignment: usize,
+    /// The alignment of the start of buffer used for uniform buffer updates, in bytes, non-zero.
+    pub min_uniform_buffer_offset_alignment: usize,
 }
 
 /// Describes what geometric primitives are created from vertex data.

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -57,12 +57,6 @@ bitflags!(
         /// Cached memory by the CPU
         const CPU_CACHED = 0x8;
 
-        /// Memory combined writes.
-        ///
-        /// Buffer writes will be combined for possible larger bus transactions.
-        /// It's not advised to use these memory allocations for reading back data.
-        const WRITE_COMBINED = 0x10;
-
         ///
         const LAZILY_ALLOCATED = 0x20;
     }
@@ -76,8 +70,6 @@ pub const COHERENT: Properties = Properties::COHERENT;
 pub const CPU_VISIBLE: Properties = Properties::CPU_VISIBLE;
 ///
 pub const CPU_CACHED: Properties = Properties::CPU_CACHED;
-///
-pub const WRITE_COMBINED: Properties = Properties::WRITE_COMBINED;
 ///
 pub const LAZILY_ALLOCATED: Properties = Properties::LAZILY_ALLOCATED;
 


### PR DESCRIPTION
* Remove the `WRITE_COMBINE` memory property and adjust it towards the vulkan model
* Implement uniform and storage buffers for dx12 where we dynamically create view objects
* Fix exposed memory heaps and types (query available memory of the system)