### PR TITLE
Remove stride parameter on buffer creation

### DIFF
--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -165,7 +165,7 @@ fn main() {
 }
 
 fn create_buffer<B: Backend>(gpu: &mut Gpu<B>, properties: memory::Properties, usage: buffer::Usage, stride: u64, len: u64) -> (B::Memory, B::Buffer) {
-    let buffer = gpu.device.create_buffer(stride * len, stride, usage).unwrap();
+    let buffer = gpu.device.create_buffer(stride * len, usage).unwrap();
     let requirements = gpu.device.get_buffer_requirements(&buffer);
 
     let ty = (&gpu.memory_types).into_iter().find(|memory_type| {

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -341,7 +341,7 @@ fn main() {
     let buffer_stride = std::mem::size_of::<Vertex>() as u64;
     let buffer_len = QUAD.len() as u64 * buffer_stride;
 
-    let buffer_unbound = device.create_buffer(buffer_len, buffer_stride, buffer::Usage::VERTEX).unwrap();
+    let buffer_unbound = device.create_buffer(buffer_len, buffer::Usage::VERTEX).unwrap();
     println!("{:?}", buffer_unbound);
     let buffer_req = device.get_buffer_requirements(&buffer_unbound);
 
@@ -375,7 +375,7 @@ fn main() {
     let upload_size = (height * row_pitch) as u64;
     println!("upload row pitch {}, total size {}", row_pitch, upload_size);
 
-    let image_buffer_unbound = device.create_buffer(upload_size, image_stride as u64, buffer::Usage::TRANSFER_SRC).unwrap();
+    let image_buffer_unbound = device.create_buffer(upload_size, buffer::Usage::TRANSFER_SRC).unwrap();
     let image_mem_reqs = device.get_buffer_requirements(&image_buffer_unbound);
     let image_upload_memory = device.allocate_memory(upload_type, image_mem_reqs.size).unwrap();
     let image_upload_buffer = device.bind_buffer_memory(&image_upload_memory, 0, image_buffer_unbound).unwrap();

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -39,6 +39,10 @@ pub(crate) struct HeapProperties {
     pub memory_pool: d3d12::D3D12_MEMORY_POOL,
 }
 
+// https://msdn.microsoft.com/de-de/library/windows/desktop/dn770377(v=vs.85).aspx
+// Only 16 input slots allowed.
+const MAX_VERTEX_BUFFERS: usize = 16;
+
 // https://msdn.microsoft.com/de-de/library/windows/desktop/dn788678(v=vs.85).aspx
 static HEAPS_NUMA: &'static [HeapProperties] = &[
     // DEFAULT

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -1,10 +1,10 @@
-use winapi::shared::minwindef::{UINT};
+use winapi::shared::minwindef::UINT;
 use winapi::shared::dxgiformat::DXGI_FORMAT;
 use winapi::um::{d3d12, d3dcommon};
 use wio::com::ComPtr;
 
 use hal::{image, pass, pso, MemoryType, DescriptorPool as HalDescriptorPool};
-use {free_list, Backend};
+use {free_list, Backend, MAX_VERTEX_BUFFERS};
 use root_constants::RootConstant;
 
 use std::collections::BTreeMap;
@@ -86,6 +86,7 @@ pub struct GraphicsPipeline {
     pub(crate) num_parameter_slots: usize, // signature parameter slots, see `PipelineLayout`
     pub(crate) topology: d3d12::D3D12_PRIMITIVE_TOPOLOGY,
     pub(crate) constants: Vec<RootConstant>,
+    pub(crate) vertex_strides: [UINT; MAX_VERTEX_BUFFERS],
 }
 unsafe impl Send for GraphicsPipeline { }
 unsafe impl Sync for GraphicsPipeline { }
@@ -135,7 +136,6 @@ pub struct Framebuffer {
 pub struct Buffer {
     pub(crate) resource: *mut d3d12::ID3D12Resource,
     pub(crate) size_in_bytes: u32,
-    pub(crate) stride: u32,
     pub(crate) clear_uav: Option<DualHandle>,
 }
 unsafe impl Send for Buffer { }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -129,7 +129,7 @@ impl hal::Device<Backend> for Device {
     fn create_sampler(&self, _: image::SamplerInfo) -> () {
         unimplemented!()
     }
-    fn create_buffer(&self, _: u64, _: u64, _: buffer::Usage) -> Result<(), buffer::CreationError> {
+    fn create_buffer(&self, _: u64, _: buffer::Usage) -> Result<(), buffer::CreationError> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -413,7 +413,7 @@ impl d::Device<B> for Device {
     }
 
     fn create_buffer(
-        &self, size: u64, stride: u64, usage: buffer::Usage,
+        &self, size: u64, usage: buffer::Usage,
     ) -> Result<UnboundBuffer, buffer::CreationError> {
         if !self.share.features.constant_buffer && usage.contains(buffer::Usage::UNIFORM) {
             error!("Constant buffers are not supported by this GL version");
@@ -440,7 +440,7 @@ impl d::Device<B> for Device {
             target,
             requirements: memory::Requirements {
                 size,
-                alignment: stride,
+                alignment: 1, // TODO: do we need specific alignment for any use-case?
                 type_mask: 0x7,
             },
         })

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1003,7 +1003,7 @@ impl hal::Device<Backend> for Device {
     }
 
     fn create_buffer(
-        &self, size: u64, _stride: u64, _usage: buffer::Usage
+        &self, size: u64, _usage: buffer::Usage
     ) -> Result<n::UnboundBuffer, buffer::CreationError> {
         Ok(n::UnboundBuffer {
             size

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -784,7 +784,7 @@ impl d::Device<B> for Device {
     }
 
     ///
-    fn create_buffer(&self, size: u64, _stride: u64, usage: buffer::Usage) -> Result<UnboundBuffer, buffer::CreationError> {
+    fn create_buffer(&self, size: u64, usage: buffer::Usage) -> Result<UnboundBuffer, buffer::CreationError> {
         let info = vk::BufferCreateInfo {
             s_type: vk::StructureType::BufferCreateInfo,
             p_next: ptr::null(),

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -226,7 +226,7 @@ pub trait Device<B: Backend> {
     ///
     /// The created buffer won't have associated memory until `bind_buffer_memory` is called.
     fn create_buffer(
-        &self, size: u64, stride: u64, buffer::Usage,
+        &self, size: u64, buffer::Usage,
     ) -> Result<B::UnboundBuffer, buffer::CreationError>;
 
     ///

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -118,7 +118,7 @@ impl<B: Backend> Device<B> {
     ) -> Result<(handle::raw::Buffer<B>, InitToken<B>), buffer::CreationError>
         where A: Allocator<B>
     {
-        let buffer = self.raw.create_buffer(size, stride, usage)?;
+        let buffer = self.raw.create_buffer(size, usage)?;
         let (buffer, memory) = allocator.allocate_buffer(self, usage, buffer);
         let info = buffer::Info::new(usage, memory, size, stride);
         let handle = handle::raw::Buffer::from(

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -190,7 +190,7 @@ impl<B: hal::Backend> Scene<B> {
                             let row_pitch = align(width_bytes, limits.min_buffer_copy_pitch_alignment);
                             let upload_size = row_pitch as u64 * h as u64 * d as u64;
                             // create upload buffer
-                            let unbound_buffer = device.create_buffer(upload_size, bits.total as _, buffer::Usage::TRANSFER_SRC)
+                            let unbound_buffer = device.create_buffer(upload_size, buffer::Usage::TRANSFER_SRC)
                                 .unwrap();
                             let upload_req = device.get_buffer_requirements(&unbound_buffer);
                             assert_ne!(upload_req.type_mask & (1<<upload_type.id), 0);
@@ -509,7 +509,7 @@ impl<B: hal::Backend> Scene<B> {
         let row_pitch = align(width_bytes, limits.min_buffer_copy_pitch_alignment);
         let down_size = row_pitch as u64 * height as u64 * depth as u64;
 
-        let unbound_buffer = self.device.create_buffer(down_size, bpp as _, buffer::Usage::TRANSFER_DST)
+        let unbound_buffer = self.device.create_buffer(down_size, buffer::Usage::TRANSFER_DST)
             .unwrap();
         let down_req = self.device.get_buffer_requirements(&unbound_buffer);
         assert_ne!(down_req.type_mask & (1<<self.download_type.id), 0);


### PR DESCRIPTION
Stride was only needed for dx12 to use it for vertex buffer binding. The PSO stride and the stride on buffer creation needed to be equal, causing issues on the user side. Caching the vertex buffers and use the strides from the active PSO fixes this. Also, helps for better vulkan portability.