### PR TITLE
Pipeline deriving

### DIFF
--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -64,7 +64,7 @@ fn main() {
         let entry_point = pso::EntryPoint { entry: "main", module: &shader };
         let pipeline = gpu.device
             .create_compute_pipelines(&[
-                (entry_point, pso::ComputePipelineDesc::new(&pipeline_layout))
+                pso::ComputePipelineDesc::new(entry_point, &pipeline_layout)
             ])
             .remove(0)
             .expect("Error creating compute pipeline!");

--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -63,7 +63,9 @@ fn main() {
         let pipeline_layout = gpu.device.create_pipeline_layout(&[&set_layout]);
         let entry_point = pso::EntryPoint { entry: "main", module: &shader };
         let pipeline = gpu.device
-            .create_compute_pipelines(&[(entry_point, &pipeline_layout)])
+            .create_compute_pipelines(&[
+                (entry_point, pso::ComputePipelineDesc::new(&pipeline_layout))
+            ])
             .remove(0)
             .expect("Error creating compute pipeline!");
 

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -232,6 +232,7 @@ fn main() {
         let subpass = Subpass { index: 0, main_pass: &render_pass };
 
         let mut pipeline_desc = pso::GraphicsPipelineDesc::new(
+            shader_entries,
             Primitive::TriangleList,
             pso::Rasterizer::FILL,
             &pipeline_layout,
@@ -264,9 +265,7 @@ fn main() {
         });
 
 
-        device.create_graphics_pipelines(&[
-            (shader_entries, pipeline_desc)
-        ])
+        device.create_graphics_pipelines(&[pipeline_desc])
     };
 
     println!("pipelines: {:?}", pipelines);

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -206,37 +206,6 @@ fn main() {
     };
 
     //
-    let mut pipeline_desc = pso::GraphicsPipelineDesc::new(
-        Primitive::TriangleList,
-        pso::Rasterizer::FILL,
-    );
-    pipeline_desc.blender.targets.push(pso::ColorBlendDesc(
-        pso::ColorMask::ALL,
-        pso::BlendState::ALPHA,
-    ));
-    pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
-        stride: std::mem::size_of::<Vertex>() as u32,
-        rate: 0,
-    });
-
-    pipeline_desc.attributes.push(pso::AttributeDesc {
-        location: 0,
-        binding: 0,
-        element: pso::Element {
-            format: Vec2::<f32>::SELF,
-            offset: 0,
-        },
-    });
-    pipeline_desc.attributes.push(pso::AttributeDesc {
-        location: 1,
-        binding: 0,
-        element: pso::Element {
-            format: Vec2::<f32>::SELF,
-            offset: 8
-        },
-    });
-
-    //
     let pipelines = {
         //TODO: remove the type annotations when we have support for
         // inidirect argument buffers in SPIRV-Cross
@@ -259,9 +228,44 @@ fn main() {
             geometry: None,
             fragment: Some(fs_entry),
         };
+
         let subpass = Subpass { index: 0, main_pass: &render_pass };
+
+        let mut pipeline_desc = pso::GraphicsPipelineDesc::new(
+            Primitive::TriangleList,
+            pso::Rasterizer::FILL,
+            &pipeline_layout,
+            subpass,
+        );
+        pipeline_desc.blender.targets.push(pso::ColorBlendDesc(
+            pso::ColorMask::ALL,
+            pso::BlendState::ALPHA,
+        ));
+        pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
+            stride: std::mem::size_of::<Vertex>() as u32,
+            rate: 0,
+        });
+
+        pipeline_desc.attributes.push(pso::AttributeDesc {
+            location: 0,
+            binding: 0,
+            element: pso::Element {
+                format: Vec2::<f32>::SELF,
+                offset: 0,
+            },
+        });
+        pipeline_desc.attributes.push(pso::AttributeDesc {
+            location: 1,
+            binding: 0,
+            element: pso::Element {
+                format: Vec2::<f32>::SELF,
+                offset: 8
+            },
+        });
+
+
         device.create_graphics_pipelines(&[
-            (shader_entries, &pipeline_layout, subpass, &pipeline_desc)
+            (shader_entries, pipeline_desc)
         ])
     };
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -765,9 +765,9 @@ impl d::Device<B> for Device {
 
     fn create_graphics_pipelines<'a>(
         &self,
-        descs: &[(pso::GraphicsShaderSet<'a, B>, pso::GraphicsPipelineDesc<'a, B>)],
+        descs: &[pso::GraphicsPipelineDesc<'a, B>],
     ) -> Vec<Result<n::GraphicsPipeline, pso::CreationError>> {
-        descs.iter().map(|&(shaders, ref desc)| {
+        descs.iter().map(|desc| {
             let build_shader = |source: Option<pso::EntryPoint<'a, B>>| {
                 // TODO: better handle case where looking up shader fails
                 let shader = source.and_then(|src| src.module.shaders.get(src.entry));
@@ -787,11 +787,11 @@ impl d::Device<B> for Device {
                 }
             };
 
-            let vs = build_shader(Some(shaders.vertex));
-            let fs = build_shader(shaders.fragment);
-            let gs = build_shader(shaders.geometry);
-            let ds = build_shader(shaders.domain);
-            let hs = build_shader(shaders.hull);
+            let vs = build_shader(Some(desc.shaders.vertex));
+            let fs = build_shader(desc.shaders.fragment);
+            let gs = build_shader(desc.shaders.geometry);
+            let ds = build_shader(desc.shaders.domain);
+            let hs = build_shader(desc.shaders.hull);
 
             // Define input element descriptions
             let mut vs_reflect = shade::reflect_shader(&vs);
@@ -936,12 +936,12 @@ impl d::Device<B> for Device {
 
     fn create_compute_pipelines<'a>(
         &self,
-        descs: &[(pso::EntryPoint<'a, B>, pso::ComputePipelineDesc<'a, B>)],
+        descs: &[pso::ComputePipelineDesc<'a, B>],
     ) -> Vec<Result<n::ComputePipeline, pso::CreationError>> {
-        descs.iter().map(|&(shader, ref desc)| {
+        descs.iter().map(|desc| {
             let cs = {
                 // TODO: better handle case where looking up shader fails
-                match shader.module.shaders.get(shader.entry) {
+                match desc.shader.module.shaders.get(desc.shader.entry) {
                     Some(shader) => {
                         winapi::D3D12_SHADER_BYTECODE {
                             pShaderBytecode: unsafe { (**shader).GetBufferPointer() as *const _ },

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -765,9 +765,9 @@ impl d::Device<B> for Device {
 
     fn create_graphics_pipelines<'a>(
         &self,
-        descs: &[(pso::GraphicsShaderSet<'a, B>, &n::PipelineLayout, pass::Subpass<'a, B>, &pso::GraphicsPipelineDesc)],
+        descs: &[(pso::GraphicsShaderSet<'a, B>, pso::GraphicsPipelineDesc<'a, B>)],
     ) -> Vec<Result<n::GraphicsPipeline, pso::CreationError>> {
-        descs.iter().map(|&(shaders, ref signature, ref subpass, ref desc)| {
+        descs.iter().map(|&(shaders, ref desc)| {
             let build_shader = |source: Option<pso::EntryPoint<'a, B>>| {
                 // TODO: better handle case where looking up shader fails
                 let shader = source.and_then(|src| src.module.shaders.get(src.entry));
@@ -842,9 +842,12 @@ impl d::Device<B> for Device {
 
             // TODO: check maximum number of rtvs
             // Get associated subpass information
-            let pass = match subpass.main_pass.subpasses.get(subpass.index) {
-                Some(subpass) => subpass,
-                None => return Err(pso::CreationError::InvalidSubpass(subpass.index)),
+            let pass = {
+                let subpass = &desc.subpass;
+                match subpass.main_pass.subpasses.get(subpass.index) {
+                    Some(subpass) => subpass,
+                    None => return Err(pso::CreationError::InvalidSubpass(subpass.index)),
+                }
             };
 
             // Get color attachment formats from subpass
@@ -854,7 +857,7 @@ impl d::Device<B> for Device {
                 for (rtv, target) in rtvs.iter_mut()
                     .zip(pass.color_attachments.iter())
                 {
-                    let format = subpass.main_pass.attachments[target.0].format;
+                    let format = desc.subpass.main_pass.attachments[target.0].format;
                     *rtv = conv::map_format(format).unwrap_or(winapi::DXGI_FORMAT_UNKNOWN);
                     num_rtvs += 1;
                 }
@@ -863,7 +866,7 @@ impl d::Device<B> for Device {
 
             // Setup pipeline description
             let pso_desc = winapi::D3D12_GRAPHICS_PIPELINE_STATE_DESC {
-                pRootSignature: signature.raw,
+                pRootSignature: desc.layout.raw,
                 VS: vs, PS: fs, GS: gs, DS: ds, HS: hs,
                 StreamOutput: winapi::D3D12_STREAM_OUTPUT_DESC {
                     pSODeclaration: ptr::null(),
@@ -889,7 +892,16 @@ impl d::Device<B> for Device {
                 NumRenderTargets: num_rtvs,
                 RTVFormats: rtvs,
                 DSVFormat: pass.depth_stencil_attachment
-                    .and_then(|att_ref| conv::map_format_dsv(subpass.main_pass.attachments[att_ref.0].format.0))
+                    .and_then(|att_ref|
+                        conv::map_format_dsv(
+                            desc
+                            .subpass
+                            .main_pass
+                            .attachments[att_ref.0]
+                            .format
+                            .0
+                        )
+                    )
                     .unwrap_or(winapi::DXGI_FORMAT_UNKNOWN),
                 SampleDesc: winapi::DXGI_SAMPLE_DESC {
                     Count: 1, // TODO
@@ -924,9 +936,9 @@ impl d::Device<B> for Device {
 
     fn create_compute_pipelines<'a>(
         &self,
-        descs: &[(pso::EntryPoint<'a, B>, &n::PipelineLayout)],
+        descs: &[(pso::EntryPoint<'a, B>, pso::ComputePipelineDesc<'a, B>)],
     ) -> Vec<Result<n::ComputePipeline, pso::CreationError>> {
-        descs.iter().map(|&(shader, ref signature)| {
+        descs.iter().map(|&(shader, ref desc)| {
             let cs = {
                 // TODO: better handle case where looking up shader fails
                 match shader.module.shaders.get(shader.entry) {
@@ -946,7 +958,7 @@ impl d::Device<B> for Device {
             };
 
             let pso_desc = winapi::D3D12_COMPUTE_PIPELINE_STATE_DESC {
-                pRootSignature: signature.raw,
+                pRootSignature: desc.layout.raw,
                 CS: cs,
                 NodeMask: 0,
                 CachedPSO: winapi::D3D12_CACHED_PIPELINE_STATE {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -97,14 +97,14 @@ impl hal::Device<Backend> for Device {
 
     fn create_graphics_pipelines<'a>(
         &self,
-        _: &[(pso::GraphicsShaderSet<'a, Backend>, &(), pass::Subpass<'a, Backend>, &pso::GraphicsPipelineDesc)],
+        _: &[(pso::GraphicsShaderSet<'a, Backend>, pso::GraphicsPipelineDesc<'a, Backend>)],
     ) -> Vec<Result<(), pso::CreationError>> {
         unimplemented!()
     }
 
     fn create_compute_pipelines<'a>(
         &self,
-        _: &[(pso::EntryPoint<'a, Backend>, &())],
+        _: &[(pso::EntryPoint<'a, Backend>, pso::ComputePipelineDesc<'a, Backend>)],
     ) -> Vec<Result<(), pso::CreationError>> {
         unimplemented!()
     }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -97,14 +97,14 @@ impl hal::Device<Backend> for Device {
 
     fn create_graphics_pipelines<'a>(
         &self,
-        _: &[(pso::GraphicsShaderSet<'a, Backend>, pso::GraphicsPipelineDesc<'a, Backend>)],
+        _: &[pso::GraphicsPipelineDesc<'a, Backend>],
     ) -> Vec<Result<(), pso::CreationError>> {
         unimplemented!()
     }
 
     fn create_compute_pipelines<'a>(
         &self,
-        _: &[(pso::EntryPoint<'a, Backend>, pso::ComputePipelineDesc<'a, Backend>)],
+        _: &[pso::ComputePipelineDesc<'a, Backend>],
     ) -> Vec<Result<(), pso::CreationError>> {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -233,13 +233,13 @@ impl d::Device<B> for Device {
 
     fn create_graphics_pipelines<'a>(
         &self,
-        descs: &[(pso::GraphicsShaderSet<'a, B>, pso::GraphicsPipelineDesc<'a, B>)],
+        descs: &[pso::GraphicsPipelineDesc<'a, B>],
     ) -> Vec<Result<n::GraphicsPipeline, pso::CreationError>> {
         let gl = &self.share.context;
         let priv_caps = &self.share.private_caps;
         let share = &self.share;
         descs.iter()
-             .map(|&(shaders, ref desc)| {
+             .map(|desc| {
                 let subpass = {
                     let subpass = desc.subpass;
                     match subpass.main_pass.subpasses.get(subpass.index) {
@@ -259,11 +259,11 @@ impl d::Device<B> for Device {
                     };
 
                     // Attach shaders to program
-                    attach_shader(Some(shaders.vertex));
-                    attach_shader(shaders.hull);
-                    attach_shader(shaders.domain);
-                    attach_shader(shaders.geometry);
-                    attach_shader(shaders.fragment);
+                    attach_shader(Some(desc.shaders.vertex));
+                    attach_shader(desc.shaders.hull);
+                    attach_shader(desc.shaders.domain);
+                    attach_shader(desc.shaders.geometry);
+                    attach_shader(desc.shaders.fragment);
 
                     if !priv_caps.program_interface && priv_caps.frag_data_location {
                         for i in 0..subpass.color_attachments.len() {
@@ -302,7 +302,7 @@ impl d::Device<B> for Device {
 
     fn create_compute_pipelines<'a>(
         &self,
-        _descs: &[(pso::EntryPoint<'a, B>, pso::ComputePipelineDesc<'a, B>)],
+        _descs: &[pso::ComputePipelineDesc<'a, B>],
     ) -> Vec<Result<n::ComputePipeline, pso::CreationError>> {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -233,16 +233,19 @@ impl d::Device<B> for Device {
 
     fn create_graphics_pipelines<'a>(
         &self,
-        descs: &[(pso::GraphicsShaderSet<'a, B>, &n::PipelineLayout, pass::Subpass<'a, B>, &pso::GraphicsPipelineDesc)],
+        descs: &[(pso::GraphicsShaderSet<'a, B>, pso::GraphicsPipelineDesc<'a, B>)],
     ) -> Vec<Result<n::GraphicsPipeline, pso::CreationError>> {
         let gl = &self.share.context;
         let priv_caps = &self.share.private_caps;
         let share = &self.share;
         descs.iter()
-             .map(|&(shaders, _layout, subpass, _desc)| {
-                let subpass = match subpass.main_pass.subpasses.get(subpass.index) {
-                    Some(sp) => sp,
-                    None => return Err(pso::CreationError::InvalidSubpass(subpass.index)),
+             .map(|&(shaders, ref desc)| {
+                let subpass = {
+                    let subpass = desc.subpass;
+                    match subpass.main_pass.subpasses.get(subpass.index) {
+                        Some(sp) => sp,
+                        None => return Err(pso::CreationError::InvalidSubpass(subpass.index)),
+                    }
                 };
 
                 let program = {
@@ -299,7 +302,7 @@ impl d::Device<B> for Device {
 
     fn create_compute_pipelines<'a>(
         &self,
-        _descs: &[(pso::EntryPoint<'a, B>, &n::PipelineLayout)],
+        _descs: &[(pso::EntryPoint<'a, B>, pso::ComputePipelineDesc<'a, B>)],
     ) -> Vec<Result<n::ComputePipeline, pso::CreationError>> {
         unimplemented!()
     }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -257,10 +257,12 @@ impl Device {
 
     fn create_graphics_pipeline<'a>(
         &self,
-        &(ref shader_set, pipeline_layout, ref pass_descriptor, pipeline_desc):
-        &(pso::GraphicsShaderSet<'a, Backend>, &n::PipelineLayout, Subpass<'a, Backend>, &pso::GraphicsPipelineDesc),
+        &(ref shader_set, ref pipeline_desc):
+        &(pso::GraphicsShaderSet<'a, Backend>, pso::GraphicsPipelineDesc<'a, Backend>),
     ) -> Result<n::GraphicsPipeline, pso::CreationError> {
-        let pipeline =  metal::RenderPipelineDescriptor::new();
+        let pipeline = metal::RenderPipelineDescriptor::new();
+        let pipeline_layout = &pipeline_desc.layout;
+        let pass_descriptor = &pipeline_desc.subpass;
 
         // FIXME: lots missing
 
@@ -542,7 +544,7 @@ impl hal::Device<Backend> for Device {
 
     fn create_graphics_pipelines<'a>(
         &self,
-        params: &[(pso::GraphicsShaderSet<'a, Backend>, &n::PipelineLayout, Subpass<'a, Backend>, &pso::GraphicsPipelineDesc)],
+        params: &[(pso::GraphicsShaderSet<'a, Backend>, pso::GraphicsPipelineDesc<'a, Backend>)],
     ) -> Vec<Result<n::GraphicsPipeline, pso::CreationError>> {
         let mut output = Vec::with_capacity(params.len());
         for param in params {
@@ -553,7 +555,7 @@ impl hal::Device<Backend> for Device {
 
     fn create_compute_pipelines<'a>(
         &self,
-        _pipelines: &[(pso::EntryPoint<'a, Backend>, &n::PipelineLayout)],
+        _pipelines: &[(pso::EntryPoint<'a, Backend>, pso::ComputePipelineDesc<'a, Backend>)],
     ) -> Vec<Result<n::ComputePipeline, pso::CreationError>> {
         unimplemented!()
     }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -490,7 +490,7 @@ impl d::Device<B> for Device {
             };
 
             let mut flags = vk::PipelineCreateFlags::empty();
-            if let pso::BaseCompute::None = desc.parent {
+            if let pso::BaseGraphics::None = desc.parent {
                 flags |= vk::PIPELINE_CREATE_DERIVATIVE_BIT;
             }
             if desc.flags.contains(pso::PipelineCreationFlags::DISABLE_OPTIMIZATION) {

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -154,7 +154,7 @@ pub trait Device<B: Backend> {
     /// Create graphics pipelines.
     fn create_graphics_pipelines<'a>(
         &self,
-        &[(pso::GraphicsShaderSet<'a, B>, pso::GraphicsPipelineDesc<'a, B>)],
+        &[pso::GraphicsPipelineDesc<'a, B>],
     ) -> Vec<Result<B::GraphicsPipeline, pso::CreationError>>;
 
     /// Destroys a graphics pipeline.
@@ -166,7 +166,7 @@ pub trait Device<B: Backend> {
     /// Create compute pipelines.
     fn create_compute_pipelines<'a>(
         &self,
-        &[(pso::EntryPoint<'a, B>, pso::ComputePipelineDesc<'a, B>)],
+        &[pso::ComputePipelineDesc<'a, B>],
     ) -> Vec<Result<B::ComputePipeline, pso::CreationError>>;
 
     /// Destroys a compute pipeline.

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -154,7 +154,7 @@ pub trait Device<B: Backend> {
     /// Create graphics pipelines.
     fn create_graphics_pipelines<'a>(
         &self,
-        &[(pso::GraphicsShaderSet<'a, B>, &B::PipelineLayout, pass::Subpass<'a, B>, &pso::GraphicsPipelineDesc)],
+        &[(pso::GraphicsShaderSet<'a, B>, pso::GraphicsPipelineDesc<'a, B>)],
     ) -> Vec<Result<B::GraphicsPipeline, pso::CreationError>>;
 
     /// Destroys a graphics pipeline.
@@ -166,7 +166,7 @@ pub trait Device<B: Backend> {
     /// Create compute pipelines.
     fn create_compute_pipelines<'a>(
         &self,
-        &[(pso::EntryPoint<'a, B>, &B::PipelineLayout)],
+        &[(pso::EntryPoint<'a, B>, pso::ComputePipelineDesc<'a, B>)],
     ) -> Vec<Result<B::ComputePipeline, pso::CreationError>>;
 
     /// Destroys a compute pipeline.

--- a/src/hal/src/pso/compute.rs
+++ b/src/hal/src/pso/compute.rs
@@ -13,3 +13,16 @@ pub struct ComputePipelineDesc<'a, B: Backend> {
     ///
     pub parent: BaseCompute<'a, B>,
 }
+
+impl<'a, B: Backend> ComputePipelineDesc<'a, B> {
+    /// Create a new empty PSO descriptor.
+    pub fn new(
+        layout: &'a B::PipelineLayout,
+    ) -> Self {
+        ComputePipelineDesc {
+            layout,
+            flags: PipelineCreationFlags::empty(),
+            parent: BaseCompute::None,
+        }
+    }
+}

--- a/src/hal/src/pso/compute.rs
+++ b/src/hal/src/pso/compute.rs
@@ -1,11 +1,13 @@
 //! Compute pipeline descriptor.
 
 use Backend;
-use super::{BaseCompute, PipelineCreationFlags};
+use super::{BaseCompute, BasePipeline, EntryPoint, PipelineCreationFlags};
 
 ///
 #[derive(Debug)]
 pub struct ComputePipelineDesc<'a, B: Backend> {
+    ///
+    pub shader: EntryPoint<'a, B>,
     /// Pipeline layout.
     pub layout: &'a B::PipelineLayout,
     ///
@@ -17,12 +19,14 @@ pub struct ComputePipelineDesc<'a, B: Backend> {
 impl<'a, B: Backend> ComputePipelineDesc<'a, B> {
     /// Create a new empty PSO descriptor.
     pub fn new(
+        shader: EntryPoint<'a, B>,
         layout: &'a B::PipelineLayout,
     ) -> Self {
         ComputePipelineDesc {
+            shader,
             layout,
             flags: PipelineCreationFlags::empty(),
-            parent: BaseCompute::None,
+            parent: BasePipeline::None,
         }
     }
 }

--- a/src/hal/src/pso/compute.rs
+++ b/src/hal/src/pso/compute.rs
@@ -1,0 +1,15 @@
+//! Compute pipeline descriptor.
+
+use Backend;
+use super::{BaseCompute, PipelineCreationFlags};
+
+///
+#[derive(Debug)]
+pub struct ComputePipelineDesc<'a, B: Backend> {
+    /// Pipeline layout.
+    pub layout: &'a B::PipelineLayout,
+    ///
+    pub flags: PipelineCreationFlags,
+    ///
+    pub parent: BaseCompute<'a, B>,
+}

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -1,7 +1,7 @@
 //! Graphics pipeline descriptor.
 
 use {pass, Backend, Primitive};
-use super::{BaseGraphics, EntryPoint, PipelineCreationFlags};
+use super::{BaseGraphics, BasePipeline, EntryPoint, PipelineCreationFlags};
 use super::input_assembler::{AttributeDesc, InputAssemblerDesc, VertexBufferDesc};
 use super::output_merger::{ColorBlendDesc, DepthStencilDesc};
 
@@ -23,6 +23,8 @@ pub struct GraphicsShaderSet<'a, B: Backend> {
 ///
 #[derive(Debug)]
 pub struct GraphicsPipelineDesc<'a, B: Backend> {
+    ///
+    pub shaders: GraphicsShaderSet<'a, B>,
     /// Rasterizer setup
     pub rasterizer: Rasterizer,
     /// Vertex buffers (IA)
@@ -48,12 +50,14 @@ pub struct GraphicsPipelineDesc<'a, B: Backend> {
 impl<'a, B: Backend> GraphicsPipelineDesc<'a, B> {
     /// Create a new empty PSO descriptor.
     pub fn new(
+        shaders: GraphicsShaderSet<'a, B>,
         primitive: Primitive,
         rasterizer: Rasterizer,
         layout: &'a B::PipelineLayout,
         subpass: pass::Subpass<'a, B>,
     ) -> Self {
         GraphicsPipelineDesc {
+            shaders,
             rasterizer,
             vertex_buffers: Vec::new(),
             attributes: Vec::new(),
@@ -63,7 +67,7 @@ impl<'a, B: Backend> GraphicsPipelineDesc<'a, B> {
             layout,
             subpass,
             flags: PipelineCreationFlags::empty(),
-            parent: BaseGraphics::None,
+            parent: BasePipeline::None,
         }
     }
 }

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -175,10 +175,10 @@ bitflags!(
 
 ///
 #[derive(Debug)]
-pub enum BaseGraphics<'a, B: Backend> {
+pub enum BasePipeline<'a, P: 'a> {
     /// Referencing an existing pipeline as parent.
-    Pipeline(&'a B::GraphicsPipeline),
-    /// A pipeline in the same `Device::create_graphics_pipelines` call.
+    Pipeline(&'a P),
+    /// A pipeline in the same create pipelines call.
     ///
     /// The index of the parent must be lower than the index of the child.
     Index(usize),
@@ -187,14 +187,6 @@ pub enum BaseGraphics<'a, B: Backend> {
 }
 
 ///
-#[derive(Debug)]
-pub enum BaseCompute<'a, B: Backend> {
-    /// Referencing an existing pipeline as parent.
-    Pipeline(&'a B::ComputePipeline),
-    /// A pipeline in the same `Device::create_graphics_pipelines` call.
-    ///
-    /// The index of the parent must be lower than the index of the child.
-    Index(usize),
-    ///
-    None,
-}
+pub type BaseGraphics<'a, B: Backend> = BasePipeline<'a, B::GraphicsPipeline>;
+///
+pub type BaseCompute<'a, B: Backend> = BasePipeline<'a, B::ComputePipeline>;

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -8,11 +8,13 @@ use pass;
 use std::error::Error;
 use std::fmt;
 
+mod compute;
 mod descriptor;
 mod graphics;
 mod input_assembler;
 mod output_merger;
 
+pub use self::compute::*;
 pub use self::descriptor::*;
 pub use self::graphics::*;
 pub use self::input_assembler::*;
@@ -154,3 +156,45 @@ impl<'a, B: Backend> PartialEq for EntryPoint<'a, B> {
 
 impl<'a, B: Backend> Copy for EntryPoint<'a, B> {}
 impl<'a, B: Backend> Eq for EntryPoint<'a, B> {}
+
+
+bitflags!(
+    /// Pipeline creation flags.
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct PipelineCreationFlags: u32 {
+        /// Disable pipeline optimizations.
+        ///
+        /// May speedup pipeline creation.
+        const DISABLE_OPTIMIZATION = 0x1;
+        /// Allow derivatives of the pipeline.
+        ///
+        /// Must be set when pipelines set the pipeline as base.
+        const ALLOW_DERIVATIVES = 0x2;
+    }
+);
+
+///
+#[derive(Debug)]
+pub enum BaseGraphics<'a, B: Backend> {
+    /// Referencing an existing pipeline as parent.
+    Pipeline(&'a B::GraphicsPipeline),
+    /// A pipeline in the same `Device::create_graphics_pipelines` call.
+    ///
+    /// The index of the parent must be lower than the index of the child.
+    Index(usize),
+    ///
+    None,
+}
+
+///
+#[derive(Debug)]
+pub enum BaseCompute<'a, B: Backend> {
+    /// Referencing an existing pipeline as parent.
+    Pipeline(&'a B::ComputePipeline),
+    /// A pipeline in the same `Device::create_graphics_pipelines` call.
+    ///
+    /// The index of the parent must be lower than the index of the child.
+    Index(usize),
+    ///
+    None,
+}

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -436,12 +436,9 @@ impl<B: Backend> Device<B> {
     #[doc(hidden)]
     pub fn create_graphics_pipeline_raw(
         &mut self,
-        shader_entries: hal::pso::GraphicsShaderSet<B>,
         desc: hal::pso::GraphicsPipelineDesc<B>,
     ) -> Result<handle::raw::GraphicsPipeline<B>, pso::CreationError> {
-        let pipeline = self.raw.create_graphics_pipelines(&[
-            (shader_entries, desc)
-        ]).pop().unwrap()?;
+        let pipeline = self.raw.create_graphics_pipelines(&[desc]).pop().unwrap()?;
         Ok(GraphicsPipeline::new(pipeline, (), self.garbage.clone()).into())
     }
 

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -437,12 +437,10 @@ impl<B: Backend> Device<B> {
     pub fn create_graphics_pipeline_raw(
         &mut self,
         shader_entries: hal::pso::GraphicsShaderSet<B>,
-        layout: &B::PipelineLayout,
-        subpass: hal::pass::Subpass<B>,
-        desc: &hal::pso::GraphicsPipelineDesc,
+        desc: hal::pso::GraphicsPipelineDesc<B>,
     ) -> Result<handle::raw::GraphicsPipeline<B>, pso::CreationError> {
         let pipeline = self.raw.create_graphics_pipelines(&[
-            (shader_entries, layout, subpass, desc)
+            (shader_entries, desc)
         ]).pop().unwrap()?;
         Ok(GraphicsPipeline::new(pipeline, (), self.garbage.clone()).into())
     }

--- a/src/render/src/macros/pipeline.rs
+++ b/src/render/src/macros/pipeline.rs
@@ -79,16 +79,18 @@ macro_rules! gfx_graphics_pipeline {
                         };
 
                         let mut pipeline_desc = cpso::GraphicsPipelineDesc::new(
-                            primitive, rasterizer, layout.resource(), subpass
+                            shader_entries,
+                            primitive,
+                            rasterizer,
+                            layout.resource(),
+                            subpass,
                         );
                         $(
                             <$cmp as pso::Component<'a, B>>::append_desc(self.$cmp_name, &mut pipeline_desc);
                         )*
 
 
-                        device.create_graphics_pipeline_raw(
-                            shader_entries, pipeline_desc
-                        )?
+                        device.create_graphics_pipeline_raw(pipeline_desc)?
                     };
                     Ok(Meta { layout, render_pass, pipeline })
                 }

--- a/src/render/src/macros/pipeline.rs
+++ b/src/render/src/macros/pipeline.rs
@@ -36,10 +36,10 @@ macro_rules! gfx_graphics_pipeline {
             impl<'a, B: Backend> pso::GraphicsPipelineInit<B> for Init<'a, B> {
                 type Pipeline = Meta<B>;
 
-                fn create(
+                fn create<'b>(
                     self,
                     device: &mut Device<B>,
-                    shader_entries: $crate::hal::pso::GraphicsShaderSet<B>,
+                    shader_entries: $crate::hal::pso::GraphicsShaderSet<'b, B>,
                     primitive: Primitive,
                     rasterizer: pso::Rasterizer
                 ) -> Result<Self::Pipeline, pso::CreationError> {
@@ -71,20 +71,23 @@ macro_rules! gfx_graphics_pipeline {
                         device.create_render_pass_raw(&attachments[..], &[subpass], &[])
                     };
 
-                    let mut pipeline_desc = cpso::GraphicsPipelineDesc::new(
-                        primitive, rasterizer
-                    );
-                    $(
-                        <$cmp as pso::Component<'a, B>>::append_desc(self.$cmp_name, &mut pipeline_desc);
-                    )*
 
                     let pipeline = {
                         let subpass = cpass::Subpass {
                             index: 0,
-                            main_pass: render_pass.resource()
+                            main_pass: render_pass.resource(),
                         };
+
+                        let mut pipeline_desc = cpso::GraphicsPipelineDesc::new(
+                            primitive, rasterizer, layout.resource(), subpass
+                        );
+                        $(
+                            <$cmp as pso::Component<'a, B>>::append_desc(self.$cmp_name, &mut pipeline_desc);
+                        )*
+
+
                         device.create_graphics_pipeline_raw(
-                            shader_entries, layout.resource(), subpass, &pipeline_desc
+                            shader_entries, pipeline_desc
                         )?
                     };
                     Ok(Meta { layout, render_pass, pipeline })

--- a/src/render/src/pso.rs
+++ b/src/render/src/pso.rs
@@ -184,10 +184,10 @@ impl<'a, B: Backend> DescriptorSetsUpdate<'a, B> {
 pub trait GraphicsPipelineInit<B: Backend> {
     type Pipeline;
 
-    fn create(
+    fn create<'a>(
         self,
         &mut Device<B>,
-        hal::pso::GraphicsShaderSet<B>,
+        hal::pso::GraphicsShaderSet<'a, B>,
         Primitive,
         Rasterizer
     ) -> Result<Self::Pipeline, CreationError>;
@@ -225,7 +225,7 @@ pub trait Component<'a, B: Backend> {
 
     fn append_desc(
         Self::Init,
-        &mut hal::pso::GraphicsPipelineDesc,
+        &mut hal::pso::GraphicsPipelineDesc<B>,
     ) {}
 
     fn require<'b>(
@@ -275,7 +275,7 @@ impl<'a, B, F> Component<'a, B> for RenderTarget<F>
 
     fn append_desc(
         init: Self::Init,
-        pipeline_desc: &mut hal::pso::GraphicsPipelineDesc
+        pipeline_desc: &mut hal::pso::GraphicsPipelineDesc<B>,
     ) {
         pipeline_desc.blender.targets.push(init);
     }
@@ -340,7 +340,7 @@ impl<'a, B, T, I> Component<'a, B> for VertexBuffer<T, I>
 
     fn append_desc(
         init: Self::Init,
-        pipeline_desc: &mut hal::pso::GraphicsPipelineDesc
+        pipeline_desc: &mut hal::pso::GraphicsPipelineDesc<B>,
     ) {
         let binding = pipeline_desc.vertex_buffers.len() as u32;
         pipeline_desc.vertex_buffers.push(hal::pso::VertexBufferDesc {


### PR DESCRIPTION
- Add support for deriving pipelines from other pipelines as supported in Vulkan.
- Additional pipeline flag (ie disable optimizations)
- Refactor pipeline descriptors a bit for compute and graphics

Only HAL and Vulkan implemented so far, others require a few adjustment due to the new API.

cc https://github.com/gfx-rs/gfx/issues/1610