### PR TITLE
[v0.16] Update winit + glutin, bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_app"
-version = "0.7.0"
+version = "0.8.0"
 description = "GFX example application framework"
 homepage = "https://github.com/gfx-rs/gfx"
 keywords = ["graphics", "gamedev"]
@@ -30,7 +30,7 @@ gfx_corell = { path = "src/corell", version = "0.1" }
 gfx = { path = "src/render", version = "0.16" }
 gfx_macros = { path = "src/macros", version = "0.2" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.14" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.18" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.19" }
 
 [dependencies.gfx_device_vulkan]
 path = "src/backend/vulkan"
@@ -44,7 +44,7 @@ optional = true
 
 [dependencies.gfx_window_vulkan]
 path = "src/window/vulkan"
-version = "0.3"
+version = "0.4"
 optional = true
 
 [dependencies.gfx_device_metal]
@@ -54,7 +54,7 @@ optional = true
 
 [dependencies.gfx_window_metal]
 path = "src/window/metal"
-version = "0.2"
+version = "0.3"
 optional = true
 
 [dependencies.gfx_window_sdl]
@@ -69,7 +69,7 @@ gfx_window_sdl = { path = "src/window/sdl", version = "0.6" }
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.6" }
 # gfx_device_dx12ll = { path = "src/backend/dx12ll", version = "0.1" }
-gfx_window_dxgi = { path = "src/window/dxgi", version = "0.10" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.11" }
 
 [[example]]
 name = "blend"
@@ -137,7 +137,7 @@ path = "examples/trianglell/main.rs"
 
 [dev-dependencies]
 cgmath = "0.15"
-gfx_gl = "0.3"
+gfx_gl = "0.4"
 rand = "0.3"
 genmesh = "0.4"
 noise = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ name = "gfx_app"
 [dependencies]
 log = "0.3"
 env_logger = "0.4"
-glutin = "0.10"
-winit = "0.8"
+glutin = "0.11"
+winit = "0.9"
 gfx_core = { path = "src/core", version = "0.7.1" }
 gfx_corell = { path = "src/corell", version = "0.1" }
 gfx = { path = "src/render", version = "0.16" }
@@ -136,9 +136,9 @@ name = "trianglell"
 path = "examples/trianglell/main.rs"
 
 [dev-dependencies]
-cgmath = "0.14"
+cgmath = "0.15"
 gfx_gl = "0.3"
 rand = "0.3"
 genmesh = "0.4"
 noise = "0.1"
-image = "0.13"
+image = "0.18"

--- a/src/backend/dx12ll/Cargo.toml
+++ b/src/backend/dx12ll/Cargo.toml
@@ -35,4 +35,4 @@ dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx"
 dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
 comptr = { git = "https://github.com/msiglreith/comptr-rs.git" }
 winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-winit = "0.8"
+winit = "0.9"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_gl"
-version = "0.14.5"
+version = "0.14.6"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,5 +29,5 @@ name = "gfx_device_gl"
 
 [dependencies]
 log = "0.3"
-gfx_gl = "0.3.1"
+gfx_gl = "0.4"
 gfx_core = { path = "../../core", version = "0.7.2" }

--- a/src/backend/vulkanll/Cargo.toml
+++ b/src/backend/vulkanll/Cargo.toml
@@ -32,7 +32,7 @@ shared_library = "0.1"
 gfx_corell = { path = "../../corell", version = "0.1.0" }
 ash = "0.15.7"
 spirv-utils = { git = "https://github.com/msiglreith/spirv-utils.git", branch = "gfx" }
-winit = "0.8"
+winit = "0.9"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ A: Sized + ApplicationBase<gfx_device_gl::Resources, gfx_device_gl::CommandBuffe
     let mut events_loop = glutin::EventsLoop::new();
     let (window, mut device, mut factory, main_color, main_depth) =
         gfx_window_glutin::init::<ColorFormat, DepthFormat>(window, context, &events_loop);
-    let (mut cur_width, mut cur_height) = window.get_inner_size_points().unwrap();
+    let (mut cur_width, mut cur_height) = window.get_inner_size().unwrap();
     let shade_lang = device.get_info().shading_language;
 
     let backend = if shade_lang.is_embedded {

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.16.1"
+version = "0.16.2"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -32,6 +32,6 @@ kernel32-sys = "0.2"
 user32-sys = "0.2"
 dxguid-sys = "0.2"
 winapi = "0.2"
-winit = "0.8"
+winit = "0.9"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.6" }

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.10.0"
+version = "0.11.0"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.18.0"
+version = "0.19.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -28,6 +28,6 @@ documentation = "https://docs.rs/gfx_window_glutin"
 name = "gfx_window_glutin"
 
 [dependencies]
-glutin = "0.10"
+glutin = "0.11"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.14" }

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_metal"
-version = "0.2.0"
+version = "0.3.0"
 description = "Metal window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -30,7 +30,7 @@ name = "gfx_window_metal"
 log = "0.3"
 cocoa = "0.9"
 objc = "0.2"
-winit = "0.8"
+winit = "0.9"
 metal-rs = "0.4"
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.2" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/gfx_window_vulkan"
 name = "gfx_window_vulkan"
 
 [dependencies]
-winit = "0.8"
+winit = "0.9"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 gfx_core = { path = "../../core", version = "0.7" }
 gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.2" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_window_vulkan"
-version = "0.3.0"
+version = "0.4.0"
 description = "Vulkan window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
Cherry pick of #1660 _without deleting trianglell_.

**winit/glutin updates**
gfx_app `0.7` -> `0.8`
~gfx_device_dx12ll `0.1.1` -> `0.2`~
~gfx_device_vulkanll `0.1` -> `0.2`~
gfx_window_dxgi `0.10` -> `0.11`
gfx_window_glutin `0.18` -> `0.19`
gfx_window_metal `0.2` -> `0.3`
gfx_window_vulkan `0.3` -> `0.4`

**nonbreaking dependency updates**
gfx_device_gl `0.14.5` -> `0.14.6` _(gfx_gl)_
~gfx_core `0.7.2` -> `0.7.3`~
gfx `0.16.1` -> `0.16.2` _(release 427ab42134de4852bb5958b5326792133699c698)_

