### PR TITLE
Update spirv_cross

### DIFF
--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -26,7 +26,7 @@ d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch 
 dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 kernel32-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-spirv_cross = "0.3"
+spirv_cross = "0.3.1"
 user32-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 winit = { version = "0.7", optional = true }

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -29,4 +29,4 @@ cocoa = "0.11"
 core-foundation = "0.3"
 core-graphics = "0.9"
 io-surface = "0.7"
-spirv_cross = { git = "https://github.com/grovesNL/spirv_cross.git", branch = "build-set-stdlib" }
+spirv_cross = "0.3.1"


### PR DESCRIPTION
cc-rs published the `stdlib` fix we were having issues with, so we can use the spirv_cross crate again now.