### PR TITLE
[metal] Add specialization constants

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -523,7 +523,6 @@ fn main() {
             cmd_buffer.bind_graphics_pipeline(&pipelines[0].as_ref().unwrap());
             cmd_buffer.bind_vertex_buffers(pso::VertexBufferSet(vec![(&vertex_buffer, 0)]));
             cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, &[&desc_sets[0]]); //TODO
-            cmd_buffer.push_graphics_constants(&pipeline_layout, pso::ShaderStageFlags::VERTEX, 0, &[0, 4]);
 
             {
                 let mut encoder = cmd_buffer.begin_renderpass_inline(

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -21,11 +21,11 @@ name = "gfx_backend_metal"
 gfx-hal = { path = "../../hal", version = "0.1" }
 log = "0.3"
 winit = { version = "0.7", optional = true }
-metal-rs = "0.5.2"
+metal-rs = "0.6"
 foreign-types = "0.3"
 objc = "0.2"
 block = "0.1"
-cocoa = "0.11"
+cocoa = "0.13"
 core-foundation = "0.3"
 core-graphics = "0.9"
 io-surface = "0.7"


### PR DESCRIPTION
- Removed push constants from quad example so Metal can run again
- Increased minimum Metal version to 1.2 (necessary for function constants), at least for now
- Added support for specialization constants

WIP because it requires https://github.com/gfx-rs/metal-rs/pull/21 to be published first.