### PR TITLE
Replace Slices for Iterators in Command Buffer API

### DIFF
--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -129,7 +129,7 @@ fn main() {
                     target: &device_buffer
                 }]);
         command_buffer.bind_compute_pipeline(&pipeline);
-        command_buffer.bind_compute_descriptor_sets(&pipeline_layout, 0, &[&desc_set]);
+        command_buffer.bind_compute_descriptor_sets(&pipeline_layout, 0, &[desc_set]);
         command_buffer.dispatch(numbers.len() as u32, 1, 1);
         command_buffer.pipeline_barrier(
             Range { start: pso::PipelineStage::COMPUTE_SHADER, end: pso::PipelineStage::TRANSFER },

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -520,7 +520,7 @@ fn main() {
             cmd_buffer.set_scissors(&[viewport.rect]);
             cmd_buffer.bind_graphics_pipeline(&pipelines[0].as_ref().unwrap());
             cmd_buffer.bind_vertex_buffers(pso::VertexBufferSet(vec![(&vertex_buffer, 0)]));
-            cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, &[&desc_sets[0]]); //TODO
+            cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, &desc_sets[0..1]); //TODO
 
             {
                 let mut encoder = cmd_buffer.begin_renderpass_inline(

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -6,6 +6,7 @@ use {conv, native as n, Backend, CmdSignatures};
 use root_constants::RootConstant;
 use smallvec::SmallVec;
 use std::{mem, ptr};
+use std::borrow::Borrow;
 use std::ops::Range;
 
 use winapi::um::d3d12;
@@ -23,6 +24,83 @@ fn get_rect(rect: &com::Rect) -> d3d12::D3D12_RECT {
         top: rect.y as i32,
         right: (rect.x + rect.w) as i32,
         bottom: (rect.y + rect.h) as i32,
+    }
+}
+
+fn bind_descriptor_sets<'a, T>(
+    raw: &ComPtr<d3d12::ID3D12GraphicsCommandList>,
+    pipeline: &mut PipelineCache,
+    layout: &n::PipelineLayout,
+    first_set: usize,
+    sets: T,
+) where
+    T: IntoIterator,
+    T::Item: Borrow<n::DescriptorSet>,
+{
+    let mut sets = sets.into_iter().peekable();
+    let (srv_cbv_uav_start, sampler_start) = if let Some(set_0) = sets.peek().map(Borrow::borrow) {
+        // Bind descriptor heaps
+        unsafe {
+            // TODO: Can we bind them always or only once?
+            //       Resize while recording?
+            let mut heaps = [
+                set_0.heap_srv_cbv_uav.as_mut() as *mut _,
+                set_0.heap_samplers.as_mut() as *mut _
+            ];
+            raw.SetDescriptorHeaps(2, heaps.as_mut_ptr())
+        }
+
+        (set_0.srv_cbv_uav_gpu_start().ptr, set_0.sampler_gpu_start().ptr)
+    } else {
+        return
+    };
+
+    pipeline.srv_cbv_uav_start = srv_cbv_uav_start;
+    pipeline.sampler_start = sampler_start;
+
+    let mut table_id = 0;
+    for table in &layout.tables[..first_set] {
+        if table.contains(n::SRV_CBV_UAV) {
+            table_id += 1;
+        }
+        if table.contains(n::SAMPLERS) {
+            table_id += 1;
+        }
+    }
+
+    let table_base_offset = layout
+        .root_constants
+        .iter()
+        .fold(0, |sum, c| sum + c.range.end - c.range.start);
+
+    for (set, table) in sets.zip(layout.tables[first_set..].iter()) {
+        let set = set.borrow();
+        set.first_gpu_view.map(|gpu| {
+            assert!(table.contains(n::SRV_CBV_UAV));
+
+            let root_offset = table_id + table_base_offset;
+            // Cast is safe as offset **must** be in u32 range. Unable to
+            // create heaps with more descriptors.
+            let table_offset = (gpu.ptr - srv_cbv_uav_start) as u32;
+            pipeline
+                .user_data
+                .set_srv_cbv_uav_table(root_offset as _, table_offset);
+
+            table_id += 1;
+        });
+        set.first_gpu_sampler.map(|gpu| {
+            assert!(table.contains(n::SAMPLERS));
+
+            let root_offset = table_id + table_base_offset;
+            // Cast is safe as offset **must** be in u32 range. Unable to
+            // create heaps with more descriptors.
+            let table_offset = (gpu.ptr - sampler_start) as u32;
+            pipeline
+                .user_data
+                .set_sampler_table(root_offset as _, table_offset);
+
+            table_id += 1;
+        });
     }
 }
 
@@ -506,14 +584,17 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.reset();
     }
 
-    fn begin_renderpass(
+    fn begin_renderpass<T>(
         &mut self,
         render_pass: &n::RenderPass,
         framebuffer: &n::Framebuffer,
         target_rect: com::Rect,
-        clear_values: &[com::ClearValue],
+        clear_values: T,
         _first_subpass: com::SubpassContents,
-    ) {
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<com::ClearValue>,
+    {
         assert_eq!(framebuffer.attachments.len(), render_pass.attachments.len());
         // Make sure that no subpass works with Present as intermediate layout.
         // This wouldn't make much sense, and proceeding with this constraint
@@ -527,18 +608,19 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 any(|aref| aref.1 == image::ImageLayout::Present)
         }));
 
-        let mut clear_iter = clear_values.iter();
+        let mut clear_iter = clear_values.into_iter();
         let attachment_clears = render_pass.attachments.iter().enumerate().map(|(i, attachment)| {
             AttachmentClear {
                 subpass_id: render_pass.subpasses.iter().position(|sp| sp.is_using(i)),
                 value: if attachment.ops.load == pass::AttachmentLoadOp::Clear {
-                    Some(*clear_iter.next().unwrap())
+                    Some(*clear_iter.next().unwrap().borrow())
                 } else {
                     None
                 },
                 stencil_value: if attachment.stencil_ops.load == pass::AttachmentLoadOp::Clear {
-                    match clear_iter.next() {
-                        Some(&com::ClearValue::DepthStencil(value)) => Some(value.1),
+                    let clear = clear_iter.next().expect("Must provide an addition DepthStencil clear value");
+                    match *clear.borrow() {
+                        com::ClearValue::DepthStencil(value) => Some(value.1),
                         other => panic!("Unexpected clear value: {:?}", other),
                     }
                 } else {
@@ -546,7 +628,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 },
             }
         }).collect();
-        assert_eq!(clear_iter.next(), None);
+
+        if let Some(_) = clear_iter.next() {
+            panic!("Too many clear values provided");
+        }
 
         self.pass_cache = Some(RenderPassCache {
             render_pass: render_pass.clone(),
@@ -571,15 +656,19 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.pass_cache = None;
     }
 
-    fn pipeline_barrier(
+    fn pipeline_barrier<'a, T>(
         &mut self,
         _stages: Range<pso::PipelineStage>,
-        barriers: &[memory::Barrier<Backend>],
-    ) {
+        barriers: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<memory::Barrier<'a, Backend>>,
+    {
         let mut raw_barriers = Vec::new();
 
         // transition barriers
         for barrier in barriers {
+            let barrier = barrier.borrow();
             match *barrier {
                 memory::Barrier::Buffer { ref states, target } => {
                     let state_src = conv::map_buffer_resource_state(states.start);
@@ -710,14 +799,17 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn clear_attachments(
-        &mut self,
-        clears: &[com::AttachmentClear],
-        rects: &[com::Rect],
-    ) {
+    fn clear_attachments<T, U>(&mut self, clears: T, rects: U)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<com::AttachmentClear>,
+        U: IntoIterator,
+        U::Item: Borrow<com::Rect>,
+    {
         assert!(self.pass_cache.is_some(), "`clear_attachments` can only be called inside a renderpass");
-        let rects: SmallVec<[d3d12::D3D12_RECT; 16]> = rects.iter().map(get_rect).collect();
+        let rects: SmallVec<[d3d12::D3D12_RECT; 16]> = rects.into_iter().map(|rect| get_rect(rect.borrow())).collect();
         for clear in clears {
+            let clear = clear.borrow();
             match *clear {
                 com::AttachmentClear::Color(index, cv) => {
                     let rtv = {
@@ -746,14 +838,17 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn resolve_image(
+    fn resolve_image<T>(
         &mut self,
         src: &n::Image,
         _: image::ImageLayout,
         dst: &n::Image,
         _: image::ImageLayout,
-        regions: &[com::ImageResolve],
-    ) {
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<com::ImageResolve>,
+    {
         {
             // Insert barrier for `COPY_DEST` to `RESOLVE_DEST` as we only expose
             // `TRANSFER_WRITE` which is used for all copy commands.
@@ -769,6 +864,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
 
         for region in regions {
+            let region = region.borrow();
             for l in 0..region.num_layers as _ {
                 unsafe {
                     self.raw.ResolveSubresource(
@@ -832,10 +928,15 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn set_viewports(&mut self, viewports: &[com::Viewport]) {
+    fn set_viewports<T>(&mut self, viewports: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<com::Viewport>,
+    {
         let viewports: SmallVec<[d3d12::D3D12_VIEWPORT; 16]> = viewports
-            .iter()
+            .into_iter()
             .map(|viewport| {
+                let viewport = viewport.borrow();
                 d3d12::D3D12_VIEWPORT {
                     TopLeftX: viewport.rect.x as _,
                     TopLeftY: viewport.rect.y as _,
@@ -855,8 +956,12 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn set_scissors(&mut self, scissors: &[com::Rect]) {
-        let rects: SmallVec<[d3d12::D3D12_RECT; 16]> = scissors.iter().map(get_rect).collect();
+    fn set_scissors<T>(&mut self, scissors: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<com::Rect>,
+    {
+        let rects: SmallVec<[d3d12::D3D12_RECT; 16]> = scissors.into_iter().map(|rect| get_rect(rect.borrow())).collect();
         unsafe {
             self.raw
                 .RSSetScissorRects(rects.len() as _, rects.as_ptr())
@@ -901,74 +1006,16 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.gr_pipeline.pipeline = Some((pipeline.raw, pipeline.signature));
     }
 
-    fn bind_graphics_descriptor_sets(
+    fn bind_graphics_descriptor_sets<'a, T>(
         &mut self,
         layout: &n::PipelineLayout,
         first_set: usize,
-        sets: &[&n::DescriptorSet],
-    ) {
-        // Bind descriptor heaps
-        unsafe {
-            // TODO: Can we bind them always or only once?
-            //       Resize while recording?
-            let mut heaps = [
-                sets[0].heap_srv_cbv_uav.as_mut() as *mut _,
-                sets[0].heap_samplers.as_mut() as *mut _
-            ];
-            self.raw.SetDescriptorHeaps(2, heaps.as_mut_ptr())
-        }
-
-        let srv_cbv_uav_base = sets[0].srv_cbv_uav_gpu_start();
-        let sampler_base = sets[0].sampler_gpu_start();
-
-        self.gr_pipeline.srv_cbv_uav_start = srv_cbv_uav_base.ptr;
-        self.gr_pipeline.sampler_start = sampler_base.ptr;
-
-        let mut table_id = 0;
-        for table in &layout.tables[.. first_set] {
-            if table.contains(n::SRV_CBV_UAV) {
-                table_id += 1;
-            }
-            if table.contains(n::SAMPLERS) {
-                table_id += 1;
-            }
-        }
-
-        let table_base_offset = layout
-            .root_constants
-            .iter()
-            .fold(0, |sum, c| sum + c.range.end - c.range.start);
-
-        for (set, table) in sets.iter().zip(layout.tables[first_set..].iter()) {
-            set.first_gpu_view.map(|gpu| {
-                assert!(table.contains(n::SRV_CBV_UAV));
-
-                let root_offset = table_id + table_base_offset;
-                // Cast is safe as offset **must** be in u32 range. Unable to
-                // create heaps with more descriptors.
-                let table_offset = (gpu.ptr - srv_cbv_uav_base.ptr) as u32;
-                self
-                    .gr_pipeline
-                    .user_data
-                    .set_srv_cbv_uav_table(root_offset as _, table_offset);
-
-                table_id += 1;
-            });
-            set.first_gpu_sampler.map(|gpu| {
-                assert!(table.contains(n::SAMPLERS));
-
-                let root_offset = table_id + table_base_offset;
-                // Cast is safe as offset **must** be in u32 range. Unable to
-                // create heaps with more descriptors.
-                let table_offset = (gpu.ptr - sampler_base.ptr) as u32;
-                self
-                    .gr_pipeline
-                    .user_data
-                    .set_sampler_table(root_offset as _, table_offset);
-
-                table_id += 1;
-            });
-        }
+        sets: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<n::DescriptorSet>,
+    {
+        bind_descriptor_sets(&self.raw, &mut self.gr_pipeline, layout, first_set, sets);
     }
 
     fn bind_compute_pipeline(&mut self, pipeline: &n::ComputePipeline) {
@@ -992,72 +1039,16 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.comp_pipeline.pipeline = Some((pipeline.raw, pipeline.signature));
     }
 
-    fn bind_compute_descriptor_sets(
+    fn bind_compute_descriptor_sets<T>(
         &mut self,
         layout: &n::PipelineLayout,
         first_set: usize,
-        sets: &[&n::DescriptorSet],
-    ) {
-        unsafe {
-            // Bind descriptor heaps
-            // TODO: Can we bind them always or only once?
-            //       Resize while recording?
-            let mut heaps = [
-                sets[0].heap_srv_cbv_uav.as_mut() as *mut _,
-                sets[0].heap_samplers.as_mut() as *mut _
-            ];
-            self.raw.SetDescriptorHeaps(2, heaps.as_mut_ptr())
-        }
-
-        let srv_cbv_uav_base = sets[0].srv_cbv_uav_gpu_start();
-        let sampler_base = sets[0].sampler_gpu_start();
-
-        self.comp_pipeline.srv_cbv_uav_start = srv_cbv_uav_base.ptr;
-        self.comp_pipeline.sampler_start = sampler_base.ptr;
-
-        let mut table_id = 0;
-        for table in &layout.tables[.. first_set] {
-            if table.contains(n::SRV_CBV_UAV) {
-                table_id += 1;
-            }
-            if table.contains(n::SAMPLERS) {
-                table_id += 1;
-            }
-        }
-        let table_base_offset = layout
-            .root_constants
-            .iter()
-            .fold(0, |sum, c| sum + c.range.end - c.range.start);
-        for (set, table) in sets.iter().zip(layout.tables[first_set..].iter()) {
-            set.first_gpu_view.map(|gpu| {
-                assert!(table.contains(n::SRV_CBV_UAV));
-
-                let root_offset = table_id + table_base_offset;
-                // Cast is safe as offset **must** be in u32 range. Unable to
-                // create heaps with more descriptors.
-                let table_offset = (gpu.ptr - srv_cbv_uav_base.ptr) as u32;
-                self
-                    .comp_pipeline
-                    .user_data
-                    .set_srv_cbv_uav_table(root_offset as _, table_offset);
-
-                table_id += 1;
-            });
-            set.first_gpu_sampler.map(|gpu| {
-                assert!(table.contains(n::SAMPLERS));
-
-                let root_offset = table_id + table_base_offset;
-                // Cast is safe as offset **must** be in u32 range. Unable to
-                // create heaps with more descriptors.
-                let table_offset = (gpu.ptr - sampler_base.ptr) as u32;
-                self
-                    .comp_pipeline
-                    .user_data
-                    .set_sampler_table(root_offset as _, table_offset);
-
-                table_id += 1;
-            });
-        }
+        sets: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<n::DescriptorSet>,
+    {
+        bind_descriptor_sets(&self.raw, &mut self.comp_pipeline, layout, first_set, sets);
     }
 
     fn dispatch(&mut self, x: u32, y: u32, z: u32) {
@@ -1134,9 +1125,14 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
-    fn copy_buffer(&mut self, src: &n::Buffer, dst: &n::Buffer, regions: &[com::BufferCopy]) {
+    fn copy_buffer<T>(&mut self, src: &n::Buffer, dst: &n::Buffer, regions: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<com::BufferCopy>,
+    {
         // copy each region
         for region in regions {
+            let region = region.borrow();
             unsafe {
                 self.raw.CopyBufferRegion(
                     dst.resource,
@@ -1151,14 +1147,17 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         // TODO: Optimization: Copy whole resource if possible
     }
 
-    fn copy_image(
+    fn copy_image<T>(
         &mut self,
         src: &n::Image,
         _: image::ImageLayout,
         dst: &n::Image,
         _: image::ImageLayout,
-        regions: &[com::ImageCopy],
-    ) {
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<com::ImageCopy>,
+    {
         let mut src_image = d3d12::D3D12_TEXTURE_COPY_LOCATION {
             pResource: src.resource,
             Type: d3d12::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
@@ -1172,6 +1171,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         };
 
         for region in regions {
+            let region = region.borrow();
             for layer in 0..region.num_layers {
                 *unsafe { src_image.u.SubresourceIndex_mut() } =
                     src.calc_subresource(region.src_subresource.0 as _, (region.src_subresource.1 + layer) as _, 0);
@@ -1200,13 +1200,16 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn copy_buffer_to_image(
+    fn copy_buffer_to_image<T>(
         &mut self,
         buffer: &n::Buffer,
         image: &n::Image,
         _: image::ImageLayout,
-        regions: &[com::BufferImageCopy],
-    ) {
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<com::BufferImageCopy>,
+    {
         let mut src = d3d12::D3D12_TEXTURE_COPY_LOCATION {
             pResource: buffer.resource,
             Type: d3d12::D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT,
@@ -1219,6 +1222,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         };
         let (width, height, depth, _) = image.kind.get_dimensions();
         for region in regions {
+            let region = region.borrow();
             // Copy each layer in the region
             let layers = region.image_layers.layers.clone();
             for layer in layers {
@@ -1264,13 +1268,16 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn copy_image_to_buffer(
+    fn copy_image_to_buffer<T>(
         &mut self,
         image: &n::Image,
         _: image::ImageLayout,
         buffer: &n::Buffer,
-        regions: &[com::BufferImageCopy],
-    ) {
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<com::BufferImageCopy>,
+    {
         let mut src = d3d12::D3D12_TEXTURE_COPY_LOCATION {
             pResource: image.resource,
             Type: d3d12::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
@@ -1283,6 +1290,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         };
         let (width, height, depth, _) = image.kind.get_dimensions();
         for region in regions {
+            let region = region.borrow();
             // Copy each layer in the region
             let layers = region.image_layers.layers.clone();
             for layer in layers {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -3,6 +3,7 @@
 
 extern crate gfx_hal as hal;
 
+use std::borrow::Borrow;
 use std::ops::Range;
 use hal::{buffer, command, device, format, image, mapping, memory, pass, pool, pso, query, queue};
 
@@ -335,11 +336,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn pipeline_barrier(
-        &mut self,
-        _: Range<pso::PipelineStage>,
-        _: &[memory::Barrier<Backend>],
-    ) {
+    fn pipeline_barrier<'a, T>(&mut self, _: Range<pso::PipelineStage>, _: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<memory::Barrier<'a, Backend>>,
+    {
         unimplemented!()
     }
 
@@ -371,18 +372,27 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn clear_attachments(&mut self, _: &[command::AttachmentClear], _: &[command::Rect]) {
+    fn clear_attachments<T, U>(&mut self, _: T, _: U)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<command::AttachmentClear>,
+        U: IntoIterator,
+        U::Item: Borrow<command::Rect>,
+    {
         unimplemented!()
     }
 
-    fn resolve_image(
+    fn resolve_image<T>(
         &mut self,
         _: &(),
         _: image::ImageLayout,
         _: &(),
         _: image::ImageLayout,
-        _: &[command::ImageResolve],
-    ) {
+        _: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<command::ImageResolve>,
+    {
         unimplemented!()
     }
 
@@ -394,11 +404,19 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn set_viewports(&mut self, _: &[command::Viewport]) {
-
+    fn set_viewports<T>(&mut self, _: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<command::Viewport>,
+    {
+        unimplemented!()
     }
 
-    fn set_scissors(&mut self, _: &[command::Rect]) {
+    fn set_scissors<T>(&mut self, _: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<command::Rect>,
+    {
         unimplemented!()
     }
 
@@ -413,14 +431,17 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
 
-    fn begin_renderpass(
+    fn begin_renderpass<T>(
         &mut self,
         _: &(),
         _: &(),
         _: command::Rect,
-        _: &[command::ClearValue],
+        _: T,
         _: command::SubpassContents,
-    ) {
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<command::ClearValue>,
+    {
         unimplemented!()
     }
 
@@ -436,12 +457,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn bind_graphics_descriptor_sets(
-        &mut self,
-        _: &(),
-        _: usize,
-        _: &[&()],
-    ) {
+    fn bind_graphics_descriptor_sets<'a, T>(&mut self, _: &(), _: usize, _: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<()>,
+    {
         unimplemented!()
     }
 
@@ -449,12 +469,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn bind_compute_descriptor_sets(
-        &mut self,
-        _: &(),
-        _: usize,
-        _: &[&()],
-    ) {
+    fn bind_compute_descriptor_sets<'a, T>(&mut self, _: &(), _: usize, _: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<()>,
+    {
         unimplemented!()
     }
 
@@ -466,38 +485,51 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn copy_buffer(&mut self, _: &(), _: &(), _: &[command::BufferCopy]) {
+    fn copy_buffer<T>(&mut self, _: &(), _: &(), _: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<command::BufferCopy>,
+    {
         unimplemented!()
     }
 
-    fn copy_image(
+    fn copy_image<T>(
         &mut self,
         _: &(),
         _: image::ImageLayout,
         _: &(),
         _: image::ImageLayout,
-        _: &[command::ImageCopy],
-    ) {
+        _: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<command::ImageCopy>,
+    {
         unimplemented!()
     }
 
-    fn copy_buffer_to_image(
+    fn copy_buffer_to_image<T>(
         &mut self,
         _: &(),
         _: &(),
         _: image::ImageLayout,
-        _: &[command::BufferImageCopy],
-    ) {
+        _: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<command::BufferImageCopy>,
+    {
         unimplemented!()
     }
 
-    fn copy_image_to_buffer(
+    fn copy_image_to_buffer<T>(
         &mut self,
         _: &(),
         _: image::ImageLayout,
         _: &(),
-        _: &[command::BufferImageCopy],
-    ) {
+        _: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<command::BufferImageCopy>,
+    {
         unimplemented!()
     }
 

--- a/src/hal/src/command/compute.rs
+++ b/src/hal/src/command/compute.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use Backend;
 use queue::capability::{Compute, Supports};
 use super::{CommandBuffer, RawCommandBuffer};
@@ -9,12 +11,15 @@ impl<'a, B: Backend, C: Supports<Compute>> CommandBuffer<'a, B, C> {
     }
 
     ///
-    pub fn bind_compute_descriptor_sets(
+    pub fn bind_compute_descriptor_sets<'i, T>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,
-        sets: &[&B::DescriptorSet],
-    ) {
+        sets: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<B::DescriptorSet>,
+    {
         self.raw.bind_compute_descriptor_sets(layout, first_set, sets)
     }
 

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::ops::Range;
 
 use Backend;
@@ -120,13 +121,16 @@ pub enum AttachmentClear {
 
 impl<'a, B: Backend, C: Supports<Graphics>> CommandBuffer<'a, B, C> {
     ///
-    pub fn begin_renderpass_inline(
+    pub fn begin_renderpass_inline<T>(
         &mut self,
         render_pass: &B::RenderPass,
         frame_buffer: &B::Framebuffer,
         render_area: Rect,
-        clear_values: &[ClearValue],
+        clear_values: T,
     ) -> RenderPassInlineEncoder<B>
+    where
+        T: IntoIterator,
+        T::Item: Borrow<ClearValue>,
     {
         RenderPassInlineEncoder::new(self, render_pass, frame_buffer, render_area, clear_values)
     }
@@ -169,22 +173,33 @@ impl<'a, B: Backend, C: Supports<Graphics>> CommandBuffer<'a, B, C> {
     }
 
     ///
-    pub fn bind_graphics_descriptor_sets(
+    pub fn bind_graphics_descriptor_sets<'i, T>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,
-        sets: &[&B::DescriptorSet],
-    ) {
+        sets: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<B::DescriptorSet>,
+    {
         self.raw.bind_graphics_descriptor_sets(layout, first_set, sets)
     }
 
     ///
-    pub fn set_viewports(&mut self, viewports: &[Viewport]) {
+    pub fn set_viewports<T>(&mut self, viewports: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<Viewport>,
+    {
         self.raw.set_viewports(viewports)
     }
 
     ///
-    pub fn set_scissors(&mut self, scissors: &[Rect]) {
+    pub fn set_scissors<T>(&mut self, scissors: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<Rect>,
+    {
         self.raw.set_scissors(scissors)
     }
 

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -1,4 +1,4 @@
-
+use std::borrow::Borrow;
 use std::ops::Range;
 use pso;
 use {Backend, IndexCount, InstanceCount, VertexCount, VertexOffset};
@@ -25,11 +25,13 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     fn reset(&mut self, release_resources: bool);
 
     ///
-    fn pipeline_barrier(
+    fn pipeline_barrier<'a, T>(
         &mut self,
         stages: Range<pso::PipelineStage>,
-        barriers: &[Barrier<B>],
-    );
+        barriers: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<Barrier<'a, B>>;
 
     ///
     fn fill_buffer(
@@ -66,17 +68,24 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     );
 
     ///
-    fn clear_attachments(&mut self, &[AttachmentClear], &[Rect]);
+    fn clear_attachments<T, U>(&mut self, clears: T, rects: U)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<AttachmentClear>,
+        U: IntoIterator,
+        U::Item: Borrow<Rect>;
 
     ///
-    fn resolve_image(
+    fn resolve_image<T>(
         &mut self,
         src: &B::Image,
         src_layout: ImageLayout,
         dst: &B::Image,
         dst_layout: ImageLayout,
-        regions: &[ImageResolve],
-    );
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<ImageResolve>;
 
     /// Bind index buffer view.
     fn bind_index_buffer(&mut self, IndexBufferView<B>);
@@ -100,7 +109,10 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     /// - Command buffer must be in recording state.
     /// - Number of viewports must be between 1 and `max_viewports`.
     /// - Only queues with graphics capability support this function.
-    fn set_viewports(&mut self, &[Viewport]);
+    fn set_viewports<T>(&mut self, viewports: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<Viewport>;
 
     /// Set the scissor rectangles for the rasterizer.
     ///
@@ -120,7 +132,10 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     /// - Command buffer must be in recording state.
     /// - Number of scissors must be between 1 and `max_viewports`.
     /// - Only queues with graphics capability support this function.
-    fn set_scissors(&mut self, &[Rect]);
+    fn set_scissors<T>(&mut self, rects: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<Rect>;
 
     ///
     fn set_stencil_reference(&mut self, front: StencilValue, back: StencilValue);
@@ -129,14 +144,16 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     fn set_blend_constants(&mut self, ColorValue);
 
     ///
-    fn begin_renderpass(
+    fn begin_renderpass<T>(
         &mut self,
         render_pass: &B::RenderPass,
         frame_buffer: &B::Framebuffer,
         render_area: Rect,
-        clear_values: &[ClearValue],
+        clear_values: T,
         first_subpass: SubpassContents,
-    );
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<ClearValue>;
     ///
     fn next_subpass(&mut self, contents: SubpassContents);
 
@@ -155,12 +172,14 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     fn bind_graphics_pipeline(&mut self, &B::GraphicsPipeline);
 
     ///
-    fn bind_graphics_descriptor_sets(
+    fn bind_graphics_descriptor_sets<'a, T>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,
-        sets: &[&B::DescriptorSet],
-    );
+        sets: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<B::DescriptorSet>;
 
     /// Bind a compute pipeline.
     ///
@@ -174,12 +193,14 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     fn bind_compute_pipeline(&mut self, &B::ComputePipeline);
 
     ///
-    fn bind_compute_descriptor_sets(
+    fn bind_compute_descriptor_sets<T>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,
-        sets: &[&B::DescriptorSet],
-    );
+        sets: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<B::DescriptorSet>;
 
     /// Execute a workgroup in the compute pipeline.
     ///
@@ -201,40 +222,48 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     fn dispatch_indirect(&mut self, buffer: &B::Buffer, offset: u64);
 
     ///
-    fn copy_buffer(
+    fn copy_buffer<T>(
         &mut self,
         src: &B::Buffer,
         dst: &B::Buffer,
-        regions: &[BufferCopy],
-    );
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<BufferCopy>;
 
     ///
-    fn copy_image(
+    fn copy_image<T>(
         &mut self,
         src: &B::Image,
         src_layout: ImageLayout,
         dst: &B::Image,
         dst_layout: ImageLayout,
-        regions: &[ImageCopy],
-    );
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<ImageCopy>;
 
     ///
-    fn copy_buffer_to_image(
+    fn copy_buffer_to_image<T>(
         &mut self,
         src: &B::Buffer,
         dst: &B::Image,
         dst_layout: ImageLayout,
-        regions: &[BufferImageCopy],
-    );
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<BufferImageCopy>;
 
     ///
-    fn copy_image_to_buffer(
+    fn copy_image_to_buffer<T>(
         &mut self,
         src: &B::Image,
         src_layout: ImageLayout,
         dst: &B::Buffer,
-        regions: &[BufferImageCopy],
-    );
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<BufferImageCopy>;
 
     ///
     fn draw(

--- a/src/hal/src/command/renderpass.rs
+++ b/src/hal/src/command/renderpass.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::ops::Range;
 use {pso, Backend, IndexCount, InstanceCount, VertexCount, VertexOffset};
 use buffer::IndexBufferView;
@@ -22,15 +23,17 @@ where B::CommandBuffer: 'a;
 
 impl<'a, B: Backend> RenderPassInlineEncoder<'a, B> {
     ///
-    pub fn new<C>(
+    pub fn new<C, T>(
         cmd_buffer: &'a mut CommandBuffer<B, C>,
         render_pass: &B::RenderPass,
         frame_buffer: &B::Framebuffer,
         render_area: Rect,
-        clear_values: &[ClearValue],
+        clear_values: T,
     ) -> Self
     where
         C: Supports<Graphics>,
+        T: IntoIterator,
+        T::Item: Borrow<ClearValue>,
     {
         cmd_buffer.raw.begin_renderpass(
             render_pass,
@@ -48,7 +51,13 @@ impl<'a, B: Backend> RenderPassInlineEncoder<'a, B> {
     }
 
     ///
-    pub fn clear_attachments(&mut self, clears: &[AttachmentClear], rects: &[Rect]) {
+    pub fn clear_attachments<T, U>(&mut self, clears: T, rects: U)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<AttachmentClear>,
+        U: IntoIterator,
+        U::Item: Borrow<Rect>,
+    {
         self.0.clear_attachments(clears, rects)
     }
 
@@ -85,22 +94,33 @@ impl<'a, B: Backend> RenderPassInlineEncoder<'a, B> {
     }
 
     ///
-    pub fn bind_graphics_descriptor_sets(
+    pub fn bind_graphics_descriptor_sets<'i, T>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,
-        sets: &[&B::DescriptorSet],
-    ) {
+        sets: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<B::DescriptorSet>,
+    {
         self.0.bind_graphics_descriptor_sets(layout, first_set, sets)
     }
 
     ///
-    pub fn set_viewports(&mut self, viewports: &[Viewport]) {
+    pub fn set_viewports<T>(&mut self, viewports: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<Viewport>,
+    {
         self.0.set_viewports(viewports)
     }
 
     ///
-    pub fn set_scissors(&mut self, scissors: &[Rect]) {
+    pub fn set_scissors<T>(&mut self, scissors: T)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<Rect>,
+    {
         self.0.set_scissors(scissors)
     }
 

--- a/src/hal/src/command/transfer.rs
+++ b/src/hal/src/command/transfer.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::ops::Range;
 use Backend;
 use image;
@@ -85,11 +86,14 @@ pub struct BufferImageCopy {
 
 impl<'a, B: Backend, C: Supports<Transfer>> CommandBuffer<'a, B, C> {
     ///
-    pub fn pipeline_barrier(
+    pub fn pipeline_barrier<'i, T>(
         &mut self,
         stages: Range<PipelineStage>,
-        barriers: &[Barrier<B>],
-    ) {
+        barriers: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<Barrier<'i, B>>,
+    {
         self.raw.pipeline_barrier(stages, barriers)
     }
 
@@ -105,12 +109,15 @@ impl<'a, B: Backend, C: Supports<Transfer>> CommandBuffer<'a, B, C> {
     }
 
     ///
-    pub fn copy_buffer(
+    pub fn copy_buffer<T>(
         &mut self,
         src: &B::Buffer,
         dst: &B::Buffer,
-        regions: &[BufferCopy],
-    ) {
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<BufferCopy>,
+    {
         self.raw.copy_buffer(src, dst, regions)
     }
 
@@ -125,36 +132,45 @@ impl<'a, B: Backend, C: Supports<Transfer>> CommandBuffer<'a, B, C> {
     }
 
     ///
-    pub fn copy_image(
+    pub fn copy_image<T>(
         &mut self,
         src: &B::Image,
         src_layout: image::ImageLayout,
         dst: &B::Image,
         dst_layout: image::ImageLayout,
-        regions: &[ImageCopy],
-    ) {
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<ImageCopy>,
+    {
         self.raw.copy_image(src, src_layout, dst, dst_layout, regions)
     }
 
     ///
-    pub fn copy_buffer_to_image(
+    pub fn copy_buffer_to_image<T>(
         &mut self,
         src: &B::Buffer,
         dst: &B::Image,
         dst_layout: image::ImageLayout,
-        regions: &[BufferImageCopy],
-    ) {
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<BufferImageCopy>,
+    {
         self.raw.copy_buffer_to_image(src, dst, dst_layout, regions)
     }
 
     ///
-    pub fn copy_image_to_buffer(
+    pub fn copy_image_to_buffer<T>(
         &mut self,
         src: &B::Image,
         src_layout: image::ImageLayout,
         dst: &B::Buffer,
-        regions: &[BufferImageCopy],
-    ) {
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<BufferImageCopy>,
+    {
         self.raw.copy_image_to_buffer(src, src_layout, dst, regions)
     }
 }

--- a/src/render/src/macros/pipeline.rs
+++ b/src/render/src/macros/pipeline.rs
@@ -139,7 +139,7 @@ macro_rules! gfx_graphics_pipeline {
                     $(
                         descs.extend(<$cmp as pso::Component<'a, B>>::descriptor_set(&self.$cmp_name));
                     )*
-                    cmd_buffer.bind_graphics_descriptor_sets(meta.layout.resource(), 0, &descs[..]);
+                    cmd_buffer.bind_graphics_descriptor_sets(meta.layout.resource(), 0, descs);
                     // TODO: difference with viewport ?
                     let extent = self.framebuffer.info().extent;
                     let render_rect = Rect {


### PR DESCRIPTION
An attempt at #1604, I haven't yet implemented the changes for metal, dx11 & dx12 as I'm on Linux and don't trust myself without a compiler. The formatting is also currently all over the place. This is my first time using rust so I don't know if this is even what you were intending, but I'm happy to have a go at fixing anything.

Are there any more areas where slices should be replaced with iterators? I think I have hit all traits but there are some plain impls that could also be subjected to this (e.g. most of render/src/encoder.rs).

(I may have introduced some bugs, I can't run the examples as I'm also having trouble with vulkan :confounded:)
