### PR TITLE
Accept iterator in `Adapter::open`

### DIFF
--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -51,7 +51,10 @@ impl core::Backend for Backend {
 /// Dummy adapter.
 pub struct Adapter;
 impl core::Adapter<Backend> for Adapter {
-    fn open(&self, _: &[(&QueueFamily, core::QueueType, u32)]) -> core::Gpu<Backend> {
+    fn open<'a, I>(&self, _: I) -> core::Gpu<Backend>
+    where
+        I: Iterator<Item = core::QueueDescriptor<'a, Backend>>
+    {
         unimplemented!()
     }
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -28,7 +28,8 @@ pub use self::device::Device;
 pub use self::pool::{CommandPool, RawCommandPool, SubpassCommandPool};
 pub use self::pso::{DescriptorPool};
 pub use self::queue::{
-    CommandQueue, QueueFamily, QueueType, RawCommandQueue, RawSubmission, Submission,
+    CommandQueue, QueueDescriptor, QueueFamily, QueueType, RawCommandQueue, RawSubmission,
+    Submission,
     General, Graphics, Compute, Transfer,
 };
 pub use self::window::{

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -17,6 +17,39 @@ use std::marker::PhantomData;
 pub use self::capability::{Compute, Graphics, General, Transfer, Supports};
 pub use self::submission::{RawSubmission, Submission};
 
+/// Queue descriptors are needed for `Gpu` creation via the `Adapter`.
+pub struct QueueDescriptor<'a, B: Backend> {
+    /// The requested queue family.
+    pub family: &'a B::QueueFamily,
+    /// Specifies the type of the queue.
+    pub ty: QueueType,
+    /// Specifies how many queues should be created.
+    pub num_queues: u32,
+}
+
+impl<'a, B: Backend> Copy for QueueDescriptor<'a, B> {}
+
+impl<'a, B: Backend> Clone for QueueDescriptor<'a, B> {
+    fn clone(&self) -> Self {
+        QueueDescriptor {
+            family: self.family,
+            ty: self.ty,
+            num_queues: self.num_queues,
+        }
+    }
+}
+
+impl<'a, B: Backend> QueueDescriptor<'a, B> {
+    /// Creates a new queue descriptor.
+    pub fn new(family: &'a B::QueueFamily, ty: QueueType, num_queues: u32) -> Self {
+        QueueDescriptor {
+            family,
+            ty,
+            num_queues,
+        }
+    }
+}
+
 ///
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]


### PR DESCRIPTION
Okay I nearly solved it, but there's one problem in the Vulkan backend:

In order to create the queues, I need a device, but for the device I need queue information, which I can only get from the iterator. This means I have to iterate it twice :(