### PR TITLE
[WIP][hal] Refine synchronization usage

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -412,7 +412,7 @@ fn main() {
     };
 
     let frame_semaphore = device.create_semaphore();
-    let frame_fence = device.create_fence(true);
+    //let frame_fence = device.create_fence(true);
     let render_semaphore = device.create_semaphore();
     let mut upload_semaphore = Some(device.create_semaphore());
     let mut used_semaphores = Vec::new();
@@ -485,8 +485,8 @@ fn main() {
 
         device.wait_idle();
 
-        device.wait_for_fences(&[&frame_fence], d::WaitFor::All, !0);
-        device.reset_fences(&[&frame_fence]);
+        //device.wait_for_fences(&[&frame_fence], d::WaitFor::All, !0);
+        //device.reset_fences(&[&frame_fence]);
 
         command_pool.reset();
         let frame = swap_chain.acquire_frame(FrameSync::Semaphore(&frame_semaphore));
@@ -528,7 +528,7 @@ fn main() {
                     .signal(&[&render_semaphore])
                     .submit(&[submit])
             };
-            queue.submit(submission, Some(&frame_fence));
+            queue.submit(submission, None/*Some(&frame_fence)*/);
         }
 
         // present frame
@@ -545,7 +545,8 @@ fn main() {
     }
 
     // wait for command buffer
-    device.wait_for_fences(&[&frame_fence], d::WaitFor::All, !0);
+    device.wait_idle();
+    //device.wait_for_fences(&[&frame_fence], d::WaitFor::All, !0);
 
     // cleanup!
     device.destroy_command_pool(command_pool.downgrade());
@@ -565,7 +566,7 @@ fn main() {
     device.destroy_image(image_logo);
     device.destroy_image_view(image_srv);
     device.destroy_sampler(sampler);
-    device.destroy_fence(frame_fence);
+    //device.destroy_fence(frame_fence);
     device.destroy_semaphore(render_semaphore);
     device.destroy_semaphore(frame_semaphore);
     for x in used_semaphores.drain(..) { device.destroy_semaphore(x); }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1711,6 +1711,10 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
+    fn wait_idle(&self) {
+        unimplemented!()
+    }
+
     fn free_memory(&self, _memory: n::Memory) {
         // Just drop
     }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -203,6 +203,10 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
+    fn wait_idle(&self) {
+        unimplemented!()
+    }
+
     fn free_memory(&self, _: ()) {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -695,6 +695,10 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
+    fn wait_idle(&self) {
+        unimplemented!()
+    }
+
     fn free_memory(&self, _: n::Memory) {
         unimplemented!()
     }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1085,6 +1085,9 @@ impl hal::Device<Backend> for Device {
     #[cfg(not(feature = "native_fence"))]
     fn destroy_fence(&self, _fence: n::Fence) {
     }
+    fn wait_idle(&self) {
+        unimplemented!()
+    }
 }
 
 #[test]

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1219,6 +1219,14 @@ impl d::Device<B> for Device {
         }
     }
 
+    fn wait_idle(&self) {
+        let result = self.raw.0.device_wait_idle();
+        match result {
+            Ok(()) => (),
+            Err(_) => panic!("Unexpected wait_idle result {:?}", result),
+        }
+    }
+
     fn free_memory(&self, memory: n::Memory) {
         if !memory.ptr.is_null() {
             unsafe { self.raw.0.unmap_memory(memory.inner) }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -392,4 +392,7 @@ pub trait Device<B: Backend> {
 
     ///
     fn destroy_fence(&self, B::Fence);
+
+    ///
+    fn wait_idle(&self);
 }


### PR DESCRIPTION
# TODOs

- [x] HAL: add `wait_idle` to Device trait
- [x] ~HAL: add `wait_idle` to CommandQueue struct~
- [x] example/hal/quad: Use upload_semaphore for uploading sync
- [x] example/hal/quad: Use render_semaphore for buffer swapping sync
- [x] example/hal/quad: Remove frame_fence completely
- [x] Vulkan backend
- [x] Empty backend
- [x] Fix CI build errors

# Why Device::wait_idle?

1. It's required to make sure no command buffer is using before calling CommandPool::reset
2. GPU resources modification (ex: Texture deallocation) should not impact GPU execution
3. frame_fence is signaled when submission is completed but the command buffer is not released => CommandPool::reset will crash

# Why not Device::wait_idle?

1. Only Vulkan provides the function (and GL equivalent: glFinish)
2. Game engines don't like it since it hurts performance => too many CPU-wait GPU-idle

# Alternative

Double/Triple-buffered command pools and semaphores => ex: one command pool each frame and do buffer swapping