### PR TITLE
dx12: Implement buffer filling command

### DIFF
--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -114,11 +114,12 @@ pub struct Framebuffer {
     pub(crate) attachments: Vec<ImageView>,
 }
 
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct Buffer {
     pub(crate) resource: *mut winapi::ID3D12Resource,
     pub(crate) size_in_bytes: u32,
     pub(crate) stride: u32,
+    pub(crate) clear_uav: Option<DualHandle>,
 }
 unsafe impl Send for Buffer { }
 unsafe impl Sync for Buffer { }


### PR DESCRIPTION
Implement the `fill_buffer` command on d3d12.
We use `ClearUnorderedAccessViewUint` for the internal clearing, requiring us to create a UAV for the buffer. Atm we have the same restrictions as for other clear commands to only allow clearing of whole resources. Otherwise we need to dynamically create views on each command (cheap?).

Additional barriers required as D3D12 needs resources to be in unordered access state whereas vulkan needs transfer write. Probably due to implementation internal things (DMA unit vs compute).

(For future reference: `vkCmdFillBuffer` is also supported on transfer queues with the maintenance extension. D3D12 doesn't support it on Copy queues so far.)

Tested and seems to work. 🏁 