### PR TITLE
Fix spurious error in creating graphics pipelines

### DIFF
--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -285,9 +285,9 @@ impl d::Device<B> for Device {
                     if status != 0 {
                         if !log.is_empty() {
                             warn!("\tLog: {}", log);
+                        } else {
+                            return Err(pso::CreationError::Other);
                         }
-                    } else {
-                        return Err(pso::CreationError::Other);
                     }
 
                     name


### PR DESCRIPTION
I came across this while I was working on the OpenGL backend. There's a missing brace causing create_graphics_pipelines to always return an error.