### PR TITLE
dx12: Implement root constants

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -174,7 +174,13 @@ fn main() {
         ],
     );
 
-    let pipeline_layout = device.create_pipeline_layout(&[&set_layout], &[]);
+    let pipeline_layout = device.create_pipeline_layout(
+        &[&set_layout],
+        &[
+            (pso::ShaderStageFlags::VERTEX, 0..16),
+            (pso::ShaderStageFlags::VERTEX, 16..32),
+        ],
+    );
 
     let render_pass = {
         let attachment = pass::Attachment {
@@ -517,6 +523,7 @@ fn main() {
             cmd_buffer.bind_graphics_pipeline(&pipelines[0].as_ref().unwrap());
             cmd_buffer.bind_vertex_buffers(pso::VertexBufferSet(vec![(&vertex_buffer, 0)]));
             cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, &[&desc_sets[0]]); //TODO
+            cmd_buffer.push_graphics_constants(&pipeline_layout, pso::ShaderStageFlags::VERTEX, 0, &[0, 4]);
 
             {
                 let mut encoder = cmd_buffer.begin_renderpass_inline(

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -177,8 +177,8 @@ fn main() {
     let pipeline_layout = device.create_pipeline_layout(
         &[&set_layout],
         &[
-            (pso::ShaderStageFlags::VERTEX, 0..16),
-            (pso::ShaderStageFlags::VERTEX, 16..32),
+            (pso::ShaderStageFlags::VERTEX, 0..4),
+            (pso::ShaderStageFlags::VERTEX, 4..8),
         ],
     );
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -26,7 +26,7 @@ d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch 
 dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 kernel32-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-spirv_cross = "0.4.1"
+spirv_cross = "0.4.2"
 user32-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 winit = { version = "0.7", optional = true }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -22,6 +22,7 @@ mod device;
 mod free_list;
 mod native;
 mod pool;
+mod root_constants;
 mod shade;
 mod window;
 

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -3,6 +3,7 @@ use wio::com::ComPtr;
 
 use hal::{image, pass, pso, MemoryType, DescriptorPool as HalDescriptorPool};
 use {free_list, Backend};
+use root_constants::RootConstant;
 
 use std::collections::BTreeMap;
 use std::ops::Range;
@@ -112,6 +113,8 @@ pub struct PipelineLayout {
     // Storing for each associated descriptor set layout, which tables we created
     // in the root signature. This is required for binding descriptor sets.
     pub(crate) tables: Vec<SetTableTypes>,
+    // Disjunct, sorted vector of root constant ranges.
+    pub(crate) root_constants: Vec<RootConstant>,
     // Number of parameter slots in this layout, can be larger than number of tables.
     // Required for updating the root signature when flusing user data.
     pub(crate) num_parameter_slots: usize,

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -83,6 +83,7 @@ pub struct GraphicsPipeline {
     pub(crate) signature: *mut winapi::ID3D12RootSignature, // weak-ptr, owned by `PipelineLayout`
     pub(crate) num_parameter_slots: usize, // signature parameter slots, see `PipelineLayout`
     pub(crate) topology: winapi::D3D12_PRIMITIVE_TOPOLOGY,
+    pub(crate) constants: Vec<RootConstant>,
 }
 unsafe impl Send for GraphicsPipeline { }
 unsafe impl Sync for GraphicsPipeline { }
@@ -92,6 +93,7 @@ pub struct ComputePipeline {
     pub(crate) raw: *mut winapi::ID3D12PipelineState,
     pub(crate) signature: *mut winapi::ID3D12RootSignature, // weak-ptr, owned by `PipelineLayout`
     pub(crate) num_parameter_slots: usize, // signature parameter slots, see `PipelineLayout`
+    pub(crate) constants: Vec<RootConstant>,
 }
 
 unsafe impl Send for ComputePipeline { }

--- a/src/backend/dx12/src/root_constants.rs
+++ b/src/backend/dx12/src/root_constants.rs
@@ -1,0 +1,302 @@
+//! Processing push constant ranges
+//!
+//! This module provides utitlity functions to make push constants root signature
+//! compatible. Root constants are non-overlapping, therefore, the push constant
+//! ranges passed at pipeline layout creation need to be `split` into disjunct
+//! ranges. The disjunct ranges can be then converted into root signature entries.
+
+use hal::pso;
+use std::cmp::Ordering;
+use std::ops::Range;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RootConstant {
+    pub stages: pso::ShaderStageFlags,
+    pub range: Range<u32>,
+}
+
+impl RootConstant {
+    fn is_empty(&self) -> bool {
+        self.range.end <= self.range.start
+    }
+
+    // Divide a root constant into two separate ranges depending on the overlap
+    // with another root constant.
+    fn divide(self, other: &RootConstant) -> (RootConstant, RootConstant) {
+        let left = RootConstant {
+            stages: self.stages,
+            range: self.range.start..other.range.start,
+        };
+
+        let right = RootConstant {
+            stages: self.stages,
+            range: other.range.start..self.range.end,
+        };
+
+        (left, right)
+    }
+}
+
+impl PartialOrd for RootConstant {
+    fn partial_cmp(&self, other: &RootConstant) -> Option<Ordering> {
+        Some(self.range.start.cmp(&other.range.start)
+            .then(self.range.end.cmp(&other.range.end))
+            .then(self.stages.cmp(&other.stages)))
+    }
+}
+
+impl Ord for RootConstant {
+    fn cmp(&self, other: &RootConstant) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+impl<'a> From<&'a (pso::ShaderStageFlags, Range<u32>)> for RootConstant {
+    fn from(&(stages, ref range): &'a (pso::ShaderStageFlags, Range<u32>)) -> Self {
+        RootConstant { stages, range: range.clone() }
+    }
+}
+
+pub fn split(
+    ranges: &[(pso::ShaderStageFlags, Range<u32>)],
+) -> Vec<RootConstant> {
+    // Frontier of unexplored root constant ranges, sorted descending
+    // (less element shifting for Vec) regarding to the start of ranges.
+    let mut ranges = into_vec(ranges);
+    ranges.sort_by(|a, b| a.cmp(b).reverse());
+
+    // Storing resulting disjunct root constant ranges.
+    let mut disjunct = Vec::with_capacity(ranges.len());
+
+    while !ranges.is_empty() {
+        // Run trough all unexplored ranges. After each run the frontier will be
+        // resorted!
+        //
+        // Case 1: Single element remaining
+        //      Push is to the disjunct list, done.
+        // Case 2: At least two ranges, which possibly overlap
+        //      Divide the first range into a left set and right set, depending
+        //      on the overlap of the two ranges:
+        //      Range 1: |---- left ---||--- right ---|
+        //      Range 2:                |--------...
+        let cur = ranges.pop().unwrap();
+        if let Some(mut next) = ranges.pop() {
+            let (left, mut right) = cur.divide(&next);
+            if !left.is_empty() {
+                // The left part is, by definition, disjunct to all other ranges.
+                // Push all remaining pieces in the frontier, handled by the next
+                // iteration.
+                disjunct.push(left);
+                ranges.push(next);
+                if !right.is_empty() {
+                    ranges.push(right);
+                }
+            } else if !right.is_empty() {
+                // If the left part is empty this means that both ranges have the
+                // same start value. The right segment is a candidate for a disjunct
+                // segment but we haven't checked against other ranges so far.
+                // Therefore, we push is on the frontier again, but added the
+                // stage flags from the overlapping segment.
+                // The second range will be shrunken to be disjunct with the pushed
+                // segment as we have already processed it.
+                // In the next iteration we will look again at the push right
+                // segment and compare it to other elements on the list until we
+                // have a small enough disjunct segment, which doesn't overlap
+                // with any part of the frontier.
+                right.stages |= next.stages;
+                next.range.start = right.range.end;
+                ranges.push(right);
+                if !next.is_empty() {
+                    ranges.push(next);
+                }
+            }
+        } else {
+            disjunct.push(cur);
+        }
+        ranges.sort_by(|a, b| a.cmp(b).reverse());
+    }
+
+    disjunct
+}
+
+fn into_vec(ranges: &[(pso::ShaderStageFlags, Range<u32>)]) -> Vec<RootConstant> {
+    ranges.iter().map(|x| x.into()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single() {
+        let range = &[(pso::ShaderStageFlags::VERTEX, 0..3)];
+        assert_eq!(into_vec(range), split(range));
+    }
+
+    #[test]
+    fn test_overlap_1() {
+        // Case:
+        //      |----------|
+        //          |------------|
+        let ranges = &[
+            (pso::ShaderStageFlags::VERTEX, 0..3),
+            (pso::ShaderStageFlags::FRAGMENT, 2..4),
+        ];
+
+        let reference = vec![
+            RootConstant {
+                stages: pso::ShaderStageFlags::VERTEX,
+                range: 0..2,
+            },
+            RootConstant {
+                stages:
+                    pso::ShaderStageFlags::VERTEX |
+                    pso::ShaderStageFlags::FRAGMENT,
+                range: 2..3,
+            },
+            RootConstant {
+                stages: pso::ShaderStageFlags::FRAGMENT,
+                range: 3..4,
+            },
+        ];
+        assert_eq!(reference, split(ranges));
+    }
+
+    #[test]
+    fn test_overlap_2() {
+        // Case:
+        //      |-------------------|
+        //          |------------|
+        let ranges = &[
+            (pso::ShaderStageFlags::VERTEX, 0..5),
+            (pso::ShaderStageFlags::FRAGMENT, 2..4),
+        ];
+
+        let reference = vec![
+            RootConstant {
+                stages: pso::ShaderStageFlags::VERTEX,
+                range: 0..2,
+            },
+            RootConstant {
+                stages:
+                    pso::ShaderStageFlags::VERTEX |
+                    pso::ShaderStageFlags::FRAGMENT,
+                range: 2..4,
+            },
+            RootConstant {
+                stages: pso::ShaderStageFlags::VERTEX,
+                range: 4..5,
+            },
+        ];
+        assert_eq!(reference, split(ranges));
+    }
+
+    #[test]
+    fn test_overlap_4() {
+        // Case:
+        //      |--------------|
+        //      |------------|
+        let ranges = &[
+            (pso::ShaderStageFlags::VERTEX, 0..5),
+            (pso::ShaderStageFlags::FRAGMENT, 0..4),
+        ];
+
+        let reference = vec![
+            RootConstant {
+                stages:
+                    pso::ShaderStageFlags::VERTEX |
+                    pso::ShaderStageFlags::FRAGMENT,
+                range: 0..4,
+            },
+            RootConstant {
+                stages: pso::ShaderStageFlags::VERTEX,
+                range: 4..5,
+            },
+        ];
+        assert_eq!(reference, split(ranges));
+    }
+
+    #[test]
+    fn test_equal() {
+        // Case:
+        //      |-----|
+        //      |-----|
+        let ranges = &[
+            (pso::ShaderStageFlags::VERTEX, 0..4),
+            (pso::ShaderStageFlags::FRAGMENT, 0..4),
+        ];
+
+        let reference = vec![
+            RootConstant {
+                stages:
+                    pso::ShaderStageFlags::VERTEX |
+                    pso::ShaderStageFlags::FRAGMENT,
+                range: 0..4,
+            },
+        ];
+        assert_eq!(reference, split(ranges));
+    }
+
+    #[test]
+    fn test_disjunct() {
+        // Case:
+        //      |------|
+        //               |------------|
+        let ranges = &[
+            (pso::ShaderStageFlags::VERTEX, 0..3),
+            (pso::ShaderStageFlags::FRAGMENT, 3..4),
+        ];
+        assert_eq!(into_vec(ranges), split(ranges));
+    }
+
+    #[test]
+    fn test_complex() {
+        let ranges = &[
+            (pso::ShaderStageFlags::VERTEX, 2..10),
+            (pso::ShaderStageFlags::FRAGMENT, 0..5),
+            (pso::ShaderStageFlags::GEOMETRY, 6..10),
+            (pso::ShaderStageFlags::HULL, 4..7),
+        ];
+
+        let reference = vec![
+            RootConstant {
+                stages: pso::ShaderStageFlags::FRAGMENT,
+                range: 0..2,
+            },
+            RootConstant {
+                stages:
+                    pso::ShaderStageFlags::VERTEX |
+                    pso::ShaderStageFlags::FRAGMENT,
+                range: 2..4,
+            },
+            RootConstant {
+                stages:
+                    pso::ShaderStageFlags::VERTEX |
+                    pso::ShaderStageFlags::FRAGMENT |
+                    pso::ShaderStageFlags::HULL,
+                range: 4..5,
+            },
+            RootConstant {
+                stages:
+                    pso::ShaderStageFlags::VERTEX |
+                    pso::ShaderStageFlags::HULL,
+                range: 5..6,
+            },
+            RootConstant {
+                stages:
+                    pso::ShaderStageFlags::VERTEX |
+                    pso::ShaderStageFlags::GEOMETRY |
+                    pso::ShaderStageFlags::HULL,
+                range: 6..7,
+            },
+            RootConstant {
+                stages:
+                    pso::ShaderStageFlags::VERTEX |
+                    pso::ShaderStageFlags::GEOMETRY,
+                range: 7..10,
+            },
+        ];
+
+        assert_eq!(reference, split(ranges));
+    }
+}

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -812,7 +812,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             )
         }
     }
-    
+
     fn push_compute_constants(
         &mut self,
         layout: &n::PipelineLayout,
@@ -824,7 +824,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 self.raw,
                 layout.raw,
                 vk::SHADER_STAGE_COMPUTE_BIT,
-                offset,
+                offset * 4,
                 constants,
             );
         }
@@ -842,7 +842,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 self.raw,
                 layout.raw,
                 conv::map_stage_flags(stages),
-                offset,
+                offset * 4,
                 constants,
             );
         }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -234,8 +234,8 @@ impl d::Device<B> for Device {
         let push_constant_ranges = push_constant_ranges.iter().map(|&(s, ref r)| {
                 vk::PushConstantRange {
                     stage_flags: conv::map_stage_flags(s),
-                    offset: r.start,
-                    size: r.end - r.start,
+                    offset: r.start * 4,
+                    size: (r.end - r.start) * 4,
                 }
             }).collect::<Vec<_>>();
 

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -147,11 +147,18 @@ pub trait Device<B: Backend> {
     ///
     fn destroy_renderpass(&self, B::RenderPass);
 
+    /// Create a new pipeline layout.
     ///
+    /// # Arguments
+    ///
+    /// * `set_layouts` - Descriptor set layouts
+    /// * `push_constants` - Ranges of push constants. A shader stage may only contain one push
+    ///     constant block. The length of the range indicates the number of u32 constants occupied
+    ///     by the push constant block.
     fn create_pipeline_layout(
         &self,
-        &[&B::DescriptorSetLayout],
-        &[(pso::ShaderStageFlags, Range<u32>)]
+        set_layouts: &[&B::DescriptorSetLayout],
+        push_constants: &[(pso::ShaderStageFlags, Range<u32>)]
     ) -> B::PipelineLayout;
 
     ///

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -73,6 +73,8 @@ pub enum ShaderError {
     CompilationFailed(String),
     /// Missing entry point.
     MissingEntryPoint(String),
+    /// Mismatch of interface (e.g missing push constants).
+    InterfaceMismatch(String),
 }
 
 /// An error from creating a framebuffer.

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -118,7 +118,7 @@ bitflags!(
     }
 );
 
-//Note: this type is only needed for backends, not used anywhere within gfx_core.
+// Note: this type is only needed for backends, not used anywhere within gfx_hal.
 /// Which program stage this shader represents.
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -132,6 +132,20 @@ pub enum Stage {
     Fragment,
     Compute
 }
+
+impl From<Stage> for ShaderStageFlags {
+    fn from(stage: Stage) -> Self {
+        match stage {
+            Stage::Vertex => ShaderStageFlags::VERTEX,
+            Stage::Hull => ShaderStageFlags::HULL,
+            Stage::Domain => ShaderStageFlags::DOMAIN,
+            Stage::Geometry => ShaderStageFlags::GEOMETRY,
+            Stage::Fragment => ShaderStageFlags::FRAGMENT,
+            Stage::Compute => ShaderStageFlags::COMPUTE,
+        }
+    }
+}
+
 
 /// Shader entry point.
 #[derive(Debug, Copy)]


### PR DESCRIPTION
Implement root constants for the d3d12 backend following https://github.com/gfx-rs/gfx/issues/1631
Push constants will be split into disjunct ranges, which can be mapped to root constants in the root signature. On pipeline creation, the generated HLSL shaders from spirv-cross will be patched to match the root signature.

- [x] Split push constants into disjunct ranges
- [x] Update root signature for root constants support
- [x] Patch generated descriptor set table register spaces
- [x] Patch push constant translation in spirv-cross

~~This PR is still in an early state. Especially, doing the spirv-cross changes will take a bit of time.~~

Closes https://github.com/gfx-rs/gfx/issues/1625 https://github.com/gfx-rs/gfx/issues/1631