### PR TITLE
[RFC] Warden test framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "src/backend/metal",
     "src/backend/vulkan",
     "src/hal",
+    "src/warden",
     "src/render",
     "examples/hal/quad",
     "examples/render/quad_render",

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 RUST_BACKTRACE:=1
 EXCLUDES:=
+FEATURES_WARDEN:=
 FEATURES_RENDER:=
 FEATURES_RENDER_ADD:= mint serialize
 FEATURES_QUAD:=
@@ -14,12 +15,14 @@ SDL2_PPA=http://ppa.launchpad.net/zoogie/sdl2-snapshots/ubuntu/pool/main/libs/li
 ifeq ($(OS),Windows_NT)
 	EXCLUDES+= --exclude gfx-backend-metal
 	FEATURES_QUAD=vulkan
+	FEATURES_WARDEN+=vulkan
 	ifeq ($(TARGET),x86_64-pc-windows-gnu)
 		# No d3d12 support on GNU windows ATM
 		# context: https://github.com/gfx-rs/gfx/pull/1417
 		EXCLUDES+= --exclude gfx-backend-dx12
 	else
 		FEATURES_QUAD2=dx12
+		FEATURES_WARDEN+=dx12
 	endif
 else
 	UNAME_S:=$(shell uname -s)
@@ -28,11 +31,13 @@ else
 	ifeq ($(UNAME_S),Linux)
 		EXCLUDES+= --exclude gfx-backend-metal
 		FEATURES_QUAD=vulkan
+		FEATURES_WARDEN+=vulkan
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		EXCLUDES+= --exclude gfx-backend-vulkan
 		EXCLUDES+= --exclude quad-render
 		FEATURES_QUAD=metal
+		FEATURES_WARDEN+=metal
 		CMD_QUAD_RENDER=pwd
 	endif
 endif
@@ -50,7 +55,7 @@ warden:
 	cd src/warden && cargo test
 
 reftests: warden
-	cd src/warden && cargo run --bin reftest
+	cd src/warden && cargo run --bin reftest --features "$(FEATURES_WARDEN)"
 
 render:
 	cd src/render && cargo test --features "$(FEATURES_RENDER)"

--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,19 @@ else
 endif
 
 
-.PHONY: all check ex-hal-quad render ex-render-quad travis-sdl2
+.PHONY: all check ex-hal-quad warden reftest render ex-render-quad travis-sdl2
 
-all: check ex-hal-quad render ex-render-quad
+all: check ex-hal-quad warden render ex-render-quad
 
 check:
 	cargo check --all $(EXCLUDES)
 	cargo test --all $(EXCLUDES)
+
+warden:
+	cd src/warden && cargo test
+
+reftest: warden
+	cd src/warden && cargo run --bin reftest
 
 render:
 	cd src/render && cargo test --features "$(FEATURES_RENDER)"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ else
 endif
 
 
-.PHONY: all check ex-hal-quad warden reftest render ex-render-quad travis-sdl2
+.PHONY: all check ex-hal-quad warden reftests render ex-render-quad travis-sdl2
 
 all: check ex-hal-quad warden render ex-render-quad
 
@@ -49,7 +49,7 @@ check:
 warden:
 	cd src/warden && cargo test
 
-reftest: warden
+reftests: warden
 	cd src/warden && cargo run --bin reftest
 
 render:

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -190,7 +190,7 @@ fn main() {
             accesses: i::Access::empty() .. (i::COLOR_ATTACHMENT_READ | i::COLOR_ATTACHMENT_WRITE),
         };
 
-        device.create_renderpass(&[attachment], &[subpass], &[dependency])
+        device.create_render_pass(&[attachment], &[subpass], &[dependency])
     };
 
     //

--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -44,15 +44,14 @@
 		),
 	},
 	jobs: {
-		"test": Graphics(
+		"empty": Graphics(
 			descriptors: {},
 			framebuffer: "fbo",
+			clear_values: [
+				Color(Float((0.8, 0.8, 0.8, 1.0))),
+			],
 			pass: ("pass", {
 				"main": (commands: [
-					//Draw(
-					//	vertices: (start: 0, end: 4),
-					//	instances: (start: 0, end: 1),
-					//),
 				]),
 			}),
 		),

--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -49,10 +49,10 @@
 			framebuffer: "fbo",
 			pass: ("pass", {
 				"main": (commands: [
-					Draw(
-						vertices: (start: 0, end: 4),
-						instances: (start: 0, end: 1),
-					),
+					//Draw(
+					//	vertices: (start: 0, end: 4),
+					//	instances: (start: 0, end: 1),
+					//),
 				]),
 			}),
 		),

--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -1,0 +1,47 @@
+(
+	resources: {
+		"im-color": Image(
+			kind: D2(1, 1, Single),
+			num_levels: 1,
+			format: (R8_G8_B8_A8, Unorm),
+			usage: (bits: 4),
+			memory: Device,
+		),
+		"pass": RenderPass(
+			attachments: {
+				"color": (
+					format: (R8_G8_B8_A8, Unorm),
+					ops: (load: Clear, store: Store),
+					layouts: (start: General, end: General),
+				),
+			},
+			subpasses: {
+				"main": (
+					colors: [("color", General)],
+				)
+			},
+			dependencies: [],
+		),
+		"im-color-view": ImageView(
+			image: "im-color",
+			format: (R8_G8_B8_A8, Unorm),
+			range: (
+				aspects: (bits: 1),
+				levels: (start: 0, end: 1),
+				layers: (start: 0, end: 1),
+			),
+		),
+		"fbo": Framebuffer(
+			pass: "pass",
+			views: {
+				"color": "im-color-view"
+			},
+			extent: (
+				width: 1,
+				height: 1,
+				depth: 1,
+			),
+		),
+	},
+	jobs: {},
+)

--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -5,11 +5,10 @@
 			num_levels: 1,
 			format: (R8_G8_B8_A8, Unorm),
 			usage: (bits: 4),
-			memory: Device,
 		),
 		"pass": RenderPass(
 			attachments: {
-				"color": (
+				"c": (
 					format: (R8_G8_B8_A8, Unorm),
 					ops: (load: Clear, store: Store),
 					layouts: (start: General, end: General),
@@ -17,7 +16,8 @@
 			},
 			subpasses: {
 				"main": (
-					colors: [("color", General)],
+					colors: [("c", General)],
+					depth_stencil: None,
 				)
 			},
 			dependencies: [],
@@ -34,7 +34,7 @@
 		"fbo": Framebuffer(
 			pass: "pass",
 			views: {
-				"color": "im-color-view"
+				"c": "im-color-view"
 			},
 			extent: (
 				width: 1,
@@ -43,5 +43,18 @@
 			),
 		),
 	},
-	jobs: {},
+	jobs: {
+		"test": Graphics(
+			descriptors: {},
+			framebuffer: "fbo",
+			pass: ("pass", {
+				"main": (commands: [
+					Draw(
+						vertices: (start: 0, end: 4),
+						instances: (start: 0, end: 1),
+					),
+				]),
+			}),
+		),
+	},
 )

--- a/reftests/suite.ron
+++ b/reftests/suite.ron
@@ -1,0 +1,8 @@
+{
+	"basic": {
+		"render-pass-clear": (
+			jobs: ["empty"],
+			expect: ImageRow("im-color", 0, [204,204,204,255])
+		),
+	},
+}

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -423,7 +423,7 @@ pub fn map_buffer_resource_state(access: buffer::Access) -> D3D12_RESOURCE_STATE
     let mut state = D3D12_RESOURCE_STATE_COMMON;
 
     if access.contains(buffer::TRANSFER_READ) {
-        state = state | D3D12_RESOURCE_STATE_COPY_SOURCE | D3D12_RESOURCE_STATE_RESOLVE_DEST;
+        state = state | D3D12_RESOURCE_STATE_COPY_SOURCE;
     }
     if access.contains(buffer::INDEX_BUFFER_READ) {
         state = state | D3D12_RESOURCE_STATE_INDEX_BUFFER;
@@ -472,7 +472,7 @@ pub fn map_image_resource_state(access: image::Access, layout: image::ImageLayou
     let mut state = D3D12_RESOURCE_STATE_COMMON;
 
     if access.contains(image::TRANSFER_READ) {
-        state = state | D3D12_RESOURCE_STATE_COPY_SOURCE | D3D12_RESOURCE_STATE_RESOLVE_DEST;
+        state = state | D3D12_RESOURCE_STATE_COPY_SOURCE;
     }
     if access.contains(image::INPUT_ATTACHMENT_READ) {
         state = state | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -427,7 +427,7 @@ impl d::Device<B> for Device {
         })
     }
 
-    fn create_renderpass(
+    fn create_render_pass(
         &mut self,
         attachments: &[pass::Attachment],
         subpasses: &[pass::SubpassDesc],

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -585,7 +585,9 @@ impl Instance {
     }
 }
 
-impl core::Instance<Backend> for Instance {
+impl core::Instance for Instance {
+    type Backend = Backend;
+
     fn enumerate_adapters(&self) -> Vec<Adapter> {
         // Enumerate adapters
         let mut cur_index = 0;

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -88,7 +88,7 @@ impl core::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_renderpass(&mut self, _: &[pass::Attachment], _: &[pass::SubpassDesc], _: &[pass::SubpassDependency]) -> () {
+    fn create_render_pass(&mut self, _: &[pass::Attachment], _: &[pass::SubpassDesc], _: &[pass::SubpassDependency]) -> () {
         unimplemented!()
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -562,7 +562,8 @@ impl core::Swapchain<Backend> for Swapchain {
 }
 
 pub struct Instance;
-impl core::Instance<Backend> for Instance {
+impl core::Instance for Instance {
+    type Backend = Backend;
     fn enumerate_adapters(&self) -> Vec<Adapter> {
         Vec::new()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -159,7 +159,7 @@ impl d::Device<B> for Device {
         })
     }
 
-    fn create_renderpass(
+    fn create_render_pass(
         &mut self,
         attachments: &[pass::Attachment],
         subpasses: &[pass::SubpassDesc],

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -143,7 +143,8 @@ pub fn config_context(
 
 pub struct Headless(pub glutin::HeadlessContext);
 
-impl core::Instance<B> for Headless {
+impl core::Instance for Headless {
+    type Backend = B;
     fn enumerate_adapters(&self) -> Vec<Adapter> {
         unsafe { self.0.make_current().unwrap() };
         let adapter = Adapter::new(|s| self.0.get_proc_address(s) as *const _);

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -113,7 +113,8 @@ impl core::Surface<B> for Surface {
     }
 }
 
-impl core::Instance<B> for Surface {
+impl core::Instance for Surface {
+    type Backend = B;
     fn enumerate_adapters(&self) -> Vec<Adapter> {
         unsafe { self.window.make_current().unwrap() };
         let adapter = Adapter::new(|s| self.window.get_proc_address(s) as *const _);

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -466,7 +466,7 @@ impl core::Device<Backend> for Device {
         &self.limits
     }
 
-    fn create_renderpass(
+    fn create_render_pass(
         &mut self,
         attachments: &[pass::Attachment],
         _subpasses: &[pass::SubpassDesc],

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -39,7 +39,9 @@ use core_graphics::geometry::CGRect;
 pub struct Instance {
 }
 
-impl core::Instance<Backend> for Instance {
+impl core::Instance for Instance {
+    type Backend = Backend;
+
     fn enumerate_adapters(&self) -> Vec<Adapter> {
         // TODO: enumerate all devices
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -82,7 +82,7 @@ impl d::Device<B> for Device {
         Ok(n::Memory { inner: memory, ptr })
     }
 
-    fn create_renderpass(&mut self, attachments: &[pass::Attachment],
+    fn create_render_pass(&mut self, attachments: &[pass::Attachment],
         subpasses: &[pass::SubpassDesc], dependencies: &[pass::SubpassDependency]) -> n::RenderPass
     {
         let map_subpass_ref = |pass: pass::SubpassRef| {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -235,7 +235,9 @@ impl Instance {
     }
 }
 
-impl core::Instance<Backend> for Instance {
+impl core::Instance for Instance {
+    type Backend = Backend;
+
     fn enumerate_adapters(&self) -> Vec<Adapter> {
         self.raw.0.enumerate_physical_devices()
             .expect("Unable to enumerate adapter")

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -124,7 +124,7 @@ pub trait Device<B: Backend>: Clone {
     fn allocate_memory(&mut self, &MemoryType, size: u64) -> Result<B::Memory, OutOfMemory>;
 
     ///
-    fn create_renderpass(
+    fn create_render_pass(
         &mut self,
         &[pass::Attachment],
         &[pass::SubpassDesc],

--- a/src/hal/src/format.rs
+++ b/src/hal/src/format.rs
@@ -276,6 +276,12 @@ impl Swizzle {
     pub const NO: Swizzle = Swizzle(Component::R, Component::G, Component::B, Component::A);
 }
 
+impl Default for Swizzle {
+    fn default() -> Self {
+        Self::NO
+    }
+}
+
 /// Complete run-time surface format.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -236,9 +236,11 @@ pub struct MemoryType {
 }
 
 /// Basic backend instance trait.
-pub trait Instance<B: Backend> {
+pub trait Instance {
+    /// Associated backend type of this instance.
+    type Backend: Backend;
     /// Enumerate all available adapters.
-    fn enumerate_adapters(&self) -> Vec<B::Adapter>;
+    fn enumerate_adapters(&self) -> Vec<<Self::Backend as Backend>::Adapter>;
 }
 
 /// Different types of a specific API.

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -54,6 +54,10 @@ impl AttachmentOps {
             store,
         }
     }
+
+    fn whatever() -> Self {
+        Self::DONT_CARE
+    }
 }
 
 ///
@@ -65,6 +69,7 @@ pub struct Attachment {
     /// Load and store operations of the attachment
     pub ops: AttachmentOps,
     /// Load and store operations of the stencil aspect, if any
+    #[cfg_attr(feature = "serialize", serde(default = "AttachmentOps::whatever"))]
     pub stencil_ops: AttachmentOps,
     /// Initial and final image layouts of the renderpass.
     pub layouts: Range<AttachmentLayout>,

--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -96,7 +96,7 @@ impl<B: Backend, C> CommandPool<B, C> {
     /// You can only record to one command buffer per pool at the same time.
     /// If more command buffers are requested than allocated, new buffers will be reserved.
     /// The command buffer will be returned in 'recording' state.
-    pub fn acquire_command_buffer<'a>(&'a mut self) -> CommandBuffer<'a, B, C> {
+    pub fn acquire_command_buffer(&mut self) -> CommandBuffer<B, C> {
         self.reserve(1);
 
         let buffer = &mut self.buffers[self.next_buffer];

--- a/src/hal/src/pso/input_assembler.rs
+++ b/src/hal/src/pso/input_assembler.rs
@@ -90,7 +90,7 @@ pub struct VertexBufferSet<'a, B: Backend>(
 
 impl<'a, B: Backend> VertexBufferSet<'a, B> {
     /// Create an empty set
-    pub fn new() -> VertexBufferSet<'a, B> {
+    pub fn new() -> Self {
         VertexBufferSet(Vec::new())
     }
 }

--- a/src/render/src/allocators/stack.rs
+++ b/src/render/src/allocators/stack.rs
@@ -68,7 +68,7 @@ impl<B: Backend> Allocator<B> for StackAllocator<B> {
             device.mut_raw(), &buffer, usage);
         let memory_type = device.find_usage_memory(inner.usage, requirements.type_mask)
             .expect("could not find suitable memory");
-        let mut stack = inner.stacks.entry(memory_type.id)
+        let stack = inner.stacks.entry(memory_type.id)
             .or_insert_with(|| ChunkStack::new(memory_type));
         let (memory, offset, release) = stack.allocate(
             device,
@@ -91,7 +91,7 @@ impl<B: Backend> Allocator<B> for StackAllocator<B> {
         let requirements = device.mut_raw().get_image_requirements(&image);
         let memory_type = device.find_usage_memory(inner.usage, requirements.type_mask)
             .expect("could not find suitable memory");
-        let mut stack = inner.stacks.entry(memory_type.id)
+        let stack = inner.stacks.entry(memory_type.id)
             .or_insert_with(|| ChunkStack::new(memory_type));
         let (memory, offset, release) = stack.allocate(
             device,

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -414,13 +414,13 @@ impl<B: Backend> Device<B> {
     }
 
     #[doc(hidden)]
-    pub fn create_renderpass_raw(
+    pub fn create_render_pass_raw(
         &mut self,
         attachments: &[core::pass::Attachment],
         subpasses: &[core::pass::SubpassDesc],
         dependencies: &[core::pass::SubpassDependency],
     ) -> handle::raw::RenderPass<B> {
-        let pass = self.raw.create_renderpass(attachments, subpasses, dependencies);
+        let pass = self.raw.create_render_pass(attachments, subpasses, dependencies);
         RenderPass::new(pass, (), self.garbage.clone()).into()
     }
 

--- a/src/render/src/macros.rs
+++ b/src/render/src/macros.rs
@@ -224,7 +224,7 @@ macro_rules! gfx_graphics_pipeline {
                             preserves: &[],
                         };
 
-                        device.create_renderpass_raw(&attachments[..], &[subpass], &[])
+                        device.create_render_pass_raw(&attachments[..], &[subpass], &[])
                     };
 
                     let mut pipeline_desc = cpso::GraphicsPipelineDesc::new(

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "gfx-warden"
+version = "0.1.0"
+description = "gfx-rs reftest framework"
+homepage = "https://github.com/gfx-rs/gfx"
+repository = "https://github.com/gfx-rs/gfx"
+keywords = ["graphics", "gamedev"]
+license = "Apache-2.0"
+authors = ["The Gfx-rs Developers"]
+readme = "../../README.md"
+documentation = "https://docs.rs/gfx-render"
+categories = ["rendering::graphics-api"]
+workspace = "../.."
+
+[lib]
+name = "gfx_warden"
+path = "src/lib.rs"
+
+[features]
+default = []
+
+#TODO: keep Warden backend-agnostic?
+
+[dependencies]
+gfx-backend-vulkan = { path = "../backend/vulkan", version = "0.1" }
+gfx-hal = { path = "../hal", version = "0.1", features = ["serialize"] }
+#log = "0.3"
+ron = "0.1"
+serde = { version = "1.0", features = ["serde_derive"] }

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
+logger = ["env_logger"]
 vulkan = ["gfx-backend-vulkan"]
 dx12 = ["gfx-backend-dx12"]
 metal = ["gfx-backend-metal"]
@@ -26,9 +27,10 @@ metal = ["gfx-backend-metal"]
 
 [dependencies]
 gfx-hal = { path = "../hal", version = "0.1", features = ["serialize"] }
-#log = "0.3"
+log = "0.3"
 ron = "0.1"
 serde = { version = "1.0", features = ["serde_derive"] }
+env_logger = { version = "0.4", optional = true }
 
 [dependencies.gfx-backend-vulkan]
 path = "../../src/backend/vulkan"

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -18,12 +18,29 @@ path = "src/lib.rs"
 
 [features]
 default = []
+vulkan = ["gfx-backend-vulkan"]
+dx12 = ["gfx-backend-dx12"]
+metal = ["gfx-backend-metal"]
 
 #TODO: keep Warden backend-agnostic?
 
 [dependencies]
-gfx-backend-vulkan = { path = "../backend/vulkan", version = "0.1" }
 gfx-hal = { path = "../hal", version = "0.1", features = ["serialize"] }
 #log = "0.3"
 ron = "0.1"
 serde = { version = "1.0", features = ["serde_derive"] }
+
+[dependencies.gfx-backend-vulkan]
+path = "../../src/backend/vulkan"
+version = "0.1"
+optional = true
+
+[target.'cfg(windows)'.dependencies.gfx-backend-dx12]
+path = "../../src/backend/dx12"
+version = "0.1"
+optional = true
+
+[target.'cfg(target_os = "macos")'.dependencies.gfx-backend-metal]
+path = "../../src/backend/metal"
+version = "0.1"
+optional = true

--- a/src/warden/README.md
+++ b/src/warden/README.md
@@ -1,8 +1,8 @@
 # Warden
 
-Warden is the data-driver reference test framework for gfx-rs Hardware Abstraction Layer (gfx-hal), heavily inspired by the Wrench component of [WebRender](https://github.com/servo/webrender/). Warden's main purpose is to run a suite of GPU workloads on all native backends supported by the host platform, then match the results against provided expectations. Both the workloads and expectations are backend-agnostic. The backend discovery and initialization is done by the `reftest` binary. All that needs to be done by a developer is typing `make reftests` from the project root and ensuring that every test passes.
+Warden is the data-driven reference test framework for gfx-rs Hardware Abstraction Layer (`gfx-hal`), heavily inspired by the Wrench component of [WebRender](https://github.com/servo/webrender/). Warden's main purpose is to run a suite of GPU workloads on all native backends supported by the host platform, then match the results against provided expectations. Both the workloads and expectations are backend-agnostic. The backend discovery and initialization is done by the `reftest` binary. All that needs to be done by a developer is typing `make reftests` from the project root and ensuring that every test passes.
 
-Warden has two types of definitions: scene and suite. Both are written in [Ron](https://github.com/ron-rs/ron), but technically the code should work with any `serde`-enabled format given minimal tweaking.
+Warden has two types of definitions: scene and suite. Both are written in [Ron](https://github.com/ron-rs/ron) format, but technically the code should work with any `serde`-enabled format given minimal tweaking.
 
 ## Scene definition
 
@@ -12,12 +12,12 @@ A scene consists of a number of resources and jobs that can be run on them. Reso
 
 Internally, a scene has a command buffer to fill up all the initial data for resources. This command buffer needs to change the resource access and image layouts, so we establish a convention here by which every resource has an associated "stable" state that the user (and the reftest framework) promises to deliver at the end of each job.
 
-For images with no source data, the stable layout is `ColorAttachmentOptimal` or `DepthStencilAttachmentOptimal` depending on the format.
+For images with no source data, the stable layout is `ColorAttachmentOptimal` or `DepthStencilAttachmentOptimal` depending on the format. For sourced images, it's `ShaderReadOnlyOptimal`.
 
 ## Test suite
 
-A test suite is just a set of scenes, each having a set of tests. A test is defined as a sequence of jobs being run on the scene and an expectation result. The central suite file can be found in [reftests](../../reftests/suite.ron).
+A test suite is just a set of scenes, each with multiple tests. A test is defined as a sequence of jobs being run on the scene and an expectation result. The central suite file can be found in [reftests](../../reftests/suite.ron), and the serialization structures are in [reftest.rs](src/bin/reftest.rs).
 
 ## Warning
 
-This gfx-rs component is heavy WIP, there is a lot of logic missing, especially with regards to error reporting.
+This gfx-rs component is heavy WIP, provided under no warranty! There is a lot of logic missing, especially with regards to error reporting.

--- a/src/warden/README.md
+++ b/src/warden/README.md
@@ -1,0 +1,23 @@
+# Warden
+
+Warden is the data-driver reference test framework for gfx-rs Hardware Abstraction Layer (gfx-hal), heavily inspired by the Wrench component of [WebRender](https://github.com/servo/webrender/). Warden's main purpose is to run a suite of GPU workloads on all native backends supported by the host platform, then match the results against provided expectations. Both the workloads and expectations are backend-agnostic. The backend discovery and initialization is done by the `reftest` binary. All that needs to be done by a developer is typing `make reftests` from the project root and ensuring that every test passes.
+
+Warden has two types of definitions: scene and suite. Both are written in [Ron](https://github.com/ron-rs/ron), but technically the code should work with any `serde`-enabled format given minimal tweaking.
+
+## Scene definition
+
+A scene consists of a number of resources and jobs that can be run on them. Resources are buffers, images, render passes, and so on. Jobs are sets of either transfer, compute, or graphics operations. The latter is contained within a single render pass. Please refer to [raw.rs](src/raw.rs) for the formal definition of the scene format. Actual reference scenes can be found in [reftests](../../reftests/scenes).
+
+### Resource states
+
+Internally, a scene has a command buffer to fill up all the initial data for resources. This command buffer needs to change the resource access and image layouts, so we establish a convention here by which every resource has an associated "stable" state that the user (and the reftest framework) promises to deliver at the end of each job.
+
+For images with no source data, the stable layout is `ColorAttachmentOptimal` or `DepthStencilAttachmentOptimal` depending on the format.
+
+## Test suite
+
+A test suite is just a set of scenes, each having a set of tests. A test is defined as a sequence of jobs being run on the scene and an expectation result. The central suite file can be found in [reftests](../../reftests/suite.ron).
+
+## Warning
+
+This gfx-rs component is heavy WIP, there is a lot of logic missing, especially with regards to error reporting.

--- a/src/warden/examples/basic.rs
+++ b/src/warden/examples/basic.rs
@@ -1,0 +1,37 @@
+extern crate gfx_backend_vulkan as back;
+extern crate gfx_hal as hal;
+extern crate gfx_warden as warden;
+extern crate ron;
+extern crate serde;
+
+use std::fs::File;
+use std::io::Read;
+
+use hal::Instance;
+use ron::de::Deserializer;
+use serde::de::Deserialize;
+
+
+fn main() {
+    let raw_scene = {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../reftests/scenes/basic.ron",
+        );
+        let mut raw_data = Vec::new();
+        File::open(path)
+            .unwrap()
+            .read_to_end(&mut raw_data)
+            .unwrap();
+        let mut deserializer = Deserializer::from_bytes(&raw_data);
+        warden::raw::Scene::deserialize(&mut deserializer)
+            .unwrap()
+    };
+
+    let instance = back::Instance::create("warden", 1);
+    let adapters = instance.enumerate_adapters();
+    let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene, "");
+    scene.run(Some("empty"));
+    let guard = scene.fetch_image("im-color");
+    println!("row: {:?}", guard.row(0));
+}

--- a/src/warden/examples/basic.rs
+++ b/src/warden/examples/basic.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "vulkan")]
 extern crate gfx_backend_vulkan as back;
 extern crate gfx_hal as hal;
 extern crate gfx_warden as warden;
@@ -28,10 +29,13 @@ fn main() {
             .unwrap()
     };
 
-    let instance = back::Instance::create("warden", 1);
-    let adapters = instance.enumerate_adapters();
-    let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene, "");
-    scene.run(Some("empty"));
-    let guard = scene.fetch_image("im-color");
-    println!("row: {:?}", guard.row(0));
+    #[cfg(feature = "vulkan")]
+    {
+        let instance = back::Instance::create("warden", 1);
+        let adapters = instance.enumerate_adapters();
+        let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene, "");
+        scene.run(Some("empty"));
+        let guard = scene.fetch_image("im-color");
+        println!("row: {:?}", guard.row(0));
+    }
 }

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -14,8 +14,12 @@ use serde::de::Deserialize;
 
 fn main() {
     let raw_scene = {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../reftests/scenes/basic.ron",
+        );
         let mut raw_data = Vec::new();
-        File::open("../../reftests/scenes/basic.ron")
+        File::open(path)
             .unwrap()
             .read_to_end(&mut raw_data)
             .unwrap();
@@ -24,8 +28,12 @@ fn main() {
             .unwrap()
     };
 
+    let data_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../reftests/data",
+    );
     let instance = back::Instance::create("warden", 1);
     let adapters = instance.enumerate_adapters();
-    let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene);
-    scene.run(&["test".to_string()]);
+    let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene, data_path);
+    scene.run(Some("empty"));
 }

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -2,40 +2,70 @@ extern crate gfx_backend_vulkan as back;
 extern crate gfx_hal as hal;
 extern crate gfx_warden as warden;
 extern crate ron;
+#[macro_use]
 extern crate serde;
 
+use std::collections::HashMap;
 use std::fs::File;
-use std::io::Read;
 
-use hal::Instance;
-use ron::de::Deserializer;
-use serde::de::Deserialize;
+use hal::{Adapter, Instance};
+use ron::de;
+
+
+#[derive(Debug, Deserialize)]
+enum Expectation {
+    ImageRow(String, usize, Vec<u8>),
+}
+
+#[derive(Debug, Deserialize)]
+struct Test {
+    jobs: Vec<String>,
+    expect: Expectation,
+}
+
+type Suite = HashMap<String, HashMap<String, Test>>;
 
 
 fn main() {
-    let raw_scene = {
-        let path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../reftests/scenes/basic.ron",
-        );
-        let mut raw_data = Vec::new();
-        File::open(path)
-            .unwrap()
-            .read_to_end(&mut raw_data)
-            .unwrap();
-        let mut deserializer = Deserializer::from_bytes(&raw_data);
-        warden::raw::Scene::deserialize(&mut deserializer)
-            .unwrap()
-    };
-
-    let data_path = concat!(
+    let base_path = concat!(
         env!("CARGO_MANIFEST_DIR"),
-        "/../../reftests/data",
+        "/../../reftests",
     );
+    let data_path = format!("{}/data", base_path);
+
     let instance = back::Instance::create("warden", 1);
     let adapters = instance.enumerate_adapters();
-    let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene, data_path);
-    scene.run(Some("empty"));
-    let guard = scene.fetch_image("im-color");
-    println!("row: {:?}", guard.row(0));
+    println!("Initialized graphics with {:#?}", adapters[0].get_info());
+
+    let suite: Suite = File::open(format!("{}/suite.ron", base_path))
+        .map_err(de::Error::from)
+        .and_then(de::from_reader)
+        .expect("failed to parse the suite definition");
+
+    for (scene_name, tests) in suite {
+        println!("Loading scene '{}'", scene_name);
+        let raw_scene = File::open(format!("{}/scenes/{}.ron", base_path, scene_name))
+            .map_err(de::Error::from)
+            .and_then(de::from_reader)
+            .expect("failed to open/parse the scene");
+
+        let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene, &data_path);
+
+        for (test_name, test) in tests {
+            print!("\tTest '{}' ... ", test_name);
+            scene.run(test.jobs.iter().map(|x| x.as_str()));
+
+            print!("ran; expectation: ");
+            match test.expect {
+                Expectation::ImageRow(image, row, data) => {
+                    let guard = scene.fetch_image(&image);
+                    if data.as_slice() == guard.row(row) {
+                        println!("PASS");
+                    } else {
+                        println!("FAIL {:?}", guard.row(row));
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -36,4 +36,6 @@ fn main() {
     let adapters = instance.enumerate_adapters();
     let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene, data_path);
     scene.run(Some("empty"));
+    let guard = scene.fetch_image("im-color");
+    println!("row: {:?}", guard.row(0));
 }

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -6,6 +6,8 @@ extern crate ron;
 #[macro_use]
 extern crate serde;
 
+#[cfg(feature = "logger")]
+extern crate env_logger;
 #[cfg(feature = "vulkan")]
 extern crate gfx_backend_vulkan;
 #[cfg(feature = "dx12")]
@@ -92,6 +94,9 @@ impl Harness {
 }
 
 fn main() {
+    #[cfg(feature = "logger")]
+    env_logger::init().unwrap();
+
     let harness = Harness::new("suite");
     #[cfg(feature = "vulkan")]
     {
@@ -101,7 +106,7 @@ fn main() {
     }
     #[cfg(feature = "dx12")]
     {
-        println!("Warding Dx12:");
+        println!("Warding DX12:");
         let instance = gfx_backend_dx12::Instance::create("warden", 1);
         harness.run(instance);
     }

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -1,0 +1,30 @@
+extern crate gfx_backend_vulkan as back;
+extern crate gfx_hal as hal;
+extern crate gfx_warden as warden;
+extern crate ron;
+extern crate serde;
+
+use std::fs::File;
+use std::io::Read;
+
+use hal::Instance;
+use ron::de::Deserializer;
+use serde::de::Deserialize;
+
+
+fn main() {
+    let raw_scene = {
+        let mut raw_data = Vec::new();
+        File::open("../../reftests/scenes/basic.ron")
+            .unwrap()
+            .read_to_end(&mut raw_data)
+            .unwrap();
+        let mut deserializer = Deserializer::from_bytes(&raw_data);
+        warden::raw::Scene::deserialize(&mut deserializer)
+            .unwrap()
+    };
+
+    let instance = back::Instance::create("warden", 1);
+    let adapters = instance.enumerate_adapters();
+    let scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene);
+}

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -26,5 +26,6 @@ fn main() {
 
     let instance = back::Instance::create("warden", 1);
     let adapters = instance.enumerate_adapters();
-    let scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene);
+    let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene);
+    scene.run(&["test".to_string()]);
 }

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -1,38 +1,193 @@
 use std::collections::HashMap;
+use std::io::Read;
+use std::fs::File;
 
-use hal::{self, Adapter};
+use hal::{self, image as i};
+use hal::{Adapter, Device};
 
 use raw;
 
 
+const COLOR_RANGE: i::SubresourceRange = i::SubresourceRange {
+    aspects: i::ASPECT_COLOR,
+    levels: 0 .. 1,
+    layers: 0 .. 1,
+};
+
 pub struct Resources<B: hal::Backend> {
-    pub buffers: HashMap<String, B::Buffer>,
-    pub images: HashMap<String, B::Image>,
+    pub buffers: HashMap<String, (B::Buffer, B::Memory)>,
+    pub images: HashMap<String, (B::Image, B::Memory)>,
 }
 
 pub struct Scene<B: hal::Backend> {
     pub resources: Resources<B>,
     pub jobs: HashMap<String, B::CommandBuffer>,
+    init_submission: hal::command::Submit<B, hal::queue::Graphics>,
+    device: B::Device,
+    queue: hal::CommandQueue<B, hal::queue::Graphics>,
+    command_pool: hal::CommandPool<B, hal::queue::Graphics>,
+    upload_buffers: HashMap<String, (B::Buffer, B::Memory)>,
 }
 
 impl<B: hal::Backend> Scene<B> {
     pub fn new(adapter: &B::Adapter, raw: &raw::Scene) -> Self {
-        // Build a new device and associated command queues
+        fn align(x: usize, y: usize) -> usize {
+            if x > 0 && y > 0 {
+                ((x - 1) | (y - 1)) + 1
+            } else {
+                x
+            }
+        }
+
+        // initialize graphics
         let hal::Gpu { mut device, mut graphics_queues, memory_types, .. } = {
             let (ref family, queue_type) = adapter.get_queue_families()[0];
             assert!(queue_type.supports_graphics());
             adapter.open(&[(family, hal::QueueType::Graphics, 1)])
         };
-        let mut queue = graphics_queues.remove(0);
+        let upload_type = memory_types
+            .iter()
+            .find(|mt| {
+                mt.properties.contains(hal::memory::CPU_VISIBLE)
+                //&&!mt.properties.contains(hal::memory::CPU_CACHED)
+            })
+            .unwrap();
+        let limits = device.get_limits().clone();
+        let queue = graphics_queues.remove(0);
+        let mut command_pool = queue.create_graphics_pool(
+            1 + raw.jobs.len(),
+            hal::pool::CommandPoolCreateFlags::empty(),
+        );
 
+        // create resources
         let mut resources = Resources {
             buffers: HashMap::new(),
             images: HashMap::new(),
         };
+        let mut upload_buffers = HashMap::new();
+        let init_submission = {
+            let mut init_cmd = command_pool.acquire_command_buffer();
+            for (name, resource) in &raw.resources {
+                match *resource {
+                    raw::Resource::Image { kind, num_levels, format, usage, ref data } => {
+                        let unbound = device.create_image(kind, num_levels, format, usage)
+                            .unwrap();
+                        let requirements = device.get_image_requirements(&unbound);
+                        let memory_type = memory_types
+                            .iter()
+                            .find(|mt| {
+                                requirements.type_mask & (1 << mt.id) != 0 &&
+                                mt.properties.contains(hal::memory::DEVICE_LOCAL)
+                            })
+                            .unwrap();
+                        let memory = device.allocate_memory(memory_type, requirements.size)
+                            .unwrap();
+                        let image = device.bind_image_memory(&memory, 0, unbound)
+                            .unwrap();
+
+                        // process initial data for the image
+                        if !data.is_empty() {
+                            // calculate required sizes
+                            let (w, h, d, aa) = kind.get_dimensions();
+                            assert_eq!(aa, i::AaMode::Single);
+                            let bpp = format.0.describe_bits().total as usize;
+                            let width_bytes = bpp * w as usize / 8;
+                            let row_pitch = align(width_bytes, limits.min_buffer_copy_pitch_alignment);
+                            let upload_size = row_pitch as u64 * h as u64 * d as u64;
+                            // create upload buffer
+                            let unbound_buffer = device.create_buffer(upload_size, bpp as _, hal::buffer::TRANSFER_SRC)
+                                .unwrap();
+                            let upload_req = device.get_buffer_requirements(&unbound_buffer);
+                            let upload_memory = device.allocate_memory(upload_type, upload_req.size)
+                                .unwrap();
+                            let upload_buffer = device.bind_buffer_memory(&upload_memory, 0, unbound_buffer)
+                                .unwrap();
+                            // write the data
+                            {
+                                let mut file = File::open(&format!("../../reftests/data/{}", data))
+                                    .unwrap();
+                                let mut mapping = device.acquire_mapping_writer::<u8>(&upload_buffer, 0..upload_size)
+                                    .unwrap();
+                                for y in 0 .. (h as usize * d as usize) {
+                                    let dest_range = y as usize * row_pitch .. y as usize * row_pitch + width_bytes;
+                                    file.read_exact(&mut mapping[dest_range])
+                                        .unwrap();
+                                }
+                                device.release_mapping_writer(mapping);
+                            }
+                            // add init commands
+                            let image_barrier = hal::memory::Barrier::Image {
+                                states: (i::Access::empty(), i::ImageLayout::Undefined) ..
+                                        (i::TRANSFER_WRITE, i::ImageLayout::TransferDstOptimal),
+                                target: &image,
+                                range: COLOR_RANGE.clone(),
+                            };
+                            init_cmd.pipeline_barrier(hal::pso::TOP_OF_PIPE .. hal::pso::TRANSFER, &[image_barrier]);
+                            init_cmd.copy_buffer_to_image(
+                                &upload_buffer,
+                                &image,
+                                i::ImageLayout::TransferDstOptimal,
+                                &[hal::command::BufferImageCopy {
+                                    buffer_offset: 0,
+                                    buffer_row_pitch: row_pitch as u32,
+                                    buffer_slice_pitch: row_pitch as u32 * h as u32,
+                                    image_layers: i::SubresourceLayers {
+                                        aspects: i::ASPECT_COLOR,
+                                        level: 0,
+                                        layers: 0 .. 1,
+                                    },
+                                    image_offset: hal::command::Offset { x: 0, y: 0, z: 0 },
+                                    image_extent: hal::device::Extent {
+                                        width: w as _,
+                                        height: h as _,
+                                        depth: d as _,
+                                    },
+                                }]);
+
+                            let image_barrier = hal::memory::Barrier::Image {
+                                states: (i::TRANSFER_WRITE, i::ImageLayout::TransferDstOptimal) ..
+                                        (i::SHADER_READ, i::ImageLayout::ShaderReadOnlyOptimal),
+                                target: &image,
+                                range: COLOR_RANGE.clone(),
+                            };
+                            init_cmd.pipeline_barrier(hal::pso::TRANSFER .. hal::pso::BOTTOM_OF_PIPE, &[image_barrier]);
+                            // done
+                            upload_buffers.insert(name.clone(), (upload_buffer, upload_memory));
+                        }
+
+                        resources.images.insert(name.clone(), (image, memory));
+                    }
+                    raw::Resource::Buffer => {
+                    }
+                    _ => unimplemented!()
+                }
+            }
+            init_cmd.finish()
+        };
+
+        // fill up command buffers
         let mut jobs = HashMap::new();
         Scene {
             resources,
             jobs,
+            init_submission,
+            device,
+            queue,
+            command_pool,
+            upload_buffers,
         }
+    }
+}
+
+impl<B: hal::Backend> Drop for Scene<B> {
+    fn drop(&mut self) {
+        for (_, (buffer, memory)) in self.upload_buffers.drain() {
+            self.device.destroy_buffer(buffer);
+            self.device.free_memory(memory);
+        }
+        //TODO: free those properly
+        let _ = &self.queue;
+        let _ = &self.command_pool;
+        //queue.destroy_command_pool(command_pool);
     }
 }

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+use hal::{self, Adapter};
+
+use raw;
+
+
+pub struct Resources<B: hal::Backend> {
+    pub buffers: HashMap<String, B::Buffer>,
+    pub images: HashMap<String, B::Image>,
+}
+
+pub struct Scene<B: hal::Backend> {
+    pub resources: Resources<B>,
+    pub jobs: HashMap<String, B::CommandBuffer>,
+}
+
+impl<B: hal::Backend> Scene<B> {
+    pub fn new(adapter: &B::Adapter, raw: &raw::Scene) -> Self {
+        // Build a new device and associated command queues
+        let hal::Gpu { mut device, mut graphics_queues, memory_types, .. } = {
+            let (ref family, queue_type) = adapter.get_queue_families()[0];
+            assert!(queue_type.supports_graphics());
+            adapter.open(&[(family, hal::QueueType::Graphics, 1)])
+        };
+        let mut queue = graphics_queues.remove(0);
+
+        let mut resources = Resources {
+            buffers: HashMap::new(),
+            images: HashMap::new(),
+        };
+        let mut jobs = HashMap::new();
+        Scene {
+            resources,
+            jobs,
+        }
+    }
+}

--- a/src/warden/src/lib.rs
+++ b/src/warden/src/lib.rs
@@ -1,0 +1,9 @@
+//! Data-driven reference test framework for warding
+//! against breaking changes.
+
+extern crate gfx_hal as hal;
+#[macro_use]
+extern crate serde;
+
+pub mod gpu;
+pub mod raw;

--- a/src/warden/src/lib.rs
+++ b/src/warden/src/lib.rs
@@ -3,6 +3,8 @@
 
 extern crate gfx_hal as hal;
 #[macro_use]
+extern crate log;
+#[macro_use]
 extern crate serde;
 
 pub mod gpu;

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -3,12 +3,6 @@ use std::ops::Range;
 
 use hal;
 
-#[derive(Debug, Deserialize)]
-pub enum Memory {
-    Device,
-    Upload,
-    Download,
-}
 
 #[derive(Debug, Deserialize)]
 pub struct AttachmentRef(pub String, pub hal::pass::AttachmentLayout);
@@ -16,7 +10,6 @@ pub struct AttachmentRef(pub String, pub hal::pass::AttachmentLayout);
 #[derive(Debug, Deserialize)]
 pub struct Subpass {
     pub colors: Vec<AttachmentRef>,
-    #[serde(default)]
     pub depth_stencil: Option<AttachmentRef>,
     #[serde(default)]
     pub inputs: Vec<AttachmentRef>,
@@ -40,7 +33,8 @@ pub enum Resource {
         num_levels: hal::image::Level,
         format: hal::format::Format,
         usage: hal::image::Usage,
-        memory: Memory,
+        #[serde(default)]
+        data: String,
     },
     ImageView {
         image: String,
@@ -108,7 +102,7 @@ pub enum Job {
     Graphics {
         descriptors: HashMap<String, DescriptorSetData>,
         framebuffer: String,
-        pass: (String, Vec<DrawPass>),
+        pass: (String, HashMap<String, DrawPass>),
     },
 }
 

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -119,6 +119,7 @@ pub enum Job {
     Graphics {
         descriptors: HashMap<String, DescriptorSetData>,
         framebuffer: String,
+        clear_values: Vec<hal::command::ClearValue>,
         pass: (String, HashMap<String, DrawPass>),
     },
 }

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -48,8 +48,20 @@ pub enum Resource {
         subpasses: HashMap<String, Subpass>,
         dependencies: Vec<SubpassDependency>,
     },
-    DescriptorSet,
-    PipelineLayout,
+    DescriptorSetLayout {
+        bindings: Vec<hal::pso::DescriptorSetLayoutBinding>,
+    },
+    DescriptorPool {
+        capacity: usize,
+        ranges: Vec<hal::pso::DescriptorRangeDesc>,
+    },
+    DescriptorSet {
+        pool: String,
+        layout: String,
+    },
+    PipelineLayout {
+        set_layouts: Vec<String>,
+    },
     GraphicsPipeline,
     Framebuffer {
         pass: String,
@@ -71,6 +83,11 @@ pub struct DescriptorSetData {
 
 #[derive(Debug, Deserialize)]
 pub enum DrawCommand {
+    BindIndexBuffer {
+        buffer: String,
+        offset: u64,
+        index_type: hal::IndexType,
+    },
     BindVertexBuffers(Vec<(String, hal::pso::BufferOffset)>),
     BindPipeline(String),
     BindDescriptorSets {
@@ -83,8 +100,8 @@ pub enum DrawCommand {
         instances: Range<hal::InstanceCount>,
     },
     DrawIndexed {
-        buffer: String,
         indices: Range<hal::IndexCount>,
+        base_vertex: hal::VertexOffset,
         instances: Range<hal::InstanceCount>,
     },
 }

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -1,0 +1,119 @@
+use std::collections::HashMap;
+use std::ops::Range;
+
+use hal;
+
+#[derive(Debug, Deserialize)]
+pub enum Memory {
+    Device,
+    Upload,
+    Download,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AttachmentRef(pub String, pub hal::pass::AttachmentLayout);
+
+#[derive(Debug, Deserialize)]
+pub struct Subpass {
+    pub colors: Vec<AttachmentRef>,
+    #[serde(default)]
+    pub depth_stencil: Option<AttachmentRef>,
+    #[serde(default)]
+    pub inputs: Vec<AttachmentRef>,
+    #[serde(default)]
+    pub preserves: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SubpassDependency {
+    pub passes: Range<String>,
+    pub stages: Range<hal::pso::PipelineStage>,
+    pub accesses: Range<hal::image::Access>,
+}
+
+#[derive(Debug, Deserialize)]
+pub enum Resource {
+    Shader,
+    Buffer,
+    Image {
+        kind: hal::image::Kind,
+        num_levels: hal::image::Level,
+        format: hal::format::Format,
+        usage: hal::image::Usage,
+        memory: Memory,
+    },
+    ImageView {
+        image: String,
+        format: hal::format::Format,
+        #[serde(default)]
+        swizzle: hal::format::Swizzle,
+        range: hal::image::SubresourceRange,
+    },
+    RenderPass {
+        attachments: HashMap<String, hal::pass::Attachment>,
+        subpasses: HashMap<String, Subpass>,
+        dependencies: Vec<SubpassDependency>,
+    },
+    DescriptorSet,
+    PipelineLayout,
+    GraphicsPipeline,
+    Framebuffer {
+        pass: String,
+        views: HashMap<String, String>,
+        extent: hal::device::Extent,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+pub enum TransferCommand {
+    CopyBufferToImage,
+    //CopyImageToBuffer,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DescriptorSetData {
+    //TODO: update_descriptor_sets
+}
+
+#[derive(Debug, Deserialize)]
+pub enum DrawCommand {
+    BindVertexBuffers(Vec<(String, hal::pso::BufferOffset)>),
+    BindPipeline(String),
+    BindDescriptorSets {
+        layout: String,
+        first: usize,
+        sets: Vec<String>,
+    },
+    Draw {
+        vertices: Range<hal::VertexCount>,
+        instances: Range<hal::InstanceCount>,
+    },
+    DrawIndexed {
+        buffer: String,
+        indices: Range<hal::IndexCount>,
+        instances: Range<hal::InstanceCount>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DrawPass {
+    pub commands: Vec<DrawCommand>,
+}
+
+#[derive(Debug, Deserialize)]
+pub enum Job {
+    Transfer {
+        commands: Vec<TransferCommand>,
+    },
+    Graphics {
+        descriptors: HashMap<String, DescriptorSetData>,
+        framebuffer: String,
+        pass: (String, Vec<DrawPass>),
+    },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Scene {
+    pub resources: HashMap<String, Resource>,
+    pub jobs: HashMap<String, Job>,
+}


### PR DESCRIPTION
This is a pre-alpha of the new test infrastructure. It's based on [RON](https://github.com/ron-rs/ron)-defined tests that are de-serialized and executed on each available native backend. See [readme](https://github.com/kvark/gfx/tree/warden/src/warden) for ~~devil in the~~ details.

For Unix machines, all you need is `make reftests`.
For Windows (without WSL): `(cd src/warden && cargo run --features vulkan,dx12,logger)`
Output:
```
Warding Vulkan:
        AdapterInfo { name: "Radeon(TM) RX 460 Graphics ", vendor: 4098, device: 26607, software_rendering: false }
        Loading scene 'basic':
                Test 'render-pass-clear' ...    ran: PASS
Warding DX12:
        AdapterInfo { name: "Radeon(TM) RX 460 Graphics", vendor: 4098, device: 26607, software_rendering: false }
        Loading scene 'basic':
                Test 'render-pass-clear' ...    ran: PASS
```

Fixes #1410
Note: it will really shine when:
  1. we get GL support - #1539 
  2. hook Warden up with headless glutin context - #1410 
  3. run on Travis CI

HAL changes:
  - `Instance` specifies `Backend` as an associated type
  - `create_renderpass` -> `create_render_pass` for naming consistency

The PR has a lot of unfinished bits (e.g. PSO creation) but it's functional and technically ready for merging. I'm not 100% confident that being data-driven is a good thing here, hence `RFC` in the subject:
-  (+) RON is more expressive (maps, enum values, etc)
-  (+) somewhat consistent with [Wrench](https://github.com/servo/webrender/tree/master/wrench/reftests)
-  (-) RON is another format/language (note: can do any `serde`-supported format, really)
-  (~) run-time checked instead of compile-time. This is not really a great point since we are supposed to run those tests everywhere all the time, so we shouldn't end up in a situation where someone built them but didn't run.