### PR TITLE
Update bitflags usage

### DIFF
--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -101,7 +101,7 @@ fn main() {
     ).unwrap();
 
     let image_range = gfx::image::SubresourceRange {
-        aspects: i::ASPECT_COLOR,
+        aspects: i::AspectFlags::COLOR,
         levels: 0 .. 1,
         layers: 0 .. 1,
     };
@@ -129,7 +129,7 @@ fn main() {
     let vertex_count = QUAD.len() as u64;
     let (vertex_buffer, vertex_token) = device.create_buffer::<Vertex, _>(
         &mut upload,
-        gfx::buffer::VERTEX,
+        gfx::buffer::Usage::VERTEX,
         vertex_count
     ).unwrap();
 
@@ -149,7 +149,7 @@ fn main() {
 
     let (image_upload_buffer, image_upload_token) = device.create_buffer_raw(
         &mut upload,
-        gfx::buffer::TRANSFER_SRC,
+        gfx::buffer::Usage::TRANSFER_SRC,
         upload_size,
         image_stride as u64
     ).unwrap();
@@ -166,7 +166,7 @@ fn main() {
 
     let (image, image_token) = device.create_image::<ColorFormat, _>(
         &mut data,
-        gfx::image::TRANSFER_DST | gfx::image::SAMPLED,
+        gfx::image::Usage::TRANSFER_DST | gfx::image::Usage::SAMPLED,
         kind,
         1,
     ).unwrap();
@@ -212,7 +212,7 @@ fn main() {
             buffer_row_pitch: row_pitch,
             buffer_slice_pitch: row_pitch * (height as u32),
             image_layers: gfx::image::SubresourceLayers {
-                aspects: i::ASPECT_COLOR,
+                aspects: i::AspectFlags::COLOR,
                 level: 0,
                 layers: 0 .. 1,
             },

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -390,7 +390,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         range: image::SubresourceRange,
         value: com::ClearColor,
     ) {
-        assert_eq!(range, image.to_subresource_range(image::ASPECT_COLOR));
+        assert_eq!(range, image.to_subresource_range(image::AspectFlags::COLOR));
         let rtv = image.clear_cv.unwrap();
         self.clear_render_target_view(rtv, value, &[]);
     }
@@ -402,13 +402,14 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         range: image::SubresourceRange,
         value: com::ClearDepthStencil,
     ) {
-        assert!((image::ASPECT_DEPTH | image::ASPECT_STENCIL).contains(range.aspects));
+        use self::image::AspectFlags;
+        assert!((AspectFlags::DEPTH | AspectFlags::STENCIL).contains(range.aspects));
         assert_eq!(range, image.to_subresource_range(range.aspects));
-        if range.aspects.contains(image::ASPECT_DEPTH) {
+        if range.aspects.contains(AspectFlags::DEPTH) {
             let dsv = image.clear_dv.unwrap();
             self.clear_depth_stencil_view(dsv, Some(value.depth), None, &[]);
         }
-        if range.aspects.contains(image::ASPECT_STENCIL) {
+        if range.aspects.contains(AspectFlags::STENCIL) {
             let dsv = image.clear_sv.unwrap();
             self.clear_depth_stencil_view(dsv, None, Some(value.stencil as _), &[]);
         }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -121,6 +121,7 @@ pub struct PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(self, families: Vec<(QueueFamily, usize)>) -> hal::Gpu<Backend> {
+        use self::memory::Properties;
         // Create D3D12 device
         let mut device_raw = ptr::null_mut();
         let hr = unsafe {
@@ -193,19 +194,19 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 // DEFAULT
                 hal::MemoryType {
                     id: 0,
-                    properties: memory::DEVICE_LOCAL,
+                    properties: Properties::DEVICE_LOCAL,
                     heap_index: 0,
                 },
                 // UPLOAD
                 hal::MemoryType {
                     id: 1,
-                    properties: memory::CPU_VISIBLE | memory::COHERENT,
+                    properties: Properties::CPU_VISIBLE | Properties::COHERENT,
                     heap_index: 1,
                 },
                 // READBACK
                 hal::MemoryType {
                     id: 2,
-                    properties: memory::CPU_VISIBLE | memory::COHERENT | memory::CPU_CACHED,
+                    properties: Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
                     heap_index: 1,
                 },
             ],
@@ -213,19 +214,19 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 // DEFAULT
                 hal::MemoryType {
                     id: 0,
-                    properties: memory::DEVICE_LOCAL,
+                    properties: Properties::DEVICE_LOCAL,
                     heap_index: 0,
                 },
                 // UPLOAD
                 hal::MemoryType {
                     id: 1,
-                    properties: memory::DEVICE_LOCAL | memory::CPU_VISIBLE | memory::COHERENT,
+                    properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT,
                     heap_index: 0,
                 },
                 // READBACK
                 hal::MemoryType {
                     id: 2,
-                    properties: memory::DEVICE_LOCAL | memory::CPU_VISIBLE | memory::COHERENT | memory::CPU_CACHED,
+                    properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
                     heap_index: 0,
                 },
             ],
@@ -233,19 +234,19 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 // DEFAULT
                 hal::MemoryType {
                     id: 0,
-                    properties: memory::DEVICE_LOCAL,
+                    properties: Properties::DEVICE_LOCAL,
                     heap_index: 0,
                 },
                 // UPLOAD
                 hal::MemoryType {
                     id: 1,
-                    properties: memory::DEVICE_LOCAL | memory::CPU_VISIBLE | memory::COHERENT | memory::CPU_CACHED,
+                    properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
                     heap_index: 0,
                 },
                 // READBACK
                 hal::MemoryType {
                     id: 2,
-                    properties: memory::DEVICE_LOCAL | memory::CPU_VISIBLE | memory::COHERENT | memory::CPU_CACHED,
+                    properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
                     heap_index: 0,
                 },
             ],

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -168,7 +168,7 @@ impl hal::Surface<Backend> for Surface {
             n::Image {
                 resource,
                 kind,
-                usage: i::COLOR_ATTACHMENT,
+                usage: i::Usage::COLOR_ATTACHMENT,
                 dxgi_format: format,
                 bits_per_texel: config.color_format.0.describe_bits().total,
                 num_levels: 1,

--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -35,11 +35,12 @@ pub fn wrap_to_gl(w: i::WrapMode) -> t::GLenum {
 }
 
 pub fn buffer_usage_to_gl_target(usage: buffer::Usage) -> Option<t::GLenum> {
-    match usage & (buffer::UNIFORM | buffer::INDEX | buffer::VERTEX | buffer::INDIRECT) {
-        buffer::UNIFORM => Some(gl::UNIFORM_BUFFER),
-        buffer::INDEX => Some(gl::ELEMENT_ARRAY_BUFFER),
-        buffer::VERTEX => Some(gl::ARRAY_BUFFER),
-        buffer::INDIRECT => unimplemented!(),
+    use self::buffer::Usage;
+    match usage & (Usage::UNIFORM | Usage::INDEX | Usage::VERTEX | Usage::INDIRECT) {
+        Usage::UNIFORM => Some(gl::UNIFORM_BUFFER),
+        Usage::INDEX => Some(gl::ELEMENT_ARRAY_BUFFER),
+        Usage::VERTEX => Some(gl::ARRAY_BUFFER),
+        Usage::INDIRECT => unimplemented!(),
         _ => None
     }
 }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -412,7 +412,7 @@ impl d::Device<B> for Device {
     fn create_buffer(
         &self, size: u64, stride: u64, usage: buffer::Usage,
     ) -> Result<UnboundBuffer, buffer::CreationError> {
-        if !self.share.features.constant_buffer && usage.contains(buffer::UNIFORM) {
+        if !self.share.features.constant_buffer && usage.contains(buffer::Usage::UNIFORM) {
             error!("Constant buffers are not supported by this GL version");
             return Err(buffer::CreationError::Other);
         }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -202,23 +202,25 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             panic!("Error opening adapter: {:?}", err);
         }
 
+        use hal::memory::Properties;
+
         // COHERENT flags require that the backend does flushing and invaldation
         // by itself. If we move towards persistent mapping we need to re-evaluate it.
         let memory_types = if self.0.private_caps.map {
             vec![
                 hal::MemoryType {
                     id: 0,
-                    properties: hal::memory::DEVICE_LOCAL,
+                    properties: Properties::DEVICE_LOCAL,
                     heap_index: 1,
                 },
                 hal::MemoryType { // upload
                     id: 1,
-                    properties: hal::memory::CPU_VISIBLE | hal::memory::COHERENT,
+                    properties: Properties::CPU_VISIBLE | Properties::COHERENT,
                     heap_index: 0,
                 },
                 hal::MemoryType { // download
                     id: 2,
-                    properties: hal::memory::CPU_VISIBLE | hal::memory::COHERENT | hal::memory::CPU_CACHED,
+                    properties: Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
                     heap_index: 0,
                 },
             ]
@@ -226,7 +228,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             vec![
                 hal::MemoryType {
                     id: 0,
-                    properties: hal::memory::DEVICE_LOCAL,
+                    properties: Properties::DEVICE_LOCAL,
                     heap_index: 0,
                 },
             ]

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -1,4 +1,5 @@
-use hal::{self, image as i, memory as mem, pass};
+use hal::{self, image as i, pass};
+use hal::memory::Properties;
 use hal::target::{Layer, Level};
 use gl;
 use Backend;
@@ -92,15 +93,15 @@ pub struct ShaderModule {
 
 #[derive(Debug)]
 pub struct Memory {
-    pub(crate) properties: mem::Properties,
+    pub(crate) properties: Properties,
 }
 
 impl Memory {
     pub fn can_upload(&self) -> bool {
-        self.properties.contains(mem::CPU_VISIBLE)
+        self.properties.contains(Properties::CPU_VISIBLE)
     }
     pub fn can_download(&self) -> bool {
-        self.properties.contains(mem::CPU_VISIBLE | mem::CPU_CACHED)
+        self.properties.contains(Properties::CPU_VISIBLE | Properties::CPU_CACHED)
     }
 }
 

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -572,7 +572,7 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
                     for (&binding, values) in set.bindings.iter() {
                         let desc_layout = set.layout.iter().find(|x| x.binding == binding).unwrap();
 
-                        if desc_layout.stage_flags.contains(pso::STAGE_VERTEX) {
+                        if desc_layout.stage_flags.contains(pso::ShaderStageFlags::VERTEX) {
                             let location = msl::ResourceBindingLocation {
                                 binding: binding as _,
                                 .. location_vs
@@ -598,7 +598,7 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
                                 _ => unimplemented!(),
                             }
                         }
-                        if desc_layout.stage_flags.contains(pso::STAGE_FRAGMENT) {
+                        if desc_layout.stage_flags.contains(pso::ShaderStageFlags::FRAGMENT) {
                             let location = msl::ResourceBindingLocation {
                                 binding: binding as _,
                                 .. location_fs
@@ -627,14 +627,14 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
                     }
                 }
                 native::DescriptorSet::ArgumentBuffer { ref buffer, offset, stage_flags, .. } => {
-                    if stage_flags.contains(pso::STAGE_VERTEX) {
+                    if stage_flags.contains(pso::ShaderStageFlags::VERTEX) {
                         let slot = layout.res_overrides[&location_vs].resource_id;
                         inner.resources_vs.add_buffer(slot as _, buffer, offset as _);
                         if let EncoderState::Render(ref encoder) = inner.encoder_state {
                             encoder.set_vertex_buffer(slot as _, offset as _, Some(buffer))
                         }
                     }
-                    if stage_flags.contains(pso::STAGE_FRAGMENT) {
+                    if stage_flags.contains(pso::ShaderStageFlags::FRAGMENT) {
                         let slot = layout.res_overrides[&location_fs].resource_id;
                         inner.resources_fs.add_buffer(slot as _, &buffer, offset as _);
                         if let EncoderState::Render(ref encoder) = inner.encoder_state {

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -121,36 +121,36 @@ pub fn map_vertex_format(format: Format) -> Option<MTLVertexFormat> {
 
 pub fn map_memory_properties_to_options(properties: memory::Properties) -> MTLResourceOptions {
     let mut options = MTLResourceOptions::empty();
-    if properties.contains(memory::CPU_VISIBLE) {
-        if properties.contains(memory::COHERENT) {
+    if properties.contains(memory::Properties::CPU_VISIBLE) {
+        if properties.contains(memory::Properties::COHERENT) {
             options |= MTLResourceOptions::StorageModeShared;
         } else {
             options |= MTLResourceOptions::StorageModeManaged;
         }
-    } else if properties.contains(memory::DEVICE_LOCAL) {
+    } else if properties.contains(memory::Properties::DEVICE_LOCAL) {
         options |= MTLResourceOptions::StorageModePrivate;
     } else {
         panic!("invalid heap properties");
     }
-    if !properties.contains(memory::CPU_CACHED) {
+    if !properties.contains(memory::Properties::CPU_CACHED) {
         options |= MTLResourceOptions::CPUCacheModeWriteCombined;
     }
     options
 }
 
 pub fn map_memory_properties_to_storage_and_cache(properties: memory::Properties) -> (MTLStorageMode, MTLCPUCacheMode) {
-    let storage = if properties.contains(memory::CPU_VISIBLE) {
-        if properties.contains(memory::COHERENT) {
+    let storage = if properties.contains(memory::Properties::CPU_VISIBLE) {
+        if properties.contains(memory::Properties::COHERENT) {
             MTLStorageMode::Shared
         } else {
             MTLStorageMode::Managed
         }
-    } else if properties.contains(memory::DEVICE_LOCAL) {
+    } else if properties.contains(memory::Properties::DEVICE_LOCAL) {
         MTLStorageMode::Private
     } else {
         panic!("invalid heap properties");
     };
-    let cpu = if properties.contains(memory::CPU_CACHED) {
+    let cpu = if properties.contains(memory::Properties::CPU_CACHED) {
         MTLCPUCacheMode::DefaultCache
     } else {
         MTLCPUCacheMode::WriteCombined
@@ -166,10 +166,10 @@ pub fn resource_options_from_storage_and_cache(storage: MTLStorageMode, cache: M
 
 pub fn map_texture_usage(usage: image::Usage) -> MTLTextureUsage {
     let mut texture_usage = MTLTextureUsage::MTLTextureUsagePixelFormatView;
-    if usage.contains(image::COLOR_ATTACHMENT) || usage.contains(image::DEPTH_STENCIL_ATTACHMENT) {
+    if usage.contains(image::Usage::COLOR_ATTACHMENT) || usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT) {
         texture_usage |= MTLTextureUsage::MTLTextureUsageRenderTarget;
     }
-    if usage.contains(image::SAMPLED) {
+    if usage.contains(image::Usage::SAMPLED) {
         texture_usage |= MTLTextureUsage::MTLTextureUsageShaderRead;
     }
     // TODO shader write

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -85,6 +85,8 @@ impl PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(self, mut families: Vec<(QueueFamily, usize)>) -> hal::Gpu<Backend> {
+        use self::memory::Properties;
+
         assert_eq!(families.len(), 1);
         let mut queue_group = hal::queue::RawQueueGroup::new(families.remove(0).0);
         let queue_raw = command::CommandQueue::new(&self.0);
@@ -122,22 +124,22 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         let memory_types = vec![
             hal::MemoryType {
                 id: 0,
-                properties: memory::CPU_VISIBLE | memory::CPU_CACHED,
+                properties: Properties::CPU_VISIBLE | Properties::CPU_CACHED,
                 heap_index: 0,
             },
             hal::MemoryType {
                 id: 1,
-                properties: memory::CPU_VISIBLE | memory::CPU_CACHED,
+                properties: Properties::CPU_VISIBLE | Properties::CPU_CACHED,
                 heap_index: 0,
             },
             hal::MemoryType {
                 id: 2,
-                properties: memory::CPU_VISIBLE | memory::COHERENT | memory::CPU_CACHED,
+                properties: Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
                 heap_index: 0,
             },
             hal::MemoryType {
                 id: 3,
-                properties: memory::DEVICE_LOCAL,
+                properties: Properties::DEVICE_LOCAL,
                 heap_index: 1,
             },
         ];
@@ -472,7 +474,7 @@ impl hal::Device<Backend> for Device {
     }
 
     fn create_pipeline_layout(&self, set_layouts: &[&n::DescriptorSetLayout]) -> n::PipelineLayout {
-        use hal::pso::{STAGE_VERTEX, STAGE_FRAGMENT};
+        use hal::pso::ShaderStageFlags;
 
         struct Counters {
             buffers: usize,
@@ -480,8 +482,8 @@ impl hal::Device<Backend> for Device {
             samplers: usize,
         }
         let mut stage_infos = [
-            (STAGE_VERTEX,   spirv::ExecutionModel::Vertex,   Counters { buffers:0, textures:0, samplers:0 }),
-            (STAGE_FRAGMENT, spirv::ExecutionModel::Fragment, Counters { buffers:0, textures:0, samplers:0 }),
+            (ShaderStageFlags::VERTEX,   spirv::ExecutionModel::Vertex,   Counters { buffers:0, textures:0, samplers:0 }),
+            (ShaderStageFlags::FRAGMENT, spirv::ExecutionModel::Fragment, Counters { buffers:0, textures:0, samplers:0 }),
         ];
         let mut res_overrides = HashMap::new();
 

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -8,10 +8,7 @@ use ash::version::DeviceV1_0;
 use hal::{command as com, memory, pso, target};
 use hal::{IndexCount, InstanceCount, VertexCount, VertexOffset, Viewport};
 use hal::buffer::IndexBufferView;
-use hal::image::{
-    ImageLayout, SubresourceRange,
-    ASPECT_COLOR, ASPECT_DEPTH, ASPECT_STENCIL,
-};
+use hal::image::{AspectFlags, ImageLayout, SubresourceRange};
 use {conv, native as n};
 use {Backend, RawDevice};
 
@@ -194,7 +191,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     });
                 }
                 memory::Barrier::Image { ref states, target, ref range } => {
-                    assert_eq!(range.aspects, ASPECT_COLOR);
+                    assert_eq!(range.aspects, AspectFlags::COLOR);
                     let subresource_range = conv::map_subresource_range(range);
                     image_bars.push(vk::ImageMemoryBarrier {
                         s_type: vk::StructureType::ImageMemoryBarrier,
@@ -265,7 +262,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         range: SubresourceRange,
         value: com::ClearColor,
     ) {
-        assert!(ASPECT_COLOR.contains(range.aspects));
+        assert!(AspectFlags::COLOR.contains(range.aspects));
         let range = conv::map_subresource_range(&range);
         let clear_value = conv::map_clear_color(value);
 
@@ -287,7 +284,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         range: SubresourceRange,
         value: com::ClearDepthStencil,
     ) {
-        assert!((ASPECT_DEPTH | ASPECT_STENCIL).contains(range.aspects));
+        assert!((AspectFlags::DEPTH | AspectFlags::STENCIL).contains(range.aspects));
         let range = conv::map_subresource_range(&range);
         let clear_value = vk::ClearDepthStencilValue {
             depth: value.depth,

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -390,14 +390,15 @@ pub fn map_image_layout(layout: image::ImageLayout) -> vk::ImageLayout {
 }
 
 pub fn map_image_aspects(aspects: image::AspectFlags) -> vk::ImageAspectFlags {
+    use self::image::AspectFlags;
     let mut flags = vk::ImageAspectFlags::empty();
-    if aspects.contains(image::ASPECT_COLOR) {
+    if aspects.contains(AspectFlags::COLOR) {
         flags |= vk::IMAGE_ASPECT_COLOR_BIT;
     }
-    if aspects.contains(image::ASPECT_DEPTH) {
+    if aspects.contains(AspectFlags::DEPTH) {
         flags |= vk::IMAGE_ASPECT_DEPTH_BIT;
     }
-    if aspects.contains(image::ASPECT_STENCIL) {
+    if aspects.contains(AspectFlags::STENCIL) {
         flags |= vk::IMAGE_ASPECT_STENCIL_BIT;
     }
     flags
@@ -498,42 +499,43 @@ pub fn map_attachment_store_op(op: pass::AttachmentStoreOp) -> vk::AttachmentSto
 }
 
 pub fn map_buffer_access(access: buffer::Access) -> vk::AccessFlags {
+    use self::buffer::Access;
     let mut flags = vk::AccessFlags::empty();
 
-    if access.contains(buffer::TRANSFER_READ) {
+    if access.contains(Access::TRANSFER_READ) {
         flags |= vk::ACCESS_TRANSFER_READ_BIT;
     }
-    if access.contains(buffer::TRANSFER_WRITE) {
+    if access.contains(Access::TRANSFER_WRITE) {
         flags |= vk::ACCESS_TRANSFER_WRITE_BIT;
     }
-    if access.contains(buffer::INDEX_BUFFER_READ) {
+    if access.contains(Access::INDEX_BUFFER_READ) {
         flags |= vk::ACCESS_INDEX_READ_BIT;
     }
-    if access.contains(buffer::VERTEX_BUFFER_READ) {
+    if access.contains(Access::VERTEX_BUFFER_READ) {
         flags |= vk::ACCESS_VERTEX_ATTRIBUTE_READ_BIT;
     }
-    if access.contains(buffer::CONSTANT_BUFFER_READ) {
+    if access.contains(Access::CONSTANT_BUFFER_READ) {
         flags |= vk::ACCESS_UNIFORM_READ_BIT;
     }
-    if access.contains(buffer::INDIRECT_COMMAND_READ) {
+    if access.contains(Access::INDIRECT_COMMAND_READ) {
         flags |= vk::ACCESS_INDIRECT_COMMAND_READ_BIT;
     }
-    if access.contains(buffer::SHADER_READ) {
+    if access.contains(Access::SHADER_READ) {
         flags |= vk::ACCESS_SHADER_READ_BIT;
     }
-    if access.contains(buffer::SHADER_WRITE) {
+    if access.contains(Access::SHADER_WRITE) {
         flags |= vk::ACCESS_SHADER_WRITE_BIT;
     }
-    if access.contains(buffer::HOST_READ) {
+    if access.contains(Access::HOST_READ) {
         flags |= vk::ACCESS_HOST_READ_BIT;
     }
-    if access.contains(buffer::HOST_WRITE) {
+    if access.contains(Access::HOST_WRITE) {
         flags |= vk::ACCESS_HOST_WRITE_BIT;
     }
-    if access.contains(buffer::MEMORY_READ) {
+    if access.contains(Access::MEMORY_READ) {
         flags |= vk::ACCESS_MEMORY_READ_BIT;
     }
-    if access.contains(buffer::MEMORY_WRITE) {
+    if access.contains(Access::MEMORY_WRITE) {
         flags |= vk::ACCESS_MEMORY_WRITE_BIT;
     }
 
@@ -541,45 +543,46 @@ pub fn map_buffer_access(access: buffer::Access) -> vk::AccessFlags {
 }
 
 pub fn map_image_access(access: image::Access) -> vk::AccessFlags {
+    use self::image::Access;
     let mut flags = vk::AccessFlags::empty();
 
-    if access.contains(image::COLOR_ATTACHMENT_READ) {
+    if access.contains(Access::COLOR_ATTACHMENT_READ) {
         flags |= vk::ACCESS_COLOR_ATTACHMENT_READ_BIT;
     }
-    if access.contains(image::COLOR_ATTACHMENT_WRITE) {
+    if access.contains(Access::COLOR_ATTACHMENT_WRITE) {
         flags |= vk::ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     }
-    if access.contains(image::TRANSFER_READ) {
+    if access.contains(Access::TRANSFER_READ) {
         flags |= vk::ACCESS_TRANSFER_READ_BIT;
     }
-    if access.contains(image::TRANSFER_WRITE) {
+    if access.contains(Access::TRANSFER_WRITE) {
         flags |= vk::ACCESS_TRANSFER_WRITE_BIT;
     }
-    if access.contains(image::SHADER_READ) {
+    if access.contains(Access::SHADER_READ) {
         flags |= vk::ACCESS_SHADER_READ_BIT;
     }
-    if access.contains(image::SHADER_WRITE) {
+    if access.contains(Access::SHADER_WRITE) {
         flags |= vk::ACCESS_SHADER_WRITE_BIT;
     }
-    if access.contains(image::DEPTH_STENCIL_ATTACHMENT_READ) {
+    if access.contains(Access::DEPTH_STENCIL_ATTACHMENT_READ) {
         flags |= vk::ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
     }
-    if access.contains(image::DEPTH_STENCIL_ATTACHMENT_WRITE) {
+    if access.contains(Access::DEPTH_STENCIL_ATTACHMENT_WRITE) {
         flags |= vk::ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
     }
-    if access.contains(image::HOST_READ) {
+    if access.contains(Access::HOST_READ) {
         flags |= vk::ACCESS_HOST_READ_BIT;
     }
-    if access.contains(image::HOST_WRITE) {
+    if access.contains(Access::HOST_WRITE) {
         flags |= vk::ACCESS_HOST_WRITE_BIT;
     }
-    if access.contains(image::MEMORY_READ) {
+    if access.contains(Access::MEMORY_READ) {
         flags |= vk::ACCESS_MEMORY_READ_BIT;
     }
-    if access.contains(image::MEMORY_WRITE) {
+    if access.contains(Access::MEMORY_WRITE) {
         flags |= vk::ACCESS_MEMORY_WRITE_BIT;
     }
-    if access.contains(image::INPUT_ATTACHMENT_READ) {
+    if access.contains(Access::INPUT_ATTACHMENT_READ) {
         flags |= vk::ACCESS_INPUT_ATTACHMENT_READ_BIT;
     }
 
@@ -587,51 +590,52 @@ pub fn map_image_access(access: image::Access) -> vk::AccessFlags {
 }
 
 pub fn map_pipeline_stage(stage: pso::PipelineStage) -> vk::PipelineStageFlags {
+    use self::pso::PipelineStage;
     let mut flags = vk::PipelineStageFlags::empty();
 
-    if stage.contains(pso::TOP_OF_PIPE) {
+    if stage.contains(PipelineStage::TOP_OF_PIPE) {
         flags |= vk::PIPELINE_STAGE_TOP_OF_PIPE_BIT;
     }
-    if stage.contains(pso::DRAW_INDIRECT) {
+    if stage.contains(PipelineStage::DRAW_INDIRECT) {
         flags |= vk::PIPELINE_STAGE_DRAW_INDIRECT_BIT;
     }
-    if stage.contains(pso::VERTEX_INPUT) {
+    if stage.contains(PipelineStage::VERTEX_INPUT) {
         flags |= vk::PIPELINE_STAGE_VERTEX_INPUT_BIT;
     }
-    if stage.contains(pso::VERTEX_SHADER) {
+    if stage.contains(PipelineStage::VERTEX_SHADER) {
         flags |= vk::PIPELINE_STAGE_VERTEX_SHADER_BIT;
     }
-    if stage.contains(pso::HULL_SHADER) {
+    if stage.contains(PipelineStage::HULL_SHADER) {
         flags |= vk::PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT;
     }
-    if stage.contains(pso::DOMAIN_SHADER) {
+    if stage.contains(PipelineStage::DOMAIN_SHADER) {
         flags |= vk::PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT;
     }
-    if stage.contains(pso::GEOMETRY_SHADER) {
+    if stage.contains(PipelineStage::GEOMETRY_SHADER) {
         flags |= vk::PIPELINE_STAGE_GEOMETRY_SHADER_BIT;
     }
-    if stage.contains(pso::FRAGMENT_SHADER) {
+    if stage.contains(PipelineStage::FRAGMENT_SHADER) {
         flags |= vk::PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
     }
-    if stage.contains(pso::EARLY_FRAGMENT_TESTS) {
+    if stage.contains(PipelineStage::EARLY_FRAGMENT_TESTS) {
         flags |= vk::PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
     }
-    if stage.contains(pso::LATE_FRAGMENT_TESTS) {
+    if stage.contains(PipelineStage::LATE_FRAGMENT_TESTS) {
         flags |= vk::PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
     }
-    if stage.contains(pso::COLOR_ATTACHMENT_OUTPUT) {
+    if stage.contains(PipelineStage::COLOR_ATTACHMENT_OUTPUT) {
         flags |= vk::PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
     }
-    if stage.contains(pso::COMPUTE_SHADER) {
+    if stage.contains(PipelineStage::COMPUTE_SHADER) {
         flags |= vk::PIPELINE_STAGE_COMPUTE_SHADER_BIT;
     }
-    if stage.contains(pso::TRANSFER) {
+    if stage.contains(PipelineStage::TRANSFER) {
         flags |= vk::PIPELINE_STAGE_TRANSFER_BIT;
     }
-    if stage.contains(pso::BOTTOM_OF_PIPE) {
+    if stage.contains(PipelineStage::BOTTOM_OF_PIPE) {
         flags |= vk::PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
     }
-    if stage.contains(pso::HOST) {
+    if stage.contains(PipelineStage::HOST) {
         flags |= vk::PIPELINE_STAGE_HOST_BIT;
     }
 
@@ -639,33 +643,34 @@ pub fn map_pipeline_stage(stage: pso::PipelineStage) -> vk::PipelineStageFlags {
 }
 
 pub fn map_buffer_usage(usage: buffer::Usage) -> vk::BufferUsageFlags {
+    use self::buffer::Usage;
     let mut flags = vk::BufferUsageFlags::empty();
 
-    if usage.contains(buffer::TRANSFER_SRC) {
+    if usage.contains(Usage::TRANSFER_SRC) {
         flags |= vk::BUFFER_USAGE_TRANSFER_SRC_BIT;
     }
-    if usage.contains(buffer::TRANSFER_DST) {
+    if usage.contains(Usage::TRANSFER_DST) {
         flags |= vk::BUFFER_USAGE_TRANSFER_DST_BIT;
     }
-    if usage.contains(buffer::UNIFORM) {
+    if usage.contains(Usage::UNIFORM) {
         flags |= vk::BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     }
-    if usage.contains(buffer::STORAGE) {
+    if usage.contains(Usage::STORAGE) {
         flags |= vk::BUFFER_USAGE_STORAGE_BUFFER_BIT;
     }
-    if usage.contains(buffer::UNIFORM_TEXEL) {
+    if usage.contains(Usage::UNIFORM_TEXEL) {
         flags |= vk::BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
     }
-    if usage.contains(buffer::STORAGE_TEXEL) {
+    if usage.contains(Usage::STORAGE_TEXEL) {
         flags |= vk::BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
     }
-    if usage.contains(buffer::INDEX) {
+    if usage.contains(Usage::INDEX) {
         flags |= vk::BUFFER_USAGE_INDEX_BUFFER_BIT;
     }
-    if usage.contains(buffer::INDIRECT) {
+    if usage.contains(Usage::INDIRECT) {
         flags |= vk::BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     }
-    if usage.contains(buffer::VERTEX) {
+    if usage.contains(Usage::VERTEX) {
         flags |= vk::BUFFER_USAGE_VERTEX_BUFFER_BIT;
     }
 
@@ -673,24 +678,25 @@ pub fn map_buffer_usage(usage: buffer::Usage) -> vk::BufferUsageFlags {
 }
 
 pub fn map_image_usage(usage: image::Usage) -> vk::ImageUsageFlags {
+    use self::image::Usage;
     let mut flags = vk::ImageUsageFlags::empty();
 
-    if usage.contains(image::TRANSFER_SRC) {
+    if usage.contains(Usage::TRANSFER_SRC) {
         flags |= vk::IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
-    if usage.contains(image::TRANSFER_DST) {
+    if usage.contains(Usage::TRANSFER_DST) {
         flags |= vk::IMAGE_USAGE_TRANSFER_DST_BIT;
     }
-    if usage.contains(image::COLOR_ATTACHMENT) {
+    if usage.contains(Usage::COLOR_ATTACHMENT) {
         flags |= vk::IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     }
-    if usage.contains(image::DEPTH_STENCIL_ATTACHMENT) {
+    if usage.contains(Usage::DEPTH_STENCIL_ATTACHMENT) {
         flags |= vk::IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     }
-    if usage.contains(image::STORAGE) {
+    if usage.contains(Usage::STORAGE) {
         flags |= vk::IMAGE_USAGE_STORAGE_BIT;
     }
-    if usage.contains(image::SAMPLED) {
+    if usage.contains(Usage::SAMPLED) {
         flags |= vk::IMAGE_USAGE_SAMPLED_BIT;
     }
 
@@ -712,29 +718,30 @@ pub fn map_descriptor_type(ty: pso::DescriptorType) -> vk::DescriptorType {
 }
 
 pub fn map_stage_flags(stages: pso::ShaderStageFlags) -> vk::ShaderStageFlags {
+    use self::pso::ShaderStageFlags;
     let mut flags = vk::ShaderStageFlags::empty();
 
-    if stages.contains(pso::STAGE_VERTEX) {
+    if stages.contains(ShaderStageFlags::VERTEX) {
         flags |= vk::SHADER_STAGE_VERTEX_BIT;
     }
 
-    if stages.contains(pso::STAGE_HULL) {
+    if stages.contains(ShaderStageFlags::HULL) {
         flags |= vk::SHADER_STAGE_TESSELLATION_CONTROL_BIT;
     }
 
-    if stages.contains(pso::STAGE_DOMAIN) {
+    if stages.contains(ShaderStageFlags::DOMAIN) {
         flags |= vk::SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
     }
 
-    if stages.contains(pso::STAGE_GEOMETRY) {
+    if stages.contains(ShaderStageFlags::GEOMETRY) {
         flags |= vk::SHADER_STAGE_GEOMETRY_BIT;
     }
 
-    if stages.contains(pso::STAGE_FRAGMENT) {
+    if stages.contains(ShaderStageFlags::FRAGMENT) {
         flags |= vk::SHADER_STAGE_FRAGMENT_BIT;
     }
 
-    if stages.contains(pso::STAGE_COMPUTE) {
+    if stages.contains(ShaderStageFlags::COMPUTE) {
         flags |= vk::SHADER_STAGE_COMPUTE_BIT;
     }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -68,7 +68,7 @@ impl d::Device<B> for Device {
             self.raw.0.allocate_memory(&info, None)
         }.expect("Error on memory allocation"); // TODO: error handling
 
-        let ptr = if memory_type.properties.contains(memory::CPU_VISIBLE) {
+        let ptr = if memory_type.properties.contains(memory::Properties::CPU_VISIBLE) {
             unsafe {
                 self.raw.0.map_memory(
                     memory,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -414,22 +414,23 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             .iter()
             .map(|mem| mem.size).collect();
         let memory_types = mem_properties.memory_types[..mem_properties.memory_type_count as usize].iter().enumerate().map(|(i, mem)| {
-            let mut type_flags = memory::Properties::empty();
+            use memory::Properties;
+            let mut type_flags = Properties::empty();
 
             if mem.property_flags.intersects(vk::MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
-                type_flags |= memory::DEVICE_LOCAL;
+                type_flags |= Properties::DEVICE_LOCAL;
             }
             if mem.property_flags.intersects(vk::MEMORY_PROPERTY_HOST_COHERENT_BIT) {
-                type_flags |= memory::COHERENT;
+                type_flags |= Properties::COHERENT;
             }
             if mem.property_flags.intersects(vk::MEMORY_PROPERTY_HOST_CACHED_BIT) {
-                type_flags |= memory::CPU_CACHED;
+                type_flags |= Properties::CPU_CACHED;
             }
             if mem.property_flags.intersects(vk::MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
-                type_flags |= memory::CPU_VISIBLE;
+                type_flags |= Properties::CPU_VISIBLE;
             }
             if mem.property_flags.intersects(vk::MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) {
-                type_flags |= memory::LAZILY_ALLOCATED;
+                type_flags |= Properties::LAZILY_ALLOCATED;
             }
 
             hal::MemoryType {

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -70,25 +70,6 @@ bitflags!(
     }
 );
 
-///
-pub const TRANSFER_SRC: Usage   = Usage::TRANSFER_SRC;
-///
-pub const TRANSFER_DST: Usage   = Usage::TRANSFER_DST;
-///
-pub const UNIFORM: Usage        = Usage::UNIFORM;
-///
-pub const STORAGE: Usage        = Usage::STORAGE;
-///
-pub const UNIFORM_TEXEL: Usage  = Usage::UNIFORM_TEXEL;
-///
-pub const STORAGE_TEXEL: Usage  = Usage::STORAGE_TEXEL;
-///
-pub const INDEX: Usage          = Usage::INDEX;
-///
-pub const INDIRECT: Usage       = Usage::INDIRECT;
-///
-pub const VERTEX: Usage         = Usage::VERTEX;
-
 impl Usage {
     /// Can this buffer be used in transfer operations ?
     pub fn can_transfer(&self) -> bool {
@@ -126,31 +107,6 @@ bitflags!(
         const MEMORY_WRITE = 0x2000;
     }
 );
-
-///
-pub const TRANSFER_READ: Access             = Access::TRANSFER_READ;
-///
-pub const TRANSFER_WRITE: Access            = Access::TRANSFER_WRITE;
-///
-pub const INDEX_BUFFER_READ: Access         = Access::INDEX_BUFFER_READ;
-///
-pub const VERTEX_BUFFER_READ: Access        = Access::VERTEX_BUFFER_READ;
-///
-pub const CONSTANT_BUFFER_READ: Access      = Access::CONSTANT_BUFFER_READ;
-///
-pub const INDIRECT_COMMAND_READ: Access     = Access::INDIRECT_COMMAND_READ;
-///
-pub const SHADER_READ: Access               = Access::SHADER_READ;
-///
-pub const SHADER_WRITE: Access              = Access::SHADER_WRITE;
-///
-pub const HOST_READ: Access                 = Access::HOST_READ;
-///
-pub const HOST_WRITE: Access                = Access::HOST_WRITE;
-///
-pub const MEMORY_READ: Access               = Access::MEMORY_READ;
-///
-pub const MEMORY_WRITE: Access              = Access::MEMORY_WRITE;
 
 /// Buffer state
 pub type State = Access;

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -559,20 +559,20 @@ bitflags!(
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub struct AspectFlags: u8 {
         /// Color aspect.
-        const ASPECT_COLOR = 0x1;
+        const COLOR = 0x1;
         /// Depth aspect.
-        const ASPECT_DEPTH = 0x2;
+        const DEPTH = 0x2;
         /// Stencil aspect.
-        const ASPECT_STENCIL = 0x4;
+        const STENCIL = 0x4;
     }
 );
 
 /// Color aspect.
-pub const ASPECT_COLOR: AspectFlags = AspectFlags::ASPECT_COLOR;
+pub const ASPECT_COLOR: AspectFlags = AspectFlags::COLOR;
 /// Depth aspect.
-pub const ASPECT_DEPTH: AspectFlags = AspectFlags::ASPECT_DEPTH;
+pub const ASPECT_DEPTH: AspectFlags = AspectFlags::DEPTH;
 /// Stencil aspect.
-pub const ASPECT_STENCIL: AspectFlags = AspectFlags::ASPECT_STENCIL;
+pub const ASPECT_STENCIL: AspectFlags = AspectFlags::STENCIL;
 
 bitflags!(
     ///

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -349,19 +349,6 @@ bitflags!(
     }
 );
 
-///
-pub const TRANSFER_SRC: Usage = Usage::TRANSFER_SRC;
-///
-pub const TRANSFER_DST: Usage = Usage::TRANSFER_DST;
-///
-pub const COLOR_ATTACHMENT: Usage = Usage::COLOR_ATTACHMENT;
-///
-pub const DEPTH_STENCIL_ATTACHMENT: Usage = Usage::DEPTH_STENCIL_ATTACHMENT;
-///
-pub const STORAGE: Usage = Usage::STORAGE;
-///
-pub const SAMPLED: Usage = Usage::SAMPLED;
-
 impl Usage {
     /// Can this image be used in transfer operations ?
     pub fn can_transfer(&self) -> bool {
@@ -501,13 +488,6 @@ bitflags!(
     }
 );
 
-///
-pub const RO_DEPTH: DepthStencilFlags = DepthStencilFlags::RO_DEPTH;
-///
-pub const RO_STENCIL: DepthStencilFlags = DepthStencilFlags::RO_STENCIL;
-///
-pub const RO_DEPTH_STENCIL: DepthStencilFlags = DepthStencilFlags::RO_DEPTH_STENCIL;
-
 /// Texture depth-stencil view descriptor.
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -567,13 +547,6 @@ bitflags!(
     }
 );
 
-/// Color aspect.
-pub const ASPECT_COLOR: AspectFlags = AspectFlags::COLOR;
-/// Depth aspect.
-pub const ASPECT_DEPTH: AspectFlags = AspectFlags::DEPTH;
-/// Stencil aspect.
-pub const ASPECT_STENCIL: AspectFlags = AspectFlags::STENCIL;
-
 bitflags!(
     ///
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
@@ -607,34 +580,6 @@ bitflags!(
         const INPUT_ATTACHMENT_READ = 0x1000;
     }
 );
-
-/// Read state but can only be combined with `COLOR_ATTACHMENT_WRITE`.
-pub const COLOR_ATTACHMENT_READ: Access = Access::COLOR_ATTACHMENT_READ;
-/// Write-only state but can be combined with `COLOR_ATTACHMENT_READ`.
-pub const COLOR_ATTACHMENT_WRITE: Access = Access::COLOR_ATTACHMENT_WRITE;
-///
-pub const TRANSFER_READ: Access = Access::TRANSFER_READ;
-/// Write-only state of copy commands.
-pub const TRANSFER_WRITE: Access = Access::TRANSFER_WRITE;
-/// Read-only state for SRV access, or combine with `SHADER_WRITE` to have r/w access to UAV.
-pub const SHADER_READ: Access = Access::SHADER_READ;
-/// Write state for UAV access.
-/// Combine with `SHADER_READ` to have r/w access to UAV.
-pub const SHADER_WRITE: Access = Access::SHADER_WRITE;
-///
-pub const DEPTH_STENCIL_ATTACHMENT_READ: Access = Access::DEPTH_STENCIL_ATTACHMENT_READ;
-/// Write-only state for depth stencil writes.
-pub const DEPTH_STENCIL_ATTACHMENT_WRITE: Access = Access::DEPTH_STENCIL_ATTACHMENT_WRITE;
-///
-pub const HOST_READ: Access = Access::HOST_READ;
-///
-pub const HOST_WRITE: Access = Access::HOST_WRITE;
-///
-pub const MEMORY_READ: Access = Access::MEMORY_READ;
-///
-pub const MEMORY_WRITE: Access = Access::MEMORY_WRITE;
-///
-pub const INPUT_ATTACHMENT_READ: Access = Access::INPUT_ATTACHMENT_READ;
 
 /// Image state
 pub type State = (Access, ImageLayout);

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -62,17 +62,6 @@ bitflags!(
     }
 );
 
-///
-pub const DEVICE_LOCAL: Properties = Properties::DEVICE_LOCAL;
-///
-pub const COHERENT: Properties = Properties::COHERENT;
-///
-pub const CPU_VISIBLE: Properties = Properties::CPU_VISIBLE;
-///
-pub const CPU_CACHED: Properties = Properties::CPU_CACHED;
-///
-pub const LAZILY_ALLOCATED: Properties = Properties::LAZILY_ALLOCATED;
-
 #[allow(missing_docs)] //TODO
 #[derive(Clone, Debug)]
 pub enum Barrier<'a, B: Backend> {

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -124,41 +124,41 @@ bitflags!(
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
     pub struct ShaderStageFlags: u16 {
         /// Vertex shader stage.
-        const STAGE_VERTEX   = 0x1;
+        const VERTEX   = 0x1;
         /// Hull (tessellation) shader stage.
-        const STAGE_HULL     = 0x2;
+        const HULL     = 0x2;
         /// Domain (tessellation) shader stage.
-        const STAGE_DOMAIN   = 0x4;
+        const DOMAIN   = 0x4;
         /// Geometry shader stage.
-        const STAGE_GEOMETRY = 0x8;
+        const GEOMETRY = 0x8;
         /// Fragment shader stage.
-        const STAGE_FRAGMENT = 0x10;
+        const FRAGMENT = 0x10;
         /// Compute shader stage.
-        const STAGE_COMPUTE  = 0x20;
+        const COMPUTE  = 0x20;
         /// All graphics pipeline shader stages.
-        const STAGE_GRAPHICS = Self::STAGE_VERTEX.bits | Self::STAGE_HULL.bits |
-            Self::STAGE_DOMAIN.bits | Self::STAGE_GEOMETRY.bits | Self::STAGE_FRAGMENT.bits;
+        const GRAPHICS = Self::VERTEX.bits | Self::HULL.bits |
+            Self::DOMAIN.bits | Self::GEOMETRY.bits | Self::FRAGMENT.bits;
         /// All shader stages.
-        const STAGE_ALL      = Self::STAGE_GRAPHICS.bits | Self::STAGE_COMPUTE.bits;
+        const ALL      = Self::GRAPHICS.bits | Self::COMPUTE.bits;
     }
 );
 
 ///
-pub const STAGE_VERTEX: ShaderStageFlags = ShaderStageFlags::STAGE_VERTEX;
+pub const STAGE_VERTEX: ShaderStageFlags = ShaderStageFlags::VERTEX;
 ///
-pub const STAGE_HULL: ShaderStageFlags = ShaderStageFlags::STAGE_HULL;
+pub const STAGE_HULL: ShaderStageFlags = ShaderStageFlags::HULL;
 ///
-pub const STAGE_DOMAIN: ShaderStageFlags = ShaderStageFlags::STAGE_DOMAIN;
+pub const STAGE_DOMAIN: ShaderStageFlags = ShaderStageFlags::DOMAIN;
 ///
-pub const STAGE_GEOMETRY: ShaderStageFlags = ShaderStageFlags::STAGE_GEOMETRY;
+pub const STAGE_GEOMETRY: ShaderStageFlags = ShaderStageFlags::GEOMETRY;
 ///
-pub const STAGE_FRAGMENT: ShaderStageFlags = ShaderStageFlags::STAGE_FRAGMENT;
+pub const STAGE_FRAGMENT: ShaderStageFlags = ShaderStageFlags::FRAGMENT;
 ///
-pub const STAGE_COMPUTE: ShaderStageFlags = ShaderStageFlags::STAGE_COMPUTE;
+pub const STAGE_COMPUTE: ShaderStageFlags = ShaderStageFlags::COMPUTE;
 ///
-pub const STAGE_GRAPHICS: ShaderStageFlags = ShaderStageFlags::STAGE_GRAPHICS;
+pub const STAGE_GRAPHICS: ShaderStageFlags = ShaderStageFlags::GRAPHICS;
 ///
-pub const STAGE_ALL: ShaderStageFlags = ShaderStageFlags::STAGE_ALL;
+pub const STAGE_ALL: ShaderStageFlags = ShaderStageFlags::ALL;
 
 //Note: this type is only needed for backends, not used anywhere within gfx_core.
 /// Which program stage this shader represents.

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -88,37 +88,6 @@ bitflags!(
     }
 );
 
-///
-pub const TOP_OF_PIPE: PipelineStage = PipelineStage::TOP_OF_PIPE;
-///
-pub const DRAW_INDIRECT: PipelineStage = PipelineStage::DRAW_INDIRECT;
-///
-pub const VERTEX_INPUT: PipelineStage = PipelineStage::VERTEX_INPUT;
-///
-pub const VERTEX_SHADER: PipelineStage = PipelineStage::VERTEX_SHADER;
-///
-pub const HULL_SHADER: PipelineStage = PipelineStage::HULL_SHADER;
-///
-pub const DOMAIN_SHADER: PipelineStage = PipelineStage::DOMAIN_SHADER;
-///
-pub const GEOMETRY_SHADER: PipelineStage = PipelineStage::GEOMETRY_SHADER;
-///
-pub const FRAGMENT_SHADER: PipelineStage = PipelineStage::FRAGMENT_SHADER;
-///
-pub const EARLY_FRAGMENT_TESTS: PipelineStage = PipelineStage::EARLY_FRAGMENT_TESTS;
-///
-pub const LATE_FRAGMENT_TESTS: PipelineStage = PipelineStage::LATE_FRAGMENT_TESTS;
-///
-pub const COLOR_ATTACHMENT_OUTPUT: PipelineStage = PipelineStage::COLOR_ATTACHMENT_OUTPUT;
-///
-pub const COMPUTE_SHADER: PipelineStage = PipelineStage::COMPUTE_SHADER;
-///
-pub const TRANSFER: PipelineStage = PipelineStage::TRANSFER;
-///
-pub const BOTTOM_OF_PIPE: PipelineStage = PipelineStage::BOTTOM_OF_PIPE;
-///
-pub const HOST: PipelineStage = PipelineStage::HOST;
-
 bitflags!(
     /// Combination of different shader pipeline stages.
     #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
@@ -142,23 +111,6 @@ bitflags!(
         const ALL      = Self::GRAPHICS.bits | Self::COMPUTE.bits;
     }
 );
-
-///
-pub const STAGE_VERTEX: ShaderStageFlags = ShaderStageFlags::VERTEX;
-///
-pub const STAGE_HULL: ShaderStageFlags = ShaderStageFlags::HULL;
-///
-pub const STAGE_DOMAIN: ShaderStageFlags = ShaderStageFlags::DOMAIN;
-///
-pub const STAGE_GEOMETRY: ShaderStageFlags = ShaderStageFlags::GEOMETRY;
-///
-pub const STAGE_FRAGMENT: ShaderStageFlags = ShaderStageFlags::FRAGMENT;
-///
-pub const STAGE_COMPUTE: ShaderStageFlags = ShaderStageFlags::COMPUTE;
-///
-pub const STAGE_GRAPHICS: ShaderStageFlags = ShaderStageFlags::GRAPHICS;
-///
-pub const STAGE_ALL: ShaderStageFlags = ShaderStageFlags::ALL;
 
 //Note: this type is only needed for backends, not used anywhere within gfx_core.
 /// Which program stage this shader represents.

--- a/src/render/src/buffer.rs
+++ b/src/render/src/buffer.rs
@@ -4,10 +4,7 @@ use {hal, handle};
 use memory::{Memory, Pod};
 use Backend;
 
-pub use hal::buffer::{CreationError, ViewError};
-pub use hal::buffer::{Usage,
-    TRANSFER_SRC, TRANSFER_DST, UNIFORM, INDEX, INDIRECT, VERTEX
-};
+pub use hal::buffer::{CreationError, Usage, ViewError};
 
 /// An information block that is immutable and associated to each buffer.
 #[derive(Debug)]

--- a/src/render/src/image.rs
+++ b/src/render/src/image.rs
@@ -6,11 +6,6 @@ pub use hal::image::{
     AspectFlags, SamplerInfo, ViewError, Usage,
     Subresource, SubresourceLayers, SubresourceRange,
 };
-pub use hal::image::{
-    TRANSFER_SRC, TRANSFER_DST,
-    COLOR_ATTACHMENT, DEPTH_STENCIL_ATTACHMENT,
-    SAMPLED,
-};
 
 #[allow(missing_docs)]
 #[derive(Debug)]

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -35,7 +35,7 @@
 //! - The [`CommandBuffer` trait](trait.CommandBuffer.html).
 //! - The [`CommandQueue` struct](struct.CommandQueue.html).
 //!
-//! ## Devoce
+//! ## Device
 //!
 //! The device is what lets you allocate GPU resources such as buffers and textures.
 //!
@@ -266,8 +266,8 @@ impl<B: Backend, C> Context<B, C>
                 let handle = handle::inner::Image::without_garbage(
                     raw,
                     image::Info {
-                        aspects: hal::image::ASPECT_COLOR,
-                        usage: image::TRANSFER_SRC | image::COLOR_ATTACHMENT,
+                        aspects: hal::image::AspectFlags::COLOR,
+                        usage: image::Usage::TRANSFER_SRC | image::Usage::COLOR_ATTACHMENT,
                         kind: surface.get_kind(),
                         mip_levels: 1,
                         format: Cf::SELF,
@@ -346,7 +346,7 @@ impl<B: Backend, C> Context<B, C>
 
         {
             let submission = hal::Submission::new()
-                .wait_on(&[(&bundle.wait_semaphore, hal::pso::BOTTOM_OF_PIPE)])
+                .wait_on(&[(&bundle.wait_semaphore, hal::pso::PipelineStage::BOTTOM_OF_PIPE)])
                 .signal(&[&bundle.signal_semaphore])
                 .promote::<C>()
                 .submit(&inner_submits);

--- a/src/render/src/macros.rs
+++ b/src/render/src/macros.rs
@@ -272,7 +272,7 @@ macro_rules! gfx_graphics_pipeline {
                             encoder.handles());
                     )*
                     encoder.require_state(
-                        cpso::VERTEX_INPUT,
+                        cpso::PipelineStage::VERTEX_INPUT,
                         &buffer_states[..],
                         &image_states[..]
                     );

--- a/src/render/src/pso.rs
+++ b/src/render/src/pso.rs
@@ -112,7 +112,7 @@ impl<B: Backend> Bind<B> for SampledImage {
         let img = view.info();
         let levels = img.info().mip_levels;
         let layers = img.info().kind.get_num_layers();
-        let state = (image::SHADER_READ, ImageLayout::ShaderReadOnlyOptimal);
+        let state = (image::Access::SHADER_READ, ImageLayout::ShaderReadOnlyOptimal);
         for level in 0..levels {
             for layer in 0..layers {
                 images.push((img, (level, layer), state));
@@ -290,7 +290,7 @@ impl<'a, B, F> Component<'a, B> for RenderTarget<F>
         let levels = img.info().mip_levels;
         let layers = img.info().kind.get_num_layers();
         // TODO: READ not always necessary
-        let state = (image::COLOR_ATTACHMENT_READ | image::COLOR_ATTACHMENT_WRITE,
+        let state = (image::Access::COLOR_ATTACHMENT_READ | image::Access::COLOR_ATTACHMENT_WRITE,
             ImageLayout::ColorAttachmentOptimal);
         for level in 0..levels {
             for layer in 0..layers {
@@ -364,7 +364,7 @@ impl<'a, B, T, I> Component<'a, B> for VertexBuffer<T, I>
         _: &mut Vec<(&'b handle::raw::Image<B>, image::Subresource, hal::image::State)>,
         _: &mut handle::Bag<B>,
     ) where 'a: 'b {
-        buffers.push((data.as_ref(), hal::buffer::VERTEX_BUFFER_READ));
+        buffers.push((data.as_ref(), hal::buffer::Access::VERTEX_BUFFER_READ));
     }
 
     fn vertex_buffer<'b>(data: &'b Self::Data) -> Option<(&'b B::Buffer, hal::pso::BufferOffset)>


### PR DESCRIPTION
Started work on #1579 

Crates updated:

- [x] hal
- [x] render
- [x] backend/gl
- [x] backend/vulkan
- [x] backend/dx12 (haven't been able to check if it compiles)
- [x] backend/metal
- [ ] ~~backend/dx11~~
- [x] examples/hal/quad
- [x] examples/render/quad_render

I haven't changed hal yet because it will break the backends that I haven't been able to update (can't build metal/dx11/dx12 on my computer).

I've avoided renaming anything but there are a few cases that I think could be changed:

- `image::Access` -> `ImageAccess`
- `buffer::Access` -> `BufferAccess`
- `image::Usage` -> `ImageUsage`
- `buffer::Usage` -> `BufferUsage` (these first four are to avoid confusion and allow the imports of both the image and buffer variants in cases where they get used together. Alternatively, they can be left as-is and instead some files could use `use image::Access as ImageAccess;`, etc.)
- Remove `ASPECT_` prefix from `image::AspectFlags::*`
- Remove `STAGE_` prefix from `pso::ShaderStageFlags::*`