### PR TITLE
hal: Custom queue priorities

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -120,7 +120,7 @@ pub struct PhysicalDevice {
 }
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
-    fn open(self, families: Vec<(QueueFamily, usize)>) -> hal::Gpu<Backend> {
+    fn open(self, families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>) -> hal::Gpu<Backend> {
         use self::memory::Properties;
         // Create D3D12 device
         let mut device_raw = ptr::null_mut();
@@ -155,7 +155,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
         let queue_groups = families
             .into_iter()
-            .map(|(family, count)| {
+            .map(|(family, priorities)| {
                 let queue_desc = winapi::D3D12_COMMAND_QUEUE_DESC {
                     Type: family.native_type(),
                     Priority: 0,
@@ -164,7 +164,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 };
                 let mut group = hal::queue::RawQueueGroup::new(family);
 
-                for _ in 0 .. count {
+                for _ in 0 .. priorities.len() {
                     let mut queue = ptr::null_mut();
                     let hr = unsafe {
                         device.raw.CreateCommandQueue(

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -51,7 +51,7 @@ impl hal::Backend for Backend {
 /// Dummy physical device.
 pub struct PhysicalDevice;
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
-    fn open(self, _: Vec<(QueueFamily, usize)>) -> hal::Gpu<Backend> {
+    fn open(self, _: Vec<(QueueFamily, Vec<hal::QueuePriority>)>) -> hal::Gpu<Backend> {
         unimplemented!()
     }
 }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -173,7 +173,7 @@ impl PhysicalDevice {
 }
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
-    fn open(self, families: Vec<(QueueFamily, usize)>) -> hal::Gpu<Backend> {
+    fn open(self, families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>) -> hal::Gpu<Backend> {
         // initialize permanent states
         let gl = &self.0.context;
         if self.0.features.srgb_color {
@@ -238,8 +238,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             device: Device::new(self.0.clone()),
             queue_groups: families
                 .into_iter()
-                .map(|(proto_family, count)| {
-                    assert_eq!(count, 1);
+                .map(|(proto_family, priorities)| {
+                    assert_eq!(priorities.len(), 1);
                     let mut family = hal::queue::RawQueueGroup::new(proto_family);
                     let queue = queue::CommandQueue::new(&self.0, vao);
                     family.add_queue(queue);

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -75,7 +75,7 @@ impl PhysicalDevice {
 
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
-    fn open(self, mut families: Vec<(QueueFamily, usize)>) -> hal::Gpu<Backend> {
+    fn open(self, mut families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>) -> hal::Gpu<Backend> {
         use self::memory::Properties;
 
         assert_eq!(families.len(), 1);

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -4,6 +4,10 @@
 
 use {Backend, Gpu};
 
+/// Scheduling hint for devices about the priority of a queue.
+/// Values ranging from `0.0` (low) to `1.0` (high).
+pub type QueuePriority = f32;
+
 /// Represents a physical or virtual device, which is capable of running the backend.
 pub trait PhysicalDevice<B: Backend>: Sized {
     /// Create a new logical GPU.
@@ -18,10 +22,10 @@ pub trait PhysicalDevice<B: Backend>: Sized {
     ///
     /// # let physical_device: empty::PhysicalDevice = return;
     /// # let family: empty::QueueFamily = return;
-    /// let gpu = physical_device.open(vec![(family, 1)]);
+    /// let gpu = physical_device.open(vec![(family, vec![1.0; 1])]);
     /// # }
     /// ```
-    fn open(self, Vec<(B::QueueFamily, usize)>) -> Gpu<B>;
+    fn open(self, Vec<(B::QueueFamily, Vec<QueuePriority>)>) -> Gpu<B>;
 }
 
 /// Information about a backend adapter.
@@ -38,7 +42,6 @@ pub struct AdapterInfo {
     pub software_rendering: bool,
 }
 
-///
 /// The list of `Adapter` instances is obtained by calling `Instance::enumerate_adapters()`.
 pub struct Adapter<B: Backend> {
     /// General information about this adapter.
@@ -78,7 +81,7 @@ impl<B: Backend> Adapter<B> {
                 selector(&family)
                     .map(|count| {
                         assert!(count != 0 && count <= family.max_queues());
-                        (family, count)
+                        (family, vec![1.0; count])
                     })
             })
             .collect();

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -21,7 +21,7 @@ use std::error::Error;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-pub use self::adapter::{Adapter, AdapterInfo, PhysicalDevice};
+pub use self::adapter::{Adapter, AdapterInfo, PhysicalDevice, QueuePriority};
 pub use self::device::Device;
 pub use self::pool::CommandPool;
 pub use self::pso::{DescriptorPool};


### PR DESCRIPTION
Small feature to allow setting queue priorities on device creation. Only used for vulkan and mainly for portability.

cc #1610