### PR TITLE
[pre-ll] Impl Display + Error for remaining error types

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -23,6 +23,8 @@ extern crate gfx_gl as gl;
 extern crate gfx_core as core;
 
 use std::cell::RefCell;
+use std::error::Error as StdError;
+use std::fmt;
 use std::rc::Rc;
 use core::{self as c, handle, state as s, format, pso, texture, command as com, buffer};
 use core::target::{Layer, Level};
@@ -149,6 +151,26 @@ pub enum Error {
     InvalidFramebufferOperation,
     OutOfMemory,
     UnknownError,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.description())
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::NoError => "no error",
+            Error::InvalidEnum => "invalid enum",
+            Error::InvalidValue => "invalid value",
+            Error::InvalidOperation => "invalid operation",
+            Error::InvalidFramebufferOperation => "invalid frame buffer operation",
+            Error::OutOfMemory => "out of memory",
+            Error::UnknownError => "unknown error",
+        }
+    }
 }
 
 impl Error {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -33,6 +33,8 @@ use core::memory::{Usage, Bind};
 use core::command::{AccessInfo, AccessGuard};
 
 use std::cell::RefCell;
+use std::error::Error;
+use std::fmt;
 use std::sync::Arc;
 // use std::{mem, ptr};
 
@@ -291,6 +293,20 @@ impl core::Device for Device {
 #[derive(Clone, Debug)]
 pub enum InitError {
     FeatureSet,
+}
+
+impl fmt::Display for InitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.description())
+    }
+}
+
+impl Error for InitError {
+    fn description(&self) -> &str {
+        match *self {
+            InitError::FeatureSet => "no feature set available",
+        }
+    }
 }
 
 pub fn create(format: core::format::Format,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -21,6 +21,7 @@ extern crate spirv_utils;
 
 use std::{fmt, iter, mem, ptr};
 use std::sync::{Arc, Mutex};
+use std::error::Error as StdError;
 use std::ffi::CStr;
 use shared_library::dynamic_library::DynamicLibrary;
 
@@ -285,9 +286,15 @@ pub fn create(app_name: &str, app_version: u32, layers: &[&str], extensions: &[&
 #[derive(Clone, PartialEq, Eq)]
 pub struct Error(pub vk::Result);
 
-impl fmt::Debug for Error {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(match self.0 {
+        f.write_str(self.description())
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match self.0 {
             vk::SUCCESS => "success",
             vk::NOT_READY => "not ready",
             vk::TIMEOUT => "timeout",
@@ -312,7 +319,13 @@ impl fmt::Debug for Error {
             vk::ERROR_INCOMPATIBLE_DISPLAY_KHR => "incompatible display (KHR)",
             vk::ERROR_VALIDATION_FAILED_EXT => "validation failed (EXT)",
             _ => "unknown",
-        })
+        }
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.description())
     }
 }
 

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -21,6 +21,8 @@ extern crate winit;
 extern crate gfx_core as core;
 extern crate gfx_device_dx11 as device_dx11;
 
+use std::error::Error;
+use std::fmt;
 use std::ptr;
 use winit::os::windows::WindowExt;
 use winapi::shared::{dxgi, dxgiformat, dxgitype, winerror};
@@ -100,6 +102,25 @@ pub enum InitError {
     Format(format::Format),
     /// Unable to find a supported driver type.
     DriverType,
+}
+
+impl fmt::Display for InitError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            InitError::Format(ref f) => write!(fmt, "{}: {:?}", self.description(), f),
+            _ => fmt.write_str(self.description()),
+        }
+    }
+}
+
+impl Error for InitError {
+    fn description(&self) -> &str {
+        match *self {
+            InitError::Window => "unable to create a window",
+            InitError::Format(_) => "unable to map format",
+            InitError::DriverType => "unable to find a supported driver type",
+        }
+    }
 }
 
 /// Initialize with a given size. Typed format version.

--- a/src/window/metal/src/lib.rs
+++ b/src/window/metal/src/lib.rs
@@ -14,9 +14,9 @@
 
 #[deny(missing_docs)]
 
-#[macro_use]
-extern crate log;
-#[macro_use]
+//#[macro_use]
+//extern crate log;
+//#[macro_use]
 extern crate objc;
 extern crate cocoa;
 extern crate winit;
@@ -45,6 +45,8 @@ use metal::*;
 
 use std::ops::Deref;
 use std::cell::Cell;
+use std::error::Error;
+use std::fmt;
 use std::mem;
 
 pub struct MetalWindow {
@@ -95,6 +97,27 @@ pub enum InitError {
     BackbufferFormat(Format),
     /// Unable to find a supported driver type.
     DriverType,
+}
+
+impl fmt::Display for InitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            InitError::Format(ref fm) => write!(f, "{}: {:?}", self.description(), fm),
+            InitError::BackbufferFormat(ref fm) => write!(f, "{}: {:?}", self.description(), fm),
+            _ => f.write_str(self.description()),
+        }
+    }
+}
+
+impl Error for InitError {
+    fn description(&self) -> &str {
+        match *self {
+            InitError::Window => "unable to create a window",
+            InitError::Format(_) => "unable to map format",
+            InitError::BackbufferFormat(_) => "format not allowed by the backbuffer",
+            InitError::DriverType => "unable to find a supported driver type",
+        }
+    }
 }
 
 pub fn init<C: RenderFormat>(wb: winit::WindowBuilder, events_loop: &winit::EventsLoop)

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -27,11 +27,34 @@ use core::{format, texture};
 use core::memory::Typed;
 use gfx_device_gl::Resources as R;
 
+use std::error::Error;
+use std::fmt;
+
 #[derive(Debug)]
 pub enum InitError {
     PixelFormatUnsupportedError,
     WindowBuildError(WindowBuildError),
     SdlError(String),
+}
+
+impl fmt::Display for InitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            InitError::WindowBuildError(ref e) => write!(f, "{}: {:?}", self.description(), e),
+            InitError::SdlError(ref e) => write!(f, "{}: {}", self.description(), e),
+            _ => f.write_str(self.description()),
+        }
+    }
+}
+
+impl Error for InitError {
+    fn description(&self) -> &str {
+        match *self {
+            InitError::PixelFormatUnsupportedError => "pixel format unsupported",
+            InitError::WindowBuildError(_) => "unable to build a window",
+            InitError::SdlError(_) => "SDL error",
+        }
+    }
 }
 
 impl From<String> for InitError {


### PR DESCRIPTION
This addresses #506 for the pre-ll version, by filling the gaps on missing `Error` and `Display` implementations.

In the event that this procedure is also required in the latest versions, that can be arranged as well in a separate PR.