### PR TITLE
Replace iterators with slices (Non command buffer)

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -434,13 +434,15 @@ impl Device {
         }
     }
 
-    fn update_descriptor_sets_impl<F, R>(
+    fn update_descriptor_sets_impl<'a, F, I, R>(
         &self,
-        writes: &[pso::DescriptorSetWrite<B, R>],
+        writes: I,
         heap_type: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE,
         mut fun: F,
     ) where
         F: FnMut(&pso::DescriptorWrite<B, R>, &mut Vec<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>),
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorSetWrite<'a, 'a, B, R>>,
         R: RangeArg<u64>,
     {
         let mut dst_starts = Vec::new();
@@ -448,7 +450,8 @@ impl Device {
         let mut src_starts = Vec::new();
         let mut src_sizes = Vec::new();
 
-        for sw in writes.iter() {
+        for sw in writes {
+            let sw = sw.borrow();
             let old_count = src_starts.len();
             fun(&sw.write, &mut src_starts);
             if old_count != src_starts.len() {
@@ -783,12 +786,20 @@ impl d::Device<B> for Device {
         // automatic
     }
 
-    fn create_render_pass(
+    fn create_render_pass<'a, IA, IS, ID>(
         &self,
-        attachments: &[pass::Attachment],
-        subpasses: &[pass::SubpassDesc],
-        dependencies: &[pass::SubpassDependency],
-    ) -> n::RenderPass {
+        attachments: IA,
+        subpasses: IS,
+        dependencies: ID,
+    ) -> n::RenderPass
+    where
+        IA: IntoIterator,
+        IA::Item: Borrow<pass::Attachment>,
+        IS: IntoIterator,
+        IS::Item: Borrow<pass::SubpassDesc<'a>>,
+        ID: IntoIterator,
+        ID::Item: Borrow<pass::SubpassDependency>,
+    {
         #[derive(Copy, Clone, Debug, PartialEq)]
         pub enum SubState {
             New(d3d12::D3D12_RESOURCE_STATES),
@@ -802,6 +813,11 @@ impl d::Device<B> for Device {
             barrier_start_index: usize,
         }
 
+        let attachments = attachments.into_iter()
+                                     .map(|attachment| attachment.borrow().clone())
+                                     .collect::<Vec<_>>();
+        let subpasses = subpasses.into_iter().collect::<Vec<_>>();
+        let dependencies = dependencies.into_iter().collect::<Vec<_>>();
         let mut att_infos = attachments
             .iter()
             .map(|att| AttachmentInfo {
@@ -818,6 +834,7 @@ impl d::Device<B> for Device {
 
         // Fill out subpass known layouts
         for (sid, sub) in subpasses.iter().enumerate() {
+            let sub = sub.borrow();
             for &(id, _layout) in sub.colors {
                 let state = SubState::New(att_infos[id].target_state);
                 let old = mem::replace(&mut att_infos[id].sub_states[sid], state);
@@ -840,7 +857,8 @@ impl d::Device<B> for Device {
         }
 
         let mut deps_left = vec![0u16; subpasses.len()];
-        for dep in dependencies {
+        for dep in &dependencies {
+            let dep = dep.borrow();
             //Note: self-dependencies are ignored
             if dep.passes.start != dep.passes.end && dep.passes.start != pass::SubpassRef::External {
                 if let pass::SubpassRef::Pass(sid) = dep.passes.end {
@@ -850,14 +868,15 @@ impl d::Device<B> for Device {
         }
 
         let mut rp = n::RenderPass {
-            attachments: attachments.to_vec(),
+            attachments: attachments.clone(),
             subpasses: Vec::new(),
             post_barriers: Vec::new(),
         };
 
         while let Some(sid) = deps_left.iter().position(|count| *count == 0) {
             deps_left[sid] = !0; // mark as done
-            for dep in dependencies {
+            for dep in &dependencies {
+                let dep = dep.borrow();
                 if dep.passes.start != dep.passes.end && dep.passes.start == pass::SubpassRef::Pass(sid) {
                     if let pass::SubpassRef::Pass(other) = dep.passes.end {
                         deps_left[other] -= 1;
@@ -889,9 +908,9 @@ impl d::Device<B> for Device {
             }
 
             rp.subpasses.push(n::SubpassDesc {
-                color_attachments: subpasses[sid].colors.iter().cloned().collect(),
-                depth_stencil_attachment: subpasses[sid].depth_stencil.cloned(),
-                input_attachments: subpasses[sid].inputs.iter().cloned().collect(),
+                color_attachments: subpasses[sid].borrow().colors.iter().cloned().collect(),
+                depth_stencil_attachment: subpasses[sid].borrow().depth_stencil.cloned(),
+                input_attachments: subpasses[sid].borrow().inputs.iter().cloned().collect(),
                 pre_barriers,
             });
         }
@@ -919,11 +938,17 @@ impl d::Device<B> for Device {
         rp
     }
 
-    fn create_pipeline_layout(
+    fn create_pipeline_layout<IS, IR>(
         &self,
-        sets: &[&n::DescriptorSetLayout],
-        push_constant_ranges: &[(pso::ShaderStageFlags, Range<u32>)],
-    ) -> n::PipelineLayout {
+        sets: IS,
+        push_constant_ranges: IR,
+    ) -> n::PipelineLayout
+    where
+        IS: IntoIterator,
+        IS::Item: Borrow<n::DescriptorSetLayout>,
+        IR: IntoIterator,
+        IR::Item: Borrow<(pso::ShaderStageFlags, Range<u32>)>,
+    {
         // Pipeline layouts are implemented as RootSignature for D3D12.
         //
         // Each descriptor set layout will be one table entry of the root signature.
@@ -938,6 +963,7 @@ impl d::Device<B> for Device {
         //     DescriptorTable1: Space: 4 (+1) (SrvCbvUav)
         //     ...
 
+        let sets = sets.into_iter().collect::<Vec<_>>();
         let root_constants = root_constants::split(push_constant_ranges)
             .iter()
             .map(|constant| {
@@ -972,11 +998,12 @@ impl d::Device<B> for Device {
         // `space0`.
         let table_space_offset = if !root_constants.is_empty() { 1 } else { 0 };
 
-        let total = sets.iter().map(|desc_sec| desc_sec.bindings.len()).sum();
+        let total = sets.iter().map(|desc_sec| desc_sec.borrow().bindings.len()).sum();
         let mut ranges = Vec::with_capacity(total);
         let mut set_tables = Vec::with_capacity(sets.len());
 
         for (i, set) in sets.iter().enumerate() {
+            let set = set.borrow();
             let mut table_type = n::SetTableTypes::empty();
 
             let mut param = d3d12::D3D12_ROOT_PARAMETER {
@@ -1079,249 +1106,249 @@ impl d::Device<B> for Device {
         }
     }
 
-    fn create_graphics_pipelines<'a>(
+    fn create_graphics_pipeline<'a>(
         &self,
-        descs: &[pso::GraphicsPipelineDesc<'a, B>],
-    ) -> Vec<Result<n::GraphicsPipeline, pso::CreationError>> {
-        descs.iter().map(|desc| {
-            let build_shader =
-                |stage: pso::Stage, source: Option<&pso::EntryPoint<'a, B>>| {
-                    let source = match source {
-                        Some(src) => src,
-                        None => return Ok((ptr::null_mut(), false)),
-                    };
-
-                    Self::extract_entry_point(stage, source, desc.layout)
-                        .map_err(|err| pso::CreationError::Shader(err))
+        desc: &pso::GraphicsPipelineDesc<'a, B>,
+    ) -> Result<n::GraphicsPipeline, pso::CreationError> {
+        let build_shader =
+            |stage: pso::Stage, source: Option<&pso::EntryPoint<'a, B>>| {
+                let source = match source {
+                    Some(src) => src,
+                    None => return Ok((ptr::null_mut(), false)),
                 };
 
-            let (vs, vs_destroy) = build_shader(pso::Stage::Vertex, Some(&desc.shaders.vertex))?;
-            let (fs, fs_destroy) = build_shader(pso::Stage::Fragment, desc.shaders.fragment.as_ref())?;
-            let (gs, gs_destroy) = build_shader(pso::Stage::Geometry, desc.shaders.geometry.as_ref())?;
-            let (ds, ds_destroy) = build_shader(pso::Stage::Domain, desc.shaders.domain.as_ref())?;
-            let (hs, hs_destroy) = build_shader(pso::Stage::Hull, desc.shaders.hull.as_ref())?;
+                Self::extract_entry_point(stage, source, desc.layout)
+                    .map_err(|err| pso::CreationError::Shader(err))
+            };
 
-            // Define input element descriptions
-            let mut vs_reflect = shade::reflect_shader(&shader_bytecode(vs));
-            let input_element_descs = {
-                let input_descs = shade::reflect_input_elements(&mut vs_reflect);
-                desc.attributes
-                    .iter()
-                    .map(|attrib| {
-                        let buffer_desc = if let Some(buffer_desc) = desc.vertex_buffers.get(attrib.binding as usize) {
-                                buffer_desc
-                            } else {
-                                error!("Couldn't find associated vertex buffer description {:?}", attrib.binding);
-                                return Err(pso::CreationError::Other);
-                            };
+        let (vs, vs_destroy) = build_shader(pso::Stage::Vertex, Some(&desc.shaders.vertex))?;
+        let (fs, fs_destroy) = build_shader(pso::Stage::Fragment, desc.shaders.fragment.as_ref())?;
+        let (gs, gs_destroy) = build_shader(pso::Stage::Geometry, desc.shaders.geometry.as_ref())?;
+        let (ds, ds_destroy) = build_shader(pso::Stage::Domain, desc.shaders.domain.as_ref())?;
+        let (hs, hs_destroy) = build_shader(pso::Stage::Hull, desc.shaders.hull.as_ref())?;
 
-                        let input_elem =
-                            if let Some(input_elem) = input_descs.iter().find(|elem| elem.semantic_index == attrib.location) {
-                                input_elem
-                            } else {
-                                error!("Couldn't find associated input element slot in the shader {:?}", attrib.location);
-                                return Err(pso::CreationError::Other);
-                            };
+        // Define input element descriptions
+        let mut vs_reflect = shade::reflect_shader(&shader_bytecode(vs));
+        let input_element_descs = {
+            let input_descs = shade::reflect_input_elements(&mut vs_reflect);
+            desc.attributes
+                .iter()
+                .map(|attrib| {
+                    let buffer_desc = if let Some(buffer_desc) = desc.vertex_buffers.get(attrib.binding as usize) {
+                        buffer_desc
+                    } else {
+                        error!("Couldn't find associated vertex buffer description {:?}", attrib.binding);
+                        return Err(pso::CreationError::Other);
+                    };
 
-                        let slot_class = match buffer_desc.rate {
-                            0 => d3d12::D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
-                            _ => d3d12::D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA,
+                    let input_elem =
+                        if let Some(input_elem) = input_descs.iter().find(|elem| elem.semantic_index == attrib.location) {
+                            input_elem
+                        } else {
+                            error!("Couldn't find associated input element slot in the shader {:?}", attrib.location);
+                            return Err(pso::CreationError::Other);
                         };
-                        let format = attrib.element.format;
 
-                        Ok(d3d12::D3D12_INPUT_ELEMENT_DESC {
-                            SemanticName: input_elem.semantic_name,
-                            SemanticIndex: input_elem.semantic_index,
-                            Format: match conv::map_format(format) {
-                                Some(fm) => fm,
-                                None => {
-                                    error!("Unable to find DXGI format for {:?}", format);
-                                    return Err(pso::CreationError::Other);
-                                }
-                            },
-                            InputSlot: attrib.binding as _,
-                            AlignedByteOffset: attrib.element.offset,
-                            InputSlotClass: slot_class,
-                            InstanceDataStepRate: buffer_desc.rate as _,
-                        })
+                    let slot_class = match buffer_desc.rate {
+                        0 => d3d12::D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
+                        _ => d3d12::D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA,
+                    };
+                    let format = attrib.element.format;
+
+                    Ok(d3d12::D3D12_INPUT_ELEMENT_DESC {
+                        SemanticName: input_elem.semantic_name,
+                        SemanticIndex: input_elem.semantic_index,
+                        Format: match conv::map_format(format) {
+                            Some(fm) => fm,
+                            None => {
+                                error!("Unable to find DXGI format for {:?}", format);
+                                return Err(pso::CreationError::Other);
+                            }
+                        },
+                        InputSlot: attrib.binding as _,
+                        AlignedByteOffset: attrib.element.offset,
+                        InputSlotClass: slot_class,
+                        InstanceDataStepRate: buffer_desc.rate as _,
                     })
-                    .collect::<Result<Vec<_>, _>>()?
-            };
-
-            // Input slots
-            let mut vertex_strides = [0; MAX_VERTEX_BUFFERS];
-            for (stride, buffer) in vertex_strides.iter_mut().zip(desc.vertex_buffers.iter()) {
-                *stride = buffer.stride;
-            }
-
-            // TODO: check maximum number of rtvs
-            // Get associated subpass information
-            let pass = {
-                let subpass = &desc.subpass;
-                match subpass.main_pass.subpasses.get(subpass.index) {
-                    Some(subpass) => subpass,
-                    None => return Err(pso::CreationError::InvalidSubpass(subpass.index)),
-                }
-            };
-
-            // Get color attachment formats from subpass
-            let (rtvs, num_rtvs) = {
-                let mut rtvs = [dxgiformat::DXGI_FORMAT_UNKNOWN; 8];
-                let mut num_rtvs = 0;
-                for (rtv, target) in rtvs.iter_mut()
-                    .zip(pass.color_attachments.iter())
-                {
-                    let format = desc.subpass.main_pass.attachments[target.0].format;
-                    *rtv = format.and_then(conv::map_format).unwrap_or(dxgiformat::DXGI_FORMAT_UNKNOWN);
-                    num_rtvs += 1;
-                }
-                (rtvs, num_rtvs)
-            };
-
-            // Setup pipeline description
-            let pso_desc = d3d12::D3D12_GRAPHICS_PIPELINE_STATE_DESC {
-                pRootSignature: desc.layout.raw,
-                VS: shader_bytecode(vs),
-                PS: shader_bytecode(fs),
-                GS: shader_bytecode(gs),
-                DS: shader_bytecode(ds),
-                HS: shader_bytecode(hs),
-                StreamOutput: d3d12::D3D12_STREAM_OUTPUT_DESC {
-                    pSODeclaration: ptr::null(),
-                    NumEntries: 0,
-                    pBufferStrides: ptr::null(),
-                    NumStrides: 0,
-                    RasterizedStream: 0,
-                },
-                BlendState: d3d12::D3D12_BLEND_DESC {
-                    AlphaToCoverageEnable: if desc.blender.alpha_coverage { TRUE } else { FALSE },
-                    IndependentBlendEnable: TRUE,
-                    RenderTarget: conv::map_render_targets(&desc.blender.targets),
-                },
-                SampleMask: UINT::max_value(),
-                RasterizerState: conv::map_rasterizer(&desc.rasterizer),
-                DepthStencilState: desc.depth_stencil.as_ref().map_or(unsafe { mem::zeroed() }, conv::map_depth_stencil),
-                InputLayout: d3d12::D3D12_INPUT_LAYOUT_DESC {
-                    pInputElementDescs: input_element_descs.as_ptr(),
-                    NumElements: input_element_descs.len() as u32,
-                },
-                IBStripCutValue: d3d12::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_DISABLED, // TODO
-                PrimitiveTopologyType: conv::map_topology_type(desc.input_assembler.primitive),
-                NumRenderTargets: num_rtvs,
-                RTVFormats: rtvs,
-                DSVFormat: pass.depth_stencil_attachment
-                    .and_then(|att_ref|
-                        desc.subpass
-                            .main_pass
-                            .attachments[att_ref.0]
-                            .format
-                            .and_then(|f| conv::map_format_dsv(f.base_format().0))
-                    )
-                    .unwrap_or(dxgiformat::DXGI_FORMAT_UNKNOWN),
-                SampleDesc: dxgitype::DXGI_SAMPLE_DESC {
-                    Count: 1, // TODO
-                    Quality: 0, // TODO
-                },
-                NodeMask: 0,
-                CachedPSO: d3d12::D3D12_CACHED_PIPELINE_STATE {
-                    pCachedBlob: ptr::null(),
-                    CachedBlobSizeInBytes: 0,
-                },
-                Flags: d3d12::D3D12_PIPELINE_STATE_FLAG_NONE,
-            };
-
-            let topology = conv::map_topology(desc.input_assembler.primitive);
-
-            // Create PSO
-            let mut pipeline = ptr::null_mut();
-            let hr = unsafe {
-                self.raw.clone().CreateGraphicsPipelineState(
-                    &pso_desc,
-                    &d3d12::IID_ID3D12PipelineState,
-                    &mut pipeline as *mut *mut _ as *mut *mut _)
-            };
-
-            let destroy_shader = |shader: *mut d3dcommon::ID3DBlob| unsafe { (*shader).Release() };
-
-            if vs_destroy { destroy_shader(vs); }
-            if fs_destroy { destroy_shader(fs); }
-            if gs_destroy { destroy_shader(gs); }
-            if hs_destroy { destroy_shader(hs); }
-            if ds_destroy { destroy_shader(ds); }
-
-            if winerror::SUCCEEDED(hr) {
-                Ok(n::GraphicsPipeline {
-                    raw: pipeline,
-                    signature: desc.layout.raw,
-                    num_parameter_slots: desc.layout.num_parameter_slots,
-                    topology,
-                    constants: desc.layout.root_constants.clone(),
-                    vertex_strides,
                 })
-            } else {
-                Err(pso::CreationError::Other)
-            }
-        }).collect()
-    }
+                .collect::<Result<Vec<_>, _>>()?
+        };
 
-    fn create_compute_pipelines<'a>(
-        &self,
-        descs: &[pso::ComputePipelineDesc<'a, B>],
-    ) -> Vec<Result<n::ComputePipeline, pso::CreationError>> {
-        descs.iter().map(|desc| {
-            let (cs, cs_destroy) =
-                Self::extract_entry_point(
-                    pso::Stage::Compute,
-                    &desc.shader,
-                    desc.layout,
+        // Input slots
+        let mut vertex_strides = [0; MAX_VERTEX_BUFFERS];
+        for (stride, buffer) in vertex_strides.iter_mut().zip(desc.vertex_buffers.iter()) {
+            *stride = buffer.stride;
+        }
+
+        // TODO: check maximum number of rtvs
+        // Get associated subpass information
+        let pass = {
+            let subpass = &desc.subpass;
+            match subpass.main_pass.subpasses.get(subpass.index) {
+                Some(subpass) => subpass,
+                None => return Err(pso::CreationError::InvalidSubpass(subpass.index)),
+            }
+        };
+
+        // Get color attachment formats from subpass
+        let (rtvs, num_rtvs) = {
+            let mut rtvs = [dxgiformat::DXGI_FORMAT_UNKNOWN; 8];
+            let mut num_rtvs = 0;
+            for (rtv, target) in rtvs.iter_mut()
+                .zip(pass.color_attachments.iter())
+            {
+                let format = desc.subpass.main_pass.attachments[target.0].format;
+                *rtv = format.and_then(conv::map_format).unwrap_or(dxgiformat::DXGI_FORMAT_UNKNOWN);
+                num_rtvs += 1;
+            }
+            (rtvs, num_rtvs)
+        };
+
+        // Setup pipeline description
+        let pso_desc = d3d12::D3D12_GRAPHICS_PIPELINE_STATE_DESC {
+            pRootSignature: desc.layout.raw,
+            VS: shader_bytecode(vs),
+            PS: shader_bytecode(fs),
+            GS: shader_bytecode(gs),
+            DS: shader_bytecode(ds),
+            HS: shader_bytecode(hs),
+            StreamOutput: d3d12::D3D12_STREAM_OUTPUT_DESC {
+                pSODeclaration: ptr::null(),
+                NumEntries: 0,
+                pBufferStrides: ptr::null(),
+                NumStrides: 0,
+                RasterizedStream: 0,
+            },
+            BlendState: d3d12::D3D12_BLEND_DESC {
+                AlphaToCoverageEnable: if desc.blender.alpha_coverage { TRUE } else { FALSE },
+                IndependentBlendEnable: TRUE,
+                RenderTarget: conv::map_render_targets(&desc.blender.targets),
+            },
+            SampleMask: UINT::max_value(),
+            RasterizerState: conv::map_rasterizer(&desc.rasterizer),
+            DepthStencilState: desc.depth_stencil.as_ref().map_or(unsafe { mem::zeroed() }, conv::map_depth_stencil),
+            InputLayout: d3d12::D3D12_INPUT_LAYOUT_DESC {
+                pInputElementDescs: input_element_descs.as_ptr(),
+                NumElements: input_element_descs.len() as u32,
+            },
+            IBStripCutValue: d3d12::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_DISABLED, // TODO
+            PrimitiveTopologyType: conv::map_topology_type(desc.input_assembler.primitive),
+            NumRenderTargets: num_rtvs,
+            RTVFormats: rtvs,
+            DSVFormat: pass.depth_stencil_attachment
+                .and_then(|att_ref|
+                    desc.subpass
+                        .main_pass
+                        .attachments[att_ref.0]
+                        .format
+                        .and_then(|f| conv::map_format_dsv(f.base_format().0))
                 )
-                .map_err(|err| pso::CreationError::Shader(err))?;
+                .unwrap_or(dxgiformat::DXGI_FORMAT_UNKNOWN),
+            SampleDesc: dxgitype::DXGI_SAMPLE_DESC {
+                Count: 1, // TODO
+                Quality: 0, // TODO
+            },
+            NodeMask: 0,
+            CachedPSO: d3d12::D3D12_CACHED_PIPELINE_STATE {
+                pCachedBlob: ptr::null(),
+                CachedBlobSizeInBytes: 0,
+            },
+            Flags: d3d12::D3D12_PIPELINE_STATE_FLAG_NONE,
+        };
 
-            let pso_desc = d3d12::D3D12_COMPUTE_PIPELINE_STATE_DESC {
-                pRootSignature: desc.layout.raw,
-                CS: shader_bytecode(cs),
-                NodeMask: 0,
-                CachedPSO: d3d12::D3D12_CACHED_PIPELINE_STATE {
-                    pCachedBlob: ptr::null(),
-                    CachedBlobSizeInBytes: 0,
-                },
-                Flags: d3d12::D3D12_PIPELINE_STATE_FLAG_NONE,
-            };
+        let topology = conv::map_topology(desc.input_assembler.primitive);
 
-            // Create PSO
-            let mut pipeline = ptr::null_mut();
-            let hr = unsafe {
-                self.raw.clone().CreateComputePipelineState(
-                    &pso_desc,
-                    &d3d12::IID_ID3D12PipelineState,
-                    &mut pipeline as *mut *mut _ as *mut *mut _)
-            };
+        // Create PSO
+        let mut pipeline = ptr::null_mut();
+        let hr = unsafe {
+            self.raw.clone().CreateGraphicsPipelineState(
+                &pso_desc,
+                &d3d12::IID_ID3D12PipelineState,
+                &mut pipeline as *mut *mut _ as *mut *mut _)
+        };
 
-            if cs_destroy {
-                unsafe { (*cs).Release(); }
-            }
+        let destroy_shader = |shader: *mut d3dcommon::ID3DBlob| unsafe { (*shader).Release() };
 
-            if winerror::SUCCEEDED(hr) {
-                Ok(n::ComputePipeline {
-                    raw: pipeline,
-                    signature: desc.layout.raw,
-                    num_parameter_slots: desc.layout.num_parameter_slots,
-                    constants: desc.layout.root_constants.clone(),
-                })
-            } else {
-                Err(pso::CreationError::Other)
-            }
-        }).collect()
+        if vs_destroy { destroy_shader(vs); }
+        if fs_destroy { destroy_shader(fs); }
+        if gs_destroy { destroy_shader(gs); }
+        if hs_destroy { destroy_shader(hs); }
+        if ds_destroy { destroy_shader(ds); }
+
+        if winerror::SUCCEEDED(hr) {
+            Ok(n::GraphicsPipeline {
+                raw: pipeline,
+                signature: desc.layout.raw,
+                num_parameter_slots: desc.layout.num_parameter_slots,
+                topology,
+                constants: desc.layout.root_constants.clone(),
+                vertex_strides,
+            })
+        } else {
+            Err(pso::CreationError::Other)
+        }
     }
 
-    fn create_framebuffer(
+    fn create_compute_pipeline<'a>(
+        &self,
+        desc: &pso::ComputePipelineDesc<'a, B>,
+    ) -> Result<n::ComputePipeline, pso::CreationError> {
+        let (cs, cs_destroy) =
+            Self::extract_entry_point(
+                pso::Stage::Compute,
+                &desc.shader,
+                desc.layout,
+            )
+            .map_err(|err| pso::CreationError::Shader(err))?;
+
+        let pso_desc = d3d12::D3D12_COMPUTE_PIPELINE_STATE_DESC {
+            pRootSignature: desc.layout.raw,
+            CS: shader_bytecode(cs),
+            NodeMask: 0,
+            CachedPSO: d3d12::D3D12_CACHED_PIPELINE_STATE {
+                pCachedBlob: ptr::null(),
+                CachedBlobSizeInBytes: 0,
+            },
+            Flags: d3d12::D3D12_PIPELINE_STATE_FLAG_NONE,
+        };
+
+        // Create PSO
+        let mut pipeline = ptr::null_mut();
+        let hr = unsafe {
+            self.raw.clone().CreateComputePipelineState(
+                &pso_desc,
+                &d3d12::IID_ID3D12PipelineState,
+                &mut pipeline as *mut *mut _ as *mut *mut _)
+        };
+
+        if cs_destroy {
+            unsafe { (*cs).Release(); }
+        }
+
+        if winerror::SUCCEEDED(hr) {
+            Ok(n::ComputePipeline {
+                raw: pipeline,
+                signature: desc.layout.raw,
+                num_parameter_slots: desc.layout.num_parameter_slots,
+                constants: desc.layout.root_constants.clone(),
+            })
+        } else {
+            Err(pso::CreationError::Other)
+        }
+    }
+
+    fn create_framebuffer<I>(
         &self,
         _renderpass: &n::RenderPass,
-        attachments: &[&n::ImageView],
+        attachments: I,
         _extent: d::Extent,
-    ) -> Result<n::Framebuffer, d::FramebufferError> {
+    ) -> Result<n::Framebuffer, d::FramebufferError>
+    where
+        I: IntoIterator,
+        I::Item: Borrow<n::ImageView>
+    {
         Ok(n::Framebuffer {
-            attachments: attachments.iter().cloned().cloned().collect(),
+            attachments: attachments.into_iter().map(|att| *att.borrow()).collect(),
         })
     }
 
@@ -1673,15 +1700,22 @@ impl d::Device<B> for Device {
         n::Sampler { handle }
     }
 
-    fn create_descriptor_pool(
+    fn create_descriptor_pool<I>(
         &self,
         max_sets: usize,
-        descriptor_pools: &[pso::DescriptorRangeDesc],
-    ) -> n::DescriptorPool {
+        descriptor_pools: I,
+    ) -> n::DescriptorPool
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorRangeDesc>
+    {
         let mut num_srv_cbv_uav = 0;
         let mut num_samplers = 0;
 
-        for desc in descriptor_pools {
+        let descriptor_pools = descriptor_pools.into_iter()
+                                               .map(|desc| *desc.borrow())
+                                               .collect::<Vec<_>>();
+        for desc in &descriptor_pools {
             match desc.ty {
                 pso::DescriptorType::Sampler => {
                     num_samplers += desc.count;
@@ -1733,22 +1767,35 @@ impl d::Device<B> for Device {
         n::DescriptorPool {
             heap_srv_cbv_uav,
             heap_sampler,
-            pools: descriptor_pools.to_vec(),
+            pools: descriptor_pools,
             max_size: max_sets as _,
         }
     }
 
-    fn create_descriptor_set_layout(
+    fn create_descriptor_set_layout<I>(
         &self,
-        bindings: &[pso::DescriptorSetLayoutBinding],
-    )-> n::DescriptorSetLayout {
-        n::DescriptorSetLayout { bindings: bindings.to_vec() }
+        bindings: I,
+    )-> n::DescriptorSetLayout
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorSetLayoutBinding>
+    {
+        n::DescriptorSetLayout {
+            bindings: bindings.into_iter().map(|bind| *bind.borrow()).collect()
+        }
     }
 
-    fn update_descriptor_sets<R: RangeArg<u64>>(&self, writes: &[pso::DescriptorSetWrite<B, R>]) {
+    fn update_descriptor_sets<'a, I, R>(&self, writes: I)
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorSetWrite<'a, 'a, B, R>>,
+        R: RangeArg<u64>,
+    {
+        let writes = writes.into_iter().collect::<Vec<_>>();
         // Create temporary non-shader visible views for uniform and storage buffers.
         let mut num_views = 0;
-        for sw in writes {
+        for sw in &writes {
+            let sw = sw.borrow();
             match sw.write {
                 pso::DescriptorWrite::UniformBuffer(ref views) |
                 pso::DescriptorWrite::StorageBuffer(ref views) => {
@@ -1773,7 +1820,8 @@ impl d::Device<B> for Device {
                 max_size: num_views as _,
             };
             // Create views
-            for sw in writes {
+            for sw in &writes {
+                let sw = sw.borrow();
                 match sw.write {
                     pso::DescriptorWrite::UniformBuffer(ref views) => {
                         handles.extend(views.iter().map(|&(buffer, ref range)| {
@@ -1833,7 +1881,7 @@ impl d::Device<B> for Device {
         };
 
         let mut cur_view = 0;
-        self.update_descriptor_sets_impl(writes,
+        self.update_descriptor_sets_impl(writes.iter().map(Borrow::borrow),
             d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
             |dw, starts| match *dw {
                 pso::DescriptorWrite::SampledImage(ref images) => {
@@ -1851,7 +1899,7 @@ impl d::Device<B> for Device {
                 _ => unimplemented!()
             });
 
-        self.update_descriptor_sets_impl(writes,
+        self.update_descriptor_sets_impl(writes.iter().map(Borrow::borrow),
             d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,
             |dw, starts| match *dw {
                 pso::DescriptorWrite::Sampler(ref samplers) => {
@@ -1991,15 +2039,18 @@ impl d::Device<B> for Device {
         }
     }
 
-    fn reset_fences(&self, fences: &[&n::Fence]) {
-        for fence in fences {
-            assert_eq!(winerror::S_OK, unsafe {
-                fence.raw.clone().Signal(0)
-            });
-        }
+    fn reset_fence(&self, fence: &n::Fence) {
+        assert_eq!(winerror::S_OK, unsafe {
+            fence.raw.clone().Signal(0)
+        });
     }
 
-    fn wait_for_fences(&self, fences: &[&n::Fence], wait: d::WaitFor, timeout_ms: u32) -> bool {
+    fn wait_for_fences<I>(&self, fences: I, wait: d::WaitFor, timeout_ms: u32) -> bool
+    where
+        I: IntoIterator,
+        I::Item: Borrow<n::Fence>,
+    {
+        let fences = fences.into_iter().collect::<Vec<_>>();
         let mut events = self.events.lock().unwrap();
         for _ in events.len() .. fences.len() {
             events.push(unsafe {
@@ -2015,7 +2066,7 @@ impl d::Device<B> for Device {
         for (&event, fence) in events.iter().zip(fences.iter()) {
             assert_eq!(winerror::S_OK, unsafe {
                 synchapi::ResetEvent(event);
-                fence.raw.clone().SetEventOnCompletion(1, event)
+                fence.borrow().raw.clone().SetEventOnCompletion(1, event)
             });
         }
 

--- a/src/backend/dx12/src/root_constants.rs
+++ b/src/backend/dx12/src/root_constants.rs
@@ -6,6 +6,7 @@
 //! ranges. The disjunct ranges can be then converted into root signature entries.
 
 use hal::pso;
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::ops::Range;
 
@@ -52,9 +53,11 @@ impl Ord for RootConstant {
     }
 }
 
-pub fn split(
-    ranges: &[(pso::ShaderStageFlags, Range<u32>)],
-) -> Vec<RootConstant> {
+pub fn split<I>(ranges: I) -> Vec<RootConstant>
+where
+    I: IntoIterator,
+    I::Item: Borrow<(pso::ShaderStageFlags, Range<u32>)>,
+{
     // Frontier of unexplored root constant ranges, sorted descending
     // (less element shifting for Vec) regarding to the start of ranges.
     let mut ranges = into_vec(ranges);
@@ -113,8 +116,13 @@ pub fn split(
     disjunct
 }
 
-fn into_vec(ranges: &[(pso::ShaderStageFlags, Range<u32>)]) -> Vec<RootConstant> {
-    ranges.iter().map(|&(stages, ref range)| {
+fn into_vec<I>(ranges: I) -> Vec<RootConstant>
+where
+    I: IntoIterator,
+    I::Item: Borrow<(pso::ShaderStageFlags, Range<u32>)>,
+{
+    ranges.into_iter().map(|borrowable| {
+        let &(stages, ref range) = borrowable.borrow();
         RootConstant { stages, range: range.clone() }
     }).collect()
 }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -119,33 +119,35 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_render_pass(&self, _: &[pass::Attachment], _: &[pass::SubpassDesc], _: &[pass::SubpassDependency]) -> () {
+    fn create_render_pass<'a ,IA, IS, ID>(&self, _: IA, _: IS, _: ID) -> ()
+    where
+        IA: IntoIterator,
+        IA::Item: Borrow<pass::Attachment>,
+        IS: IntoIterator,
+        IS::Item: Borrow<pass::SubpassDesc<'a>>,
+        ID: IntoIterator,
+        ID::Item: Borrow<pass::SubpassDependency>,
+    {
         unimplemented!()
     }
 
-    fn create_pipeline_layout(&self, _: &[&()], _: &[(pso::ShaderStageFlags, Range<u32>)]) -> () {
+    fn create_pipeline_layout<IS, IR>(&self, _: IS, _: IR) -> ()
+    where
+        IS: IntoIterator,
+        IS::Item: Borrow<()>,
+        IR: IntoIterator,
+        IR::Item: Borrow<(pso::ShaderStageFlags, Range<u32>)>,
+    {
         unimplemented!()
     }
 
-    fn create_graphics_pipelines<'a>(
-        &self,
-        _: &[pso::GraphicsPipelineDesc<'a, Backend>],
-    ) -> Vec<Result<(), pso::CreationError>> {
-        unimplemented!()
-    }
-
-    fn create_compute_pipelines<'a>(
-        &self,
-        _: &[pso::ComputePipelineDesc<'a, Backend>],
-    ) -> Vec<Result<(), pso::CreationError>> {
-        unimplemented!()
-    }
-
-    fn create_framebuffer(
-        &self, _: &(),
-        _: &[&()],
-        _: device::Extent,
-    ) -> Result<(), device::FramebufferError> {
+    fn create_framebuffer<I>(
+        &self, _: &(), _: I, _: device::Extent
+    ) -> Result<(), device::FramebufferError>
+    where
+        I: IntoIterator,
+        I::Item: Borrow<()>,
+    {
         unimplemented!()
     }
 
@@ -196,14 +198,28 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_descriptor_pool(&self, _: usize, _: &[pso::DescriptorRangeDesc]) -> DescriptorPool {
-        unimplemented!()
-    }
-    fn create_descriptor_set_layout(&self, _: &[pso::DescriptorSetLayoutBinding]) -> () {
+    fn create_descriptor_pool<I>(&self, _: usize, _: I) -> DescriptorPool
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorRangeDesc>,
+    {
         unimplemented!()
     }
 
-    fn update_descriptor_sets<R: RangeArg<u64>>(&self, _: &[pso::DescriptorSetWrite<Backend, R>]) {
+    fn create_descriptor_set_layout<I>(&self, _: I) -> ()
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorSetLayoutBinding>,
+    {
+        unimplemented!()
+    }
+
+    fn update_descriptor_sets<'a, I, R>(&self, _: I)
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorSetWrite<'a, 'a, Backend, R>>,
+        R: RangeArg<u64>,
+    {
         unimplemented!()
     }
 
@@ -215,13 +231,6 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn reset_fences(&self, _: &[&()]) {
-        unimplemented!()
-    }
-
-    fn wait_for_fences(&self, _: &[&()], _: device::WaitFor, _: u32) -> bool {
-        unimplemented!()
-    }
     fn get_fence_status(&self, _: &()) -> bool {
         unimplemented!()
     }
@@ -497,10 +506,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn bind_graphics_descriptor_sets<'a, T>(&mut self, _: &(), _: usize, _: T)
+    fn bind_graphics_descriptor_sets<I>(&mut self, _: &(), _: usize, _: I)
     where
-        T: IntoIterator,
-        T::Item: Borrow<()>,
+        I: IntoIterator,
+        I::Item: Borrow<()>,
     {
         unimplemented!()
     }
@@ -509,10 +518,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn bind_compute_descriptor_sets<'a, T>(&mut self, _: &(), _: usize, _: T)
+    fn bind_compute_descriptor_sets<I>(&mut self, _: &(), _: usize, _: I)
     where
-        T: IntoIterator,
-        T::Item: Borrow<()>,
+        I: IntoIterator,
+        I::Item: Borrow<()>,
     {
         unimplemented!()
     }
@@ -669,10 +678,6 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 #[derive(Debug)]
 pub struct DescriptorPool;
 impl hal::DescriptorPool<Backend> for DescriptorPool {
-    fn allocate_sets(&mut self, _: &[&()]) -> Vec<()> {
-        unimplemented!()
-    }
-
     fn reset(&mut self) {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -804,7 +804,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         self.update_blend_targets(blend_targets);
     }
 
-    fn bind_graphics_descriptor_sets<'a, T>(
+    fn bind_graphics_descriptor_sets<T>(
         &mut self,
         _layout: &n::PipelineLayout,
         _first_set: usize,
@@ -827,7 +827,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         }
     }
 
-    fn bind_compute_descriptor_sets<'a, T>(
+    fn bind_compute_descriptor_sets<T>(
         &mut self,
         _layout: &n::PipelineLayout,
         _first_set: usize,

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -5,6 +5,7 @@ use hal::memory::Properties;
 
 use gl;
 use Backend;
+use std::borrow::Borrow;
 
 
 pub type RawBuffer   = gl::types::GLuint;
@@ -90,8 +91,12 @@ pub struct DescriptorSet;
 pub struct DescriptorPool {}
 
 impl hal::DescriptorPool<Backend> for DescriptorPool {
-    fn allocate_sets(&mut self, layouts: &[&DescriptorSetLayout]) -> Vec<DescriptorSet> {
-        layouts.iter().map(|_| DescriptorSet).collect()
+    fn allocate_sets<I>(&mut self, layouts: I) -> Vec<DescriptorSet>
+    where
+        I: IntoIterator,
+        I::Item: Borrow<DescriptorSetLayout>,
+    {
+        layouts.into_iter().map(|_| DescriptorSet).collect()
     }
 
     fn reset(&mut self) {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -412,6 +412,163 @@ impl Device {
 
         arg
     }
+}
+
+impl hal::Device<Backend> for Device {
+    fn create_command_pool(
+        &self, _family: QueueFamilyId, flags: CommandPoolCreateFlags
+    ) -> command::CommandPool {
+        command::CommandPool {
+            queue: self.queue.clone(),
+            managed: if flags.contains(CommandPoolCreateFlags::RESET_INDIVIDUAL) {
+                None
+            } else {
+                Some(Vec::new())
+            },
+        }
+    }
+
+    fn destroy_command_pool(&self, _pool: command::CommandPool) {
+        //TODO?
+    }
+
+    fn create_render_pass<'a, IA, IS, ID>(
+        &self,
+        attachments: IA,
+        _subpasses: IS,
+        _dependencies: ID,
+    ) -> n::RenderPass
+    where
+        IA: IntoIterator,
+        IA::Item: Borrow<pass::Attachment>,
+        IS: IntoIterator,
+        IS::Item: Borrow<pass::SubpassDesc<'a>>,
+        ID: IntoIterator,
+        ID::Item: Borrow<pass::SubpassDependency>,
+    {
+        //TODO: subpasses, dependencies
+        let pass = metal::RenderPassDescriptor::new().to_owned();
+
+        let attachments = attachments.into_iter()
+            .map(|attachment| attachment.borrow().clone())
+            .collect::<Vec<_>>();
+        let mut color_attachment_index = 0;
+        for attachment in &attachments {
+            if let Some((_format, is_depth)) = attachment.format.and_then(map_format) {
+                let mtl_attachment: &metal::RenderPassAttachmentDescriptorRef;
+                if !is_depth {
+                    let color_attachment = pass.color_attachments().object_at(color_attachment_index).expect("too many color attachments");
+                    color_attachment_index += 1;
+
+                    mtl_attachment = color_attachment;
+                } else {
+                    let depth_attachment = pass.depth_attachment().expect("no depth attachement");
+
+                    mtl_attachment = depth_attachment;
+                }
+
+                mtl_attachment.set_load_action(map_load_operation(attachment.ops.load));
+                mtl_attachment.set_store_action(map_store_operation(attachment.ops.store));
+            }
+        }
+
+        n::RenderPass {
+            desc: pass,
+            attachments,
+            num_colors: color_attachment_index,
+        }
+    }
+
+    fn create_pipeline_layout<IS, IR>(
+        &self,
+        set_layouts: IS,
+        _push_constant_ranges: IR,
+    ) -> n::PipelineLayout
+    where
+        IS: IntoIterator,
+        IS::Item: Borrow<n::DescriptorSetLayout>,
+        IR: IntoIterator,
+        IR::Item: Borrow<(pso::ShaderStageFlags, Range<u32>)>
+    {
+        use hal::pso::ShaderStageFlags;
+
+        struct Counters {
+            buffers: usize,
+            textures: usize,
+            samplers: usize,
+        }
+        let mut stage_infos = [
+            (ShaderStageFlags::VERTEX,   spirv::ExecutionModel::Vertex,    Counters { buffers:0, textures:0, samplers:0 }),
+            (ShaderStageFlags::FRAGMENT, spirv::ExecutionModel::Fragment,  Counters { buffers:0, textures:0, samplers:0 }),
+            (ShaderStageFlags::COMPUTE,  spirv::ExecutionModel::GlCompute, Counters { buffers:0, textures:0, samplers:0 }),
+        ];
+        let mut res_overrides = HashMap::new();
+
+        for (set_index, set_layout) in set_layouts.into_iter().enumerate() {
+            match set_layout.borrow() {
+                &n::DescriptorSetLayout::Emulated(ref set_bindings) => {
+                    for set_binding in set_bindings {
+                        for &mut(stage_bit, stage, ref mut counters) in stage_infos.iter_mut() {
+                            if !set_binding.stage_flags.contains(stage_bit) {
+                                continue
+                            }
+                            let count = match set_binding.ty {
+                                DescriptorType::UniformBuffer |
+                                DescriptorType::StorageBuffer => &mut counters.buffers,
+                                DescriptorType::SampledImage => &mut counters.textures,
+                                DescriptorType::StorageImage => &mut counters.textures,
+                                DescriptorType::Sampler => &mut counters.samplers,
+                                _ => unimplemented!()
+                            };
+                            for i in 0 .. set_binding.count {
+                                let location = msl::ResourceBindingLocation {
+                                    stage,
+                                    desc_set: set_index as _,
+                                    binding: (set_binding.binding + i) as _,
+                                };
+                                let res_binding = msl::ResourceBinding {
+                                    resource_id: *count as _,
+                                    force_used: false,
+                                };
+                                *count += 1;
+                                res_overrides.insert(location, res_binding);
+                            }
+                        }
+                    }
+                }
+                &n::DescriptorSetLayout::ArgumentBuffer(_, stage_flags) => {
+                    for &mut(stage_bit, stage, ref mut counters) in stage_infos.iter_mut() {
+                        if !stage_flags.contains(stage_bit) {
+                            continue
+                        }
+                        let location = msl::ResourceBindingLocation {
+                            stage,
+                            desc_set: set_index as _,
+                            binding: 0,
+                        };
+                        let res_binding = msl::ResourceBinding {
+                            resource_id: counters.buffers as _,
+                            force_used: false,
+                        };
+                        res_overrides.insert(location, res_binding);
+                        counters.buffers += 1;
+                    }
+                }
+            }
+        }
+
+        // TODO: return an `Err` when HAL signature of the function supports it
+        for &(_, _, ref counters) in &stage_infos {
+            assert!(counters.buffers <= self.private_caps.max_buffers_per_stage);
+            assert!(counters.textures <= self.private_caps.max_textures_per_stage);
+            assert!(counters.samplers <= self.private_caps.max_samplers_per_stage);
+        }
+
+        n::PipelineLayout {
+            attribute_buffer_index: stage_infos[0].2.buffers as _,
+            res_overrides,
+        }
+    }
 
     fn create_graphics_pipeline<'a>(
         &self,
@@ -599,186 +756,34 @@ impl Device {
             })
         }
     }
-}
 
-impl hal::Device<Backend> for Device {
-    fn create_command_pool(
-        &self, _family: QueueFamilyId, flags: CommandPoolCreateFlags
-    ) -> command::CommandPool {
-        command::CommandPool {
-            queue: self.queue.clone(),
-            managed: if flags.contains(CommandPoolCreateFlags::RESET_INDIVIDUAL) {
-                None
-            } else {
-                Some(Vec::new())
-            },
-        }
-    }
-
-    fn destroy_command_pool(&self, _pool: command::CommandPool) {
-        //TODO?
-    }
-
-    fn create_render_pass(
-        &self,
-        attachments: &[pass::Attachment],
-        _subpasses: &[pass::SubpassDesc],
-        _dependencies: &[pass::SubpassDependency],
-    ) -> n::RenderPass {
-        //TODO: subpasses, dependencies
-        let pass = metal::RenderPassDescriptor::new().to_owned();
-
-        let mut color_attachment_index = 0;
-        for attachment in attachments {
-            if let Some((_format, is_depth)) = attachment.format.and_then(map_format) {
-                let mtl_attachment: &metal::RenderPassAttachmentDescriptorRef;
-                if !is_depth {
-                    let color_attachment = pass.color_attachments().object_at(color_attachment_index).expect("too many color attachments");
-                    color_attachment_index += 1;
-
-                    mtl_attachment = color_attachment;
-                } else {
-                    let depth_attachment = pass.depth_attachment().expect("no depth attachement");
-
-                    mtl_attachment = depth_attachment;
-                }
-
-                mtl_attachment.set_load_action(map_load_operation(attachment.ops.load));
-                mtl_attachment.set_store_action(map_store_operation(attachment.ops.store));
-            }
-        }
-
-        n::RenderPass {
-            desc: pass,
-            attachments: attachments.into(),
-            num_colors: color_attachment_index,
-        }
-    }
-
-    fn create_pipeline_layout(
-        &self,
-        set_layouts: &[&n::DescriptorSetLayout],
-        _push_constant_ranges: &[(pso::ShaderStageFlags, Range<u32>)],
-    ) -> n::PipelineLayout {
-        use hal::pso::ShaderStageFlags;
-
-        struct Counters {
-            buffers: usize,
-            textures: usize,
-            samplers: usize,
-        }
-        let mut stage_infos = [
-            (ShaderStageFlags::VERTEX,   spirv::ExecutionModel::Vertex,    Counters { buffers:0, textures:0, samplers:0 }),
-            (ShaderStageFlags::FRAGMENT, spirv::ExecutionModel::Fragment,  Counters { buffers:0, textures:0, samplers:0 }),
-            (ShaderStageFlags::COMPUTE,  spirv::ExecutionModel::GlCompute, Counters { buffers:0, textures:0, samplers:0 }),
-        ];
-        let mut res_overrides = HashMap::new();
-
-        for (set_index, set_layout) in set_layouts.iter().enumerate() {
-            match set_layout {
-                &&n::DescriptorSetLayout::Emulated(ref set_bindings) => {
-                    for set_binding in set_bindings {
-                        for &mut(stage_bit, stage, ref mut counters) in stage_infos.iter_mut() {
-                            if !set_binding.stage_flags.contains(stage_bit) {
-                                continue
-                            }
-                            let count = match set_binding.ty {
-                                DescriptorType::UniformBuffer |
-                                DescriptorType::StorageBuffer => &mut counters.buffers,
-                                DescriptorType::SampledImage => &mut counters.textures,
-                                DescriptorType::StorageImage => &mut counters.textures,
-                                DescriptorType::Sampler => &mut counters.samplers,
-                                _ => unimplemented!()
-                            };
-                            for i in 0 .. set_binding.count {
-                                let location = msl::ResourceBindingLocation {
-                                    stage,
-                                    desc_set: set_index as _,
-                                    binding: (set_binding.binding + i) as _,
-                                };
-                                let res_binding = msl::ResourceBinding {
-                                    resource_id: *count as _,
-                                    force_used: false,
-                                };
-                                *count += 1;
-                                res_overrides.insert(location, res_binding);
-                            }
-                        }
-                    }
-                }
-                &&n::DescriptorSetLayout::ArgumentBuffer(_, stage_flags) => {
-                    for &mut(stage_bit, stage, ref mut counters) in stage_infos.iter_mut() {
-                        if !stage_flags.contains(stage_bit) {
-                            continue
-                        }
-                        let location = msl::ResourceBindingLocation {
-                            stage,
-                            desc_set: set_index as _,
-                            binding: 0,
-                        };
-                        let res_binding = msl::ResourceBinding {
-                            resource_id: counters.buffers as _,
-                            force_used: false,
-                        };
-                        res_overrides.insert(location, res_binding);
-                        counters.buffers += 1;
-                    }
-                }
-            }
-        }
-
-        // TODO: return an `Err` when HAL signature of the function supports it
-        for &(_, _, ref counters) in &stage_infos {
-            assert!(counters.buffers <= self.private_caps.max_buffers_per_stage);
-            assert!(counters.textures <= self.private_caps.max_textures_per_stage);
-            assert!(counters.samplers <= self.private_caps.max_samplers_per_stage);
-        }
-
-        n::PipelineLayout {
-            attribute_buffer_index: stage_infos[0].2.buffers as _,
-            res_overrides,
-        }
-    }
-
-    fn create_graphics_pipelines<'a>(
-        &self,
-        params: &[pso::GraphicsPipelineDesc<'a, Backend>],
-    ) -> Vec<Result<n::GraphicsPipeline, pso::CreationError>> {
-        params
-            .into_iter()
-            .map(|p| self.create_graphics_pipeline(p))
-            .collect()
-    }
-
-    fn create_compute_pipelines<'a>(
-        &self,
-        params: &[pso::ComputePipelineDesc<'a, Backend>],
-    ) -> Vec<Result<n::ComputePipeline, pso::CreationError>> {
-        params
-            .into_iter()
-            .map(|p| self.create_compute_pipeline(p))
-            .collect()
-    }
-
-    fn create_framebuffer(
-        &self, renderpass: &n::RenderPass, attachments: &[&n::ImageView], extent: Extent
-    ) -> Result<n::FrameBuffer, FramebufferError> {
+    fn create_framebuffer<I>(
+        &self, renderpass: &n::RenderPass, attachments: I, extent: Extent
+    ) -> Result<n::FrameBuffer, FramebufferError>
+    where
+        I: IntoIterator,
+        I::Item: Borrow<n::ImageView>
+    {
         let descriptor = unsafe {
             let desc: metal::RenderPassDescriptor = msg_send![renderpass.desc, copy];
 
             msg_send![&*desc, setRenderTargetArrayLength: extent.depth as usize];
 
-            for (i, attachment) in attachments[..renderpass.num_colors].iter().enumerate() {
+            let mut attachments = attachments.into_iter();
+            for i in 0..renderpass.num_colors {
                 let mtl_attachment = desc.color_attachments().object_at(i).expect("too many color attachments");
-                mtl_attachment.set_texture(Some(&attachment.0));
+                let attachment = attachments.next().expect("Not enough colour attachments provided");
+                mtl_attachment.set_texture(Some(&attachment.borrow().0));
             }
 
-            assert!(renderpass.num_colors + 1 >= attachments.len(),
-                "Metal does not support multiple depth attachments");
+            let depth_attachment = attachments.next();
+            if let Some(_) = attachments.next() {
+                panic!("Metal does not support multiple depth attachments")
+            }
 
-            if let Some(attachment) = attachments.get(renderpass.num_colors) {
+            if let Some(attachment) = depth_attachment {
                 let mtl_attachment = desc.depth_attachment().unwrap();
-                mtl_attachment.set_texture(Some(&attachment.0));
+                mtl_attachment.set_texture(Some(&attachment.borrow().0));
                 // TODO: stencil
             }
 
@@ -906,9 +911,11 @@ impl hal::Device<Backend> for Device {
         unsafe { n::Semaphore(n::dispatch_semaphore_create(1)) } // Returns retained
     }
 
-    fn create_descriptor_pool(
-        &self, _max_sets: usize, descriptor_ranges: &[pso::DescriptorRangeDesc]
-    ) -> n::DescriptorPool {
+    fn create_descriptor_pool<I>(&self, _max_sets: usize, descriptor_ranges: I) -> n::DescriptorPool
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorRangeDesc>,
+    {
         if !self.private_caps.argument_buffers {
             return n::DescriptorPool::Emulated;
         }
@@ -917,7 +924,8 @@ impl hal::Device<Backend> for Device {
         let mut num_textures = 0;
         let mut num_uniforms = 0;
 
-        let arguments = descriptor_ranges.iter().map(|desc| {
+        let arguments = descriptor_ranges.into_iter().map(|desc| {
+            let desc = desc.borrow();
             let offset_ref = match desc.ty {
                 DescriptorType::Sampler => &mut num_samplers,
                 DescriptorType::SampledImage => &mut num_textures,
@@ -942,15 +950,20 @@ impl hal::Device<Backend> for Device {
         }
     }
 
-    fn create_descriptor_set_layout(
-        &self, bindings: &[DescriptorSetLayoutBinding]
-    ) -> n::DescriptorSetLayout {
+    fn create_descriptor_set_layout<I>(&self, bindings: I) -> n::DescriptorSetLayout
+    where
+        I: IntoIterator,
+        I::Item: Borrow<DescriptorSetLayoutBinding>,
+    {
         if !self.private_caps.argument_buffers {
-            return n::DescriptorSetLayout::Emulated(bindings.to_vec())
+            return n::DescriptorSetLayout::Emulated(
+                bindings.into_iter().map(|desc| *desc.borrow()).collect()
+            )
         }
 
         let mut stage_flags = pso::ShaderStageFlags::empty();
-        let arguments = bindings.iter().map(|desc| {
+        let arguments = bindings.into_iter().map(|desc| {
+            let desc = desc.borrow();
             stage_flags |= desc.stage_flags;
             Self::describe_argument(desc.ty, desc.binding, desc.count)
         }).collect::<Vec<_>>();
@@ -960,7 +973,12 @@ impl hal::Device<Backend> for Device {
         n::DescriptorSetLayout::ArgumentBuffer(encoder, stage_flags)
     }
 
-    fn update_descriptor_sets<R: RangeArg<u64>>(&self, writes: &[pso::DescriptorSetWrite<Backend, R>]) {
+    fn update_descriptor_sets<'a, I, R>(&self, writes: I)
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorSetWrite<'a, 'a, Backend, R>>,
+        R: RangeArg<u64>,
+    {
         use hal::pso::DescriptorWrite::*;
 
         let mut mtl_samplers = Vec::new();
@@ -968,7 +986,8 @@ impl hal::Device<Backend> for Device {
         let mut mtl_buffers = Vec::new();
         let mut mtl_offsets = Vec::new();
 
-        for write in writes {
+        for write in writes.into_iter() {
+            let write = write.borrow();
             match *write.set {
                 n::DescriptorSet::Emulated(ref inner) => {
                     let mut set = inner.lock().unwrap();
@@ -1334,20 +1353,14 @@ impl hal::Device<Backend> for Device {
     fn create_fence(&self, signaled: bool) -> n::Fence {
         n::Fence(Arc::new(Mutex::new(signaled)))
     }
-    fn reset_fences(&self, fences: &[&n::Fence]) {
-        for fence in fences {
-            *fence.0.lock().unwrap() = false;
-        }
+    fn reset_fence(&self, fence: &n::Fence) {
+        *fence.0.lock().unwrap() = false;
     }
-    fn wait_for_fences(&self, fences: &[&n::Fence], wait: WaitFor, mut timeout_ms: u32) -> bool {
+    fn wait_for_fence(&self, fence: &n::Fence, mut timeout_ms: u32) -> bool {
         use std::{thread, time};
         let tick = 1;
         loop {
-            let done = match wait {
-                WaitFor::Any => fences.iter().any(|fence| *fence.0.lock().unwrap()),
-                WaitFor::All => fences.iter().all(|fence| *fence.0.lock().unwrap()),
-            };
-            if done {
+            if *fence.0.lock().unwrap() {
                 return true
             }
             if timeout_ms < tick {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -135,60 +135,56 @@ unsafe impl Send for DescriptorPool {}
 unsafe impl Sync for DescriptorPool {}
 
 impl hal::DescriptorPool<Backend> for DescriptorPool {
-    fn allocate_sets(&mut self, layouts: &[&DescriptorSetLayout]) -> Vec<DescriptorSet> {
+    fn allocate_set(&mut self, layout: &DescriptorSetLayout) -> DescriptorSet {
         match *self {
             DescriptorPool::Emulated => {
-                layouts.iter().map(|layout| {
-                    let layout_bindings = match layout {
-                        &&DescriptorSetLayout::Emulated(ref bindings) => bindings,
-                        _ => panic!("Incompatible descriptor set layout type"),
-                    };
+                let layout_bindings = match layout {
+                    &DescriptorSetLayout::Emulated(ref bindings) => bindings,
+                    _ => panic!("Incompatible descriptor set layout type"),
+                };
 
-                    let bindings = layout_bindings.iter().map(|layout| {
-                        let binding = match layout.ty {
-                            pso::DescriptorType::Sampler => {
-                                DescriptorSetBinding::Sampler(vec![None; layout.count])
-                            }
-                            pso::DescriptorType::SampledImage |
-                            pso::DescriptorType::StorageImage => {
-                                DescriptorSetBinding::Image(vec![None; layout.count])
-                            }
-                            pso::DescriptorType::UniformBuffer |
-                            pso::DescriptorType::StorageBuffer => {
-                                DescriptorSetBinding::Buffer(vec![None; layout.count])
-                            }
-                            pso::DescriptorType::UniformTexelBuffer |
-                            pso::DescriptorType::StorageTexelBuffer |
-                            pso::DescriptorType::InputAttachment => unimplemented!()
-                        };
-                        (layout.binding, binding)
-                    }).collect();
-
-                    let inner = DescriptorSetInner {
-                        layout: layout_bindings.to_vec(),
-                        bindings,
+                let bindings = layout_bindings.iter().map(|layout| {
+                    let binding = match layout.ty {
+                        pso::DescriptorType::Sampler => {
+                            DescriptorSetBinding::Sampler(vec![None; layout.count])
+                        }
+                        pso::DescriptorType::SampledImage |
+                        pso::DescriptorType::StorageImage => {
+                            DescriptorSetBinding::Image(vec![None; layout.count])
+                        }
+                        pso::DescriptorType::UniformBuffer |
+                        pso::DescriptorType::StorageBuffer => {
+                            DescriptorSetBinding::Buffer(vec![None; layout.count])
+                        }
+                        pso::DescriptorType::UniformTexelBuffer |
+                        pso::DescriptorType::StorageTexelBuffer |
+                        pso::DescriptorType::InputAttachment => unimplemented!()
                     };
-                    DescriptorSet::Emulated(Arc::new(Mutex::new(inner)))
-                }).collect()
+                    (layout.binding, binding)
+                }).collect();
+
+                let inner = DescriptorSetInner {
+                    layout: layout_bindings.to_vec(),
+                    bindings,
+                };
+                DescriptorSet::Emulated(Arc::new(Mutex::new(inner)))
             }
             DescriptorPool::ArgumentBuffer { ref buffer, total_size, ref mut offset } => {
-                layouts.iter().map(|layout| {
-                    let (encoder, stage_flags) = match layout {
-                        &&DescriptorSetLayout::ArgumentBuffer(ref encoder, stages) => (encoder, stages),
-                        _ => panic!("Incompatible descriptor set layout type"),
-                    };
+                let (encoder, stage_flags) = match layout {
+                    &DescriptorSetLayout::ArgumentBuffer(ref encoder, stages) => (encoder, stages),
+                    _ => panic!("Incompatible descriptor set layout type"),
+                };
 
-                    let cur_offset = *offset;
-                    *offset += encoder.encoded_length();
-                    assert!(*offset <= total_size);
+                let cur_offset = *offset;
+                *offset += encoder.encoded_length();
+                assert!(*offset <= total_size);
 
-                    DescriptorSet::ArgumentBuffer {
-                        buffer: buffer.clone(),
-                        offset: cur_offset,
-                        encoder: encoder.clone(),
-                        stage_flags,
-                    }
-                }).collect()
+                DescriptorSet::ArgumentBuffer {
+                    buffer: buffer.clone(),
+                    offset: cur_offset,
+                    encoder: encoder.clone(),
+                    stage_flags,
+                }
             }
         }
     }

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -2,6 +2,7 @@ use ash::vk;
 use ash::version::DeviceV1_0;
 use hal;
 use hal::image::SubresourceRange;
+use std::borrow::Borrow;
 use std::sync::Arc;
 use {Backend, RawDevice};
 
@@ -88,11 +89,15 @@ pub struct DescriptorPool {
 }
 
 impl hal::DescriptorPool<Backend> for DescriptorPool {
-    fn allocate_sets(&mut self, layouts: &[&DescriptorSetLayout]) -> Vec<DescriptorSet> {
+    fn allocate_sets<I>(&mut self, layouts: I) -> Vec<DescriptorSet>
+    where
+        I: IntoIterator,
+        I::Item: Borrow<DescriptorSetLayout>,
+    {
         use std::ptr;
 
-        let layouts = layouts.iter().map(|layout| {
-            layout.raw
+        let layouts = layouts.into_iter().map(|layout| {
+            layout.borrow().raw
         }).collect::<Vec<_>>();
 
         let info = vk::DescriptorSetAllocateInfo {

--- a/src/hal/src/command/compute.rs
+++ b/src/hal/src/command/compute.rs
@@ -11,7 +11,7 @@ impl<'a, B: Backend, C: Supports<Compute>, S: Shot, L: Level> CommandBuffer<'a, 
     }
 
     ///
-    pub fn bind_compute_descriptor_sets<'i, T>(
+    pub fn bind_compute_descriptor_sets<T>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -186,7 +186,7 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     ///
-    pub fn bind_graphics_descriptor_sets<'i, T>(
+    pub fn bind_graphics_descriptor_sets<T>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -301,7 +301,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     fn bind_graphics_pipeline(&mut self, &B::GraphicsPipeline);
 
     ///
-    fn bind_graphics_descriptor_sets<'a, T>(
+    fn bind_graphics_descriptor_sets<T>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,

--- a/src/hal/src/command/renderpass.rs
+++ b/src/hal/src/command/renderpass.rs
@@ -67,7 +67,7 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
     }
 
     ///
-    pub fn bind_graphics_descriptor_sets<'i, T>(
+    pub fn bind_graphics_descriptor_sets<T>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,

--- a/src/hal/src/queue/submission.rs
+++ b/src/hal/src/queue/submission.rs
@@ -50,15 +50,23 @@ impl<'a, B, C> Submission<'a, B, C>
 where
     B: Backend
 {
-    /// Set semaphores which will waited on to be signalled before the submission will be executed.
-    pub fn wait_on(mut self, semaphores: &[(&'a B::Semaphore, pso::PipelineStage)]) -> Self {
-        self.wait_semaphores.extend_from_slice(semaphores);
+    /// Add to semaphores which will waited on to be signalled before the submission will be executed.
+    pub fn wait_on<I>(mut self, semaphores: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Borrow<(&'a B::Semaphore, pso::PipelineStage)>,
+    {
+        self.wait_semaphores.extend(semaphores.into_iter().map(|semaphore| *semaphore.borrow()));
         self
     }
 
-    /// Set semaphores which will be signalled once this submission has finished executing.
-    pub fn signal(mut self, semaphores: &[&'a B::Semaphore]) -> Self {
-        self.signal_semaphores.extend_from_slice(semaphores);
+    /// Add to semaphores which will be signalled once this submission has finished executing.
+    pub fn signal<I>(mut self, semaphores: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Borrow<&'a B::Semaphore>,
+    {
+        self.signal_semaphores.extend(semaphores.into_iter().map(|semaphore| *semaphore.borrow()));
         self
     }
 

--- a/src/window/glfw/src/lib.rs
+++ b/src/window/glfw/src/lib.rs
@@ -59,8 +59,11 @@ impl<'a> core::Swapchain<device_gl::Backend> for Swapchain {
         core::Frame::new(0)
     }
 
-    fn present<Q>(&mut self, _: &mut Q, _: &[&handle::Semaphore<device_gl::Resources>])
-        where Q: AsMut<device_gl::CommandQueue>
+    fn present<'i, Q, I>(&mut self, _: &mut Q, _: I)
+    where
+        Q: AsMut<device_gl::CommandQueue>,
+        I: IntoIterator,
+        I::Item: Borrow<handle::Semaphore<device_gl::Resources>>,
     {
         self.window.borrow_mut().swap_buffers();
     }


### PR DESCRIPTION
A more debatable half of #1604, which APIs use slices and which should use iterators is more up for consideration. My implementation for the Device iterators frequently just collects them anyway which to me suggests there isn't much point (apart from some idea of API uniformity).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/1665)
<!-- Reviewable:end -->
