### PR TITLE
Port to winapi 0.3

### DIFF
--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -19,16 +19,11 @@ name = "gfx_backend_dx12"
 
 [dependencies]
 bitflags = "1.0"
-log = "0.3"
+derivative = "1"
 gfx-hal = { path = "../../hal", version = "0.1" }
-d3d12-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-d3dcompiler-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-dxgi-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-dxguid-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-kernel32-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
+log = "0.3"
+smallvec = "0.4"
 spirv_cross = "0.4.2"
-user32-sys = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
-winapi = { git = "https://github.com/msiglreith/winapi-rs.git", branch = "gfx" }
+winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgiformat","dxgitype","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.7", optional = true }
 wio = { git = "https://github.com/msiglreith/wio-rs.git", branch = "stable" }
-smallvec = "0.4"

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -1,11 +1,15 @@
 use std::mem;
 use spirv_cross::spirv;
-use winapi::*;
+
+use winapi::shared::basetsd::UINT8;
+use winapi::shared::dxgiformat::*;
+use winapi::shared::minwindef::{FALSE, INT, TRUE};
+use winapi::um::d3d12::*;
+use winapi::um::d3dcommon::*;
 
 use hal::format::{Format, SurfaceType};
 use hal::{buffer, image, pso, Primitive};
 use hal::pso::DescriptorSetLayoutBinding;
-
 
 pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
     use hal::format::SurfaceType::*;
@@ -162,7 +166,7 @@ pub fn map_topology(primitive: Primitive) -> D3D12_PRIMITIVE_TOPOLOGY {
         TriangleStrip          => D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
         TriangleStripAdjacency => D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
         PatchList(num) => { assert!(num != 0);
-            D3D_PRIMITIVE_TOPOLOGY(D3D_PRIMITIVE_TOPOLOGY_1_CONTROL_POINT_PATCHLIST.0 + (num as u32) - 1)
+            D3D_PRIMITIVE_TOPOLOGY_1_CONTROL_POINT_PATCHLIST + (num as u32) - 1
         },
     }
 }

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -1,38 +1,38 @@
 use wio::com::ComPtr;
-use dxguid;
 use std::ptr;
-use std::os::raw::c_void;
-use winapi;
+
+use winapi::um::d3d12;
+use winapi::shared::winerror::SUCCEEDED;
 
 use hal::pool;
 use command::CommandBuffer;
 use {Backend, CmdSignatures};
 
 pub struct RawCommandPool {
-    pub(crate) inner: ComPtr<winapi::ID3D12CommandAllocator>,
-    pub(crate) device: ComPtr<winapi::ID3D12Device>,
-    pub(crate) list_type: winapi::D3D12_COMMAND_LIST_TYPE,
+    pub(crate) inner: ComPtr<d3d12::ID3D12CommandAllocator>,
+    pub(crate) device: ComPtr<d3d12::ID3D12Device>,
+    pub(crate) list_type: d3d12::D3D12_COMMAND_LIST_TYPE,
     pub(crate) signatures: CmdSignatures,
 }
 
 impl RawCommandPool {
-    fn create_command_list(&mut self) -> ComPtr<winapi::ID3D12GraphicsCommandList> {
+    fn create_command_list(&mut self) -> ComPtr<d3d12::ID3D12GraphicsCommandList> {
         // allocate command lists
-        let mut command_list = {
-            let mut command_list: *mut winapi::ID3D12GraphicsCommandList = ptr::null_mut();
+        let command_list = {
+            let mut command_list: *mut d3d12::ID3D12GraphicsCommandList = ptr::null_mut();
             let hr = unsafe {
                 self.device.CreateCommandList(
                     0, // single gpu only atm
                     self.list_type,
                     self.inner.as_mut() as *mut _,
                     ptr::null_mut(),
-                    &dxguid::IID_ID3D12GraphicsCommandList,
-                    &mut command_list as *mut *mut _ as *mut *mut c_void,
+                    &d3d12::IID_ID3D12GraphicsCommandList,
+                    &mut command_list as *mut *mut _ as *mut *mut _,
                 )
             };
 
             // TODO: error handling
-            if !winapi::SUCCEEDED(hr) {
+            if !SUCCEEDED(hr) {
                 error!("error on command list creation: {:x}", hr);
             }
 

--- a/src/backend/dx12/src/shade.rs
+++ b/src/backend/dx12/src/shade.rs
@@ -1,20 +1,20 @@
+use winapi::um::{d3d12, d3dcompiler, d3d12shader, winnt};
+use winapi::shared::winerror::SUCCEEDED;
+use winapi::shared::minwindef::UINT;
 use wio::com::ComPtr;
-use d3dcompiler;
-use dxguid;
-use winapi;
 
 use std::{mem, ptr};
 
-pub fn reflect_shader(code: &winapi::D3D12_SHADER_BYTECODE) -> ComPtr<winapi::ID3D12ShaderReflection> {
+pub fn reflect_shader(code: &d3d12::D3D12_SHADER_BYTECODE) -> ComPtr<d3d12shader::ID3D12ShaderReflection> {
     let mut reflection = ptr::null_mut();
     let hr = unsafe {
         d3dcompiler::D3DReflect(
             code.pShaderBytecode,
             code.BytecodeLength,
-            &dxguid::IID_ID3D12ShaderReflection,
-            &mut reflection as *mut *mut _ as *mut *mut winapi::c_void)
+            &d3d12shader::IID_ID3D12ShaderReflection,
+            &mut reflection as *mut *mut _ as *mut *mut _)
     };
-    if !winapi::SUCCEEDED(hr) {
+    if !SUCCEEDED(hr) {
         panic!("Shader reflection failed with code {:x}", hr);
     }
 
@@ -23,13 +23,13 @@ pub fn reflect_shader(code: &winapi::D3D12_SHADER_BYTECODE) -> ComPtr<winapi::ID
 
 #[derive(Debug)]
 pub struct InputElemDesc {
-    pub semantic_name: winapi::LPCSTR,
-    pub semantic_index: winapi::UINT,
-    pub input_slot: winapi::UINT,
+    pub semantic_name: winnt::LPCSTR,
+    pub semantic_index: UINT,
+    pub input_slot: UINT,
 }
 
 pub fn reflect_input_elements(
-    vertex_reflection: &mut ComPtr<winapi::ID3D12ShaderReflection>
+    vertex_reflection: &mut ComPtr<d3d12shader::ID3D12ShaderReflection>
 ) -> Vec<InputElemDesc> {
     let shader_desc = unsafe {
         let mut desc = mem::zeroed();

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -3,7 +3,10 @@ use std::mem;
 
 #[cfg(feature = "winit")]
 use winit;
-use winapi;
+
+use winapi::shared::dxgi1_4;
+use winapi::shared::windef::{HWND, RECT};
+use winapi::um::winuser::GetClientRect;
 use wio::com::ComPtr;
 
 use hal::{self, format as f, image as i};
@@ -14,8 +17,6 @@ use std::os::raw::c_void;
 impl Instance {
     pub fn create_surface_from_hwnd(&self, hwnd: *mut c_void) -> Surface {
         let (width, height) = unsafe {
-            use winapi::RECT;
-            use user32::GetClientRect;
             let mut rect: RECT = mem::zeroed();
             if GetClientRect(hwnd as *mut _, &mut rect as *mut RECT) == 0 {
                 panic!("GetClientRect failed");
@@ -39,8 +40,8 @@ impl Instance {
 }
 
 pub struct Surface {
-    pub(crate) factory: ComPtr<winapi::IDXGIFactory4>,
-    pub(crate) wnd_handle: winapi::HWND,
+    pub(crate) factory: ComPtr<dxgi1_4::IDXGIFactory4>,
+    pub(crate) wnd_handle: HWND,
     pub(crate) width: u32,
     pub(crate) height: u32,
 }
@@ -87,7 +88,7 @@ impl hal::Surface<Backend> for Surface {
 }
 
 pub struct Swapchain {
-    pub(crate) inner: ComPtr<winapi::IDXGISwapChain3>,
+    pub(crate) inner: ComPtr<dxgi1_4::IDXGISwapChain3>,
     pub(crate) next_frame: usize,
     pub(crate) frame_queue: VecDeque<usize>,
     #[allow(dead_code)]


### PR DESCRIPTION
Worked around the lacking `Debug` derives using `derivative` crates and ignore the relevant winapi structs.
Most work was finding the relevant new type locations, shouldn't include any semantic changes.