### PR TITLE
[pre-ll] [dx11] Add memory::TRANSFER_SRC to main target

### DIFF
--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -60,7 +60,7 @@ impl Window {
             kind: tex::Kind::D2(self.size.0, self.size.1, tex::AaMode::Single),
             levels: 1,
             format: self.color_format.0,
-            bind: memory::RENDER_TARGET,
+            bind: memory::RENDER_TARGET | memory::TRANSFER_SRC,
             usage: memory::Usage::Data,
         };
         let desc = tex::RenderDesc {


### PR DESCRIPTION
Added the `memory::TRANSFER_SRC` bind flag for the main_color. This is required, if we want to copy the main_color's content into a staging texture with `copy_texture_to_texture_raw`, and read the data from the staging buffer with `map_texture_read` introduced in #1630.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/1649)
<!-- Reviewable:end -->
