### PR TITLE
Redefine image extents semantic

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -5,7 +5,7 @@ use core::buffer::IndexBufferView;
 use winapi::{self, UINT64, UINT};
 use {conv, native as n, Backend};
 use smallvec::SmallVec;
-use std::{cmp, mem, ptr};
+use std::{mem, ptr};
 use std::ops::Range;
 
 fn get_rect(rect: &target::Rect) -> winapi::D3D12_RECT {
@@ -807,8 +807,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 assert_eq!(region.buffer_row_pitch % winapi::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as u32, 0);
                 assert!(region.buffer_row_pitch >= width as u32 * image.bits_per_texel as u32 / 8);
 
-                let height = cmp::max(1, height as _);
-                let depth = cmp::max(1, depth as _);
+                let height = height as _;
+                let depth = depth as _;
 
                 // Advance buffer offset with each layer
                 *unsafe { src.PlacedFootprint_mut() } = winapi::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
@@ -871,8 +871,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 assert_eq!(region.buffer_row_pitch % winapi::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as u32, 0);
                 assert!(region.buffer_row_pitch >= width as u32 * image.bits_per_texel as u32 / 8);
 
-                let height = cmp::max(1, height as _);
-                let depth = cmp::max(1, depth as _);
+                let height = height as _;
+                let depth = depth as _;
 
                 // Advance buffer offset with each layer
                 *unsafe { src.SubresourceIndex_mut() } =

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -7,7 +7,6 @@ use d3dcompiler;
 use dxguid;
 use kernel32;
 use spirv_cross::{hlsl, spirv, ErrorCode as SpirvErrorCode};
-use std::cmp;
 use std::collections::BTreeMap;
 use std::ops::Range;
 use std::{ffi, mem, ptr, slice};
@@ -1064,7 +1063,7 @@ impl d::Device<B> for Device {
             Alignment: 0,
             Width: width as u64,
             Height: height as u32,
-            DepthOrArraySize: cmp::max(1, depth),
+            DepthOrArraySize: depth,
             MipLevels: mip_levels as u16,
             Format: match conv::map_format(format) {
                 Some(format) => format,

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -262,13 +262,13 @@ pub enum Kind {
 }
 
 impl Kind {
-    /// Get texture dimensions, with 0 values where not applicable.
+    /// Get texture dimensions
     pub fn get_dimensions(&self) -> Dimensions {
         let s0 = AaMode::Single;
         match *self {
-            Kind::D1(w) => (w, 0, 0, s0),
-            Kind::D1Array(w, a) => (w, 0, a as Size, s0),
-            Kind::D2(w, h, s) => (w, h, 0, s),
+            Kind::D1(w) => (w, 1, 1, s0),
+            Kind::D1Array(w, a) => (w, 1, a as Size, s0),
+            Kind::D2(w, h, s) => (w, h, 1, s),
             Kind::D2Array(w, h, a, s) => (w, h, a as Size, s),
             Kind::D3(w, h, d) => (w, h, d, s0),
             Kind::Cube(w) => (w, w, 6, s0),
@@ -278,11 +278,11 @@ impl Kind {
     /// Get the dimensionality of a particular mipmap level.
     pub fn get_level_dimensions(&self, level: Level) -> Dimensions {
         use std::cmp::{max, min};
-        // unused dimensions must stay 0, all others must be at least 1
+        // must be at least 1
         let map = |val| max(min(val, 1), val >> min(level, MAX_LEVEL));
         let (w, h, da, _) = self.get_dimensions();
         let dm = if self.get_num_slices().is_some() {
-            0
+            1
         } else {
             map(da)
         };


### PR DESCRIPTION
Image extents need to be at least 1 in each dimensions in contrast to 0 for unused dimensions in the older implementation.