### PR TITLE
d3d12: Refactor pipeline layouts to match Vulkan's compatibility rules.

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -760,6 +760,7 @@ impl d::Device<B> for Device {
         n::PipelineLayout {
             raw: signature,
             tables: set_tables,
+            num_parameter_slots: parameters.len(),
         }
     }
 
@@ -927,7 +928,12 @@ impl d::Device<B> for Device {
             };
 
             if winapi::SUCCEEDED(hr) {
-                Ok(n::GraphicsPipeline { raw: pipeline, topology })
+                Ok(n::GraphicsPipeline {
+                    raw: pipeline,
+                    signature: desc.layout.raw,
+                    num_parameter_slots: desc.layout.num_parameter_slots,
+                    topology,
+                })
             } else {
                 Err(pso::CreationError::Other)
             }
@@ -978,7 +984,11 @@ impl d::Device<B> for Device {
             };
 
             if winapi::SUCCEEDED(hr) {
-                Ok(n::ComputePipeline { raw: pipeline })
+                Ok(n::ComputePipeline {
+                    raw: pipeline,
+                    signature: desc.layout.raw,
+                    num_parameter_slots: desc.layout.num_parameter_slots,
+                })
             } else {
                 Err(pso::CreationError::Other)
             }


### PR DESCRIPTION
Switching root signatures requires rebinding all tables. Rebinding will now be done automatically and data tracked internally to allow support of two different pipeline bind points.

We now cache the user data inside the command buffer and rebind the required parts on draw/dispatch calls. Upcoming push constant support was considered during implementation. This mostly follows the compatibility aspect from the RFC #1631. Actual compatibility check is not required and the user is supposed to update the corresponding parts following vulkan specs. Therefore a valid program in Vulkan will run in D3D12, and an invalid application might still run correctly in D3D12. Corresponding parts of the Vulkan API specified the behavior as implementation specific.

Next step is to unify the `bind_graphics_descriptor_sets`/`bind_compute_descriptor_sets` and `bind_graphics_pipeline`/`bind_compute_pipeline` calls.