### PR TITLE
mask out content types of memory type ID when indexing into `heap_properties`

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -393,8 +393,8 @@ impl d::Device<B> for Device {
 
         let properties = winapi::D3D12_HEAP_PROPERTIES {
             Type: winapi::D3D12_HEAP_TYPE_CUSTOM,
-            CPUPageProperty: self.heap_properties[mem_type.id].page_property,
-            MemoryPoolPreference: self.heap_properties[mem_type.id].memory_pool,
+            CPUPageProperty: self.heap_properties[mem_type.id % 4].page_property,
+            MemoryPoolPreference: self.heap_properties[mem_type.id % 4].memory_pool,
             CreationNodeMask: 0,
             VisibleNodeMask: 0,
         };


### PR DESCRIPTION
Follow up of #1590 
See discussions there for details