### PR TITLE
Merge v0.16 version bumps into pre-ll

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_app"
-version = "0.7.0"
+version = "0.8.0"
 description = "GFX example application framework"
 homepage = "https://github.com/gfx-rs/gfx"
 keywords = ["graphics", "gamedev"]
@@ -32,7 +32,7 @@ gfx_corell = { path = "src/corell", version = "0.1" }
 gfx = { path = "src/render", version = "0.16" }
 gfx_macros = { path = "src/macros", version = "0.2" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.14" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.18" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.19" }
 
 [dependencies.gfx_device_vulkan]
 path = "src/backend/vulkan"
@@ -46,7 +46,7 @@ optional = true
 
 [dependencies.gfx_window_vulkan]
 path = "src/window/vulkan"
-version = "0.3"
+version = "0.4"
 optional = true
 
 [dependencies.gfx_device_metal]
@@ -77,7 +77,7 @@ gfx_window_sdl = { path = "src/window/sdl", version = "0.7" }
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.6" }
 gfx_device_dx12ll = { path = "src/backend/dx12ll", version = "0.1" }
-gfx_window_dxgi = { path = "src/window/dxgi", version = "0.9" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.11" }
 
 [[example]]
 name = "blend"
@@ -145,7 +145,7 @@ path = "examples/render_target/main.rs"
 
 [dev-dependencies]
 cgmath = "0.15"
-gfx_gl = "0.3"
+gfx_gl = "0.4"
 rand = "0.3"
 genmesh = "0.4"
 noise = "0.1"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_gl"
-version = "0.14.0"
+version = "0.14.6"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,5 +29,5 @@ name = "gfx_device_gl"
 
 [dependencies]
 log = "0.3"
-gfx_gl = "0.3.1"
-gfx_core = { path = "../../core", version = "0.7" }
+gfx_gl = "0.4"
+gfx_core = { path = "../../core", version = "0.7.2" }

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_core"
-version = "0.7.1"
+version = "0.7.2"
 description = "Core library of Gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.16.0"
+version = "0.16.2"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.9.0"
+version = "0.11.0"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.18.0"
+version = "0.19.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_window_vulkan"
-version = "0.3.0"
+version = "0.4.0"
 description = "Vulkan window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
I thought it would be helpful to merge the bumped versions from _v0.16_ into _pre-ll_ to keep track of future releases more easily. If this isn't necessary feel free to simply close this PR.