### PR TITLE
quick fix for invalid vulkan api usage (via validation layers)

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -177,8 +177,7 @@ fn main() {
     let pipeline_layout = device.create_pipeline_layout(
         &[&set_layout],
         &[
-            (pso::ShaderStageFlags::VERTEX, 0..4),
-            (pso::ShaderStageFlags::VERTEX, 4..8),
+            (pso::ShaderStageFlags::VERTEX, 0..8),
         ],
     );
 


### PR DESCRIPTION
The hal/quad demo had two vertex shader push constant ranges that the vulkan validation layers were complaining about. I combined them into one range.

ERROR:gfx_backend_vulkan: [DS] vkCreatePipelineLayout() Duplicate stage flags found in ranges 0 and 1. The spec valid usage text states 'Any two elements of pPushConstantRanges must not include the same stage in stageFlags'