### PR TITLE
Query operations

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1387,12 +1387,26 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         _pool: &n::QueryPool,
         _queries: Range<query::QueryId>,
     ) {
-        // Nothing todo here
+        // Nothing to do here
         // vkCmdResetQueryPool sets the queries to `unavailable` but the specification
         // doesn't state an affect on the `active` state. Every queries at the end of the command
         // buffer must be made inactive, which can only be done with EndQuery.
         // Therefore, every `begin_query` must follow a `end_query` state, the resulting values
         // after calling are undefined.
+    }
+
+    fn write_timestamp(
+        &mut self,
+        _: pso::PipelineStage,
+        query: query::Query<Backend>,
+    ) {
+        unsafe {
+            self.raw.EndQuery(
+                query.pool.raw.as_mut() as *mut _,
+                winapi::D3D12_QUERY_TYPE_TIMESTAMP,
+                query.id,
+            );
+        }
     }
 }
 

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -32,6 +32,12 @@ pub struct RenderPassCache {
     attachment_clears: Vec<AttachmentClear>,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum OcclusionQuery {
+    Binary(UINT),
+    Precise(UINT),
+}
+
 /// Strongly-typed root signature element
 ///
 /// Could be removed for an unsafer variant to occupy less memory
@@ -142,6 +148,14 @@ pub struct CommandBuffer {
     // D3D12 only has one slot for both bindpoints. Need to rebind everything if we want to switch
     // between different bind points (ie. calling draw or dispatch).
     active_bindpoint: BindPoint,
+
+    // Active queries in the command buffer.
+    // Queries must begin and end in the same command buffer, which allows us to track them.
+    // The query pool type on `begin_query` must differ from all currently active queries.
+    // Therefore, only one query per query type can be active at the same time. Binary and precise
+    // occlusion queries share one queue type in Vulkan.
+    occlusion_query: Option<OcclusionQuery>,
+    pipeline_stats_query: Option<UINT>,
 }
 
 unsafe impl Send for CommandBuffer { }
@@ -161,6 +175,8 @@ impl CommandBuffer {
             gr_pipeline: PipelineCache::new(),
             comp_pipeline: PipelineCache::new(),
             active_bindpoint: BindPoint::Graphics,
+            occlusion_query: None,
+            pipeline_stats_query: None,
         }
     }
 
@@ -175,6 +191,8 @@ impl CommandBuffer {
         self.gr_pipeline = PipelineCache::new();
         self.comp_pipeline = PipelineCache::new();
         self.active_bindpoint = BindPoint::Graphics;
+        self.occlusion_query = None;
+        self.pipeline_stats_query = None;
     }
 
     fn insert_subpass_barriers(&self) {
@@ -1294,25 +1312,87 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn begin_query(
         &mut self,
-        _query: com::Query<Backend>,
-        _flags: com::QueryControl,
+        query: com::Query<Backend>,
+        flags: com::QueryControl,
     ) {
-        unimplemented!()
+        let query_ty = match query.pool.ty {
+            winapi::D3D12_QUERY_HEAP_TYPE_OCCLUSION => {
+                if flags.contains(com::QueryControl::PRECISE) {
+                    self.occlusion_query = Some(OcclusionQuery::Precise(query.id));
+                    winapi::D3D12_QUERY_TYPE_OCCLUSION
+                } else {
+                    // Default to binary occlusion as it might be faster due to early depth/stencil
+                    // tests.
+                    self.occlusion_query = Some(OcclusionQuery::Binary(query.id));
+                    winapi::D3D12_QUERY_TYPE_BINARY_OCCLUSION
+                }
+            }
+            winapi::D3D12_QUERY_HEAP_TYPE_TIMESTAMP => {
+                panic!("Timestap queries are issued via ")
+            }
+            winapi::D3D12_QUERY_HEAP_TYPE_PIPELINE_STATISTICS => {
+                self.pipeline_stats_query = Some(query.id);
+                winapi::D3D12_QUERY_TYPE_PIPELINE_STATISTICS
+            }
+            _ => unreachable!(),
+        };
+
+        unsafe {
+            self.raw.BeginQuery(
+                query.pool.raw.as_mut() as *mut _,
+                query_ty,
+                query.id,
+            );
+        }
     }
 
     fn end_query(
         &mut self,
-        _query: com::Query<Backend>,
+        query: com::Query<Backend>,
     ) {
-        unimplemented!()
+        let id = query.id;
+        let query_ty = match query.pool.ty {
+            winapi::D3D12_QUERY_HEAP_TYPE_OCCLUSION
+                if self.occlusion_query == Some(OcclusionQuery::Precise(id)) =>
+            {
+                self.occlusion_query = None;
+                winapi::D3D12_QUERY_TYPE_OCCLUSION
+            }
+            winapi::D3D12_QUERY_HEAP_TYPE_OCCLUSION
+                if self.occlusion_query == Some(OcclusionQuery::Binary(id)) =>
+            {
+                self.occlusion_query = None;
+                winapi::D3D12_QUERY_TYPE_BINARY_OCCLUSION
+            }
+            winapi::D3D12_QUERY_HEAP_TYPE_PIPELINE_STATISTICS
+                if self.pipeline_stats_query == Some(id) =>
+            {
+                self.pipeline_stats_query = None;
+                winapi::D3D12_QUERY_TYPE_PIPELINE_STATISTICS
+            }
+            _ => panic!("Missing `begin_query` call for query: {:?}", query),
+        };
+
+        unsafe {
+            self.raw.EndQuery(
+                query.pool.raw.as_mut() as *mut _,
+                query_ty,
+                id,
+            );
+        }
     }
 
     fn reset_query_pool(
         &mut self,
-        _pool: &(),
+        _pool: &n::QueryPool,
         _queries: Range<com::QueryId>,
     ) {
-        unimplemented!()
+        // Nothing todo here
+        // vkCmdResetQueryPool sets the queries to `unavailable` but the specification
+        // doesn't state an affect on the `active` state. Every queries at the end of the command
+        // buffer must be made inactive, which can only be done with EndQuery.
+        // Therefore, every `begin_query` must follow a `end_query` state, the resulting values
+        // after calling are undefined.
     }
 }
 

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1,5 +1,5 @@
 use wio::com::ComPtr;
-use hal::{command as com, image, memory, pass, pso};
+use hal::{command as com, image, memory, pass, pso, query};
 use hal::{IndexCount, IndexType, InstanceCount, VertexCount, VertexOffset};
 use hal::buffer::IndexBufferView;
 use winapi::{self, UINT64, UINT};
@@ -1312,12 +1312,12 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn begin_query(
         &mut self,
-        query: com::Query<Backend>,
-        flags: com::QueryControl,
+        query: query::Query<Backend>,
+        flags: query::QueryControl,
     ) {
         let query_ty = match query.pool.ty {
             winapi::D3D12_QUERY_HEAP_TYPE_OCCLUSION => {
-                if flags.contains(com::QueryControl::PRECISE) {
+                if flags.contains(query::QueryControl::PRECISE) {
                     self.occlusion_query = Some(OcclusionQuery::Precise(query.id));
                     winapi::D3D12_QUERY_TYPE_OCCLUSION
                 } else {
@@ -1348,7 +1348,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn end_query(
         &mut self,
-        query: com::Query<Backend>,
+        query: query::Query<Backend>,
     ) {
         let id = query.id;
         let query_ty = match query.pool.ty {
@@ -1385,7 +1385,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn reset_query_pool(
         &mut self,
         _pool: &n::QueryPool,
-        _queries: Range<com::QueryId>,
+        _queries: Range<query::QueryId>,
     ) {
         // Nothing todo here
         // vkCmdResetQueryPool sets the queries to `unavailable` but the specification

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1291,6 +1291,29 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             );
         }
     }
+
+    fn begin_query(
+        &mut self,
+        _query: com::Query<Backend>,
+        _flags: com::QueryControl,
+    ) {
+        unimplemented!()
+    }
+
+    fn end_query(
+        &mut self,
+        _query: com::Query<Backend>,
+    ) {
+        unimplemented!()
+    }
+
+    fn reset_query_pool(
+        &mut self,
+        _pool: &(),
+        _queries: Range<com::QueryId>,
+    ) {
+        unimplemented!()
+    }
 }
 
 pub struct SubpassCommandBuffer {}

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -10,7 +10,7 @@ use spirv_cross::{hlsl, spirv, ErrorCode as SpirvErrorCode};
 use winapi;
 use wio::com::ComPtr;
 
-use hal::{buffer, device as d, format, image, mapping, memory, pass, pso};
+use hal::{buffer, device as d, format, image, mapping, memory, pass, pso, query};
 use hal::{Features, Limits, MemoryType};
 use hal::memory::Requirements;
 use hal::pool::CommandPoolCreateFlags;
@@ -1801,6 +1801,14 @@ impl d::Device<B> for Device {
     }
 
     fn free_memory(&self, _memory: n::Memory) {
+        // Just drop
+    }
+
+    fn create_query_pool(&self, ty: query::QueryType, count: u32) -> n::QueryPool {
+        unimplemented!()
+    }
+
+    fn destroy_query_pool(&self, pool: n::QueryPool) {
         // Just drop
     }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -512,6 +512,8 @@ impl Device {
                 sampler_border_color: false,
                 sampler_lod_bias: false,
                 sampler_objects: false,
+                precise_occlusion_query: true,
+                pipeline_statistics_query: true,
             },
             limits: Limits { // TODO
                 max_texture_size: 0,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -713,5 +713,5 @@ impl hal::Backend for Backend {
 
     type Fence = native::Fence;
     type Semaphore = native::Semaphore;
-    type QueryPool = ();
+    type QueryPool = native::QueryPool;
 }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -713,4 +713,5 @@ impl hal::Backend for Backend {
 
     type Fence = native::Fence;
     type Semaphore = native::Semaphore;
+    type QueryPool = ();
 }

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -406,3 +406,12 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
         unimplemented!()
     }
 }
+
+#[derive(Debug)]
+pub struct QueryPool {
+    pub(crate) raw: ComPtr<winapi::ID3D12QueryHeap>,
+    pub(crate) ty: winapi::D3D12_QUERY_HEAP_TYPE,
+}
+
+unsafe impl Send for QueryPool {}
+unsafe impl Sync for QueryPool {}

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate gfx_hal as hal;
 
 use std::ops::Range;
-use hal::{buffer, command, device, format, image, mapping, memory, pass, pool, pso, queue};
+use hal::{buffer, command, device, format, image, mapping, memory, pass, pool, pso, query, queue};
 
 /// Dummy backend.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -197,10 +197,19 @@ impl hal::Device<Backend> for Device {
     fn reset_fences(&self, _: &[&()]) {
         unimplemented!()
     }
+
     fn wait_for_fences(&self, _: &[&()], _: device::WaitFor, _: u32) -> bool {
         unimplemented!()
     }
     fn get_fence_status(&self, _: &()) -> bool {
+        unimplemented!()
+    }
+
+    fn create_query_pool(&self, _: query::QueryType, _: u32) -> () {
+        unimplemented!()
+    }
+
+    fn destroy_query_pool(&self, _: ()) {
         unimplemented!()
     }
 
@@ -512,15 +521,15 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
     fn begin_query(
         &mut self,
-        _: command::Query<Backend>,
-        _: command::QueryControl,
+        _: query::Query<Backend>,
+        _: query::QueryControl,
     ) {
         unimplemented!()
     }
 
     fn end_query(
         &mut self,
-        _: command::Query<Backend>,
+        _: query::Query<Backend>,
     ) {
         unimplemented!()
     }
@@ -528,7 +537,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     fn reset_query_pool(
         &mut self,
         _: &(),
-        _: Range<command::QueryId>,
+        _: Range<query::QueryId>,
     ) {
         unimplemented!()
     }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -541,6 +541,14 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     ) {
         unimplemented!()
     }
+
+    fn write_timestamp(
+        &mut self,
+        _: pso::PipelineStage,
+        _: query::Query<Backend>,
+    ) {
+        unimplemented!()
+    }
 }
 
 // Dummy descriptor pool.

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -46,6 +46,7 @@ impl hal::Backend for Backend {
 
     type Fence = ();
     type Semaphore = ();
+    type QueryPool = ();
 }
 
 /// Dummy physical device.
@@ -505,6 +506,29 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         _: u64,
         _: u32,
         _: u32,
+    ) {
+        unimplemented!()
+    }
+
+    fn begin_query(
+        &mut self,
+        _: command::Query<Backend>,
+        _: command::QueryControl,
+    ) {
+        unimplemented!()
+    }
+
+    fn end_query(
+        &mut self,
+        _: command::Query<Backend>,
+    ) {
+        unimplemented!()
+    }
+
+    fn reset_query_pool(
+        &mut self,
+        _: &(),
+        _: Range<command::QueryId>,
     ) {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1,8 +1,9 @@
 #![allow(missing_docs)]
 
 use gl;
-use hal::{self, command, image, memory};
+use hal::{self, image, memory};
 use hal::buffer::IndexBufferView;
+use hal::command::{self, Query, QueryControl, QueryId};
 use {native as n, Backend};
 use pool::{self, BufferMemory};
 
@@ -590,6 +591,29 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         _offset: u64,
         _draw_count: u32,
         _stride: u32,
+    ) {
+        unimplemented!()
+    }
+
+    fn begin_query(
+        &mut self,
+        _query: Query<Backend>,
+        _flags: QueryControl,
+    ) {
+        unimplemented!()
+    }
+
+    fn end_query(
+        &mut self,
+        _query: Query<Backend>,
+    ) {
+        unimplemented!()
+    }
+
+    fn reset_query_pool(
+        &mut self,
+        _pool: &(),
+        _queries: Range<QueryId>,
     ) {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1,9 +1,8 @@
 #![allow(missing_docs)]
 
 use gl;
-use hal::{self, image, memory};
+use hal::{self, command, image, memory, query};
 use hal::buffer::IndexBufferView;
-use hal::command::{self, Query, QueryControl, QueryId};
 use {native as n, Backend};
 use pool::{self, BufferMemory};
 
@@ -597,15 +596,15 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
     fn begin_query(
         &mut self,
-        _query: Query<Backend>,
-        _flags: QueryControl,
+        _query: query::Query<Backend>,
+        _flags: query::QueryControl,
     ) {
         unimplemented!()
     }
 
     fn end_query(
         &mut self,
-        _query: Query<Backend>,
+        _query: query::Query<Backend>,
     ) {
         unimplemented!()
     }
@@ -613,7 +612,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     fn reset_query_pool(
         &mut self,
         _pool: &(),
-        _queries: Range<QueryId>,
+        _queries: Range<query::QueryId>,
     ) {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use gl;
-use hal::{self, command, image, memory, query};
+use hal::{self, command, image, memory, pso, query};
 use hal::buffer::IndexBufferView;
 use {native as n, Backend};
 use pool::{self, BufferMemory};
@@ -613,6 +613,14 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         &mut self,
         _pool: &(),
         _queries: Range<query::QueryId>,
+    ) {
+        unimplemented!()
+    }
+
+    fn write_timestamp(
+        &mut self,
+        _: pso::PipelineStage,
+        _: query::Query<Backend>,
     ) {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use gl;
 use gl::types::{GLint, GLenum, GLfloat};
-use hal::{self as c, device as d, image as i, memory, pass, pso, buffer, mapping};
+use hal::{self as c, device as d, image as i, memory, pass, pso, buffer, mapping, query};
 use hal::format::{Format, Swizzle};
 use hal::pool::CommandPoolCreateFlags;
 
@@ -696,6 +696,14 @@ impl d::Device<B> for Device {
     }
 
     fn free_memory(&self, _: n::Memory) {
+        unimplemented!()
+    }
+
+    fn create_query_pool(&self, _ty: query::QueryType, _count: u32) -> () {
+        unimplemented!()
+    }
+
+    fn destroy_query_pool(&self, _: ()) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -322,6 +322,8 @@ pub fn query_all(gl: &gl::Gl) -> (Info, Features, Limits, PrivateCaps) {
                                                                 Ext ("GL_ARB_texture_filter_anisotropic"),
                                                                 Ext ("GL_EXT_texture_filter_anisotropic")]),
         sampler_border_color:               info.is_supported(&[Core(3,3)]), // TODO: extensions
+        precise_occlusion_query: false, // TODO
+        pipeline_statistics_query: false, // TODO
     };
     let private = PrivateCaps {
         vertex_array:                       info.is_supported(&[Core(3,0),

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -68,6 +68,7 @@ impl hal::Backend for Backend {
 
     type Fence = native::Fence;
     type Semaphore = native::Semaphore;
+    type QueryPool = ();
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -14,6 +14,7 @@ use hal::command::{
     BufferImageCopy, BufferCopy, ImageCopy, ImageResolve,
     SubpassContents, RawCommandBuffer,
     ColorValue, StencilValue, Rect, Viewport,
+    Query, QueryControl, QueryId,
 };
 use hal::queue::{RawCommandQueue, RawSubmission};
 
@@ -831,6 +832,29 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
         _offset: u64,
         _draw_count: u32,
         _stride: u32,
+    ) {
+        unimplemented!()
+    }
+
+    fn begin_query(
+        &mut self,
+        _query: Query<Backend>,
+        _flags: QueryControl,
+    ) {
+        unimplemented!()
+    }
+
+    fn end_query(
+        &mut self,
+        _query: Query<Backend>,
+    ) {
+        unimplemented!()
+    }
+
+    fn reset_query_pool(
+        &mut self,
+        _pool: &(),
+        _queries: Range<QueryId>,
     ) {
         unimplemented!()
     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -858,4 +858,12 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
     ) {
         unimplemented!()
     }
+
+    fn write_timestamp(
+        &mut self,
+        _: pso::PipelineStage,
+        _: query::Query<Backend>,
+    ) {
+        // nothing to do, timestamps are unsupported on Metal
+    }
 }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -862,7 +862,7 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
     fn write_timestamp(
         &mut self,
         _: pso::PipelineStage,
-        _: query::Query<Backend>,
+        _: Query<Backend>,
     ) {
         // nothing to do, timestamps are unsupported on Metal
     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -14,8 +14,8 @@ use hal::command::{
     BufferImageCopy, BufferCopy, ImageCopy, ImageResolve,
     SubpassContents, RawCommandBuffer,
     ColorValue, StencilValue, Rect, Viewport,
-    Query, QueryControl, QueryId,
 };
+use hal::query::{Query, QueryControl, QueryId};
 use hal::queue::{RawCommandQueue, RawSubmission};
 
 use metal::{self, MTLViewport, MTLScissorRect, MTLPrimitiveType, MTLClearColor, MTLSize, MTLOrigin};

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::{cmp, mem, ptr, slice};
 
 use hal::{self,
-        image, pass, format, mapping, memory, buffer, pso};
+        image, pass, format, mapping, memory, buffer, pso, query};
 use hal::device::{WaitFor, BindError, OutOfMemory, FramebufferError, ShaderError, Extent};
 use hal::pool::CommandPoolCreateFlags;
 use hal::pso::{DescriptorSetWrite, DescriptorType, DescriptorSetLayoutBinding, AttributeDesc};
@@ -1084,6 +1084,14 @@ impl hal::Device<Backend> for Device {
     }
     #[cfg(not(feature = "native_fence"))]
     fn destroy_fence(&self, _fence: n::Fence) {
+    }
+
+    fn create_query_pool(&self, _ty: query::QueryType, _count: u32) -> () {
+        unimplemented!()
+    }
+
+    fn destroy_query_pool(&self, _: ()) {
+        unimplemented!()
     }
 }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -143,6 +143,7 @@ impl hal::Backend for Backend {
 
     type Fence = native::Fence;
     type Semaphore = native::Semaphore;
+    type QueryPool = ();
 }
 
 pub struct AutoreleasePool {

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1"
 log = "0.3"
 lazy_static = "0.2"
 shared_library = "0.1"
-ash = "0.19.1"
+ash = "0.20.2"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.4"
 winit = { version = "0.7", optional = true }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -5,7 +5,7 @@ use smallvec::SmallVec;
 use ash::vk;
 use ash::version::DeviceV1_0;
 
-use hal::{command as com, memory, pso};
+use hal::{command as com, memory, pso, query};
 use hal::{IndexCount, InstanceCount, VertexCount, VertexOffset};
 use hal::buffer::IndexBufferView;
 use hal::image::{AspectFlags, ImageLayout, SubresourceRange};
@@ -752,11 +752,11 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn begin_query(
         &mut self,
-        query: com::Query<Backend>,
-        control: com::QueryControl,
+        query: query::Query<Backend>,
+        control: query::QueryControl,
     ) {
         let mut flags = vk::QueryControlFlags::empty();
-        if control.contains(com::QueryControl::PRECISE) {
+        if control.contains(query::QueryControl::PRECISE) {
             flags |= vk::QUERY_CONTROL_PRECISE_BIT;
         }
 
@@ -772,7 +772,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn end_query(
         &mut self,
-        query: com::Query<Backend>,
+        query: query::Query<Backend>,
     ) {
         unsafe {
             self.device.0.cmd_end_query(
@@ -786,7 +786,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn reset_query_pool(
         &mut self,
         pool: &n::QueryPool,
-        queries: Range<com::QueryId>,
+        queries: Range<query::QueryId>,
     ) {
         unsafe {
             self.device.0.cmd_reset_query_pool(

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -752,25 +752,50 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn begin_query(
         &mut self,
-        _query: com::Query<Backend>,
-        _flags: com::QueryControl,
+        query: com::Query<Backend>,
+        control: com::QueryControl,
     ) {
-        unimplemented!()
+        let mut flags = vk::QueryControlFlags::empty();
+        if control.contains(com::QueryControl::PRECISE) {
+            flags |= vk::QUERY_CONTROL_PRECISE_BIT;
+        }
+
+        unsafe {
+            self.device.0.cmd_begin_query(
+                self.raw,
+                query.pool.0,
+                query.id,
+                flags
+            )
+        }
     }
 
     fn end_query(
         &mut self,
-        _query: com::Query<Backend>,
+        query: com::Query<Backend>,
     ) {
-        unimplemented!()
+        unsafe {
+            self.device.0.cmd_end_query(
+                self.raw,
+                query.pool.0,
+                query.id,
+            )
+        }
     }
 
     fn reset_query_pool(
         &mut self,
-        _pool: &(),
-        _queries: Range<com::QueryId>,
+        pool: &n::QueryPool,
+        queries: Range<com::QueryId>,
     ) {
-        unimplemented!()
+        unsafe {
+            self.device.0.cmd_reset_query_pool(
+                self.raw,
+                pool.0,
+                queries.start,
+                queries.end - queries.start,
+            )
+        }
     }
 }
 

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -797,6 +797,21 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             )
         }
     }
+
+    fn write_timestamp(
+        &mut self,
+        stage: pso::PipelineStage,
+        query: query::Query<Backend>,
+    ) {
+        unsafe {
+            self.device.0.cmd_write_timestamp(
+                self.raw,
+                conv::map_pipeline_stage(stage),
+                query.pool.0,
+                query.id,
+            )
+        }
+    }
 }
 
 pub struct SubpassCommandBuffer(pub CommandBuffer);

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -749,6 +749,29 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             )
         }
     }
+
+    fn begin_query(
+        &mut self,
+        _query: com::Query<Backend>,
+        _flags: com::QueryControl,
+    ) {
+        unimplemented!()
+    }
+
+    fn end_query(
+        &mut self,
+        _query: com::Query<Backend>,
+    ) {
+        unimplemented!()
+    }
+
+    fn reset_query_pool(
+        &mut self,
+        _pool: &(),
+        _queries: Range<com::QueryId>,
+    ) {
+        unimplemented!()
+    }
 }
 
 pub struct SubpassCommandBuffer(pub CommandBuffer);

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -1,6 +1,6 @@
 use ash::vk;
 use byteorder::{NativeEndian, WriteBytesExt};
-use hal::{buffer, command, format, image, pass, pso};
+use hal::{buffer, command, format, image, pass, pso, query};
 use hal::device::Extent;
 use hal::{IndexType, Primitive};
 use smallvec::SmallVec;
@@ -947,4 +947,48 @@ pub fn map_specialization_constants(
             })
         })
         .collect::<Result<_, _>>()
+}
+
+pub fn map_pipeline_statistics(
+    statistics: query::PipelineStatistic,
+) -> vk::QueryPipelineStatisticFlags {
+    use hal::query::PipelineStatistic as stat;
+
+    let mut flags = vk::QueryPipelineStatisticFlags::empty();
+
+    if statistics.contains(stat::INPUT_ASSEMBLY_VERTICES) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT;
+    }
+    if statistics.contains(stat::INPUT_ASSEMBLY_PRIMITIVES) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT;
+    }
+    if statistics.contains(stat::VERTEX_SHADER_INVOCATIONS) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT;
+    }
+    if statistics.contains(stat::GEOMETRY_SHADER_INVOCATIONS) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_INVOCATIONS_BIT;
+    }
+    if statistics.contains(stat::GEOMETRY_SHADER_PRIMITIVES) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_PRIMITIVES_BIT;
+    }
+    if statistics.contains(stat::CLIPPING_INVOCATIONS) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_CLIPPING_INVOCATIONS_BIT;
+    }
+    if statistics.contains(stat::CLIPPING_PRIMITIVES) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT;
+    }
+    if statistics.contains(stat::FRAGMENT_SHADER_INVOCATIONS) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT;
+    }
+    if statistics.contains(stat::HULL_SHADER_PATCHES) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT;
+    }
+    if statistics.contains(stat::DOMAIN_SHADER_INVOCATIONS) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT;
+    }
+    if statistics.contains(stat::COMPUTE_SHADER_INVOCATIONS) {
+        flags |= vk::QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT;
+    }
+
+    flags
 }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -376,6 +376,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 sampler_border_color: false,
                 sampler_lod_bias: false,
                 sampler_objects: false,
+                precise_occlusion_query: false,
+                pipeline_statistics_query: false,
             },
             limits: Limits {
                 max_texture_size: limits.max_image_dimension3d as _,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -560,4 +560,5 @@ impl hal::Backend for Backend {
 
     type Fence = native::Fence;
     type Semaphore = native::Semaphore;
+    type QueryPool = ();
 }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -560,5 +560,5 @@ impl hal::Backend for Backend {
 
     type Fence = native::Fence;
     type Semaphore = native::Semaphore;
-    type QueryPool = ();
+    type QueryPool = native::QueryPool;
 }

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -127,3 +127,6 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
         });
     }
 }
+
+#[derive(Debug, Hash)]
+pub struct QueryPool(pub vk::QueryPool);

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -4,8 +4,11 @@ use Backend;
 use pso;
 use buffer::IndexBufferView;
 use image::{ImageLayout, SubresourceRange};
-use queue::capability::{Graphics, Supports};
-use super::{CommandBuffer, RawCommandBuffer, RenderPassInlineEncoder};
+use queue::capability::{Graphics, GraphicsOrCompute, Supports};
+use super::{
+    CommandBuffer, RawCommandBuffer, RenderPassInlineEncoder,
+    Query, QueryControl, QueryId,
+};
 
 
 #[allow(missing_docs)]
@@ -195,5 +198,22 @@ impl<'a, B: Backend, C: Supports<Graphics>> CommandBuffer<'a, B, C> {
     ///
     pub fn set_blend_constants(&mut self, cv: ColorValue) {
         self.raw.set_blend_constants(cv)
+    }
+}
+
+impl<'a, B: Backend, C: Supports<GraphicsOrCompute>> CommandBuffer<'a, B, C> {
+    ///
+    fn begin_query(&mut self, query: Query<B>, flags: QueryControl) {
+        self.raw.begin_query(query, flags)
+    }
+
+    ///
+    fn end_query(&mut self, query: Query<B>) {
+        self.raw.end_query(query)
+    }
+
+    ///
+    fn reset_query_pool(&mut self, pool: &B::QueryPool, queries: Range<QueryId>) {
+        self.raw.reset_query_pool(pool, queries)
     }
 }

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -201,17 +201,22 @@ impl<'a, B: Backend, C: Supports<Graphics>> CommandBuffer<'a, B, C> {
 
 impl<'a, B: Backend, C: Supports<GraphicsOrCompute>> CommandBuffer<'a, B, C> {
     ///
-    fn begin_query(&mut self, query: Query<B>, flags: QueryControl) {
+    pub fn begin_query(&mut self, query: Query<B>, flags: QueryControl) {
         self.raw.begin_query(query, flags)
     }
 
     ///
-    fn end_query(&mut self, query: Query<B>) {
+    pub fn end_query(&mut self, query: Query<B>) {
         self.raw.end_query(query)
     }
 
     ///
-    fn reset_query_pool(&mut self, pool: &B::QueryPool, queries: Range<QueryId>) {
+    pub fn reset_query_pool(&mut self, pool: &B::QueryPool, queries: Range<QueryId>) {
         self.raw.reset_query_pool(pool, queries)
+    }
+
+    ///
+    pub fn write_timestamp(&mut self, stage: pso::PipelineStage, query: Query<B>) {
+        self.raw.write_timestamp(stage, query)
     }
 }

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -4,11 +4,9 @@ use Backend;
 use pso;
 use buffer::IndexBufferView;
 use image::{ImageLayout, SubresourceRange};
+use query::{Query, QueryControl, QueryId};
 use queue::capability::{Graphics, GraphicsOrCompute, Supports};
-use super::{
-    CommandBuffer, RawCommandBuffer, RenderPassInlineEncoder,
-    Query, QueryControl, QueryId,
-};
+use super::{CommandBuffer, RawCommandBuffer, RenderPassInlineEncoder};
 
 
 #[allow(missing_docs)]

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -54,26 +54,3 @@ impl<'a, B: Backend, C> Drop for CommandBuffer<'a, B, C> {
         self.raw.finish();
     }
 }
-
-///
-pub type QueryId = u32;
-
-///
-#[derive(Debug)]
-pub struct Query<'a, B: Backend> {
-    ///
-    pub pool: &'a B::QueryPool,
-    ///
-    pub id: QueryId,
-}
-
-bitflags!(
-    /// Query control flags.
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct QueryControl: u8 {
-        /// Occlusion queries **must** return the exact sampler number.
-        ///
-        /// Requires `precise_occlusion_query` device feature.
-        const PRECISE = 0x1;
-    }
-);

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -59,6 +59,7 @@ impl<'a, B: Backend, C> Drop for CommandBuffer<'a, B, C> {
 pub type QueryId = u32;
 
 ///
+#[derive(Debug)]
 pub struct Query<'a, B: Backend> {
     ///
     pub pool: &'a B::QueryPool,

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -54,3 +54,25 @@ impl<'a, B: Backend, C> Drop for CommandBuffer<'a, B, C> {
         self.raw.finish();
     }
 }
+
+///
+pub type QueryId = u32;
+
+///
+pub struct Query<'a, B: Backend> {
+    ///
+    pub pool: &'a B::QueryPool,
+    ///
+    pub id: QueryId,
+}
+
+bitflags!(
+    /// Query control flags.
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct QueryControl: u8 {
+        /// Occlusion queries **must** return the exact sampler number.
+        ///
+        /// Requires `precise_occlusion_query` device feature.
+        const PRECISE = 0x1;
+    }
+);

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -277,4 +277,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
 
     ///
     fn reset_query_pool(&mut self, pool: &B::QueryPool, queries: Range<QueryId>);
+
+    ///
+    fn write_timestamp(&mut self, pso::PipelineStage, Query<B>);
 }

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -10,6 +10,7 @@ use super::{
     AttachmentClear, BufferCopy, BufferImageCopy,
     ClearColor, ClearDepthStencil, ClearValue,
     ImageCopy, ImageResolve, SubpassContents,
+    Query, QueryControl, QueryId,
 };
 
 ///
@@ -267,4 +268,13 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
         draw_count: u32,
         stride: u32,
     );
+
+    ///
+    fn begin_query(&mut self, query: Query<B>, flags: QueryControl);
+
+    ///
+    fn end_query(&mut self, query: Query<B>);
+
+    ///
+    fn reset_query_pool(&mut self, pool: &B::QueryPool, queries: Range<QueryId>);
 }

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -5,12 +5,12 @@ use {Backend, IndexCount, InstanceCount, VertexCount, VertexOffset};
 use buffer::IndexBufferView;
 use image::{ImageLayout, SubresourceRange};
 use memory::Barrier;
+use query::{Query, QueryControl, QueryId};
 use super::{
     ColorValue, StencilValue, Rect, Viewport,
     AttachmentClear, BufferCopy, BufferImageCopy,
     ClearColor, ClearDepthStencil, ClearValue,
     ImageCopy, ImageResolve, SubpassContents,
-    Query, QueryControl, QueryId,
 };
 
 ///

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -6,7 +6,7 @@
 use std::{fmt, mem, slice};
 use std::error::Error;
 use std::ops::Range;
-use {buffer, format, image, mapping, pass, pso};
+use {buffer, format, image, mapping, pass, pso, query};
 use pool::{CommandPool, CommandPoolCreateFlags};
 use queue::QueueGroup;
 use {Backend, Features, Limits, MemoryType};
@@ -394,4 +394,10 @@ pub trait Device<B: Backend> {
 
     ///
     fn destroy_fence(&self, B::Fence);
+
+    ///
+    fn create_query_pool(&self, ty: query::QueryType, count: u32) -> B::QueryPool;
+
+    ///
+    fn destroy_query_pool(&self, B::QueryPool);
 }

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -113,6 +113,11 @@ pub struct Features {
     pub sampler_anisotropy: bool,
     /// Support setting border texel colors.
     pub sampler_border_color: bool,
+    /// Support precise occlusion queries, returning the actual number of samples.
+    /// If not supported, queries return a non-zero value when at least **one** sample passes.
+    pub precise_occlusion_query: bool,
+    /// Support query of pipeline statistics.
+    pub pipeline_statistics_query: bool,
 }
 
 /// Limits of the device.

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -44,6 +44,7 @@ pub mod memory;
 pub mod pass;
 pub mod pool;
 pub mod pso;
+pub mod query;
 pub mod queue;
 pub mod window;
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -259,6 +259,7 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any {
 
     type Fence:               Debug + Any + Send + Sync;
     type Semaphore:           Debug + Any + Send + Sync;
+    type QueryPool:           Debug + Any + Send + Sync;
 }
 
 #[allow(missing_docs)]

--- a/src/hal/src/query.rs
+++ b/src/hal/src/query.rs
@@ -1,0 +1,66 @@
+//! Query operations
+
+use Backend;
+
+
+///
+pub type QueryId = u32;
+
+///
+#[derive(Debug)]
+pub struct Query<'a, B: Backend> {
+    ///
+    pub pool: &'a B::QueryPool,
+    ///
+    pub id: QueryId,
+}
+
+bitflags!(
+    /// Query control flags.
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct QueryControl: u8 {
+        /// Occlusion queries **must** return the exact sampler number.
+        ///
+        /// Requires `precise_occlusion_query` device feature.
+        const PRECISE = 0x1;
+    }
+);
+
+/// Type of queries in a query pool.
+pub enum QueryType {
+    /// Occlusion query.
+    Occlusion,
+    /// Pipeline statistic data.
+    PipelineStatistics(PipelineStatistic),
+    ///
+    Timestamp,
+}
+
+bitflags!(
+    /// Pipeline statistic flags
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct PipelineStatistic: u16 {
+        ///
+        const INPUT_ASSEMBLY_VERTICES = 0x1;
+        ///
+        const INPUT_ASSEMBLY_PRIMITIVES = 0x2;
+        ///
+        const VERTEX_SHADER_INVOCATIONS = 0x4;
+        ///
+        const GEOMETRY_SHADER_INVOCATIONS = 0x8;
+        ///
+        const GEOMETRY_SHADER_PRIMITIVES = 0x10;
+        ///
+        const CLIPPING_INVOCATIONS = 0x20;
+        ///
+        const CLIPPING_PRIMITIVES = 0x40;
+        ///
+        const FRAGMENT_SHADER_INVOCATIONS = 0x80;
+        ///
+        const HULL_SHADER_PATCHES = 0x100;
+        ///
+        const DOMAIN_SHADER_INVOCATIONS = 0x200;
+        ///
+        const COMPUTE_SHADER_INVOCATIONS = 0x400;
+    }
+);

--- a/src/hal/src/queue/capability.rs
+++ b/src/hal/src/queue/capability.rs
@@ -10,6 +10,9 @@ pub enum Compute {}
 /// Transfer capability, supporting only transfer operations.
 pub enum Transfer {}
 
+/// Graphics or compute capability.
+pub enum GraphicsOrCompute {}
+
 ///
 pub trait Capability {
     /// Return true if this type level capability is supported by
@@ -58,6 +61,10 @@ impl Supports<Compute> for General { }
 impl Supports<Transfer> for General { }
 impl Supports<Transfer> for Graphics { }
 impl Supports<Transfer> for Compute { }
+
+impl Supports<GraphicsOrCompute> for General { }
+impl Supports<GraphicsOrCompute> for Graphics { }
+impl Supports<GraphicsOrCompute> for Compute { }
 
 /// Encoding the minimal capability to support a combination of other capabilities.
 pub trait Upper {


### PR DESCRIPTION
First steps regarding full query support. This PR only contains query pool creation and recording. Resolve is still up to discussion #1638 .

Implementation details:
* D3D12 uses binary occlusion queries if `PRECISE` is not specified
* D3D12 internally caches the currently used query to have access on the query type on end
* Query operations are supported on compute and graphics command buffers. Therefore a new helper capability is introduced which is implemented for Compute, Graphics and General command buffers to circumvent this.

~~**WIP** as there are outstanding ash changes (and might include resolve operations)~~