### PR TITLE
Reoder CI commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,16 +43,16 @@ endif
 all: check test
 
 check:
-	cargo check --all $(EXCLUDES)
-	cd src/warden && cargo check --features "gl $(FEATURES_HAL) $(FEATURES_HAL2)" #TODO: run
+	#Note: excluding `warden` here, since it depends on serialization
+	cargo check --all $(EXCLUDES) --exclude gfx-warden
 	cd examples/hal && cargo check --features "gl"
 	cd examples/hal && cargo check --features "$(FEATURES_HAL)"
 	cd examples/hal && cargo check --features "$(FEATURES_HAL2)"
 	cd examples/render/quad_render && $(CMD_QUAD_RENDER)
+	cd src/warden && cargo check --features "gl $(FEATURES_HAL) $(FEATURES_HAL2)" #TODO: run
 
 test:
 	cargo test --all $(EXCLUDES)
-	cd src/render && cargo test --features "$(FEATURES_RENDER)"
 	cd src/render && cargo test --features "$(FEATURES_RENDER) $(FEATURES_EXTRA)"
 
 reftests:


### PR DESCRIPTION
This cleans up our feature build ordering:
  1. no features are enabled, everything is built except `warden`
  2. examples are built with various backends
  3. `warden` is built with all the backends, which triggers a rebuild of `hal` due to required `serialize` feature
  4. test everything
  5. re-test `render` with `mint` feature