### PR TITLE
[hal][Vulkan][Metal][Empty] Add get_fence_status method to Device trait

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1697,6 +1697,10 @@ impl d::Device<B> for Device {
         }
     }
 
+    fn get_fence_status(&self, fence: &n::Fence) -> bool {
+        unimplemented!()
+    }
+
     fn free_memory(&self, _memory: n::Memory) {
         // Just drop
     }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -199,6 +199,9 @@ impl hal::Device<Backend> for Device {
     fn wait_for_fences(&self, _: &[&()], _: device::WaitFor, _: u32) -> bool {
         unimplemented!()
     }
+    fn get_fence_status(&self, _: &()) -> bool {
+        unimplemented!()
+    }
 
     fn free_memory(&self, _: ()) {
         unimplemented!()

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -691,6 +691,10 @@ impl d::Device<B> for Device {
         }
     }
 
+    fn get_fence_status(&self, _: &n::Fence) -> bool {
+        unimplemented!()
+    }
+
     fn free_memory(&self, _: n::Memory) {
         unimplemented!()
     }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1079,6 +1079,9 @@ impl hal::Device<Backend> for Device {
             thread::sleep(time::Duration::from_millis(tick as u64));
         }
     }
+    fn get_fence_status(&self, fence: &n::Fence) -> bool {
+        *fence.0.lock().unwrap()
+    }
     #[cfg(not(feature = "native_fence"))]
     fn destroy_fence(&self, _fence: n::Fence) {
     }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1208,6 +1208,17 @@ impl d::Device<B> for Device {
         }
     }
 
+    fn get_fence_status(&self, fence: &n::Fence) -> bool {
+        let result = unsafe {
+            self.raw.0.get_fence_status(fence.0)
+        };
+        match result {
+            Ok(()) | Err(vk::Result::Success) => true,
+            Err(vk::Result::NotReady) => false,
+            _ => panic!("Unexpected get_fence_status result {:?}", result),
+        }
+    }
+
     fn free_memory(&self, memory: n::Memory) {
         if !memory.ptr.is_null() {
             unsafe { self.raw.0.unmap_memory(memory.inner) }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -387,6 +387,9 @@ pub trait Device<B: Backend> {
     /// Returns true if fences were signaled before the timeout.
     fn wait_for_fences(&self, &[&B::Fence], WaitFor, timeout_ms: u32) -> bool;
 
+    /// true for signaled, false for not ready
+    fn get_fence_status(&self, &B::Fence) -> bool;
+
     ///
     fn destroy_fence(&self, B::Fence);
 }


### PR DESCRIPTION
In order to query the status of a fence, `Device` trait needs `get_fence_status` method.

- [X] Vulkan
- [x] Metal
- [x] Empty

For GL and DX12 backend, I decided to implement them later since they are not high priorities for our working project.