### PR TITLE
Revised Adapter, QueueFamily, and CommandPool interaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ EXCLUDES:=
 FEATURES_WARDEN:=
 FEATURES_RENDER:=
 FEATURES_RENDER_ADD:= mint serialize
-FEATURES_QUAD:=
-FEATURES_QUAD2:=
+FEATURES_HAL:=
+FEATURES_HAL2:=
 CMD_QUAD_RENDER:=cargo check
 
 SDL2_DEST=$(HOME)/deps
@@ -14,14 +14,14 @@ SDL2_PPA=http://ppa.launchpad.net/zoogie/sdl2-snapshots/ubuntu/pool/main/libs/li
 
 ifeq ($(OS),Windows_NT)
 	EXCLUDES+= --exclude gfx-backend-metal
-	FEATURES_QUAD=vulkan
+	FEATURES_HAL=vulkan
 	FEATURES_WARDEN+=vulkan
 	ifeq ($(TARGET),x86_64-pc-windows-gnu)
 		# No d3d12 support on GNU windows ATM
 		# context: https://github.com/gfx-rs/gfx/pull/1417
 		EXCLUDES+= --exclude gfx-backend-dx12
 	else
-		FEATURES_QUAD2=dx12
+		FEATURES_HAL2=dx12
 		FEATURES_WARDEN+=dx12
 	endif
 else
@@ -30,22 +30,22 @@ else
 	GLUTIN_HEADLESS_FEATURE="--features headless" #TODO?
 	ifeq ($(UNAME_S),Linux)
 		EXCLUDES+= --exclude gfx-backend-metal
-		FEATURES_QUAD=vulkan
+		FEATURES_HAL=vulkan
 		FEATURES_WARDEN+=vulkan
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		EXCLUDES+= --exclude gfx-backend-vulkan
 		EXCLUDES+= --exclude quad-render
-		FEATURES_QUAD=metal
+		FEATURES_HAL=metal
 		FEATURES_WARDEN+=metal
 		CMD_QUAD_RENDER=pwd
 	endif
 endif
 
 
-.PHONY: all check ex-hal-quad warden reftests render ex-render-quad travis-sdl2
+.PHONY: all check ex-hal-quad ex-hal-compute warden reftests render ex-render-quad travis-sdl2
 
-all: check ex-hal-quad warden render ex-render-quad
+all: check ex-hal-quad ex-hal-compute warden render ex-render-quad
 
 check:
 	cargo check --all $(EXCLUDES)
@@ -64,8 +64,12 @@ render:
 
 ex-hal-quad:
 	cd examples/hal/quad && cargo check --features "gl"
-	cd examples/hal/quad && cargo check --features "$(FEATURES_QUAD2)"
-	cd examples/hal/quad && cargo check --features "$(FEATURES_QUAD)"
+	cd examples/hal/quad && cargo check --features "$(FEATURES_HAL2)"
+	cd examples/hal/quad && cargo check --features "$(FEATURES_HAL)"
+
+ex-hal-compute:
+	cd examples/hal/compute && cargo check --features "$(FEATURES_HAL2)"
+	cd examples/hal/compute && cargo check --features "$(FEATURES_HAL)"
 
 ex-render-quad:
 	cd examples/render/quad_render && $(CMD_QUAD_RENDER)

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -95,7 +95,7 @@ fn main() {
         (instance, adapters, surface)
     };
     #[cfg(feature = "gl")]
-    let (adapters, mut surface) = {
+    let (mut adapters, mut surface) = {
         let surface = back::Surface::from_window(window);
         let adapters = surface.enumerate_adapters();
         (adapters, surface)

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -18,7 +18,7 @@ extern crate winit;
 extern crate image;
 
 use hal::{buffer, command, device as d, image as i, memory as m, pass, pso, pool, state};
-use hal::{Capability, Device, Instance, QueueFamily, Surface, Swapchain};
+use hal::{Device, Instance, QueueFamily, Surface, Swapchain};
 use hal::{
     DescriptorPool, Gpu, FrameSync, Primitive,
     Backbuffer, SwapchainConfig,
@@ -107,7 +107,7 @@ fn main() {
     // Build a new device and associated command queues
     let Gpu { mut device, mut queue_groups, memory_types, .. } =
         adapters.remove(0).open_with(|family| {
-            if hal::Graphics::supported_by(family.queue_type()) && surface.supports_queue_family(family) {
+            if family.supports_graphics() && surface.supports_queue_family(family) {
                 Some(1)
             } else { None }
         });

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -10,7 +10,7 @@ extern crate image;
 use std::io::Cursor;
 
 use hal::{command, device as d, image as i, pso, state};
-use hal::{Adapter, Device, Instance, Primitive};
+use hal::{Device, Instance, Primitive};
 use gfx::format::{Srgba8 as ColorFormat};
 use gfx::allocators::StackAllocator as Allocator;
 use hal::target::Rect;
@@ -64,7 +64,7 @@ fn main() {
     let surface = instance.create_surface(&window);
     let mut adapters = instance.enumerate_adapters();
     for adapter in &adapters {
-        println!("{:?}", adapter.info());
+        println!("{:?}", adapter.info);
     }
     let adapter = adapters.remove(0);
 

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -1,5 +1,5 @@
 extern crate env_logger;
-extern crate gfx_hal as core;
+extern crate gfx_hal as hal;
 extern crate gfx_backend_vulkan as back;
 #[macro_use]
 extern crate gfx_render as gfx;
@@ -9,11 +9,11 @@ extern crate image;
 
 use std::io::Cursor;
 
-use core::{command, device as d, image as i, pso, state};
-use core::{Adapter, Device, Instance, Primitive};
+use hal::{command, device as d, image as i, pso, state};
+use hal::{Adapter, Device, Instance, Primitive};
 use gfx::format::{Srgba8 as ColorFormat};
-use core::target::Rect;
 use gfx::allocators::StackAllocator as Allocator;
+use hal::target::Rect;
 
 gfx_buffer_struct! {
     Vertex {
@@ -62,15 +62,15 @@ fn main() {
     // instantiate backend
     let instance = back::Instance::create("gfx-rs quad", 1);
     let surface = instance.create_surface(&window);
-    let adapters = instance.enumerate_adapters();
+    let mut adapters = instance.enumerate_adapters();
     for adapter in &adapters {
         println!("{:?}", adapter.info());
     }
-    let adapter = &adapters[0];
+    let adapter = adapters.remove(0);
 
-    type Context<C> = gfx::Context<back::Backend, C>;
     let (mut context, backbuffers) =
-        Context::init_graphics::<ColorFormat>(surface, adapter);
+        gfx::Context::<back::Backend, hal::Graphics>
+        ::init::<ColorFormat>(surface, adapter);
     let mut device = (*context.ref_device()).clone();
 
     // Setup renderpass and pipeline
@@ -187,7 +187,7 @@ fn main() {
         .finish();
 
     // Rendering setup
-    let viewport = core::Viewport {
+    let viewport = hal::Viewport {
         x: 0, y: 0,
         w: pixel_width, h: pixel_height,
         near: 0.0, far: 1.0,

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1,7 +1,7 @@
 use wio::com::ComPtr;
-use core::{command as com, image, memory, pass, pso, target};
-use core::{IndexCount, IndexType, InstanceCount, VertexCount, VertexOffset, Viewport};
-use core::buffer::IndexBufferView;
+use hal::{command as com, image, memory, pass, pso, target};
+use hal::{IndexCount, IndexType, InstanceCount, VertexCount, VertexOffset, Viewport};
+use hal::buffer::IndexBufferView;
 use winapi::{self, UINT64, UINT};
 use {conv, native as n, Backend};
 use smallvec::SmallVec;

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -1,14 +1,16 @@
-use core::format::{Format, SurfaceType};
-use core::{buffer, state, pso, Primitive};
-use core::image::{self, FilterMethod, WrapMode};
-use core::pso::DescriptorSetLayoutBinding;
-use core::state::Comparison;
 use std::fmt;
 use winapi::*;
 
+use hal::format::{Format, SurfaceType};
+use hal::{buffer, state, pso, Primitive};
+use hal::image::{self, FilterMethod, WrapMode};
+use hal::pso::DescriptorSetLayoutBinding;
+use hal::state::Comparison;
+
+
 pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
-    use core::format::SurfaceType::*;
-    use core::format::ChannelType::*;
+    use hal::format::SurfaceType::*;
+    use hal::format::ChannelType::*;
     Some(match format.0 {
         R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 => return None,
         R8 => match format.1 {
@@ -133,7 +135,7 @@ pub fn map_format_dsv(surface: SurfaceType) -> Option<DXGI_FORMAT> {
 }
 
 pub fn map_topology_type(primitive: Primitive) -> D3D12_PRIMITIVE_TOPOLOGY_TYPE {
-    use core::Primitive::*;
+    use hal::Primitive::*;
     match primitive {
         PointList  => D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT,
         LineList |
@@ -200,8 +202,8 @@ pub fn map_rasterizer(rasterizer: &pso::Rasterizer) -> D3D12_RASTERIZER_DESC {
 }
 
 fn map_blend_factor(factor: state::Factor, scalar: bool) -> D3D12_BLEND {
-    use core::state::BlendValue::*;
-    use core::state::Factor::*;
+    use hal::state::BlendValue::*;
+    use hal::state::Factor::*;
     match factor {
         Zero => D3D12_BLEND_ZERO,
         One => D3D12_BLEND_ONE,
@@ -227,7 +229,7 @@ fn map_blend_factor(factor: state::Factor, scalar: bool) -> D3D12_BLEND {
 }
 
 fn map_blend_op(equation: state::Equation) -> D3D12_BLEND_OP {
-    use core::state::Equation::*;
+    use hal::state::Equation::*;
     match equation {
         Add => D3D12_BLEND_OP_ADD,
         Sub => D3D12_BLEND_OP_SUBTRACT,
@@ -308,7 +310,7 @@ fn map_comparison(func: state::Comparison) -> D3D12_COMPARISON_FUNC {
 }
 
 fn map_stencil_op(op: state::StencilOp) -> D3D12_STENCIL_OP {
-    use core::state::StencilOp::*;
+    use hal::state::StencilOp::*;
     match op {
         Keep => D3D12_STENCIL_OP_KEEP,
         Zero => D3D12_STENCIL_OP_ZERO,
@@ -377,7 +379,7 @@ pub enum FilterOp {
 }
 
 pub fn map_filter(filter: FilterMethod, op: FilterOp) -> D3D12_FILTER {
-    use core::image::FilterMethod::*;
+    use hal::image::FilterMethod::*;
     match op {
         FilterOp::Product => match filter {
             Scale          => D3D12_FILTER_MIN_MAG_MIP_POINT,

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -1,8 +1,8 @@
-use core::{self, image, pass, pso, MemoryType};
-use free_list;
 use winapi::{self, UINT};
 use wio::com::ComPtr;
-use Backend;
+
+use hal::{image, pass, pso, MemoryType, DescriptorPool as HalDescriptorPool};
+use {free_list, Backend};
 
 use std::collections::BTreeMap;
 use std::ops::Range;
@@ -313,7 +313,7 @@ pub struct DescriptorPool {
 unsafe impl Send for DescriptorPool {}
 unsafe impl Sync for DescriptorPool {}
 
-impl core::DescriptorPool<Backend> for DescriptorPool {
+impl HalDescriptorPool<Backend> for DescriptorPool {
     fn allocate_sets(&mut self, layouts: &[&DescriptorSetLayout]) -> Vec<DescriptorSet> {
         layouts
             .iter()

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -4,14 +4,14 @@ use std::ptr;
 use std::os::raw::c_void;
 use winapi;
 
-use core::pool;
+use hal::pool;
 use command::CommandBuffer;
-use {Backend, CommandQueue};
+use Backend;
 
 pub struct RawCommandPool {
-    inner: ComPtr<winapi::ID3D12CommandAllocator>,
-    device: ComPtr<winapi::ID3D12Device>,
-    list_type: winapi::D3D12_COMMAND_LIST_TYPE,
+    pub(crate) inner: ComPtr<winapi::ID3D12CommandAllocator>,
+    pub(crate) device: ComPtr<winapi::ID3D12Device>,
+    pub(crate) list_type: winapi::D3D12_COMMAND_LIST_TYPE,
 }
 
 impl RawCommandPool {
@@ -61,28 +61,6 @@ impl pool::RawCommandPool<Backend> for RawCommandPool {
 
     unsafe fn free(&mut self, _cbufs: Vec<CommandBuffer>) {
         // Just let the command buffers drop
-    }
-
-    unsafe fn from_queue(queue: &CommandQueue, _create_flags: pool::CommandPoolCreateFlags) -> RawCommandPool {
-        // create command allocator
-        let mut command_allocator: *mut winapi::ID3D12CommandAllocator = ptr::null_mut();
-        let hr = queue.device
-            .as_mut()
-            .CreateCommandAllocator(
-                queue.list_type,
-                &dxguid::IID_ID3D12CommandAllocator,
-                &mut command_allocator as *mut *mut _ as *mut *mut c_void,
-            );
-        // TODO: error handling
-        if !winapi::SUCCEEDED(hr) {
-            error!("error on command allocator creation: {:x}", hr);
-        }
-
-        RawCommandPool {
-            inner: ComPtr::new(command_allocator),
-            device: queue.device.clone(),
-            list_type: queue.list_type,
-        }
     }
 }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate gfx_hal as core;
 
 use std::ops::Range;
-use core::{buffer, command, device, format, image, target, mapping, memory, pass, pool, pso};
+use core::{buffer, command, device, format, image, target, mapping, memory, pass, pool, pso, queue};
 
 /// Dummy backend.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -16,10 +16,10 @@ impl core::Backend for Backend {
     type Surface = Surface;
     type Swapchain = Swapchain;
 
-    type CommandQueue = CommandQueue;
+    type CommandQueue = RawCommandQueue;
     type CommandBuffer = RawCommandBuffer;
     type SubpassCommandBuffer = SubpassCommandBuffer;
-    type QueueFamily = QueueFamily;
+    type QueueFamily = RawQueueFamily;
 
     type Memory = ();
     type CommandPool = RawCommandPool;
@@ -51,7 +51,7 @@ impl core::Backend for Backend {
 /// Dummy adapter.
 pub struct Adapter;
 impl core::Adapter<Backend> for Adapter {
-    fn open(&self, _: &[(&QueueFamily, core::QueueType, u32)]) -> core::Gpu<Backend> {
+    fn open(&self) -> core::Gpu<Backend> {
         unimplemented!()
     }
 
@@ -59,15 +59,15 @@ impl core::Adapter<Backend> for Adapter {
         unimplemented!()
     }
 
-    fn queue_families(&self) -> &[(QueueFamily, core::QueueType)] {
+    fn queue_families(&self) -> &[&RawQueueFamily] {
         unimplemented!()
     }
 }
 
 /// Dummy command queue doing nothing.
-pub struct CommandQueue;
-impl core::RawCommandQueue<Backend> for CommandQueue {
-    unsafe fn submit_raw(&mut self, _: core::RawSubmission<Backend>, _: Option<&()>) {
+pub struct RawCommandQueue;
+impl queue::RawCommandQueue<Backend> for RawCommandQueue {
+    unsafe fn submit_raw(&mut self, _: queue::RawSubmission<Backend>, _: Option<&()>) {
         unimplemented!()
     }
 }
@@ -260,9 +260,18 @@ impl core::Device<Backend> for Device {
 }
 
 /// Dummy queue family;
-pub struct QueueFamily;
-impl core::QueueFamily for QueueFamily {
-    fn num_queues(&self) -> u32 {
+pub struct RawQueueFamily;
+impl queue::RawQueueFamily<Backend> for RawQueueFamily {
+    fn queue_type(&self) -> core::QueueType {
+        unimplemented!()
+    }
+    fn max_queues(&self) -> usize {
+        unimplemented!()
+    }
+    fn create_queue(&mut self) -> RawCommandQueue {
+        unimplemented!()
+    }
+    fn create_pool(&mut self, _: pool::CommandPoolCreateFlags) -> RawCommandPool {
         unimplemented!()
     }
 }
@@ -272,12 +281,8 @@ pub struct SubpassCommandBuffer;
 
 /// Dummy raw command pool.
 pub struct RawCommandPool;
-impl core::RawCommandPool<Backend> for RawCommandPool {
+impl pool::RawCommandPool<Backend> for RawCommandPool {
     fn reset(&mut self) {
-        unimplemented!()
-    }
-
-    unsafe fn from_queue(_: &CommandQueue, _: pool::CommandPoolCreateFlags) -> Self {
         unimplemented!()
     }
 
@@ -292,14 +297,14 @@ impl core::RawCommandPool<Backend> for RawCommandPool {
 
 /// Dummy subpass command pool.
 pub struct SubpassCommandPool;
-impl core::SubpassCommandPool<Backend> for SubpassCommandPool {
+impl pool::SubpassCommandPool<Backend> for SubpassCommandPool {
 
 }
 
 /// Dummy command buffer, which ignores all the calls.
 #[derive(Clone)]
 pub struct RawCommandBuffer;
-impl core::RawCommandBuffer<Backend> for RawCommandBuffer {
+impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     fn begin(&mut self) {
         unimplemented!()
     }
@@ -533,7 +538,7 @@ impl core::Surface<Backend> for Surface {
         unimplemented!()
     }
 
-    fn supports_queue(&self, _: &QueueFamily) -> bool {
+    fn supports_queue(&self, _: &RawQueueFamily) -> bool {
         unimplemented!()
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -1,25 +1,25 @@
 //! Dummy backend implementation to test the code for compile errors
 //! outside of the graphics development environment.
 
-extern crate gfx_hal as core;
+extern crate gfx_hal as hal;
 
 use std::ops::Range;
-use core::{buffer, command, device, format, image, target, mapping, memory, pass, pool, pso, queue};
+use hal::{buffer, command, device, format, image, target, mapping, memory, pass, pool, pso, queue};
 
 /// Dummy backend.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Backend { }
-impl core::Backend for Backend {
+impl hal::Backend for Backend {
     type Adapter = Adapter;
     type Device = Device;
 
     type Surface = Surface;
     type Swapchain = Swapchain;
 
+    type ProtoQueueFamily = ProtoQueueFamily;
     type CommandQueue = RawCommandQueue;
     type CommandBuffer = RawCommandBuffer;
     type SubpassCommandBuffer = SubpassCommandBuffer;
-    type QueueFamily = RawQueueFamily;
 
     type Memory = ();
     type CommandPool = RawCommandPool;
@@ -50,16 +50,16 @@ impl core::Backend for Backend {
 
 /// Dummy adapter.
 pub struct Adapter;
-impl core::Adapter<Backend> for Adapter {
-    fn open(&self) -> core::Gpu<Backend> {
+impl hal::Adapter<Backend> for Adapter {
+    fn open(self, _: Vec<(ProtoQueueFamily, usize)>) -> hal::Gpu<Backend> {
         unimplemented!()
     }
 
-    fn info(&self) -> &core::AdapterInfo {
+    fn info(&self) -> &hal::AdapterInfo {
         unimplemented!()
     }
 
-    fn queue_families(&self) -> &[&RawQueueFamily] {
+    fn list_queue_families(&mut self) -> Vec<ProtoQueueFamily> {
         unimplemented!()
     }
 }
@@ -75,16 +75,24 @@ impl queue::RawCommandQueue<Backend> for RawCommandQueue {
 /// Dummy device doing nothing.
 #[derive(Clone)]
 pub struct Device;
-impl core::Device<Backend> for Device {
-    fn get_features(&self) -> &core::Features {
+impl hal::Device<Backend> for Device {
+    fn get_features(&self) -> &hal::Features {
         unimplemented!()
     }
 
-    fn get_limits(&self) -> &core::Limits {
+    fn get_limits(&self) -> &hal::Limits {
         unimplemented!()
     }
 
-    fn allocate_memory(&mut self, _: &core::MemoryType, _: u64) -> Result<(), device::OutOfMemory> {
+    fn create_command_pool(&mut self, _: &ProtoQueueFamily, _: pool::CommandPoolCreateFlags) -> RawCommandPool {
+        unimplemented!()
+    }
+
+    fn destroy_command_pool(&mut self, _: RawCommandPool) {
+        unimplemented!()
+    }
+
+    fn allocate_memory(&mut self, _: &hal::MemoryType, _: u64) -> Result<(), device::OutOfMemory> {
         unimplemented!()
     }
 
@@ -259,19 +267,13 @@ impl core::Device<Backend> for Device {
     }
 }
 
-/// Dummy queue family;
-pub struct RawQueueFamily;
-impl queue::RawQueueFamily<Backend> for RawQueueFamily {
-    fn queue_type(&self) -> core::QueueType {
+#[derive(Debug)]
+pub struct ProtoQueueFamily;
+impl queue::ProtoQueueFamily for ProtoQueueFamily {
+    fn queue_type(&self) -> hal::QueueType {
         unimplemented!()
     }
     fn max_queues(&self) -> usize {
-        unimplemented!()
-    }
-    fn create_queue(&mut self) -> RawCommandQueue {
-        unimplemented!()
-    }
-    fn create_pool(&mut self, _: pool::CommandPoolCreateFlags) -> RawCommandPool {
         unimplemented!()
     }
 }
@@ -376,7 +378,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn set_viewports(&mut self, _: &[core::Viewport]) {
+    fn set_viewports(&mut self, _: &[hal::Viewport]) {
 
     }
 
@@ -484,17 +486,17 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
     fn draw(&mut self,
-        _: Range<core::VertexCount>,
-        _: Range<core::InstanceCount>,
+        _: Range<hal::VertexCount>,
+        _: Range<hal::InstanceCount>,
     ) {
         unimplemented!()
     }
 
     fn draw_indexed(
         &mut self,
-        _: Range<core::IndexCount>,
-        _: core::VertexOffset,
-        _: Range<core::InstanceCount>,
+        _: Range<hal::IndexCount>,
+        _: hal::VertexOffset,
+        _: Range<hal::InstanceCount>,
     ) {
         unimplemented!()
     }
@@ -517,7 +519,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 // Dummy descriptor pool.
 #[derive(Debug)]
 pub struct DescriptorPool;
-impl core::DescriptorPool<Backend> for DescriptorPool {
+impl hal::DescriptorPool<Backend> for DescriptorPool {
     fn allocate_sets(&mut self, _: &[&()]) -> Vec<()> {
         unimplemented!()
     }
@@ -529,37 +531,37 @@ impl core::DescriptorPool<Backend> for DescriptorPool {
 
 /// Dummy surface.
 pub struct Surface;
-impl core::Surface<Backend> for Surface {
-    fn get_kind(&self) -> core::image::Kind {
+impl hal::Surface<Backend> for Surface {
+    fn get_kind(&self) -> hal::image::Kind {
         unimplemented!()
     }
 
-    fn surface_capabilities(&self, _: &Adapter) -> core::SurfaceCapabilities {
+    fn surface_capabilities(&self, _: &Adapter) -> hal::SurfaceCapabilities {
         unimplemented!()
     }
 
-    fn supports_queue(&self, _: &RawQueueFamily) -> bool {
+    fn supports_queue_family(&self, _: &ProtoQueueFamily) -> bool {
         unimplemented!()
     }
 
     fn build_swapchain<C>(&mut self,
-        _: core::SwapchainConfig,
-        _: &core::CommandQueue<Backend, C>
-    ) -> (Swapchain, core::Backbuffer<Backend>) {
+        _: hal::SwapchainConfig,
+        _: &hal::CommandQueue<Backend, C>
+    ) -> (Swapchain, hal::Backbuffer<Backend>) {
         unimplemented!()
     }
 }
 
 /// Dummy swapchain.
 pub struct Swapchain;
-impl core::Swapchain<Backend> for Swapchain {
-    fn acquire_frame(&mut self, _: core::FrameSync<Backend>) -> core::Frame {
+impl hal::Swapchain<Backend> for Swapchain {
+    fn acquire_frame(&mut self, _: hal::FrameSync<Backend>) -> hal::Frame {
         unimplemented!()
     }
 
     fn present<C>(
         &mut self,
-        _: &mut core::CommandQueue<Backend, C>,
+        _: &mut hal::CommandQueue<Backend, C>,
         _: &[&()],
     ) {
         unimplemented!()
@@ -567,7 +569,7 @@ impl core::Swapchain<Backend> for Swapchain {
 }
 
 pub struct Instance;
-impl core::Instance for Instance {
+impl hal::Instance for Instance {
     type Backend = Backend;
     fn enumerate_adapters(&self) -> Vec<Adapter> {
         Vec::new()

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -10,13 +10,13 @@ use hal::{buffer, command, device, format, image, target, mapping, memory, pass,
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Backend { }
 impl hal::Backend for Backend {
-    type Adapter = Adapter;
+    type PhysicalDevice = PhysicalDevice;
     type Device = Device;
 
     type Surface = Surface;
     type Swapchain = Swapchain;
 
-    type ProtoQueueFamily = ProtoQueueFamily;
+    type QueueFamily = QueueFamily;
     type CommandQueue = RawCommandQueue;
     type CommandBuffer = RawCommandBuffer;
     type SubpassCommandBuffer = SubpassCommandBuffer;
@@ -48,18 +48,10 @@ impl hal::Backend for Backend {
     type Semaphore = ();
 }
 
-/// Dummy adapter.
-pub struct Adapter;
-impl hal::Adapter<Backend> for Adapter {
-    fn open(self, _: Vec<(ProtoQueueFamily, usize)>) -> hal::Gpu<Backend> {
-        unimplemented!()
-    }
-
-    fn info(&self) -> &hal::AdapterInfo {
-        unimplemented!()
-    }
-
-    fn list_queue_families(&mut self) -> Vec<ProtoQueueFamily> {
+/// Dummy physical device.
+pub struct PhysicalDevice;
+impl hal::PhysicalDevice<Backend> for PhysicalDevice {
+    fn open(self, _: Vec<(QueueFamily, usize)>) -> hal::Gpu<Backend> {
         unimplemented!()
     }
 }
@@ -84,7 +76,7 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_command_pool(&mut self, _: &ProtoQueueFamily, _: pool::CommandPoolCreateFlags) -> RawCommandPool {
+    fn create_command_pool(&mut self, _: &QueueFamily, _: pool::CommandPoolCreateFlags) -> RawCommandPool {
         unimplemented!()
     }
 
@@ -268,8 +260,8 @@ impl hal::Device<Backend> for Device {
 }
 
 #[derive(Debug)]
-pub struct ProtoQueueFamily;
-impl queue::ProtoQueueFamily for ProtoQueueFamily {
+pub struct QueueFamily;
+impl queue::QueueFamily for QueueFamily {
     fn queue_type(&self) -> hal::QueueType {
         unimplemented!()
     }
@@ -536,11 +528,11 @@ impl hal::Surface<Backend> for Surface {
         unimplemented!()
     }
 
-    fn surface_capabilities(&self, _: &Adapter) -> hal::SurfaceCapabilities {
+    fn surface_capabilities(&self, _: &PhysicalDevice) -> hal::SurfaceCapabilities {
         unimplemented!()
     }
 
-    fn supports_queue_family(&self, _: &ProtoQueueFamily) -> bool {
+    fn supports_queue_family(&self, _: &QueueFamily) -> bool {
         unimplemented!()
     }
 
@@ -571,7 +563,7 @@ impl hal::Swapchain<Backend> for Swapchain {
 pub struct Instance;
 impl hal::Instance for Instance {
     type Backend = Backend;
-    fn enumerate_adapters(&self) -> Vec<Adapter> {
-        Vec::new()
+    fn enumerate_adapters(&self) -> Vec<hal::Adapter<Backend>> {
+        unimplemented!()
     }
 }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -68,7 +68,7 @@ pub enum Command {
         instances: Range<c::InstanceCount>,
     },
     BindIndexBuffer(gl::types::GLuint),
-    BindVertexBuffers(BufferSlice),
+    //BindVertexBuffers(BufferSlice),
     SetViewports {
         viewport_ptr: BufferSlice,
         depth_range_ptr: BufferSlice,

--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -1,7 +1,7 @@
 use gl::{self, types as t};
 use hal::{buffer, image as i};
 
-pub fn image_kind_to_gl(kind: i::Kind) -> t::GLenum {
+pub fn _image_kind_to_gl(kind: i::Kind) -> t::GLenum {
     match kind {
         i::Kind::D1(_) => gl::TEXTURE_1D,
         i::Kind::D1Array(_, _) => gl::TEXTURE_1D_ARRAY,

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -11,7 +11,7 @@ use hal::{self as c, device as d, image as i, memory, pass, pso, buffer, mapping
 use hal::format::{Format, Swizzle};
 use hal::pool::CommandPoolCreateFlags;
 
-use {Backend as B, ProtoQueueFamily, Share};
+use {Backend as B, QueueFamily, Share};
 use {conv, native as n, state};
 use pool::{BufferMemory, OwnedBuffer, RawCommandPool};
 
@@ -174,7 +174,7 @@ impl d::Device<B> for Device {
 
     fn create_command_pool(
         &mut self,
-        _family: &ProtoQueueFamily,
+        _family: &QueueFamily,
         flags: CommandPoolCreateFlags,
     ) -> RawCommandPool {
         let fbo = create_fbo_internal(&self.share.context);

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)] //TODO: remove
+
 use hal::{ColorSlot};
 use hal::state as s;
 use hal::state::{

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -43,9 +43,9 @@
 //! }
 //! ```
 
-use hal::{self as core, format, image};
+use hal::{self, format, image};
 
-use {native as n, Adapter, Backend as B, QueueFamily};
+use {native as n, Adapter, Backend as B, ProtoQueueFamily};
 
 use glutin::{self, GlContext};
 use std::rc::Rc;
@@ -62,13 +62,13 @@ pub struct Swapchain {
     window: Rc<glutin::GlWindow>,
 }
 
-impl core::Swapchain<B> for Swapchain {
-    fn acquire_frame(&mut self, _sync: core::FrameSync<B>) -> core::Frame {
+impl hal::Swapchain<B> for Swapchain {
+    fn acquire_frame(&mut self, _sync: hal::FrameSync<B>) -> hal::Frame {
         // TODO: sync
-        core::Frame::new(0)
+        hal::Frame::new(0)
     }
 
-    fn present<C>(&mut self, _: &mut core::CommandQueue<B, C>, _: &[&n::Semaphore]) {
+    fn present<C>(&mut self, _: &mut hal::CommandQueue<B, C>, _: &[&n::Semaphore]) {
         self.window.swap_buffers().unwrap();
     }
 }
@@ -88,32 +88,32 @@ impl Surface {
     }
 }
 
-impl core::Surface<B> for Surface {
-    fn get_kind(&self) -> core::image::Kind {
+impl hal::Surface<B> for Surface {
+    fn get_kind(&self) -> hal::image::Kind {
         let (w, h, _, a) = get_window_dimensions(&self.window);
-        core::image::Kind::D2(w, h, a)
+        hal::image::Kind::D2(w, h, a)
     }
 
-    fn surface_capabilities(&self, _: &Adapter) -> core::SurfaceCapabilities {
+    fn surface_capabilities(&self, _: &Adapter) -> hal::SurfaceCapabilities {
         unimplemented!()
     }
 
-    fn supports_queue(&self, _: &QueueFamily) -> bool { true }
+    fn supports_queue_family(&self, _: &ProtoQueueFamily) -> bool { true }
 
     fn build_swapchain<C>(
         &mut self,
-        _config: core::SwapchainConfig,
-        _: &core::CommandQueue<B, C>,
-    ) -> (Swapchain, core::Backbuffer<B>) {
+        _config: hal::SwapchainConfig,
+        _: &hal::CommandQueue<B, C>,
+    ) -> (Swapchain, hal::Backbuffer<B>) {
         let swapchain = Swapchain {
             window: self.window.clone(),
         };
-        let backbuffer = core::Backbuffer::Framebuffer(0);
+        let backbuffer = hal::Backbuffer::Framebuffer(0);
         (swapchain, backbuffer)
     }
 }
 
-impl core::Instance for Surface {
+impl hal::Instance for Surface {
     type Backend = B;
     fn enumerate_adapters(&self) -> Vec<Adapter> {
         unsafe { self.window.make_current().unwrap() };
@@ -143,7 +143,7 @@ pub fn config_context(
 
 pub struct Headless(pub glutin::HeadlessContext);
 
-impl core::Instance for Headless {
+impl hal::Instance for Headless {
     type Backend = B;
     fn enumerate_adapters(&self) -> Vec<Adapter> {
         unsafe { self.0.make_current().unwrap() };

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -45,7 +45,7 @@
 
 use hal::{self, format, image};
 
-use {native as n, Adapter, Backend as B, ProtoQueueFamily};
+use {native as n, Backend as B, PhysicalDevice, QueueFamily};
 
 use glutin::{self, GlContext};
 use std::rc::Rc;
@@ -94,11 +94,11 @@ impl hal::Surface<B> for Surface {
         hal::image::Kind::D2(w, h, a)
     }
 
-    fn surface_capabilities(&self, _: &Adapter) -> hal::SurfaceCapabilities {
+    fn surface_capabilities(&self, _: &PhysicalDevice) -> hal::SurfaceCapabilities {
         unimplemented!()
     }
 
-    fn supports_queue_family(&self, _: &ProtoQueueFamily) -> bool { true }
+    fn supports_queue_family(&self, _: &QueueFamily) -> bool { true }
 
     fn build_swapchain<C>(
         &mut self,
@@ -115,9 +115,9 @@ impl hal::Surface<B> for Surface {
 
 impl hal::Instance for Surface {
     type Backend = B;
-    fn enumerate_adapters(&self) -> Vec<Adapter> {
+    fn enumerate_adapters(&self) -> Vec<hal::Adapter<B>> {
         unsafe { self.window.make_current().unwrap() };
-        let adapter = Adapter::new(|s| self.window.get_proc_address(s) as *const _);
+        let adapter = PhysicalDevice::new_adapter(|s| self.window.get_proc_address(s) as *const _);
         vec![adapter]
     }
 }
@@ -145,9 +145,9 @@ pub struct Headless(pub glutin::HeadlessContext);
 
 impl hal::Instance for Headless {
     type Backend = B;
-    fn enumerate_adapters(&self) -> Vec<Adapter> {
+    fn enumerate_adapters(&self) -> Vec<hal::Adapter<B>> {
         unsafe { self.0.make_current().unwrap() };
-        let adapter = Adapter::new(|s| self.0.get_proc_address(s) as *const _);
+        let adapter = PhysicalDevice::new_adapter(|s| self.0.get_proc_address(s) as *const _);
         vec![adapter]
     }
 }

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -1,12 +1,11 @@
-use core;
-use core::{pass, image, memory};
-use core::format::Format;
+use hal::{pass, image, memory, state};
+use hal::format::Format;
 use metal::*;
 
 // The boolean indicates whether this is a depth format
 pub fn map_format(format: Format) -> Option<(MTLPixelFormat, bool)> {
-    use core::format::SurfaceType::*;
-    use core::format::ChannelType::*;
+    use hal::format::SurfaceType::*;
+    use hal::format::ChannelType::*;
 
     // TODO: more formats
     match format {
@@ -47,9 +46,7 @@ pub fn map_store_operation(operation: pass::AttachmentStoreOp) -> MTLStoreAction
     }
 }
 
-pub fn map_write_mask(mask: core::state::ColorMask) -> MTLColorWriteMask {
-    use core::state;
-
+pub fn map_write_mask(mask: state::ColorMask) -> MTLColorWriteMask {
     let mut mtl_mask = MTLColorWriteMaskNone;
 
     if mask.contains(state::RED) {
@@ -68,8 +65,8 @@ pub fn map_write_mask(mask: core::state::ColorMask) -> MTLColorWriteMask {
     mtl_mask
 }
 
-pub fn map_blend_op(equation: core::state::Equation) -> MTLBlendOperation {
-    use core::state::Equation::*;
+pub fn map_blend_op(equation: state::Equation) -> MTLBlendOperation {
+    use hal::state::Equation::*;
 
     match equation {
         Add => MTLBlendOperation::Add,
@@ -80,9 +77,9 @@ pub fn map_blend_op(equation: core::state::Equation) -> MTLBlendOperation {
     }
 }
 
-pub fn map_blend_factor(factor: core::state::Factor, scalar: bool) -> MTLBlendFactor {
-    use core::state::BlendValue::*;
-    use core::state::Factor::*;
+pub fn map_blend_factor(factor: state::Factor, scalar: bool) -> MTLBlendFactor {
+    use hal::state::BlendValue::*;
+    use hal::state::Factor::*;
 
     match factor {
         Zero => MTLBlendFactor::Zero,
@@ -110,8 +107,8 @@ pub fn map_blend_factor(factor: core::state::Factor, scalar: bool) -> MTLBlendFa
 
 
 pub fn map_vertex_format(format: Format) -> Option<MTLVertexFormat> {
-    use core::format::SurfaceType::*;
-    use core::format::ChannelType::*;
+    use hal::format::SurfaceType::*;
+    use hal::format::ChannelType::*;
 
     // TODO: more formats
     Some(match format {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -5,14 +5,13 @@ use std::sync::{Arc, Mutex};
 use std::os::raw::{c_void, c_long, c_int};
 use std::ptr;
 
-use core::{self, image, pass, pso};
+use hal::{self, image, pass, pso};
 
 use cocoa::foundation::{NSRange, NSUInteger};
 use metal::*;
 use objc;
 use spirv_cross::msl;
 
-pub struct QueueFamily {}
 
 /// Shader module can be compiled in advance if it's resource bindings do not
 /// depend on pipeline layout, in which case the value would become `Compiled`.
@@ -110,7 +109,7 @@ pub enum DescriptorPool {
 unsafe impl Send for DescriptorPool {}
 unsafe impl Sync for DescriptorPool {}
 
-impl core::DescriptorPool<Backend> for DescriptorPool {
+impl hal::DescriptorPool<Backend> for DescriptorPool {
     fn allocate_sets(&mut self, layouts: &[&DescriptorSetLayout]) -> Vec<DescriptorSet> {
         match *self {
             DescriptorPool::Emulated => {
@@ -239,7 +238,7 @@ impl Drop for DescriptorSetBinding {
 
 #[derive(Debug)]
 pub enum Memory {
-    Emulated { memory_type: core::MemoryType, size: u64 },
+    Emulated { memory_type: hal::MemoryType, size: u64 },
     Native(MTLHeap),
 }
 
@@ -260,11 +259,6 @@ unsafe impl Sync for UnboundImage {}
 #[derive(Debug)]
 pub struct Fence(pub Arc<Mutex<bool>>);
 
-impl core::QueueFamily for QueueFamily {
-    fn num_queues(&self) -> u32 {
-        1 // TODO: don't think there is a queue limit
-    }
-}
 
 pub unsafe fn objc_err_description(object: *mut objc::runtime::Object) -> String {
     let description: *mut objc::runtime::Object = msg_send![object, localizedDescription];

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -5,10 +5,10 @@ use smallvec::SmallVec;
 use ash::vk;
 use ash::version::DeviceV1_0;
 
-use core::{command as com, memory, pso, target};
-use core::{IndexCount, InstanceCount, VertexCount, VertexOffset, Viewport};
-use core::buffer::IndexBufferView;
-use core::image::{
+use hal::{command as com, memory, pso, target};
+use hal::{IndexCount, InstanceCount, VertexCount, VertexOffset, Viewport};
+use hal::buffer::IndexBufferView;
+use hal::image::{
     ImageLayout, SubresourceRange,
     ASPECT_COLOR, ASPECT_DEPTH, ASPECT_STENCIL,
 };

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -1,14 +1,14 @@
 use ash::vk;
-use core::{buffer, format, image, pass, pso, state};
-use core::command::{ClearColor, ClearDepthStencil, ClearValue, Offset};
-use core::device::Extent;
-use core::{IndexType, Primitive};
+use hal::{buffer, format, image, pass, pso, state};
+use hal::command::{ClearColor, ClearDepthStencil, ClearValue, Offset};
+use hal::device::Extent;
+use hal::{IndexType, Primitive};
 use std::ops::Range;
 
 
 pub fn map_format(surface: format::SurfaceType, chan: format::ChannelType) -> Option<vk::Format> {
-    use core::format::SurfaceType::*;
-    use core::format::ChannelType::*;
+    use hal::format::SurfaceType::*;
+    use hal::format::ChannelType::*;
     Some(match surface {
         R4_G4 => match chan {
             Unorm => vk::Format::R4g4UnormPack8,
@@ -149,7 +149,7 @@ pub fn map_format(surface: format::SurfaceType, chan: format::ChannelType) -> Op
 }
 
 pub fn map_component(component: format::Component) -> vk::ComponentSwizzle {
-    use core::format::Component::*;
+    use hal::format::Component::*;
     match component {
         Zero => vk::ComponentSwizzle::Zero,
         One  => vk::ComponentSwizzle::One,
@@ -177,7 +177,7 @@ pub fn map_index_type(index_type: IndexType) -> vk::IndexType {
 }
 
 pub fn map_image_layout(layout: image::ImageLayout) -> vk::ImageLayout {
-    use core::image::ImageLayout as Il;
+    use hal::image::ImageLayout as Il;
     match layout {
         Il::General => vk::ImageLayout::General,
         Il::ColorAttachmentOptimal => vk::ImageLayout::ColorAttachmentOptimal,
@@ -284,7 +284,7 @@ pub fn map_subresource_range(
 }
 
 pub fn map_attachment_load_op(op: pass::AttachmentLoadOp) -> vk::AttachmentLoadOp {
-    use core::pass::AttachmentLoadOp as Alo;
+    use hal::pass::AttachmentLoadOp as Alo;
     match op {
         Alo::Load => vk::AttachmentLoadOp::Load,
         Alo::Clear => vk::AttachmentLoadOp::Clear,
@@ -293,7 +293,7 @@ pub fn map_attachment_load_op(op: pass::AttachmentLoadOp) -> vk::AttachmentLoadO
 }
 
 pub fn map_attachment_store_op(op: pass::AttachmentStoreOp) -> vk::AttachmentStoreOp {
-    use core::pass::AttachmentStoreOp as Aso;
+    use hal::pass::AttachmentStoreOp as Aso;
     match op {
         Aso::Store => vk::AttachmentStoreOp::Store,
         Aso::DontCare => vk::AttachmentStoreOp::DontCare,
@@ -501,7 +501,7 @@ pub fn map_image_usage(usage: image::Usage) -> vk::ImageUsageFlags {
 }
 
 pub fn map_descriptor_type(ty: pso::DescriptorType) -> vk::DescriptorType {
-    use core::pso::DescriptorType as Dt;
+    use hal::pso::DescriptorType as Dt;
     match ty {
         Dt::Sampler            => vk::DescriptorType::Sampler,
         Dt::SampledImage       => vk::DescriptorType::SampledImage,
@@ -546,7 +546,7 @@ pub fn map_stage_flags(stages: pso::ShaderStageFlags) -> vk::ShaderStageFlags {
 
 
 pub fn map_filter(filter: image::FilterMethod) -> (vk::Filter, vk::Filter, vk::SamplerMipmapMode, f32) {
-    use core::image::FilterMethod as Fm;
+    use hal::image::FilterMethod as Fm;
     match filter {
         Fm::Scale          => (vk::Filter::Nearest, vk::Filter::Nearest, vk::SamplerMipmapMode::Nearest, 1.0),
         Fm::Mipmap         => (vk::Filter::Nearest, vk::Filter::Nearest, vk::SamplerMipmapMode::Linear,  1.0),
@@ -557,7 +557,7 @@ pub fn map_filter(filter: image::FilterMethod) -> (vk::Filter, vk::Filter, vk::S
 }
 
 pub fn map_wrap(wrap: image::WrapMode) -> vk::SamplerAddressMode {
-    use core::image::WrapMode as Wm;
+    use hal::image::WrapMode as Wm;
     match wrap {
         Wm::Tile   => vk::SamplerAddressMode::Repeat,
         Wm::Mirror => vk::SamplerAddressMode::MirroredRepeat,
@@ -614,7 +614,7 @@ pub fn map_front_face(ff: state::FrontFace) -> vk::FrontFace {
 }
 
 pub fn map_comparison(fun: state::Comparison) -> vk::CompareOp {
-    use core::state::Comparison::*;
+    use hal::state::Comparison::*;
     match fun {
         Never        => vk::CompareOp::Never,
         Less         => vk::CompareOp::Less,
@@ -628,7 +628,7 @@ pub fn map_comparison(fun: state::Comparison) -> vk::CompareOp {
 }
 
 pub fn map_stencil_op(op: state::StencilOp) -> vk::StencilOp {
-    use core::state::StencilOp::*;
+    use hal::state::StencilOp::*;
     match op {
         Keep           => vk::StencilOp::Keep,
         Zero           => vk::StencilOp::Zero,
@@ -654,8 +654,8 @@ pub fn map_stencil_side(side: &state::StencilSide) -> vk::StencilOpState {
 }
 
 pub fn map_blend_factor(factor: state::Factor, scalar: bool) -> vk::BlendFactor {
-    use core::state::BlendValue::*;
-    use core::state::Factor::*;
+    use hal::state::BlendValue::*;
+    use hal::state::Factor::*;
     match factor {
         Zero => vk::BlendFactor::Zero,
         One => vk::BlendFactor::One,
@@ -681,7 +681,7 @@ pub fn map_blend_factor(factor: state::Factor, scalar: bool) -> vk::BlendFactor 
 }
 
 pub fn map_blend_op(equation: state::Equation) -> vk::BlendOp {
-    use core::state::Equation::*;
+    use hal::state::Equation::*;
     match equation {
         Add => vk::BlendOp::Add,
         Sub => vk::BlendOp::Subtract,

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1,16 +1,18 @@
 use ash::vk;
 use ash::version::DeviceV1_0;
-use core::{buffer, device as d, format, image, mapping, pass, pso};
-use core::{Features, Limits, MemoryType};
-use core::memory::Requirements;
+use hal::{buffer, device as d, format, image, mapping, pass, pso};
+use hal::{Features, Limits, MemoryType};
+use hal::memory::Requirements;
+use hal::pool::CommandPoolCreateFlags;
 use native as n;
 use smallvec::SmallVec;
 use std::{mem, ptr};
 use std::ffi::CString;
 use std::ops::Range;
 
-use {Backend as B, Device};
+use {Backend as B, Device, ProtoQueueFamily};
 use {conv, memory};
+use pool::RawCommandPool;
 
 
 #[derive(Debug)]
@@ -80,6 +82,42 @@ impl d::Device<B> for Device {
         } as *mut _;
 
         Ok(n::Memory { inner: memory, ptr })
+    }
+
+    fn create_command_pool(
+        &mut self, family: &ProtoQueueFamily, create_flags: CommandPoolCreateFlags
+    ) -> RawCommandPool {
+        let mut flags = vk::CommandPoolCreateFlags::empty();
+        if create_flags.contains(CommandPoolCreateFlags::TRANSIENT) {
+            flags |= vk::COMMAND_POOL_CREATE_TRANSIENT_BIT;
+        }
+        if create_flags.contains(CommandPoolCreateFlags::RESET_INDIVIDUAL) {
+            flags |= vk::COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+        }
+
+        let info = vk::CommandPoolCreateInfo {
+            s_type: vk::StructureType::CommandPoolCreateInfo,
+            p_next: ptr::null(),
+            flags,
+            queue_family_index: family.index,
+        };
+
+        let command_pool_raw = unsafe {
+            self.raw.0
+                .create_command_pool(&info, None)
+        }.expect("Error on command pool creation"); // TODO: better error handling
+
+        RawCommandPool {
+            raw: command_pool_raw,
+            device: self.raw.clone(),
+        }
+    }
+
+    fn destroy_command_pool(&mut self, pool: RawCommandPool) {
+        unsafe {
+            self.raw.0
+                .destroy_command_pool(pool.raw, None)
+        };
     }
 
     fn create_render_pass(&mut self, attachments: &[pass::Attachment],
@@ -213,7 +251,7 @@ impl d::Device<B> for Device {
         &mut self,
         descs: &[(pso::GraphicsShaderSet<'a, B>, &n::PipelineLayout, pass::Subpass<'a, B>, &pso::GraphicsPipelineDesc)],
     ) -> Vec<Result<n::GraphicsPipeline, pso::CreationError>> {
-        use core::state as s;
+        use hal::state as s;
 
         debug!("create_graphics_pipelines {:?}", descs);
         // Store pipeline parameters to avoid stack usage
@@ -624,7 +662,7 @@ impl d::Device<B> for Device {
     }
 
     fn create_sampler(&mut self, sampler_info: image::SamplerInfo) -> n::Sampler {
-        use core::state::Comparison;
+        use hal::state::Comparison;
 
         let (min_filter, mag_filter, mipmap_mode, aniso) = conv::map_filter(sampler_info.filter);
         let info = vk::SamplerCreateInfo {
@@ -736,7 +774,7 @@ impl d::Device<B> for Device {
     fn create_image(&mut self, kind: image::Kind, mip_levels: image::Level, format: format::Format, usage: image::Usage)
          -> Result<UnboundImage, image::CreationError>
     {
-        use core::image::Kind::*;
+        use hal::image::Kind::*;
 
         let flags = match kind {
             Cube(_) => vk::IMAGE_CREATE_CUBE_COMPATIBLE_BIT,

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -10,7 +10,7 @@ use std::{mem, ptr};
 use std::ffi::CString;
 use std::ops::Range;
 
-use {Backend as B, Device, ProtoQueueFamily};
+use {Backend as B, Device, QueueFamily};
 use {conv, memory};
 use pool::RawCommandPool;
 
@@ -85,7 +85,7 @@ impl d::Device<B> for Device {
     }
 
     fn create_command_pool(
-        &mut self, family: &ProtoQueueFamily, create_flags: CommandPoolCreateFlags
+        &mut self, family: &QueueFamily, create_flags: CommandPoolCreateFlags
     ) -> RawCommandPool {
         let mut flags = vk::CommandPoolCreateFlags::empty();
         if create_flags.contains(CommandPoolCreateFlags::TRANSIENT) {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -309,7 +309,9 @@ pub struct Adapter {
 }
 
 impl hal::Adapter<Backend> for Adapter {
-    fn open(self, families: Vec<(ProtoQueueFamily, usize)>) -> hal::Gpu<Backend> {
+    fn open<'a, I>(&self, family_iter: I) -> hal::Gpu<Backend>
+    where I: Iterator<Item = (&'a QueueFamily, usize)>
+    {
         let max_queue_count = families.iter().map(|&(_, count)| count).max().unwrap_or(0);
         let queue_priorities = vec![0.0f32; max_queue_count];
         let family_infos = families
@@ -455,8 +457,8 @@ impl hal::Adapter<Backend> for Adapter {
         &self.info
     }
 
-    fn list_queue_families(&mut self) -> Vec<ProtoQueueFamily> {
-        mem::replace(&mut self.queue_families, Vec::new())
+    fn queue_families(&self) -> &[QueueFamily] {
+        &self.queue_families
     }
 }
 

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -1,7 +1,7 @@
 use ash::vk;
 use ash::version::DeviceV1_0;
-use core;
-use core::image::SubresourceRange;
+use hal;
+use hal::image::SubresourceRange;
 use std::sync::Arc;
 use {Backend, RawDevice};
 
@@ -92,7 +92,7 @@ pub struct DescriptorPool {
     pub(crate) device: Arc<RawDevice>,
 }
 
-impl core::DescriptorPool<Backend> for DescriptorPool {
+impl hal::DescriptorPool<Backend> for DescriptorPool {
     fn allocate_sets(&mut self, layouts: &[&DescriptorSetLayout]) -> Vec<DescriptorSet> {
         use std::ptr;
 

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -6,13 +6,13 @@ use std::os::raw::c_void;
 use ash::vk;
 use ash::extensions as ext;
 
-use core;
+use hal;
 
 #[cfg(feature = "winit")]
 use winit;
 
 use {conv, native};
-use {VK_ENTRY, Adapter, Backend, Instance, QueueFamily, RawInstance};
+use {VK_ENTRY, Adapter, Backend, Instance, ProtoQueueFamily, RawInstance};
 
 
 pub struct Surface {
@@ -199,18 +199,18 @@ impl Instance {
     }
 }
 
-impl core::Surface<Backend> for Surface {
-    fn get_kind(&self) -> core::image::Kind {
-        use core::image::Size;
+impl hal::Surface<Backend> for Surface {
+    fn get_kind(&self) -> hal::image::Kind {
+        use hal::image::Size;
 
-        let aa = core::image::AaMode::Single;
-        core::image::Kind::D2(self.width as Size, self.height as Size, aa)
+        let aa = hal::image::AaMode::Single;
+        hal::image::Kind::D2(self.width as Size, self.height as Size, aa)
     }
 
-    fn surface_capabilities(&self, adapter: &Adapter) -> core::SurfaceCapabilities {
+    fn surface_capabilities(&self, adapter: &Adapter) -> hal::SurfaceCapabilities {
         let caps =
             self.raw.functor.get_physical_device_surface_capabilities_khr(
-                adapter.handle(),
+                adapter.handle,
                 self.raw.handle,
             )
             .expect("Unable to query surface capabilities");
@@ -221,7 +221,7 @@ impl core::Surface<Backend> for Surface {
         // `0xFFFFFFFF` indicates that the extent depends on the created swapchain.
         let current_extent =
             if caps.current_extent.width != 0xFFFFFFFF && caps.current_extent.height != 0xFFFFFFFF {
-                Some(core::window::Extent2d {
+                Some(hal::window::Extent2d {
                     width: caps.current_extent.width,
                     height: caps.current_extent.height,
                 })
@@ -229,17 +229,17 @@ impl core::Surface<Backend> for Surface {
                 None
             };
 
-        let min_extent = core::window::Extent2d {
+        let min_extent = hal::window::Extent2d {
             width: caps.min_image_extent.width,
             height: caps.min_image_extent.height,
         };
 
-        let max_extent = core::window::Extent2d {
+        let max_extent = hal::window::Extent2d {
             width: caps.max_image_extent.width,
             height: caps.max_image_extent.height,
         };
 
-        core::SurfaceCapabilities {
+        hal::SurfaceCapabilities {
             image_count: caps.min_image_count..max_images,
             current_extent,
             extents: min_extent..max_extent,
@@ -247,20 +247,20 @@ impl core::Surface<Backend> for Surface {
         }
     }
 
-    fn supports_queue(&self, queue_family: &QueueFamily) -> bool {
+    fn supports_queue_family(&self, queue_family: &ProtoQueueFamily) -> bool {
         self.raw.functor.get_physical_device_surface_support_khr(
-            queue_family.device(),
-            queue_family.family_index(), //Note: should be queue index?
+            queue_family.device,
+            queue_family.index,
             self.raw.handle,
         )
     }
 
     fn build_swapchain<C>(
         &mut self,
-        config: core::SwapchainConfig,
-        present_queue: &core::CommandQueue<Backend, C>,
-    ) -> (Swapchain, core::Backbuffer<Backend>) {
-        let functor = ext::Swapchain::new(&self.raw.instance.0, &present_queue.as_raw().device().0)
+        config: hal::SwapchainConfig,
+        present_queue: &hal::CommandQueue<Backend, C>,
+    ) -> (Swapchain, hal::Backbuffer<Backend>) {
+        let functor = ext::Swapchain::new(&self.raw.instance.0, &present_queue.as_raw().device.0)
             .expect("Unable to query swapchain function");
 
         // TODO: check for better ones if available
@@ -320,7 +320,7 @@ impl core::Surface<Backend> for Surface {
             })
             .collect();
 
-        (swapchain, core::Backbuffer::Images(images))
+        (swapchain, hal::Backbuffer::Images(images))
     }
 }
 
@@ -332,11 +332,11 @@ pub struct Swapchain {
 }
 
 
-impl core::Swapchain<Backend> for Swapchain {
-    fn acquire_frame(&mut self, sync: core::FrameSync<Backend>) -> core::Frame {
+impl hal::Swapchain<Backend> for Swapchain {
+    fn acquire_frame(&mut self, sync: hal::FrameSync<Backend>) -> hal::Frame {
         let (semaphore, fence) = match sync {
-            core::FrameSync::Semaphore(semaphore) => (semaphore.0, vk::Fence::null()),
-            core::FrameSync::Fence(fence) => (vk::Semaphore::null(), fence.0),
+            hal::FrameSync::Semaphore(semaphore) => (semaphore.0, vk::Fence::null()),
+            hal::FrameSync::Fence(fence) => (vk::Semaphore::null(), fence.0),
         };
 
         let index = unsafe {
@@ -345,12 +345,12 @@ impl core::Swapchain<Backend> for Swapchain {
         }.expect("Unable to acquire a swapchain image");
 
         self.frame_queue.push_back(index as usize);
-        core::Frame::new(index as usize)
+        hal::Frame::new(index as usize)
     }
 
     fn present<C>(
         &mut self,
-        present_queue: &mut core::CommandQueue<Backend, C>,
+        present_queue: &mut hal::CommandQueue<Backend, C>,
         wait_semaphores: &[&native::Semaphore],
     ) {
         let frame = self.frame_queue.pop_front().expect(
@@ -373,7 +373,7 @@ impl core::Swapchain<Backend> for Swapchain {
 
         assert_eq!(Ok(()), unsafe {
             self.functor
-                .queue_present_khr(*present_queue.as_raw().raw(), &info)
+                .queue_present_khr(*present_queue.as_raw().raw, &info)
         });
         // TODO: handle result and return code
     }

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -12,7 +12,7 @@ use hal;
 use winit;
 
 use {conv, native};
-use {VK_ENTRY, Adapter, Backend, Instance, ProtoQueueFamily, RawInstance};
+use {VK_ENTRY, Backend, Instance, PhysicalDevice, QueueFamily, RawInstance};
 
 
 pub struct Surface {
@@ -207,10 +207,10 @@ impl hal::Surface<Backend> for Surface {
         hal::image::Kind::D2(self.width as Size, self.height as Size, aa)
     }
 
-    fn surface_capabilities(&self, adapter: &Adapter) -> hal::SurfaceCapabilities {
+    fn surface_capabilities(&self, physical_device: &PhysicalDevice) -> hal::SurfaceCapabilities {
         let caps =
             self.raw.functor.get_physical_device_surface_capabilities_khr(
-                adapter.handle,
+                physical_device.handle,
                 self.raw.handle,
             )
             .expect("Unable to query surface capabilities");
@@ -247,7 +247,7 @@ impl hal::Surface<Backend> for Surface {
         }
     }
 
-    fn supports_queue_family(&self, queue_family: &ProtoQueueFamily) -> bool {
+    fn supports_queue_family(&self, queue_family: &QueueFamily) -> bool {
         self.raw.functor.get_physical_device_surface_support_khr(
             queue_family.device,
             queue_family.index,

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -6,25 +6,8 @@ use {Backend, Gpu};
 
 /// Represents a physical or virtual device, which is capable of running the backend.
 ///
-/// The `Adapter` is typically obtained from objects implementing `gfx::WindowExt` or
-/// `gfx::Headless`. How these types are created is backend-specific.
+/// The list of `Adapter` instances is obtained by calling `Instance::enumerate_adapters()`.
 pub trait Adapter<B: Backend>: Sized {
-    /// Create a new logical GPU.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # extern crate gfx_backend_empty as empty;
-    /// # extern crate gfx_hal;
-    /// # fn main() {
-    /// use gfx_hal::{Adapter};
-    ///
-    /// # let adapter: empty::Adapter = return;
-    /// let gpu = adapter.open();
-    /// # }
-    /// ```
-    fn open(&self) -> Gpu<B>;
-
     /// Get the `AdapterInfo` for this adapter.
     ///
     /// # Examples
@@ -41,7 +24,7 @@ pub trait Adapter<B: Backend>: Sized {
     /// ```
     fn info(&self) -> &AdapterInfo;
 
-    /// Return the supported queue families for this adapter.
+    /// Create a new logical GPU.
     ///
     /// # Examples
     ///
@@ -49,16 +32,34 @@ pub trait Adapter<B: Backend>: Sized {
     /// # extern crate gfx_backend_empty as empty;
     /// # extern crate gfx_hal;
     /// # fn main() {
-    /// use gfx_hal::Adapter;
-    /// use gfx_hal::queue::RawQueueFamily;
+    /// use gfx_hal::{Adapter};
     ///
     /// # let adapter: empty::Adapter = return;
-    /// for (i, qf) in adapter.queue_families().into_iter().enumerate() {
-    ///     println!("Queue family ({:?}) type: {:?}", i, qf.queue_type());
+    /// let gpu = adapter.open(vec![]);
+    /// # }
+    /// ```
+    fn open(self, Vec<(B::ProtoQueueFamily, usize)>) -> Gpu<B>;
+
+    /// Return the supported queue families information for this adapter.
+    ///
+    /// *Note*: supposed to be called once. A subsequent call returns
+    /// an empty vector.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # extern crate gfx_backend_empty as empty;
+    /// # extern crate gfx_hal;
+    /// # fn main() {
+    /// use gfx_hal::{Adapter, ProtoQueueFamily};
+    ///
+    /// # let mut adapter: empty::Adapter = return;
+    /// for (i, qf) in adapter.list_queue_families().into_iter().enumerate() {
+    ///     println!("Queue families ({:?}) type: {:?}", i, qf.queue_type());
     /// }
     /// # }
     /// ```
-    fn queue_families(&self) -> &[&B::QueueFamily];
+    fn list_queue_families(&mut self) -> Vec<B::ProtoQueueFamily>;
 }
 
 /// Information about a backend adapter.

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -34,8 +34,9 @@ pub trait Adapter<B: Backend>: Sized {
     /// # fn main() {
     /// use gfx_hal::{Adapter};
     ///
-    /// # let adapter: empty::Adapter = return;
-    /// let gpu = adapter.open(vec![]);
+    /// # let mut adapter: empty::Adapter = return;
+    /// let family: empty::ProtoQueueFamily = return;
+    /// let gpu = adapter.open(vec![(family, 1)]);
     /// # }
     /// ```
     fn open(self, Vec<(B::ProtoQueueFamily, usize)>) -> Gpu<B>;

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -2,14 +2,14 @@
 //!
 //! Adapters are the main entry point for opening a [Device](../struct.Device).
 
-use {Backend, Gpu, QueueType};
+use {Backend, Gpu};
 
 /// Represents a physical or virtual device, which is capable of running the backend.
 ///
 /// The `Adapter` is typically obtained from objects implementing `gfx::WindowExt` or
 /// `gfx::Headless`. How these types are created is backend-specific.
 pub trait Adapter<B: Backend>: Sized {
-    /// Create a new logical gpu with the specified queues.
+    /// Create a new logical GPU.
     ///
     /// # Examples
     ///
@@ -17,58 +17,13 @@ pub trait Adapter<B: Backend>: Sized {
     /// # extern crate gfx_backend_empty as empty;
     /// # extern crate gfx_hal;
     /// # fn main() {
-    /// use gfx_hal::{Adapter, QueueFamily};
+    /// use gfx_hal::{Adapter};
     ///
     /// # let adapter: empty::Adapter = return;
-    /// let queue_desc = adapter
-    ///     .queue_families()
-    ///     .iter()
-    ///     .map(|&(ref family, ty)| (family, ty, family.num_queues()))
-    ///     .collect::<Vec<_>>();
-    /// let gpu = adapter.open(&queue_desc);
+    /// let gpu = adapter.open();
     /// # }
     /// ```
-    fn open(&self, queue_descs: &[(&B::QueueFamily, QueueType, u32)]) -> Gpu<B>;
-
-    /// Create a new gpu with the specified queues.
-    ///
-    /// Takes an closure and creates the number of queues for each queue type
-    /// as returned by the closure. Queues returning a number of 0 will be filtered out.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # extern crate gfx_backend_empty as empty;
-    /// # extern crate gfx_hal;
-    /// # fn main() {
-    /// use gfx_hal::{Adapter, QueueType, Surface};
-    ///
-    /// # let adapter: empty::Adapter = return;
-    /// # let surface: empty::Surface = return;
-    /// // Open a gpu with a graphics queue, which can be used for presentation.
-    /// // GeneralQueues will be down-casted to GraphicsQueues.
-    /// let gpu = adapter.open_with(|family, ty| {
-    ///     ((ty.supports_graphics() && surface.supports_queue(&family)) as u32, QueueType::Graphics)
-    /// });
-    /// # }
-    /// ```
-    fn open_with<F>(&self, mut f: F) -> Gpu<B>
-    where
-        F: FnMut(&B::QueueFamily, QueueType) -> (u32, QueueType),
-    {
-        let queue_desc = self.queue_families()
-            .iter()
-            .filter_map(|&(ref family, ty)| {
-                let (num_queues, ty) = f(family, ty);
-                if num_queues > 0 {
-                    Some((family, ty, num_queues))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        self.open(&queue_desc)
-    }
+    fn open(&self) -> Gpu<B>;
 
     /// Get the `AdapterInfo` for this adapter.
     ///
@@ -88,9 +43,6 @@ pub trait Adapter<B: Backend>: Sized {
 
     /// Return the supported queue families for this adapter.
     ///
-    /// * `QueueType` will be the one with the most capabilities.
-    /// * There can be multiple families with the same queue type.
-    ///
     /// # Examples
     ///
     /// ```no_run
@@ -98,14 +50,15 @@ pub trait Adapter<B: Backend>: Sized {
     /// # extern crate gfx_hal;
     /// # fn main() {
     /// use gfx_hal::Adapter;
+    /// use gfx_hal::queue::RawQueueFamily;
     ///
     /// # let adapter: empty::Adapter = return;
-    /// for (i, &(_, ty)) in adapter.queue_families().into_iter().enumerate() {
-    ///     println!("Queue family ({:?}) type: {:?}", i, ty);
+    /// for (i, qf) in adapter.queue_families().into_iter().enumerate() {
+    ///     println!("Queue family ({:?}) type: {:?}", i, qf.queue_type());
     /// }
     /// # }
     /// ```
-    fn queue_families(&self) -> &[(B::QueueFamily, QueueType)];
+    fn queue_families(&self) -> &[&B::QueueFamily];
 }
 
 /// Information about a backend adapter.

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -8,7 +8,7 @@ use std::error::Error;
 use std::ops::Range;
 use {buffer, format, image, mapping, pass, pso};
 use pool::{CommandPool, CommandPoolCreateFlags};
-use queue::QueueFamily;
+use queue::QueueGroup;
 use {Backend, Features, Limits, MemoryType};
 use memory::Requirements;
 
@@ -128,16 +128,19 @@ pub trait Device<B: Backend>: Clone {
     ///
     fn free_memory(&mut self, B::Memory);
 
-    /// Creates a new command pool for a given queue family prototype.
+    /// Creates a new command pool for a given queue family.
     ///
-    /// *Note*: the prototype has to be one of the `Gpu::queue_families`.
-    fn create_command_pool(&mut self, &B::ProtoQueueFamily, CommandPoolCreateFlags) -> B::CommandPool;
+    /// *Note*: the family has to be associated by one as the `Gpu::queue_groups`.
+    fn create_command_pool(&mut self, &B::QueueFamily, CommandPoolCreateFlags) -> B::CommandPool;
 
     /// Creates a strongly typed command pool wrapper.
     fn create_command_pool_typed<C>(
-        &mut self, family: &QueueFamily<B, C>, flags: CommandPoolCreateFlags, max_buffers: usize
+        &mut self,
+        group: &QueueGroup<B, C>,
+        flags: CommandPoolCreateFlags,
+        max_buffers: usize,
     ) -> CommandPool<B, C> {
-        let raw = self.create_command_pool(&family.prototype, flags);
+        let raw = self.create_command_pool(&group.family, flags);
         CommandPool::new(raw, max_buffers)
     }
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -22,12 +22,12 @@ use std::error::Error;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-pub use self::adapter::{Adapter, AdapterInfo};
+pub use self::adapter::{Adapter, AdapterInfo, PhysicalDevice};
 pub use self::device::Device;
 pub use self::pool::CommandPool;
 pub use self::pso::{DescriptorPool};
 pub use self::queue::{
-    CommandQueue, QueueFamily, QueueType, ProtoQueueFamily, Submission,
+    CommandQueue, QueueGroup, QueueFamily, QueueType, Submission,
     Capability, General, Graphics, Compute, Transfer,
 };
 pub use self::window::{
@@ -240,20 +240,20 @@ pub trait Instance {
     /// Associated backend type of this instance.
     type Backend: Backend;
     /// Enumerate all available adapters.
-    fn enumerate_adapters(&self) -> Vec<<Self::Backend as Backend>::Adapter>;
+    fn enumerate_adapters(&self) -> Vec<Adapter<Self::Backend>>;
 }
 
 /// Different types of a specific API.
 #[allow(missing_docs)]
 pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any {
     //type Instance:          Instance<Self>;
-    type Adapter:             Adapter<Self>;
+    type PhysicalDevice:      PhysicalDevice<Self>;
     type Device:              Device<Self>;
 
     type Surface:             Surface<Self>;
     type Swapchain:           Swapchain<Self>;
 
-    type ProtoQueueFamily:    queue::ProtoQueueFamily;
+    type QueueFamily:         QueueFamily;
     type CommandQueue:        queue::RawCommandQueue<Self>;
     type CommandBuffer:       command::RawCommandBuffer<Self>;
     type SubpassCommandBuffer;
@@ -312,9 +312,9 @@ pub type SubmissionResult<T> = Result<T, SubmissionError>;
 pub struct Gpu<B: Backend> {
     /// Logical device.
     pub device: B::Device,
-    /// Raw queue families. Each element in this vector
+    /// Raw queue groups. Each element in this vector
     /// matches the corresponding argument in `Adapter::open`.
-    pub queue_families: Vec<queue::RawQueueFamily<B>>,
+    pub queue_groups: Vec<queue::RawQueueGroup<B>>,
     /// Types of memory.
     ///
     /// Each memory type is associated with one heap of `memory_heaps`.

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -55,6 +55,7 @@ impl AttachmentOps {
         }
     }
 
+    #[cfg(feature = "serialize")]
     fn whatever() -> Self {
         Self::DONT_CARE
     }

--- a/src/hal/src/queue/capability.rs
+++ b/src/hal/src/queue/capability.rs
@@ -1,4 +1,5 @@
 //! Type system encoded queue capabilities.
+use queue::QueueType;
 
 /// General capability, supporting graphics, compute and transfer operations.
 pub enum General {}
@@ -8,6 +9,46 @@ pub enum Graphics {}
 pub enum Compute {}
 /// Transfer capability, supporting only transfer operations.
 pub enum Transfer {}
+
+///
+pub trait Capability {
+    /// Return true if this type level capability is supported by
+    /// a run-time queue type.
+    fn supported_by(QueueType) -> bool;
+}
+impl Capability for General {
+    fn supported_by(qt: QueueType) -> bool {
+        match qt {
+            QueueType::General => true,
+            _ => false,
+        }
+    }
+}
+impl Capability for Graphics {
+    fn supported_by(qt: QueueType) -> bool {
+        match qt {
+            QueueType::General |
+            QueueType::Graphics => true,
+            _ => false,
+        }
+    }
+}
+impl Capability for Compute {
+    fn supported_by(qt: QueueType) -> bool {
+        match qt {
+            QueueType::General |
+            QueueType::Compute => true,
+            _ => false,
+        }
+    }
+}
+impl Capability for Transfer {
+    fn supported_by(qt: QueueType) -> bool {
+        match qt {
+            _ => true
+        }
+    }
+}
 
 ///
 pub trait Supports<T> { }

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -42,6 +42,14 @@ pub trait QueueFamily: Debug {
     fn queue_type(&self) -> QueueType;
     /// Returns maximum number of queues created from this family.
     fn max_queues(&self) -> usize;
+    /// Returns true if the queue supports graphics operations.
+    fn supports_graphics(&self) -> bool {
+        Graphics::supported_by(self.queue_type())
+    }
+    /// Returns true if the queue supports graphics operations.
+    fn supports_compute(&self) -> bool {
+        Compute::supported_by(self.queue_type())
+    }
 }
 
 /// `RawQueueGroup` denotes a group of command queues provided by the backend

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -82,8 +82,9 @@ pub struct QueueFamily<B: Backend, C> {
 impl<B: Backend, C: Capability> QueueFamily<B, C> {
     /// Create a new strongly typed queue family from a raw one.
     ///
-    /// *Note*: panics if the family doesn't expose required
-    /// queue capabilities.
+    /// # Panics
+    ///
+    /// Panics if the family doesn't expose required queue capabilities.
     pub fn new(raw: RawQueueFamily<B>) -> Self {
         assert!(C::supported_by(raw.prototype.queue_type()));
         QueueFamily {

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -104,12 +104,12 @@ pub trait Surface<B: Backend> {
     /// ```no_run
     ///
     /// ```
-    fn supports_queue(&self, queue_family: &B::QueueFamily) -> bool;
+    fn supports_queue_family(&self, &B::ProtoQueueFamily) -> bool;
 
     /// Query surface capabilities for this adapter.
     ///
     /// Use this function for configuring your swapchain creation.
-    fn surface_capabilities(&self, adapter: &B::Adapter) -> SurfaceCapabilities;
+    fn surface_capabilities(&self, &B::Adapter) -> SurfaceCapabilities;
 
     /// Create a new swapchain from a surface and a queue.
     ///
@@ -139,7 +139,8 @@ pub trait Surface<B: Backend> {
     /// surface.build_swapchain(swapchain_config, &queue);
     /// # }
     /// ```
-    fn build_swapchain<C>(&mut self,
+    fn build_swapchain<C>(
+        &mut self,
         config: SwapchainConfig,
         present_queue: &CommandQueue<B, C>,
     ) -> (B::Swapchain, Backbuffer<B>);

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -104,12 +104,12 @@ pub trait Surface<B: Backend> {
     /// ```no_run
     ///
     /// ```
-    fn supports_queue_family(&self, &B::ProtoQueueFamily) -> bool;
+    fn supports_queue_family(&self, &B::QueueFamily) -> bool;
 
-    /// Query surface capabilities for this adapter.
+    /// Query surface capabilities for this physical device.
     ///
     /// Use this function for configuring your swapchain creation.
-    fn surface_capabilities(&self, &B::Adapter) -> SurfaceCapabilities;
+    fn surface_capabilities(&self, &B::PhysicalDevice) -> SurfaceCapabilities;
 
     /// Create a new swapchain from a surface and a queue.
     ///

--- a/src/render/src/allocators/boxed.rs
+++ b/src/render/src/allocators/boxed.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use core::{Device as CoreDevice};
+use hal::{Device as CoreDevice};
 use memory::{self, Allocator, Memory};
 use {buffer, image};
 use {Backend, Device};

--- a/src/render/src/allocators/stack.rs
+++ b/src/render/src/allocators/stack.rs
@@ -1,8 +1,8 @@
 use std::sync::mpsc;
 use std::collections::HashMap;
 
-use core::{self, MemoryType, Device as CoreDevice};
-use core::memory::Requirements;
+use hal::{self, MemoryType, Device as Device_};
+use hal::memory::Requirements;
 use memory::{self, Allocator, Memory, ReleaseFn, Provider, Dependency};
 use {buffer, image};
 use {Backend, Device};
@@ -64,7 +64,7 @@ impl<B: Backend> Allocator<B> for StackAllocator<B> {
     ) -> (B::Buffer, Memory) {
         let dependency = self.0.dependency();
         let inner: &mut InnerStackAllocator<B> = &mut self.0;
-        let requirements = core::buffer::complete_requirements::<B>(
+        let requirements = hal::buffer::complete_requirements::<B>(
             device.mut_raw(), &buffer, usage);
         let memory_type = device.find_usage_memory(inner.usage, requirements.type_mask)
             .expect("could not find suitable memory");

--- a/src/render/src/buffer.rs
+++ b/src/render/src/buffer.rs
@@ -1,11 +1,11 @@
 use std::sync::atomic::{self, AtomicBool, AtomicUsize};
 
-use {core, handle};
+use {hal, handle};
 use memory::{Memory, Pod};
 use Backend;
 
-pub use core::buffer::{CreationError, ViewError};
-pub use core::buffer::{Usage,
+pub use hal::buffer::{CreationError, ViewError};
+pub use hal::buffer::{Usage,
     TRANSFER_SRC, TRANSFER_DST, UNIFORM, INDEX, INDIRECT, VERTEX
 };
 
@@ -21,7 +21,7 @@ pub struct Info {
     /// Stride of a single element, in bytes. Only used for structured buffers
     /// that you use via shader resource / unordered access views.
     pub stride: u64,
-    pub(crate) stable_state: core::buffer::State,
+    pub(crate) stable_state: hal::buffer::State,
     /// Exclusive access
     pub(crate) access: Access,
 }
@@ -30,7 +30,7 @@ impl Info {
     pub(crate) fn new(usage: Usage, memory: Memory, size: u64, stride: u64)
         -> Self
     {
-        let stable_state = core::buffer::Access::empty();
+        let stable_state = hal::buffer::Access::empty();
         let access = Access {
             cpu: AtomicBool::new(false),
             gpu: AtomicUsize::new(0),

--- a/src/render/src/handle.rs
+++ b/src/render/src/handle.rs
@@ -45,7 +45,7 @@ impl<B: Backend> GarbageCollector<B> {
 
 impl<B: Backend> InnerGarbageCollector<B> {
     fn collect(&mut self) {
-        use core::Device;
+        use hal::Device;
 
         let dev = &mut self.device;
         for garbage in self.receiver.try_iter() {

--- a/src/render/src/image.rs
+++ b/src/render/src/image.rs
@@ -1,12 +1,12 @@
-use core;
+use hal;
 use memory::Memory;
 
-pub use core::image::{
+pub use hal::image::{
     CreationError, Kind, AaMode, Size, Level, Layer, Dimensions,
     AspectFlags, SamplerInfo, ViewError, Usage,
     Subresource, SubresourceLayers, SubresourceRange,
 };
-pub use core::image::{
+pub use hal::image::{
     TRANSFER_SRC, TRANSFER_DST,
     COLOR_ATTACHMENT, DEPTH_STENCIL_ATTACHMENT,
     SAMPLED,
@@ -19,9 +19,9 @@ pub struct Info {
     pub usage: Usage,
     pub kind: Kind,
     pub mip_levels: Level,
-    pub format: core::format::Format,
+    pub format: hal::format::Format,
     pub origin: Origin,
-    pub(crate) stable_state: core::image::State,
+    pub(crate) stable_state: hal::image::State,
 }
 
 #[derive(Debug)]

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -107,7 +107,7 @@ pub use draw_state::target::*;
 // public re-exports
 pub use hal::format;
 pub use hal::{Backend, Frame, Primitive};
-pub use hal::queue::{Capability, Supports, Transfer, Compute, Graphics, General};
+pub use hal::queue::{Supports, Transfer, Compute, Graphics, General};
 pub use hal::{VertexCount, InstanceCount};
 pub use hal::device::Extent;
 // pub use hal::{ShaderSet, VertexShader, HullShader, DomainShader, GeometryShader, PixelShader};
@@ -132,9 +132,9 @@ pub mod shade;
 pub mod macros;
 
 use std::collections::VecDeque;
-use hal::{CommandQueue, QueueFamily, Surface, Swapchain, Device as Device_};
-use hal::pool::CommandPoolCreateFlags;
+use hal::{Capability, CommandQueue, QueueFamily, Surface, Swapchain, Device as Device_};
 use hal::format::RenderFormat;
+use hal::pool::CommandPoolCreateFlags;
 use memory::Typed;
 
 struct Queue<B: Backend, C> {

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -93,11 +93,11 @@ extern crate serde;
 #[macro_use]
 extern crate log;
 extern crate draw_state;
-pub extern crate gfx_hal as core;
+pub extern crate gfx_hal as hal;
 
 /// public re-exported traits
 pub mod traits {
-    pub use core::memory::Pod;
+    pub use hal::memory::Pod;
 }
 
 // draw state re-exports
@@ -105,12 +105,12 @@ pub use draw_state::{preset, state};
 pub use draw_state::target::*;
 
 // public re-exports
-pub use core::format;
-pub use core::{Adapter, Backend, Frame, Primitive};
-pub use core::queue::{Supports, Transfer, Compute, Graphics, General};
-pub use core::{VertexCount, InstanceCount};
-pub use core::device::Extent;
-// pub use core::{ShaderSet, VertexShader, HullShader, DomainShader, GeometryShader, PixelShader};
+pub use hal::format;
+pub use hal::{Adapter, Backend, Frame, Primitive};
+pub use hal::queue::{Capability, Supports, Transfer, Compute, Graphics, General};
+pub use hal::{VertexCount, InstanceCount};
+pub use hal::device::Extent;
+// pub use hal::{ShaderSet, VertexShader, HullShader, DomainShader, GeometryShader, PixelShader};
 pub use encoder::Encoder;
 pub use device::Device;
 
@@ -132,42 +132,43 @@ pub mod shade;
 pub mod macros;
 
 use std::collections::VecDeque;
-use core::{CommandQueue, QueueType, Surface, Swapchain, Device as CoreDevice};
-use core::pool::{CommandPool, CommandPoolCreateFlags};
-use core::format::RenderFormat;
+use hal::{CommandQueue, ProtoQueueFamily, Surface, Swapchain, Device as Device_};
+use hal::pool::CommandPoolCreateFlags;
+use hal::format::RenderFormat;
 use memory::Typed;
 
 struct Queue<B: Backend, C> {
-    inner: CommandQueue<B, C>,
-    command_pool_receiver: encoder::CommandPoolReceiver<B, C>,
-    command_pool_sender: encoder::CommandPoolSender<B, C>,
+    family: hal::QueueFamily<B, C>,
+    pool_receiver: encoder::CommandPoolReceiver<B, C>,
+    pool_sender: encoder::CommandPoolSender<B, C>,
 }
 
-impl<B: Backend, C> Queue<B, C> {
-    fn new(inner: CommandQueue<B, C>) -> Self {
-        let (command_pool_sender, command_pool_receiver) =
+impl<B: Backend, C: hal::Capability> Queue<B, C> {
+    fn new(family_raw: hal::queue::RawQueueFamily<B>) -> Self {
+        let family = hal::QueueFamily::new(family_raw);
+        let (pool_sender, pool_receiver) =
             encoder::command_pool_channel();
-        Queue { inner, command_pool_sender, command_pool_receiver }
+        Queue { family, pool_sender, pool_receiver }
     }
 
-    fn acquire_encoder_pool(&mut self) -> encoder::Pool<B, C> {
-        let initial_capacity = 4;
-        let flags = CommandPoolCreateFlags::empty();
-        let pool = self.command_pool_receiver.try_recv()
+    fn acquire_encoder_pool(
+        &mut self, device: &mut B::Device
+    ) -> encoder::Pool<B, C> {
+        let pool = self.pool_receiver.try_recv()
             .map(|mut recycled| {
                 recycled.reset();
                 recycled
             })
             .unwrap_or_else(|_| {
-                CommandPool::from_queue(&self.inner, initial_capacity, flags)
+                let initial_capacity = 4;
+                let flags = CommandPoolCreateFlags::empty();
+                device.create_command_pool_typed(&self.family, flags, initial_capacity)
             });
-        encoder::Pool::new(pool, self.command_pool_sender.clone())
+        encoder::Pool::new(pool, self.pool_sender.clone())
     }
 }
 
-pub struct Context<B: Backend, C>
-    where C: Supports<Transfer>
-{
+pub struct Context<B: Backend, C> {
     surface: B::Surface,
     device: Device<B>,
     queue: Queue<B, C>,
@@ -212,103 +213,45 @@ struct FrameBundle<B: Backend, C> {
     signal_fence: Sync<B::Fence>,
 }
 
-trait Capability: Sized {
-    fn open<B: Backend>(
-        surface: &B::Surface,
-        adapter: &B::Adapter,
-    ) -> (Device<B>, Queue<B, Self>, handle::GarbageCollector<B>);
-}
-
-impl Capability for core::General {
-    fn open<B: Backend>(
-        surface: &B::Surface,
-        adapter: &B::Adapter,
-    ) -> (Device<B>, Queue<B, Self>, handle::GarbageCollector<B>) {
-        let core::Gpu {
-            device,
-            mut general_queues,
-            memory_types,
-            memory_heaps,
-            ..
-        } = adapter.open_with(|ref family, qtype| {
-            if qtype.supports_graphics()
-               && qtype.supports_compute()
-               && surface.supports_queue(family) {
-                (1, QueueType::General)
-            } else {
-                (0, QueueType::Transfer)
-            }
-        });
-
-        let (device, garbage) = Device::new(device, memory_types, memory_heaps);
-        let queue = Queue::new(general_queues.remove(0));
-        (device, queue, garbage)
-    }
-}
-
-impl Capability for core::Graphics {
-    fn open<B: Backend>(
-        surface: &B::Surface,
-        adapter: &B::Adapter,
-    ) -> (Device<B>, Queue<B, Self>, handle::GarbageCollector<B>) {
-        let core::Gpu {
-            device,
-            mut graphics_queues,
-            memory_types,
-            memory_heaps,
-            ..
-        } = adapter.open_with(|ref family, qtype| {
-            if qtype.supports_graphics() && surface.supports_queue(family) {
-                (1, QueueType::Graphics)
-            } else {
-                (0, QueueType::Transfer)
-            }
-        });
-
-        let (device, garbage) = Device::new(device, memory_types, memory_heaps);
-        let queue = Queue::new(graphics_queues.remove(0));
-        (device, queue, garbage)
-    }
-}
-
-impl<B: Backend> Context<B, core::General> {
-    pub fn init_general<Cf>(
-        surface: B::Surface,
-        adapter: &B::Adapter
-    ) -> (Self, Vec<Backbuffer<B, Cf>>)
-        where Cf: RenderFormat
-    {
-        Context::init(surface, adapter)
-    }
-}
-
-impl<B: Backend> Context<B, core::Graphics> {
-    pub fn init_graphics<Cf>(
-        surface: B::Surface,
-        adapter: &B::Adapter
-    ) -> (Self, Vec<Backbuffer<B, Cf>>)
-        where Cf: RenderFormat
-    {
-        Context::init(surface, adapter)
-    }
-}
-
 impl<B: Backend, C> Context<B, C>
-    where C: Supports<Transfer>
+    where C: Capability + Supports<Transfer>
 {
-    fn init<Cf>(mut surface: B::Surface, adapter: &B::Adapter)
-        -> (Self, Vec<Backbuffer<B, Cf>>)
-        where Cf: RenderFormat, C: Capability
+    pub fn init<Cf>(
+        mut surface: B::Surface, mut adapter: B::Adapter
+    ) -> (Self, Vec<Backbuffer<B, Cf>>)
+    where
+        Cf: RenderFormat,
     {
-        let (mut device, queue, garbage) = Capability::open(&surface, adapter);
+        let proto_family = {
+            let mut families = adapter.list_queue_families();
+            let pos = families
+                .iter()
+                .position(|family| {
+                    let ty = family.queue_type();
+                    Graphics::supported_by(ty) &&
+                    Compute::supported_by(ty) &&
+                    surface.supports_queue_family(family)
+                })
+                .unwrap();
+            families.remove(pos)
+        };
 
-        let swap_config = core::SwapchainConfig::new()
+        let hal::Gpu {
+            mut device,
+            mut queue_families,
+            memory_types,
+            memory_heaps,
+        } = adapter.open(vec![(proto_family, 1)]);
+
+        let queue = Queue::new(queue_families.remove(0));
+
+        let swap_config = hal::SwapchainConfig::new()
             .with_color::<Cf>();
-        let (swapchain, backbuffer) = surface.build_swapchain(swap_config, &queue.inner);
+        let (swapchain, backbuffer) = surface.build_swapchain(swap_config, &queue.family.queues[0]);
 
         let backbuffer_images = match backbuffer {
-            core::Backbuffer::Images(images) => images,
-            core::Backbuffer::Framebuffer(_) => unimplemented!(), //TODO
+            hal::Backbuffer::Images(images) => images,
+            hal::Backbuffer::Framebuffer(_) => unimplemented!(), //TODO
         };
 
         let frame_bundles = backbuffer_images
@@ -317,21 +260,21 @@ impl<B: Backend, C> Context<B, C>
                 handles: handle::Bag::new(),
                 access_info: encoder::AccessInfo::new(),
                 encoder_pools: Vec::new(),
-                wait_semaphore: device.mut_raw().create_semaphore(),
-                signal_semaphore: device.mut_raw().create_semaphore(),
+                wait_semaphore: device.create_semaphore(),
+                signal_semaphore: device.create_semaphore(),
                 signal_fence: Sync::reached(
-                    device.mut_raw().create_fence(true)),
+                    device.create_fence(true)),
             }).collect();
 
         let backbuffers = backbuffer_images
             .into_iter()
             .map(|raw| {
-                let stable_access = core::image::Access::empty();
-                let stable_layout = core::image::ImageLayout::Present;
+                let stable_access = hal::image::Access::empty();
+                let stable_layout = hal::image::ImageLayout::Present;
                 let handle = handle::inner::Image::without_garbage(
                     raw,
                     image::Info {
-                        aspects: core::image::ASPECT_COLOR,
+                        aspects: hal::image::ASPECT_COLOR,
                         usage: image::TRANSFER_SRC | image::COLOR_ATTACHMENT,
                         kind: surface.get_kind(),
                         mip_levels: 1,
@@ -344,6 +287,8 @@ impl<B: Backend, C> Context<B, C>
                     color: Typed::new(handle.into()),
                 }
             }).collect();
+
+        let (device, garbage) = Device::new(device, memory_types, memory_heaps);
 
         let context = Context {
             surface,
@@ -368,7 +313,7 @@ impl<B: Backend, C> Context<B, C>
             self.device.mut_raw()
                 .wait_for_fences(
                     &[&bundle.signal_fence.inner],
-                    core::device::WaitFor::All,
+                    hal::device::WaitFor::All,
                     !0);
         }
         self.device.mut_raw().reset_fences(&[&bundle.signal_fence.inner]);
@@ -380,7 +325,7 @@ impl<B: Backend, C> Context<B, C>
         bundle.encoder_pools.clear();
 
         let frame = self.swapchain.acquire_frame(
-            core::FrameSync::Semaphore(&mut bundle.wait_semaphore)
+            hal::FrameSync::Semaphore(&mut bundle.wait_semaphore)
         );
         self.frame_acquired = Some(bundle);
 
@@ -389,7 +334,7 @@ impl<B: Backend, C> Context<B, C>
     }
 
     pub fn acquire_encoder_pool(&mut self) -> encoder::Pool<B, C> {
-        self.queue.acquire_encoder_pool()
+        self.queue.acquire_encoder_pool(self.device.mut_raw())
     }
 
     // TODO: allow submissions before present
@@ -408,22 +353,25 @@ impl<B: Backend, C> Context<B, C>
         bundle.access_info.start_gpu_access();
 
         {
-            let submission = core::Submission::new()
-                .wait_on(&[(&bundle.wait_semaphore, core::pso::BOTTOM_OF_PIPE)])
+            let submission = hal::Submission::new()
+                .wait_on(&[(&bundle.wait_semaphore, hal::pso::BOTTOM_OF_PIPE)])
                 .signal(&[&bundle.signal_semaphore])
                 .promote::<C>()
                 .submit(&inner_submits);
-            self.queue.inner.submit::<C>(submission, Some(&bundle.signal_fence.inner));
+            let fence = Some(&bundle.signal_fence.inner);
+            self.queue.family.queues[0].submit::<C>(submission, fence);
         }
         bundle.signal_fence.signal = Pending;
 
         self.swapchain.present(
-            &mut self.queue.inner,
+            &mut self.queue.family.queues[0],
             &[&bundle.signal_semaphore]);
 
         self.frame_bundles.push_back(bundle);
     }
+}
 
+impl<B: Backend, C> Context<B, C> {
     fn wait_idle(&mut self) {
         assert!(self.frame_acquired.is_none());
 
@@ -442,7 +390,7 @@ impl<B: Backend, C> Context<B, C>
             }).collect();
 
         self.device.mut_raw()
-            .wait_for_fences(&fences, core::device::WaitFor::All, !0);
+            .wait_for_fences(&fences, hal::device::WaitFor::All, !0);
     }
 
     pub fn ref_device(&self) -> &Device<B> {
@@ -455,13 +403,11 @@ impl<B: Backend, C> Context<B, C>
 
     // TODO: remove
     pub fn mut_queue(&mut self) -> &mut CommandQueue<B, C> {
-        &mut self.queue.inner
+        &mut self.queue.family.queues[0]
     }
 }
 
-impl<B: Backend, C> Drop for Context<B, C>
-    where C: Supports<Transfer>
-{
+impl<B: Backend, C> Drop for Context<B, C> {
     fn drop(&mut self) {
         let _ = &self.surface;
         self.wait_idle();

--- a/src/render/src/macros.rs
+++ b/src/render/src/macros.rs
@@ -27,11 +27,11 @@ macro_rules! gfx_buffer_struct {
         impl $crate::pso::Structure for $name
             where $( $ty: $crate::format::BufferFormat, )*
         {
-            fn elements() -> Vec<$crate::core::pso::Element<$crate::format::Format>> {
+            fn elements() -> Vec<$crate::hal::pso::Element<$crate::format::Format>> {
                 let mut elements = Vec::new();
                 let mut offset = 0;
                 $(
-                    elements.push($crate::core::pso::Element {
+                    elements.push($crate::hal::pso::Element {
                         format: <$ty as $crate::format::Formatted>::SELF,
                         offset: offset as u32,
                     });
@@ -51,7 +51,7 @@ macro_rules! gfx_descriptors {
         pub mod $name {
             #[allow(unused_imports)]
             use super::*;
-            use $crate::{core, pso, handle, image};
+            use $crate::{hal, pso, handle, image};
             use $crate::Backend;
 
             pub struct Set<B: Backend> {
@@ -84,16 +84,16 @@ macro_rules! gfx_descriptors {
                     })
                 }
 
-                fn layout_bindings() -> Vec<core::pso::DescriptorSetLayoutBinding> {
+                fn layout_bindings() -> Vec<hal::pso::DescriptorSetLayoutBinding> {
                     let mut bindings = Vec::new();
                     $({
                         let binding = bindings.len();
-                        bindings.push(core::pso::DescriptorSetLayoutBinding {
+                        bindings.push(hal::pso::DescriptorSetLayoutBinding {
                             binding,
                             ty: <$bind as pso::BindDesc>::TYPE,
                             count: <$bind as pso::BindDesc>::COUNT,
                             // TODO: specify stage
-                            stage_flags: core::pso::ShaderStageFlags::all(),
+                            stage_flags: hal::pso::ShaderStageFlags::all(),
                         });
                     })*
                     bindings
@@ -135,8 +135,8 @@ macro_rules! gfx_descriptors {
 
                 fn require<'b>(
                     data: &'b Self::Data,
-                    buffers: &mut Vec<(&'b handle::raw::Buffer<B>, core::buffer::State)>,
-                    images: &mut Vec<(&'b handle::raw::Image<B>, image::Subresource, core::image::State)>,
+                    buffers: &mut Vec<(&'b handle::raw::Buffer<B>, hal::buffer::State)>,
+                    images: &mut Vec<(&'b handle::raw::Image<B>, image::Subresource, hal::image::State)>,
                     others: &mut handle::Bag<B>,
                 )
                     where 'a: 'b
@@ -168,8 +168,8 @@ macro_rules! gfx_graphics_pipeline {
                 Backend, Supports, Transfer, Graphics, Encoder,
                 Device, Primitive
             };
-            use $crate::core::{pass as cpass, pso as cpso};
-            use $crate::core::command::RenderPassInlineEncoder;
+            use $crate::hal::{pass as cpass, pso as cpso};
+            use $crate::hal::command::RenderPassInlineEncoder;
 
             pub struct Meta<B: Backend> {
                 layout: handle::raw::PipelineLayout<B>,
@@ -183,8 +183,8 @@ macro_rules! gfx_graphics_pipeline {
 
             pub struct Data<'a, B: Backend> {
                 // TODO:
-                pub viewports: &'a [$crate::core::Viewport],
-                pub scissors: &'a [$crate::core::target::Rect],
+                pub viewports: &'a [$crate::hal::Viewport],
+                pub scissors: &'a [$crate::hal::target::Rect],
                 pub framebuffer: &'a handle::raw::Framebuffer<B>,
                 $( pub $cmp_name: <$cmp as pso::Component<'a, B>>::Data, )*
             }
@@ -195,7 +195,7 @@ macro_rules! gfx_graphics_pipeline {
                 fn create(
                     self,
                     device: &mut Device<B>,
-                    shader_entries: $crate::core::pso::GraphicsShaderSet<B>,
+                    shader_entries: $crate::hal::pso::GraphicsShaderSet<B>,
                     primitive: Primitive,
                     rasterizer: pso::Rasterizer
                 ) -> Result<Self::Pipeline, pso::CreationError> {
@@ -293,7 +293,7 @@ macro_rules! gfx_graphics_pipeline {
                     cmd_buffer.bind_graphics_descriptor_sets(meta.layout.resource(), 0, &descs[..]);
                     // TODO: difference with viewport ?
                     let extent = self.framebuffer.info().extent;
-                    let render_rect = $crate::core::target::Rect {
+                    let render_rect = $crate::hal::target::Rect {
                         x: 0,
                         y: 0,
                         w: extent.width as u16,

--- a/src/render/src/mapping.rs
+++ b/src/render/src/mapping.rs
@@ -1,7 +1,7 @@
 use std::{fmt, ops};
 use std::error::Error as StdError;
 
-use {core, memory, buffer};
+use {hal, memory, buffer};
 use {Backend, Device};
 
 /// Error accessing a mapping.
@@ -9,12 +9,12 @@ use {Backend, Device};
 pub enum Error {
     /// The requested mapping access did not match the expected usage.
     InvalidAccess(memory::Access, memory::Usage),
-    /// Another error reported by GFX's core
-    Core(core::mapping::Error)
+    /// Another error reported by gfx-hal
+    Core(hal::mapping::Error)
 }
 
-impl From<core::mapping::Error> for Error {
-    fn from(c: core::mapping::Error) -> Self {
+impl From<hal::mapping::Error> for Error {
+    fn from(c: hal::mapping::Error) -> Self {
         Error::Core(c)
     }
 }
@@ -42,7 +42,7 @@ impl StdError for Error {
 }
 
 pub struct Reader<'a, B: Backend, T: 'a> {
-    pub(crate) inner: core::mapping::Reader<'a, B, T>,
+    pub(crate) inner: hal::mapping::Reader<'a, B, T>,
     pub(crate) info: &'a buffer::Info,
 }
 
@@ -53,7 +53,7 @@ impl<'a, B: Backend, T: 'a> ops::Deref for Reader<'a, B, T> {
 }
 
 pub struct Writer<'a, B: Backend, T: 'a> {
-    pub(crate) inner: core::mapping::Writer<'a, B, T>,
+    pub(crate) inner: hal::mapping::Writer<'a, B, T>,
     pub(crate) info: &'a buffer::Info,
 }
 

--- a/src/render/src/memory.rs
+++ b/src/render/src/memory.rs
@@ -1,4 +1,4 @@
-pub use core::memory::{Pod, cast_slice};
+pub use hal::memory::{Pod, cast_slice};
 
 use std::marker::PhantomData;
 use std::{ops, cmp, fmt, hash};

--- a/src/render/src/shade.rs
+++ b/src/render/src/shade.rs
@@ -5,19 +5,19 @@ use mint;
 
 use std::error::Error;
 use std::fmt;
-pub use core::shade::{self as core, ConstFormat, Formatted, Usage};
+pub use hal::shade::{self as core, ConstFormat, Formatted, Usage};
 
 #[allow(missing_docs)]
 pub trait ToUniform: Copy {
-    fn convert(self) -> core::UniformValue;
+    fn convert(self) -> hal::UniformValue;
 }
 
 macro_rules! impl_uniforms {
     ( $( $ty_src:ty = $ty_dst:ident ,)* ) => {
         $(
             impl ToUniform for $ty_src {
-                fn convert(self) -> core::UniformValue {
-                    core::UniformValue::$ty_dst(self.into())
+                fn convert(self) -> hal::UniformValue {
+                    hal::UniformValue::$ty_dst(self.into())
                 }
             }
         )*
@@ -54,17 +54,17 @@ impl_uniforms! {
 #[derive(Clone, Debug, PartialEq)]
 pub enum ProgramError {
     /// Unable to compile the vertex shader
-    Vertex(core::CreateShaderError),
+    Vertex(hal::CreateShaderError),
     /// Unable to compile the hull shader
-    Hull(core::CreateShaderError),
+    Hull(hal::CreateShaderError),
     /// Unable to compile the domain shader
-    Domain(core::CreateShaderError),
+    Domain(hal::CreateShaderError),
     /// Unable to compile the geometry shader
-    Geometry(core::CreateShaderError),
+    Geometry(hal::CreateShaderError),
     /// Unable to compile the pixel shader
-    Pixel(core::CreateShaderError),
+    Pixel(hal::CreateShaderError),
     /// Unable to link
-    Link(core::CreateProgramError),
+    Link(hal::CreateProgramError),
 }
 
 impl fmt::Display for ProgramError {

--- a/src/render/src/slice.rs
+++ b/src/render/src/slice.rs
@@ -2,11 +2,11 @@
 //!
 //! See `Slice`-structure documentation for more information on this module.
 
-use core::{handle, buffer};
-use core::{Primitive, Backend, VertexCount};
-use core::command::InstanceParams;
-use core::device::Device;
-use core::memory::Bind;
+use hal::{handle, buffer};
+use hal::{Primitive, Backend, VertexCount};
+use hal::command::InstanceParams;
+use hal::device::Device;
+use hal::memory::Bind;
 use format::Format;
 use pso;
 
@@ -76,7 +76,7 @@ impl<B: Backend> Slice<B> {
 
     /// Calculates the number of primitives of the specified type in this `Slice`.
     pub fn get_prim_count(&self, prim: Primitive) -> u32 {
-        use core::Primitive as p;
+        use hal::Primitive as p;
         let nv = (self.end - self.start) as u32;
         match prim {
             p::PointList => nv,

--- a/src/render/src/tracker.rs
+++ b/src/render/src/tracker.rs
@@ -1,6 +1,6 @@
 //! Automatic resource mapping and handling
 
-use core::handle;
+use hal::handle;
 use Resources;
 
 /// TODO

--- a/src/warden/examples/basic.rs
+++ b/src/warden/examples/basic.rs
@@ -8,7 +8,6 @@ extern crate serde;
 use std::fs::File;
 use std::io::Read;
 
-use hal::Instance;
 use ron::de::Deserializer;
 use serde::de::Deserialize;
 
@@ -31,6 +30,7 @@ fn main() {
 
     #[cfg(feature = "vulkan")]
     {
+        use hal::Instance;
         let instance = back::Instance::create("warden", 1);
         let adapters = instance.enumerate_adapters();
         let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene, "");
@@ -38,4 +38,6 @@ fn main() {
         let guard = scene.fetch_image("im-color");
         println!("row: {:?}", guard.row(0));
     }
+
+    let _ = raw_scene;
 }

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -62,13 +62,10 @@ impl Harness {
     }
 
     fn run<I: hal::Instance>(&self, instance: I) {
-        use hal::Adapter;
-
-        let adapters = instance.enumerate_adapters();
-        let adapter = &adapters[0];
-        println!("\t{:?}", adapter.info());
-
         for (scene_name, tests) in &self.suite {
+            let mut adapters = instance.enumerate_adapters();
+            let adapter = adapters.remove(0);
+            //println!("\t{:?}", adapter.info);
             println!("\tLoading scene '{}':", scene_name);
             let raw_scene = File::open(format!("{}/scenes/{}.ron", self.base_path, scene_name))
                 .map_err(de::Error::from)

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::slice;
 
 use hal::{self, image as i};
-use hal::{Adapter, Device, DescriptorPool};
+use hal::{Capability, Device, DescriptorPool, QueueFamily};
 
 use raw;
 
@@ -75,7 +75,7 @@ pub struct Scene<B: hal::Backend> {
     pub jobs: HashMap<String, hal::command::Submit<B, hal::queue::Graphics>>,
     init_submit: Option<hal::command::Submit<B, hal::queue::Graphics>>,
     device: B::Device,
-    queue: hal::CommandQueue<B, hal::queue::Graphics>,
+    queue_group: hal::QueueGroup<B, hal::queue::Graphics>,
     command_pool: hal::CommandPool<B, hal::queue::Graphics>,
     upload_buffers: HashMap<String, (B::Buffer, B::Memory)>,
     download_type: hal::MemoryType,
@@ -90,14 +90,16 @@ fn align(x: usize, y: usize) -> usize {
 }
 
 impl<B: hal::Backend> Scene<B> {
-    pub fn new(adapter: &B::Adapter, raw: &raw::Scene, data_path: &str) -> Self {
+    pub fn new(adapter: hal::Adapter<B>, raw: &raw::Scene, data_path: &str) -> Self {
         info!("creating Scene from {}", data_path);
         // initialize graphics
-        let hal::Gpu { mut device, mut graphics_queues, memory_types, .. } = {
-            let (ref family, queue_type) = adapter.queue_families()[0];
-            assert!(queue_type.supports_graphics());
-            adapter.open(&[(family, hal::QueueType::Graphics, 1)])
-        };
+        let hal::Gpu { mut device, mut queue_groups, memory_types, .. } =
+            adapter.open_with(|family| {
+                if hal::Graphics::supported_by(family.queue_type()) {
+                    Some(1)
+                } else { None }
+            });
+
         let upload_type = memory_types
             .iter()
             .find(|mt| {
@@ -116,10 +118,11 @@ impl<B: hal::Backend> Scene<B> {
         info!("download memory: {:?}", &download_type);
 
         let limits = device.get_limits().clone();
-        let queue = graphics_queues.remove(0);
-        let mut command_pool = queue.create_graphics_pool(
-            1 + raw.jobs.len(),
+        let queue_group = hal::QueueGroup::<_, hal::Graphics>::new(queue_groups.remove(0));
+        let mut command_pool = device.create_command_pool_typed(
+            &queue_group,
             hal::pool::CommandPoolCreateFlags::empty(),
+            1 + raw.jobs.len(),
         );
 
         // create resources
@@ -472,7 +475,7 @@ impl<B: hal::Backend> Scene<B> {
             jobs,
             init_submit,
             device,
-            queue,
+            queue_group,
             command_pool,
             upload_buffers,
             download_type,
@@ -492,7 +495,7 @@ impl<B: hal::Backend> Scene<B> {
         let submission = hal::queue::Submission::new()
             .submit(&[self.init_submit.take().unwrap()])
             .submit(&values);
-        self.queue.submit(submission, None);
+        self.queue_group.queues[0].submit(submission, None);
     }
 
     pub fn fetch_image(&mut self, name: &str) -> FetchGuard<B> {
@@ -515,9 +518,10 @@ impl<B: hal::Backend> Scene<B> {
         let down_buffer = self.device.bind_buffer_memory(&down_memory, 0, unbound_buffer)
             .unwrap();
 
-        let mut command_pool = self.queue.create_graphics_pool(
-            1,
+        let mut command_pool = self.device.create_command_pool_typed(
+            &self.queue_group,
             hal::pool::CommandPoolCreateFlags::empty(),
+            1,
         );
         let copy_submit = {
             let mut cmd_buffer = command_pool.acquire_command_buffer();
@@ -559,7 +563,7 @@ impl<B: hal::Backend> Scene<B> {
         let copy_fence = self.device.create_fence(false);
         let submission = hal::queue::Submission::new()
             .submit(&[copy_submit]);
-        self.queue.submit(submission, Some(&copy_fence));
+        self.queue_group.queues[0].submit(submission, Some(&copy_fence));
         //queue.destroy_command_pool(command_pool);
         self.device.wait_for_fences(&[&copy_fence], hal::device::WaitFor::Any, !0);
         self.device.destroy_fence(copy_fence);
@@ -585,8 +589,8 @@ impl<B: hal::Backend> Drop for Scene<B> {
             self.device.free_memory(memory);
         }
         //TODO: free those properly
-        let _ = &self.queue;
+        let _ = &self.queue_group;
         let _ = &self.command_pool;
-        //queue.destroy_command_pool(command_pool);
+        //self.device.destroy_command_pool(self.command_pool.downgrade())
     }
 }

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::slice;
 
 use hal::{self, image as i};
-use hal::{Capability, Device, DescriptorPool, QueueFamily};
+use hal::{Device, DescriptorPool, QueueFamily};
 
 use raw;
 
@@ -95,7 +95,7 @@ impl<B: hal::Backend> Scene<B> {
         // initialize graphics
         let hal::Gpu { mut device, mut queue_groups, memory_types, .. } =
             adapter.open_with(|family| {
-                if hal::Graphics::supported_by(family.queue_type()) {
+                if family.supports_graphics() {
                     Some(1)
                 } else { None }
             });


### PR DESCRIPTION
Fixes #1578
Closes #1605
Also adds hal/compute to CI

This is an attempt to refactor our queue families so that we can create command pools from them as opposed to the queues. It refactors the way we discover adapters and queue families.

The PR introduces a concept of a `QueueGroup`, which is spawned from a particular queue family. There is `RawQueueGroup` and a stronger-typed `QueueGroup` that is capability-aware. Command pools can be made out of queue groups.

TODO:
- [x] hal
- [x] empty
- [x] vulkan
- [x] dx12
- [x] metal
- [x] gl
- [x] warden
- [x] hal examples
- [x] render + example