### PR TITLE
Vulkanify swapchain creation

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -127,7 +127,7 @@ fn main() {
     println!("{:?}", surface_format);
     let swap_config = SwapchainConfig::new()
         .with_color(surface_format);
-    let (mut swap_chain, backbuffer) = surface.build_swapchain(swap_config, &queue);
+    let (mut swap_chain, backbuffer) = device.create_swapchain(&mut surface, swap_config);
 
     // Setup renderpass and pipeline
     let vs_module = device

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -1,14 +1,13 @@
 use std::collections::VecDeque;
-use std::{mem, ptr};
+use std::mem;
 
-use dxguid;
 #[cfg(feature = "winit")]
 use winit;
 use winapi;
 use wio::com::ComPtr;
 
 use hal::{self, format as f, image as i};
-use {conv, native as n, Backend, Device, Instance, PhysicalDevice, QueueFamily};
+use {native as n, Backend, Instance, PhysicalDevice, QueueFamily};
 
 use std::os::raw::c_void;
 
@@ -40,10 +39,10 @@ impl Instance {
 }
 
 pub struct Surface {
-    factory: ComPtr<winapi::IDXGIFactory4>,
-    wnd_handle: winapi::HWND,
-    width: u32,
-    height: u32,
+    pub(crate) factory: ComPtr<winapi::IDXGIFactory4>,
+    pub(crate) wnd_handle: winapi::HWND,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
 }
 
 impl hal::Surface<Backend> for Surface {
@@ -85,117 +84,14 @@ impl hal::Surface<Backend> for Surface {
 
         (capabilities, formats)
     }
-
-    fn build_swapchain<C>(
-        &mut self,
-        config: hal::SwapchainConfig,
-        present_queue: &hal::CommandQueue<Backend, C>,
-    ) -> (Swapchain, hal::Backbuffer<Backend>) {
-        let mut swap_chain: *mut winapi::IDXGISwapChain1 = ptr::null_mut();
-        let mut format = config.color_format;
-        if format.1 == f::ChannelType::Srgb {
-            // Apparently, swap chain doesn't like sRGB, but the RTV can still have some:
-            // https://www.gamedev.net/forums/topic/670546-d3d12srgb-buffer-format-for-swap-chain/
-            // [15716] DXGI ERROR: IDXGIFactory::CreateSwapchain: Flip model swapchains (DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL and DXGI_SWAP_EFFECT_FLIP_DISCARD) only support the following Formats: (DXGI_FORMAT_R16G16B16A16_FLOAT, DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_R10G10B10A2_UNORM), assuming the underlying Device does as well.
-            format.1 = f::ChannelType::Unorm;
-        }
-        let format = conv::map_format(format).unwrap(); // TODO: error handling
-        let mut device = present_queue.as_raw().device.clone();
-
-        let rtv_desc = winapi::D3D12_RENDER_TARGET_VIEW_DESC {
-            Format: conv::map_format(config.color_format).unwrap(),
-            ViewDimension: winapi::D3D12_RTV_DIMENSION_TEXTURE2D,
-            .. unsafe { mem::zeroed() }
-        };
-        let rtv_heap = Device::create_descriptor_heap_impl(
-            &mut device,
-            winapi::D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
-            false,
-            config.image_count as _,
-        );
-
-        // TODO: double-check values
-        let desc = winapi::DXGI_SWAP_CHAIN_DESC1 {
-            AlphaMode: winapi::DXGI_ALPHA_MODE_IGNORE,
-            BufferCount: config.image_count,
-            Width: self.width,
-            Height: self.height,
-            Format: format,
-            Flags: 0,
-            BufferUsage: winapi::DXGI_USAGE_RENDER_TARGET_OUTPUT,
-            SampleDesc: winapi::DXGI_SAMPLE_DESC {
-                Count: 1,
-                Quality: 0,
-            },
-            Scaling: winapi::DXGI_SCALING_STRETCH,
-            Stereo: false as winapi::BOOL,
-            SwapEffect: winapi::DXGI_SWAP_EFFECT(4), // TODO: DXGI_SWAP_EFFECT_FLIP_DISCARD missing in winapi
-        };
-
-        let hr = unsafe {
-            self.factory.CreateSwapChainForHwnd(
-                present_queue.as_raw().raw.as_mut() as *mut _ as *mut winapi::IUnknown,
-                self.wnd_handle,
-                &desc,
-                ptr::null(),
-                ptr::null_mut(),
-                &mut swap_chain as *mut *mut _,
-            )
-        };
-
-        if !winapi::SUCCEEDED(hr) {
-            error!("error on swapchain creation 0x{:x}", hr);
-        }
-
-        let mut swap_chain = unsafe { ComPtr::<winapi::IDXGISwapChain3>::new(swap_chain as *mut winapi::IDXGISwapChain3) };
-
-        // Get backbuffer images
-        let images = (0 .. config.image_count).map(|i| {
-            let mut resource: *mut winapi::ID3D12Resource = ptr::null_mut();
-            unsafe {
-                swap_chain.GetBuffer(
-                    i as _,
-                    &dxguid::IID_ID3D12Resource,
-                    &mut resource as *mut *mut _ as *mut *mut _);
-            }
-
-            let rtv_handle = rtv_heap.at(i as _).cpu;
-            unsafe {
-                device.CreateRenderTargetView(resource, &rtv_desc, rtv_handle);
-            }
-
-            let kind = i::Kind::D2(self.width as u16, self.height as u16, 1.into());
-            n::Image {
-                resource,
-                kind,
-                usage: i::Usage::COLOR_ATTACHMENT,
-                dxgi_format: format,
-                bits_per_texel: config.color_format.0.describe_bits().total,
-                num_levels: 1,
-                num_layers: 1,
-                clear_cv: Some(rtv_handle),
-                clear_dv: None,
-                clear_sv: None,
-            }
-        }).collect();
-
-        let swapchain = Swapchain {
-            inner: swap_chain,
-            next_frame: 0,
-            frame_queue: VecDeque::new(),
-            rtv_heap,
-        };
-
-        (swapchain, hal::Backbuffer::Images(images))
-    }
 }
 
 pub struct Swapchain {
-    inner: ComPtr<winapi::IDXGISwapChain3>,
-    next_frame: usize,
-    frame_queue: VecDeque<usize>,
+    pub(crate) inner: ComPtr<winapi::IDXGISwapChain3>,
+    pub(crate) next_frame: usize,
+    pub(crate) frame_queue: VecDeque<usize>,
     #[allow(dead_code)]
-    rtv_heap: n::DescriptorHeap,
+    pub(crate) rtv_heap: n::DescriptorHeap,
 }
 
 impl hal::Swapchain<Backend> for Swapchain {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -269,6 +269,14 @@ impl hal::Device<Backend> for Device {
     fn destroy_semaphore(&self, _: ()) {
         unimplemented!()
     }
+
+    fn create_swapchain(
+        &self,
+        _: &mut Surface,
+        _: hal::SwapchainConfig,
+    ) -> (Swapchain, hal::Backbuffer<Backend>) {
+        unimplemented!()
+    }
 }
 
 #[derive(Debug)]
@@ -578,13 +586,6 @@ impl hal::Surface<Backend> for Surface {
     }
 
     fn supports_queue_family(&self, _: &QueueFamily) -> bool {
-        unimplemented!()
-    }
-
-    fn build_swapchain<C>(&mut self,
-        _: hal::SwapchainConfig,
-        _: &hal::CommandQueue<Backend, C>
-    ) -> (Swapchain, hal::Backbuffer<Backend>) {
         unimplemented!()
     }
 }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -11,7 +11,7 @@ use hal::{self as c, device as d, image as i, memory, pass, pso, buffer, mapping
 use hal::format::{Format, Swizzle};
 use hal::pool::CommandPoolCreateFlags;
 
-use {Backend as B, QueueFamily, Share};
+use {Backend as B, QueueFamily, Share, Surface, Swapchain};
 use {conv, native as n, state};
 use pool::{BufferMemory, OwnedBuffer, RawCommandPool};
 
@@ -758,6 +758,14 @@ impl d::Device<B> for Device {
 
     fn destroy_semaphore(&self, _: n::Semaphore) {
         unimplemented!()
+    }
+
+    fn create_swapchain(
+        &self,
+        surface: &mut Surface,
+        config: c::SwapchainConfig,
+    ) -> (Swapchain, c::Backbuffer<B>) {
+        self.create_swapchain_impl(surface, config)
     }
 }
 

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -45,7 +45,7 @@
 
 use hal::{self, format as f, image};
 
-use {native as n, Backend as B, PhysicalDevice, QueueFamily};
+use {native as n, Backend as B, Device, PhysicalDevice, QueueFamily};
 
 use glutin::{self, GlContext};
 use std::rc::Rc;
@@ -123,14 +123,16 @@ impl hal::Surface<B> for Surface {
     }
 
     fn supports_queue_family(&self, _: &QueueFamily) -> bool { true }
+}
 
-    fn build_swapchain<C>(
-        &mut self,
+impl Device {
+    pub(crate) fn create_swapchain_impl(
+        &self,
+        surface: &mut Surface,
         _config: hal::SwapchainConfig,
-        _: &hal::CommandQueue<B, C>,
     ) -> (Swapchain, hal::Backbuffer<B>) {
         let swapchain = Swapchain {
-            window: self.window.clone(),
+            window: surface.window.clone(),
         };
         let backbuffer = hal::Backbuffer::Framebuffer(0);
         (swapchain, backbuffer)

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1,6 +1,5 @@
-use {Backend};
+use {Backend, QueueFamily, Surface, Swapchain};
 use {native as n, command};
-use {QueueFamily};
 use conversions::*;
 
 use std::collections::HashMap;
@@ -57,7 +56,7 @@ struct PrivateCapabilities {
 
 #[derive(Clone)]
 pub struct Device {
-    device: metal::Device,
+    pub(crate) device: metal::Device,
     private_caps: PrivateCapabilities,
     limits: hal::Limits,
     queue: Arc<command::QueueInner>,
@@ -1092,6 +1091,14 @@ impl hal::Device<Backend> for Device {
 
     fn destroy_query_pool(&self, _: ()) {
         unimplemented!()
+    }
+
+    fn create_swapchain(
+        &self,
+        surface: &mut Surface,
+        config: hal::SwapchainConfig,
+    ) -> (Swapchain, hal::Backbuffer<Backend>) {
+        self.build_swapchain(surface, config)
     }
 }
 

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -11,6 +11,7 @@ use pool::{CommandPool, CommandPoolCreateFlags};
 use queue::QueueGroup;
 use {Backend, Features, Limits, MemoryType};
 use memory::Requirements;
+use window::{Backbuffer, SwapchainConfig};
 
 
 /// Error allocating memory.
@@ -400,4 +401,38 @@ pub trait Device<B: Backend> {
 
     ///
     fn destroy_query_pool(&self, B::QueryPool);
+
+    /// Create a new swapchain from a surface and a queue family.
+    ///
+    /// *Note*: The number of exposed images in the back buffer might differ
+    /// from number of internally used buffers.
+    ///
+    /// # Safety
+    ///
+    /// The queue family _must_ support surface presentation.
+    /// This can be checked by calling [`supports_queue_family`](trait.Surface.html#tymethod.supports_queue_family)
+    /// on this surface.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # extern crate gfx_backend_empty as empty;
+    /// # extern crate gfx_hal;
+    /// # fn main() {
+    /// use gfx_hal::{Device, SwapchainConfig};
+    /// use gfx_hal::format::Srgba8;
+    /// # use gfx_hal::{CommandQueue, Graphics};
+    ///
+    /// # let mut surface: empty::Surface = return;
+    /// # let device: empty::Device = return;
+    /// let swapchain_config = SwapchainConfig::new()
+    ///                             .with_color_typed::<Srgba8>();
+    /// device.create_swapchain(&mut surface, swapchain_config);
+    /// # }
+    /// ```
+    fn create_swapchain(
+        &self,
+        surface: &mut B::Surface,
+        config: SwapchainConfig,
+    ) -> (B::Swapchain, Backbuffer<B>);
 }

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -110,40 +110,6 @@ pub trait Surface<B: Backend> {
     ///
     /// Use this function for configuring your swapchain creation.
     fn capabilities_and_formats(&self, &B::PhysicalDevice) -> (SurfaceCapabilities, Vec<Format>);
-
-    /// Create a new swapchain from a surface and a queue.
-    ///
-    /// *Note*: The number of exposed images in the back buffer might differ
-    /// from number of internally used buffers.
-    ///
-    /// # Safety
-    ///
-    /// The queue family of the passed `present_queue` _must_ support surface presentation.
-    /// This can be checked by calling [`supports_queue`](trait.Surface.html#tymethod.supports_queue)
-    /// on this surface.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # extern crate gfx_backend_empty as empty;
-    /// # extern crate gfx_hal;
-    /// # fn main() {
-    /// use gfx_hal::{Surface, SwapchainConfig};
-    /// use gfx_hal::format::Srgba8;
-    /// # use gfx_hal::{CommandQueue, Graphics};
-    ///
-    /// # let mut surface: empty::Surface = return;
-    /// # let queue: CommandQueue<empty::Backend, Graphics> = return;
-    /// let swapchain_config = SwapchainConfig::new()
-    ///                             .with_color_typed::<Srgba8>();
-    /// surface.build_swapchain(swapchain_config, &queue);
-    /// # }
-    /// ```
-    fn build_swapchain<C>(
-        &mut self,
-        config: SwapchainConfig,
-        present_queue: &CommandQueue<B, C>,
-    ) -> (B::Swapchain, Backbuffer<B>);
 }
 
 /// Handle to a backbuffer of the swapchain.
@@ -316,7 +282,8 @@ pub trait Swapchain<B: Backend> {
     ///
     /// # Safety
     ///
-    /// The passed queue _must_ be the **same** queue as used for creation.
+    /// The passed queue _must_ support presentation on the surface, which is
+    /// used for creating this swapchain.
     ///
     /// # Examples
     ///

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -234,7 +234,7 @@ impl<B: Backend, C> Context<B, C>
 
         let swap_config = hal::SwapchainConfig::new()
             .with_color_typed::<Cf>(); // TODO: check support
-        let (swapchain, backbuffer) = surface.build_swapchain(swap_config, &queue.group.queues[0]);
+        let (swapchain, backbuffer) = device.create_swapchain(&mut surface, swap_config);
 
         let backbuffer_images = match backbuffer {
             hal::Backbuffer::Images(images) => images,


### PR DESCRIPTION
Remove the requirement for specifying a present queue on swapchain creation. D3D12 requires to hide the present queue inside the device and have a single queue family supporting presentation. This changes aligns swapchain creation more with Vulkan for the sake of the portability layer.

I didn't touch the actual swapchain creation implementations only shift code a bit around.

Old API:
```rust
fn Surface::build_swapchain(&mut self, config: SwapchainConfig, present_queue: &CommandQueue<B, C>);
```
New API:
```rust
fn Device::create_swapchain(&mut self, surface: &mut Surface, config: SwapchainConfig);
```