### PR TITLE
Rename Adapter methods to match conventions

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -102,7 +102,7 @@ fn main() {
     };
 
     for adapter in &adapters {
-        println!("{:?}", adapter.get_info());
+        println!("{:?}", adapter.info());
     }
     let adapter = &adapters[0];
 

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -64,7 +64,7 @@ fn main() {
     let surface = instance.create_surface(&window);
     let adapters = instance.enumerate_adapters();
     for adapter in &adapters {
-        println!("{:?}", adapter.get_info());
+        println!("{:?}", adapter.info());
     }
     let adapter = &adapters[0];
 

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -390,11 +390,11 @@ impl core::Adapter<Backend> for Adapter {
         gpu
     }
 
-    fn get_info(&self) -> &core::AdapterInfo {
+    fn info(&self) -> &core::AdapterInfo {
         &self.info
     }
 
-    fn get_queue_families(&self) -> &[(QueueFamily, QueueType)] {
+    fn queue_families(&self) -> &[(QueueFamily, QueueType)] {
         &self.queue_family
     }
 }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -309,11 +309,11 @@ impl core::Adapter<Backend> for Adapter {
         }
     }
 
-    fn get_info(&self) -> &core::AdapterInfo {
+    fn info(&self) -> &core::AdapterInfo {
         &self.info
     }
 
-    fn get_queue_families(&self) -> &[(QueueFamily, QueueType)] {
+    fn queue_families(&self) -> &[(QueueFamily, QueueType)] {
         &self.queue_families
     }
 }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -55,11 +55,11 @@ impl core::Adapter<Backend> for Adapter {
         unimplemented!()
     }
 
-    fn get_info(&self) -> &core::AdapterInfo {
+    fn info(&self) -> &core::AdapterInfo {
         unimplemented!()
     }
 
-    fn get_queue_families(&self) -> &[(QueueFamily, core::QueueType)] {
+    fn queue_families(&self) -> &[(QueueFamily, core::QueueType)] {
         unimplemented!()
     }
 }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -273,11 +273,11 @@ impl c::Adapter<Backend> for Adapter {
         gpu
     }
 
-    fn get_info(&self) -> &c::AdapterInfo {
+    fn info(&self) -> &c::AdapterInfo {
         &self.adapter_info
     }
 
-    fn get_queue_families(&self) -> &[(QueueFamily, QueueType)] {
+    fn queue_families(&self) -> &[(QueueFamily, QueueType)] {
         &self.queue_family
     }
 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -184,11 +184,11 @@ impl core::Adapter<Backend> for Adapter {
         }
     }
 
-    fn get_info(&self) -> &core::AdapterInfo {
+    fn info(&self) -> &core::AdapterInfo {
         &self.adapter_info
     }
 
-    fn get_queue_families(&self) -> &[(n::QueueFamily, core::QueueType)] {
+    fn queue_families(&self) -> &[(n::QueueFamily, core::QueueType)] {
         &self.queue_families
     }
 }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -491,11 +491,11 @@ impl core::Adapter<Backend> for Adapter {
         }
     }
 
-    fn get_info(&self) -> &core::AdapterInfo {
+    fn info(&self) -> &core::AdapterInfo {
         &self.info
     }
 
-    fn get_queue_families(&self) -> &[(QueueFamily, QueueType)] {
+    fn queue_families(&self) -> &[(QueueFamily, QueueType)] {
         &self.queue_families
     }
 }

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -21,7 +21,7 @@ pub trait Adapter<B: Backend>: Sized {
     ///
     /// # let adapter: empty::Adapter = return;
     /// let queue_desc = adapter
-    ///     .get_queue_families()
+    ///     .queue_families()
     ///     .iter()
     ///     .map(|&(ref family, ty)| (family, ty, family.num_queues()))
     ///     .collect::<Vec<_>>();
@@ -56,7 +56,7 @@ pub trait Adapter<B: Backend>: Sized {
     where
         F: FnMut(&B::QueueFamily, QueueType) -> (u32, QueueType),
     {
-        let queue_desc = self.get_queue_families()
+        let queue_desc = self.queue_families()
             .iter()
             .filter_map(|&(ref family, ty)| {
                 let (num_queues, ty) = f(family, ty);
@@ -81,10 +81,10 @@ pub trait Adapter<B: Backend>: Sized {
     /// use gfx_hal::Adapter;
     ///
     /// # let adapter: empty::Adapter = return;
-    /// println!("Adapter info: {:?}", adapter.get_info());
+    /// println!("Adapter info: {:?}", adapter.info());
     /// # }
     /// ```
-    fn get_info(&self) -> &AdapterInfo;
+    fn info(&self) -> &AdapterInfo;
 
     /// Return the supported queue families for this adapter.
     ///
@@ -100,12 +100,12 @@ pub trait Adapter<B: Backend>: Sized {
     /// use gfx_hal::Adapter;
     ///
     /// # let adapter: empty::Adapter = return;
-    /// for (i, &(_, ty)) in adapter.get_queue_families().into_iter().enumerate() {
+    /// for (i, &(_, ty)) in adapter.queue_families().into_iter().enumerate() {
     ///     println!("Queue family ({:?}) type: {:?}", i, ty);
     /// }
     /// # }
     /// ```
-    fn get_queue_families(&self) -> &[(B::QueueFamily, QueueType)];
+    fn queue_families(&self) -> &[(B::QueueFamily, QueueType)];
 }
 
 /// Information about a backend adapter.

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -66,7 +66,7 @@ impl Harness {
 
         let adapters = instance.enumerate_adapters();
         let adapter = &adapters[0];
-        println!("\t{:?}", adapter.get_info());
+        println!("\t{:?}", adapter.info());
 
         for (scene_name, tests) in &self.suite {
             println!("\tLoading scene '{}':", scene_name);

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -94,7 +94,7 @@ impl<B: hal::Backend> Scene<B> {
         info!("creating Scene from {}", data_path);
         // initialize graphics
         let hal::Gpu { mut device, mut graphics_queues, memory_types, .. } = {
-            let (ref family, queue_type) = adapter.get_queue_families()[0];
+            let (ref family, queue_type) = adapter.queue_families()[0];
             assert!(queue_type.supports_graphics());
             adapter.open(&[(family, hal::QueueType::Graphics, 1)])
         };


### PR DESCRIPTION
Not sure if you care about this stuff.