### PR TITLE
Push constants!

### DIFF
--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -60,7 +60,7 @@ fn main() {
             ],
         );
 
-        let pipeline_layout = gpu.device.create_pipeline_layout(&[&set_layout]);
+        let pipeline_layout = gpu.device.create_pipeline_layout(&[&set_layout], &[]);
         let entry_point = pso::EntryPoint { entry: "main", module: &shader, specialization: &[] };
         let pipeline = gpu.device
             .create_compute_pipelines(&[

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -174,7 +174,7 @@ fn main() {
         ],
     );
 
-    let pipeline_layout = device.create_pipeline_layout(&[&set_layout]);
+    let pipeline_layout = device.create_pipeline_layout(&[&set_layout], &[]);
 
     let render_pass = {
         let attachment = pass::Attachment {

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1408,6 +1408,25 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             );
         }
     }
+
+    fn push_graphics_constants(
+        &mut self,
+        layout: &n::PipelineLayout,
+        stages: pso::ShaderStageFlags,
+        offset: u32,
+        constants: &[u32],
+    ) {
+        unimplemented!()
+    }
+
+    fn push_compute_constants(
+        &mut self,
+        layout: &n::PipelineLayout,
+        offset: u32,
+        constants: &[u32],
+    ) {
+        unimplemented!()
+    }
 }
 
 pub struct SubpassCommandBuffer {}

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -798,7 +798,7 @@ impl d::Device<B> for Device {
         rp
     }
 
-    fn create_pipeline_layout(&self, sets: &[&n::DescriptorSetLayout]) -> n::PipelineLayout {
+    fn create_pipeline_layout(&self, sets: &[&n::DescriptorSetLayout], push_constant_ranges: &[(pso::ShaderStageFlags, Range<u32>)]) -> n::PipelineLayout {
         // Pipeline layouts are implemented as RootSignature for D3D12.
         //
         // Each descriptor set layout will be one table entry of the root signature.

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -92,7 +92,7 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_pipeline_layout(&self, _: &[&()]) -> () {
+    fn create_pipeline_layout(&self, _: &[&()], _: &[(pso::ShaderStageFlags, Range<u32>)]) -> () {
         unimplemented!()
     }
 
@@ -554,6 +554,25 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         &mut self,
         _: pso::PipelineStage,
         _: query::Query<Backend>,
+    ) {
+        unimplemented!()
+    }
+    
+    fn push_graphics_constants(
+        &mut self,
+        _: &(),
+        _: pso::ShaderStageFlags,
+        _: u32,
+        _: &[u32],
+    ) {
+        unimplemented!()
+    }
+
+    fn push_compute_constants(
+        &mut self,
+        _: &(),
+        _: u32,
+        _: &[u32],
     ) {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -601,6 +601,16 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     ) {
         unimplemented!()
     }
+    
+    fn push_graphics_constants(
+        &mut self,
+        layout: &n::PipelineLayout,
+        stages: pso::ShaderStageFlags,
+        offset: u32,
+        constants: &[u32],
+    ) {
+        unimplemented!()
+    }
 
     fn end_query(
         &mut self,
@@ -621,6 +631,15 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         &mut self,
         _: pso::PipelineStage,
         _: query::Query<Backend>,
+    ) {
+        unimplemented!()
+    }
+    
+    fn push_compute_constants(
+        &mut self,
+        layout: &n::PipelineLayout,
+        offset: u32,
+        constants: &[u32],
     ) {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -227,7 +227,7 @@ impl d::Device<B> for Device {
         }
     }
 
-    fn create_pipeline_layout(&self, _: &[&n::DescriptorSetLayout]) -> n::PipelineLayout {
+    fn create_pipeline_layout(&self, _: &[&n::DescriptorSetLayout], _: &[(pso::ShaderStageFlags, Range<u32>)]) -> n::PipelineLayout {
         n::PipelineLayout
     }
 

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -843,7 +843,7 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
     ) {
         unimplemented!()
     }
-
+    
     fn end_query(
         &mut self,
         _query: Query<Backend>,
@@ -866,4 +866,24 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
     ) {
         // nothing to do, timestamps are unsupported on Metal
     }
+
+    fn push_graphics_constants(
+        &mut self,
+        layout: &native::PipelineLayout,
+        stages: pso::ShaderStageFlags,
+        offset: u32,
+        constants: &[u32],
+    ) {
+        unimplemented!()
+    }
+
+    fn push_compute_constants(
+        &mut self,
+        layout: &native::PipelineLayout,
+        offset: u32,
+        constants: &[u32],
+    ) {
+        unimplemented!()
+    }
+
 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -511,7 +511,7 @@ impl hal::Device<Backend> for Device {
         }
     }
 
-    fn create_pipeline_layout(&self, set_layouts: &[&n::DescriptorSetLayout]) -> n::PipelineLayout {
+    fn create_pipeline_layout(&self, set_layouts: &[&n::DescriptorSetLayout], push_constant_ranges: &[(pso::ShaderStageFlags, Range<u32>)]) -> n::PipelineLayout {
         use hal::pso::ShaderStageFlags;
 
         struct Counters {

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -812,6 +812,41 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             )
         }
     }
+    
+    fn push_compute_constants(
+        &mut self,
+        layout: &n::PipelineLayout,
+        offset: u32,
+        constants: &[u32],
+    ) {
+        unsafe {
+            self.device.0.cmd_push_constants(
+                self.raw,
+                layout.raw,
+                vk::SHADER_STAGE_COMPUTE_BIT,
+                offset,
+                constants,
+            );
+        }
+    }
+
+    fn push_graphics_constants(
+        &mut self,
+        layout: &n::PipelineLayout,
+        stages: pso::ShaderStageFlags,
+        offset: u32,
+        constants: &[u32],
+    ) {
+        unsafe {
+            self.device.0.cmd_push_constants(
+                self.raw,
+                layout.raw,
+                conv::map_stage_flags(stages),
+                offset,
+                constants,
+            );
+        }
+    }
 }
 
 pub struct SubpassCommandBuffer(pub CommandBuffer);

--- a/src/hal/src/command/compute.rs
+++ b/src/hal/src/command/compute.rs
@@ -2,7 +2,6 @@ use Backend;
 use queue::capability::{Compute, Supports};
 use super::{CommandBuffer, RawCommandBuffer};
 
-
 impl<'a, B: Backend, C: Supports<Compute>> CommandBuffer<'a, B, C> {
     ///
     pub fn bind_compute_pipeline(&mut self, pipeline: &B::ComputePipeline) {
@@ -27,5 +26,10 @@ impl<'a, B: Backend, C: Supports<Compute>> CommandBuffer<'a, B, C> {
     ///
     pub fn dispatch_indirect(&mut self, buffer: &B::Buffer, offset: u64) {
         self.raw.dispatch_indirect(buffer, offset)
+    }
+
+    ///
+    pub fn push_compute_constants(&mut self, layout: &B::PipelineLayout, offset: u32, constants: &[u32]) {
+        self.raw.push_compute_constants(layout, offset, constants);
     }
 }

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -197,6 +197,11 @@ impl<'a, B: Backend, C: Supports<Graphics>> CommandBuffer<'a, B, C> {
     pub fn set_blend_constants(&mut self, cv: ColorValue) {
         self.raw.set_blend_constants(cv)
     }
+
+    ///
+    pub fn push_graphics_constants(&mut self, layout: &B::PipelineLayout, stages: pso::ShaderStageFlags, offset: u32, constants: &[u32]) {
+        self.raw.push_graphics_constants(layout, stages, offset, constants);
+    }
 }
 
 impl<'a, B: Backend, C: Supports<GraphicsOrCompute>> CommandBuffer<'a, B, C> {

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -280,4 +280,21 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
 
     ///
     fn write_timestamp(&mut self, pso::PipelineStage, Query<B>);
+
+    ///
+    fn push_graphics_constants(
+        &mut self,
+        layout: &B::PipelineLayout,
+        stages: pso::ShaderStageFlags,
+        offset: u32,
+        constants: &[u32],
+    );
+
+    ///
+    fn push_compute_constants(
+        &mut self,
+        layout: &B::PipelineLayout,
+        offset: u32,
+        constants: &[u32],
+    );
 }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -149,6 +149,7 @@ pub trait Device<B: Backend> {
     fn create_pipeline_layout(
         &self,
         &[&B::DescriptorSetLayout],
+        &[(pso::ShaderStageFlags, Range<u32>)]
     ) -> B::PipelineLayout;
 
     ///

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -427,9 +427,10 @@ impl<B: Backend> Device<B> {
     #[doc(hidden)]
     pub fn create_pipeline_layout_raw(
         &mut self,
-        layouts: &[&B::DescriptorSetLayout]
+        layouts: &[&B::DescriptorSetLayout],
+        push_constant_ranges: &[(hal::pso::ShaderStageFlags, Range<u32>)],
     ) -> handle::raw::PipelineLayout<B> {
-        let layout = self.raw.create_pipeline_layout(layouts);
+        let layout = self.raw.create_pipeline_layout(layouts, push_constant_ranges);
         PipelineLayout::new(layout, (), self.garbage.clone()).into()
     }
 

--- a/src/render/src/macros/pipeline.rs
+++ b/src/render/src/macros/pipeline.rs
@@ -45,7 +45,7 @@ macro_rules! gfx_graphics_pipeline {
                 ) -> Result<Self::Pipeline, pso::CreationError> {
                     let mut desc_layouts = Vec::new();
                     $( desc_layouts.extend(<$cmp as pso::Component<'a, B>>::descriptor_layout(&self.$cmp_name)); )*
-                    let layout = device.create_pipeline_layout_raw(&desc_layouts[..]);
+                    let layout = device.create_pipeline_layout_raw(&desc_layouts[..], &[]);
                     let render_pass = {
                         let mut attachments = Vec::new();
                         let mut color_attachments = Vec::new();

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -357,13 +357,13 @@ impl<B: hal::Backend> Scene<B> {
                             .unwrap();
                         resources.desc_sets.insert(name.clone(), set);
                     }
-                    raw::Resource::PipelineLayout { ref set_layouts } => {
+                    raw::Resource::PipelineLayout { ref set_layouts, ref push_constant_ranges } => {
                         let layout = {
                             let layouts = set_layouts
                                 .iter()
                                 .map(|sl| &resources.desc_set_layouts[sl])
                                 .collect::<Vec<_>>();
-                            device.create_pipeline_layout(&layouts)
+                            device.create_pipeline_layout(&layouts, &push_constant_ranges)
                         };
                         resources.pipeline_layouts.insert(name.clone(), layout);
                     }

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -61,6 +61,7 @@ pub enum Resource {
     },
     PipelineLayout {
         set_layouts: Vec<String>,
+        push_constant_ranges: Vec<(hal::pso::ShaderStageFlags, Range<u32>)>
     },
     GraphicsPipeline,
     Framebuffer {


### PR DESCRIPTION
This PR adds support for the use of push constants in shaders. 
It consists of three public api additions/changes: an extra parameter to `Device::create_pipeline_layout`, and the addition of `push_graphics_constants` and `push_compute_constants` to appropriate command buffers.

These can be easily implemented on Vulkan and ~~DX12~~ (nevermind, we need shader reflection it seems), I will see about other backends before this is merged, hopefully.