### PR TITLE
Fix heap mapping in `Device::allocate_memory` for the dx12 backend

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -393,8 +393,8 @@ impl d::Device<B> for Device {
 
         let properties = winapi::D3D12_HEAP_PROPERTIES {
             Type: winapi::D3D12_HEAP_TYPE_CUSTOM,
-            CPUPageProperty: self.heap_properties[mem_type.id].page_property,
-            MemoryPoolPreference: self.heap_properties[mem_type.id].memory_pool,
+            CPUPageProperty: self.heap_properties[mem_type.heap_index].page_property,
+            MemoryPoolPreference: self.heap_properties[mem_type.heap_index].memory_pool,
             CreationNodeMask: 0,
             VisibleNodeMask: 0,
         };


### PR DESCRIPTION
I came across a tiny nit when tinkering with the `hal/quad` example under dx12, thus this PR

The index used for `heap_properties` should be `mem_type.heap_index` instead of `mem_type.id`.

The fix should make the example workable with dx12!