### PR TITLE
Allow device information acquisition on physical devices

### DIFF
--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -15,7 +15,10 @@ extern crate gfx_backend_metal as back;
 use std::str::FromStr;
 use std::ops::Range;
 
-use hal::{Backend, Compute, Gpu, Device, DescriptorPool, Instance, QueueFamily, QueueGroup};
+use hal::{
+    Backend, Compute, Gpu, Device, DescriptorPool, Instance,
+    PhysicalDevice, QueueFamily, QueueGroup,
+};
 use hal::{queue, pso, memory, buffer, pool, command, device};
 
 #[cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]

--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -33,12 +33,15 @@ fn main() {
     #[cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]
     let instance = back::Instance::create("gfx-rs compute", 1);
 
-    let mut gpu = instance.enumerate_adapters().into_iter()
+    let adapter = instance.enumerate_adapters().into_iter()
         .find(|a| a.queue_families
             .iter()
             .any(|family| family.supports_compute())
         )
-        .expect("Failed to find a GPU with compute support!")
+        .expect("Failed to find a GPU with compute support!");
+
+    let memory_properties = adapter.physical_device.memory_properties();
+    let mut gpu = adapter
         .open_with(|family| {
             if family.supports_compute() {
                 Some(1)
@@ -83,6 +86,7 @@ fn main() {
 
     let (staging_memory, staging_buffer) = create_buffer(
         &mut gpu,
+        &memory_properties.memory_types,
         memory::Properties::CPU_VISIBLE | memory::Properties::COHERENT,
         buffer::Usage::TRANSFER_SRC,
         stride,
@@ -97,6 +101,7 @@ fn main() {
 
     let (device_memory, device_buffer) = create_buffer(
         &mut gpu,
+        &memory_properties.memory_types,
         memory::Properties::DEVICE_LOCAL,
         buffer::Usage::TRANSFER_DST,
         stride,
@@ -164,11 +169,18 @@ fn main() {
     gpu.device.destroy_compute_pipeline(pipeline);
 }
 
-fn create_buffer<B: Backend>(gpu: &mut Gpu<B>, properties: memory::Properties, usage: buffer::Usage, stride: u64, len: u64) -> (B::Memory, B::Buffer) {
+fn create_buffer<B: Backend>(
+    gpu: &mut Gpu<B>,
+    memory_types: &[hal::MemoryType],
+    properties: memory::Properties,
+    usage: buffer::Usage,
+    stride: u64,
+    len: u64,
+) -> (B::Memory, B::Buffer) {
     let buffer = gpu.device.create_buffer(stride * len, usage).unwrap();
     let requirements = gpu.device.get_buffer_requirements(&buffer);
 
-    let ty = (&gpu.memory_types).into_iter().find(|memory_type| {
+    let ty = memory_types.into_iter().find(|memory_type| {
         requirements.type_mask & (1 << memory_type.id) != 0 &&
         memory_type.properties.contains(properties)
     }).unwrap();

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -18,7 +18,7 @@ extern crate winit;
 extern crate image;
 
 use hal::{buffer, command, device as d, image as i, memory as m, pass, pso, pool};
-use hal::{Device, Instance, QueueFamily, Surface, Swapchain};
+use hal::{Device, Instance, PhysicalDevice, QueueFamily, Surface, Swapchain};
 use hal::{
     DescriptorPool, Gpu, FrameSync, Primitive,
     Backbuffer, SwapchainConfig,
@@ -112,8 +112,16 @@ fn main() {
         .find(|format| format.1 == ChannelType::Srgb)
         .unwrap();
 
+    let memory_types = adapter
+        .physical_device
+        .memory_properties()
+        .memory_types;
+    let limits = adapter
+        .physical_device
+        .get_limits();
+
     // Build a new device and associated command queues
-    let Gpu { device, mut queue_groups, memory_types, .. } =
+    let Gpu { device, mut queue_groups } =
         adapter.open_with(|family| {
             if family.supports_graphics() && surface.supports_queue_family(family) {
                 Some(1)
@@ -369,7 +377,7 @@ fn main() {
     let img = image::load(Cursor::new(&img_data[..]), image::PNG).unwrap().to_rgba();
     let (width, height) = img.dimensions();
     let kind = i::Kind::D2(width as i::Size, height as i::Size, i::AaMode::Single);
-    let row_alignment_mask = device.get_limits().min_buffer_copy_pitch_alignment as u32 - 1;
+    let row_alignment_mask = limits.min_buffer_copy_pitch_alignment as u32 - 1;
     let image_stride = 4usize;
     let row_pitch = (width * image_stride as u32 + row_alignment_mask) & !row_alignment_mask;
     let upload_size = (height * row_pitch) as u64;

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -10,7 +10,7 @@ use winapi::shared::{dxgi, dxgi1_2, dxgi1_4, dxgiformat, dxgitype, winerror};
 use wio::com::ComPtr;
 
 use hal::{self, buffer, device as d, format, image, mapping, memory, pass, pso, query};
-use hal::{Features, Limits, MemoryType};
+use hal::{MemoryType};
 use hal::memory::Requirements;
 use hal::pool::CommandPoolCreateFlags;
 
@@ -631,9 +631,6 @@ impl Device {
 }
 
 impl d::Device<B> for Device {
-    fn get_features(&self) -> &Features { &self.features }
-    fn get_limits(&self) -> &Limits { &self.limits }
-
     fn allocate_memory(
         &self,
         mem_type: &MemoryType,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -140,17 +140,21 @@ impl QueueFamily {
 pub struct PhysicalDevice {
     adapter: ComPtr<dxgi1_2::IDXGIAdapter2>,
     factory: ComPtr<dxgi1_4::IDXGIFactory4>,
+    features: hal::Features,
+    limits: hal::Limits,
+    private_caps: Capabilities,
+    heap_properties: &'static [HeapProperties],
+    memory_properties: hal::MemoryProperties,
 }
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(self, families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>) -> hal::Gpu<Backend> {
-        use self::memory::Properties;
         // Create D3D12 device
         let mut device_raw = ptr::null_mut();
         let hr = unsafe {
             d3d12::D3D12CreateDevice(
                 self.adapter.as_mut() as *mut _ as *mut _,
-                d3dcommon::D3D_FEATURE_LEVEL_12_0, // TODO: correct feature level?
+                d3dcommon::D3D_FEATURE_LEVEL_11_0, // Minimum required feature level
                 &d3d12::IID_ID3D12Device,
                 &mut device_raw as *mut *mut _ as *mut *mut _,
             )
@@ -158,21 +162,10 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         if !winerror::SUCCEEDED(hr) {
             error!("error on device creation: {:x}", hr);
         }
-        let mut device = Device::new(unsafe { ComPtr::new(device_raw) });
-
-        // Get the IDXGIAdapter3 from the created device to query video memory information.
-        let adapter_id = unsafe { device.raw.GetAdapterLuid() };
-        let adapter = {
-            let mut adapter: *mut dxgi1_4::IDXGIAdapter3 = ptr::null_mut();
-            unsafe {
-                assert_eq!(winerror::S_OK, self.factory.as_mut().EnumAdapterByLuid(
-                    adapter_id,
-                    &dxgi1_4::IID_IDXGIAdapter3,
-                    &mut adapter as *mut *mut _ as *mut *mut _,
-                ));
-                ComPtr::new(adapter)
-            }
-        };
+        let mut device = Device::new(
+            unsafe { ComPtr::new(device_raw) },
+            &self,
+        );
 
         // Always create the presentation queue in case we want to build a swapchain.
         let mut present_queue = {
@@ -252,122 +245,22 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             mem::forget(present_queue);
         }
 
-        // https://msdn.microsoft.com/en-us/library/windows/desktop/dn788678(v=vs.85).aspx
-        let base_memory_types = match device.private_caps.memory_architecture {
-            MemoryArchitecture::NUMA => [
-                // DEFAULT
-                hal::MemoryType {
-                    id: 0,
-                    properties: Properties::DEVICE_LOCAL,
-                    heap_index: 0,
-                },
-                // UPLOAD
-                hal::MemoryType {
-                    id: 1,
-                    properties: Properties::CPU_VISIBLE | Properties::COHERENT,
-                    heap_index: 1,
-                },
-                // READBACK
-                hal::MemoryType {
-                    id: 2,
-                    properties: Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
-                    heap_index: 1,
-                },
-            ],
-            MemoryArchitecture::UMA => [
-                // DEFAULT
-                hal::MemoryType {
-                    id: 0,
-                    properties: Properties::DEVICE_LOCAL,
-                    heap_index: 0,
-                },
-                // UPLOAD
-                hal::MemoryType {
-                    id: 1,
-                    properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT,
-                    heap_index: 0,
-                },
-                // READBACK
-                hal::MemoryType {
-                    id: 2,
-                    properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
-                    heap_index: 0,
-                },
-            ],
-            MemoryArchitecture::CacheCoherentUMA => [
-                // DEFAULT
-                hal::MemoryType {
-                    id: 0,
-                    properties: Properties::DEVICE_LOCAL,
-                    heap_index: 0,
-                },
-                // UPLOAD
-                hal::MemoryType {
-                    id: 1,
-                    properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
-                    heap_index: 0,
-                },
-                // READBACK
-                hal::MemoryType {
-                    id: 2,
-                    properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
-                    heap_index: 0,
-                },
-            ],
-        };
-
-        let memory_types = if device.private_caps.heterogeneous_resource_heaps {
-            base_memory_types.to_vec()
-        } else {
-            // the bit pattern of ID becomes 0bTTII, where
-            // TT=1 for buffers, TT=2 for images, and TT=3 for targets
-            // TT=0 is reserved for future use, helps to avoid ambiguity
-            // and II is the same `id` as the `base_memory_types` have
-            let mut types = Vec::new();
-            for &tt in &[1, 2, 3] {
-                types.extend(base_memory_types
-                    .iter()
-                    .map(|&mt| hal::MemoryType {
-                        id: mt.id + (tt << 2),
-                        .. mt
-                    })
-                );
-            }
-            types
-        };
-
-        let memory_heaps = {
-            let query_memory = |segment: dxgi1_4::DXGI_MEMORY_SEGMENT_GROUP| unsafe {
-                let mut mem_info: dxgi1_4::DXGI_QUERY_VIDEO_MEMORY_INFO = mem::uninitialized();
-                assert_eq!(winerror::S_OK, adapter.QueryVideoMemoryInfo(
-                    0,
-                    segment,
-                    &mut mem_info,
-                ));
-                mem_info.Budget
-            };
-
-            let local = query_memory(dxgi1_4::DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
-            match device.private_caps.memory_architecture {
-                MemoryArchitecture::NUMA => {
-                    let non_local = query_memory(dxgi1_4::DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
-                    vec![local, non_local]
-                },
-                _ => vec![local],
-            }
-        };
-
         hal::Gpu {
             device,
             queue_groups,
-            memory_types,
-            memory_heaps,
         }
     }
 
     fn format_properties(&self, _: format::Format) -> format::Properties {
         unimplemented!()
     }
+
+    fn memory_properties(&self) -> hal::MemoryProperties {
+        self.memory_properties.clone()
+    }
+
+    fn get_features(&self) -> Features { self.features }
+    fn get_limits(&self) -> Limits { self.limits }
 }
 
 pub struct CommandQueue {
@@ -397,14 +290,14 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 enum MemoryArchitecture {
     NUMA,
     UMA,
     CacheCoherentUMA,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Capabilities {
     heterogeneous_resource_heaps: bool,
     memory_architecture: MemoryArchitecture,
@@ -419,8 +312,6 @@ struct CmdSignatures {
 
 pub struct Device {
     raw: ComPtr<d3d12::ID3D12Device>,
-    features: hal::Features,
-    limits: hal::Limits,
     private_caps: Capabilities,
     heap_properties: &'static [HeapProperties],
     // CPU only pools
@@ -442,21 +333,7 @@ unsafe impl Send for Device {} //blocked by ComPtr
 unsafe impl Sync for Device {} //blocked by ComPtr
 
 impl Device {
-    fn new(mut device: ComPtr<d3d12::ID3D12Device>) -> Self {
-        let mut features: d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS = unsafe { mem::zeroed() };
-        assert_eq!(winerror::S_OK, unsafe {
-            device.CheckFeatureSupport(d3d12::D3D12_FEATURE_D3D12_OPTIONS,
-                &mut features as *mut _ as *mut _,
-                mem::size_of::<d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS>() as _)
-        });
-
-        let mut features_architecture: d3d12::D3D12_FEATURE_DATA_ARCHITECTURE = unsafe { mem::zeroed() };
-        assert_eq!(winerror::S_OK, unsafe {
-            device.CheckFeatureSupport(d3d12::D3D12_FEATURE_ARCHITECTURE,
-                &mut features_architecture as *mut _ as *mut _,
-                mem::size_of::<d3d12::D3D12_FEATURE_DATA_ARCHITECTURE>() as _)
-        });
-
+    fn new(mut device: ComPtr<d3d12::ID3D12Device>, physical_device: &PhysicalDevice) -> Self {
         // Allocate descriptor heaps
         let max_rtvs = 256; // TODO
         let rtv_pool = native::DescriptorCpuPool {
@@ -537,15 +414,6 @@ impl Device {
             max_samplers,
         );
 
-        let uma = features_architecture.UMA == TRUE;
-        let cc_uma = features_architecture.CacheCoherentUMA == TRUE;
-
-        let (memory_architecture, heap_properties) = match (uma, cc_uma) {
-            (true, true)  => (MemoryArchitecture::CacheCoherentUMA, HEAPS_CCUMA),
-            (true, false) => (MemoryArchitecture::UMA, HEAPS_UMA),
-            (false, _)            => (MemoryArchitecture::NUMA, HEAPS_NUMA),
-        };
-
         let draw_signature = Self::create_command_signature(
             &mut device,
             device::CommandSignature::Draw,
@@ -563,51 +431,8 @@ impl Device {
 
         Device {
             raw: device,
-            features: Features { // TODO
-                indirect_execution: true,
-                draw_instanced: true,
-                draw_instanced_base: true,
-                draw_indexed_base: true,
-                draw_indexed_instanced: true,
-                draw_indexed_instanced_base_vertex: true,
-                draw_indexed_instanced_base: true,
-                instance_rate: false,
-                vertex_base: false,
-                srgb_color: false,
-                constant_buffer: false,
-                unordered_access_view: false,
-                separate_blending_slots: false,
-                copy_buffer: false,
-                sampler_anisotropy: false,
-                sampler_border_color: false,
-                sampler_lod_bias: false,
-                sampler_objects: false,
-                precise_occlusion_query: true,
-                pipeline_statistics_query: true,
-            },
-            limits: Limits { // TODO
-                max_texture_size: 0,
-                max_patch_size: 0,
-                max_viewports: 0,
-                max_compute_group_count: [
-                    d3d12::D3D12_CS_THREAD_GROUP_MAX_X  as _,
-                    d3d12::D3D12_CS_THREAD_GROUP_MAX_Y  as _,
-                    d3d12::D3D12_CS_THREAD_GROUP_MAX_Z  as _,
-                ],
-                max_compute_group_size: [
-                    d3d12::D3D12_CS_THREAD_GROUP_MAX_THREADS_PER_GROUP as _,
-                    1, //TODO
-                    1, //TODO
-                ],
-                min_buffer_copy_offset_alignment: d3d12::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as _,
-                min_buffer_copy_pitch_alignment: d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as _,
-                min_uniform_buffer_offset_alignment: 256, // Required alignment for CBVs
-            },
-            private_caps: Capabilities {
-                heterogeneous_resource_heaps: features.ResourceHeapTier != d3d12::D3D12_RESOURCE_HEAP_TIER_1,
-                memory_architecture,
-            },
-            heap_properties,
+            private_caps: physical_device.private_caps,
+            heap_properties: physical_device.heap_properties,
             rtv_pool: Mutex::new(rtv_pool),
             dsv_pool: Mutex::new(dsv_pool),
             srv_pool: Mutex::new(srv_pool),
@@ -673,6 +498,8 @@ impl hal::Instance for Instance {
     type Backend = Backend;
 
     fn enumerate_adapters(&self) -> Vec<hal::Adapter<Backend>> {
+        use self::memory::Properties;
+
         // Enumerate adapters
         let mut cur_index = 0;
         let mut adapters = Vec::new();
@@ -692,55 +519,255 @@ impl hal::Instance for Instance {
                 unsafe { ComPtr::new(adapter as *mut dxgi1_2::IDXGIAdapter2) }
             };
 
+            cur_index += 1;
+
             // Check for D3D12 support
-            let hr = unsafe {
-                d3d12::D3D12CreateDevice(
-                    adapter.as_mut() as *mut _ as *mut _,
-                    d3dcommon::D3D_FEATURE_LEVEL_11_0, // TODO: correct feature level?
-                    &d3d12::IID_ID3D12Device,
-                    ptr::null_mut(),
-                )
+            // Create temporaty device to get physical device information
+            let device = {
+                let mut device = ptr::null_mut();
+                let hr = unsafe {
+                    d3d12::D3D12CreateDevice(
+                        adapter.as_mut() as *mut _ as *mut _,
+                        d3dcommon::D3D_FEATURE_LEVEL_11_0,
+                        &d3d12::IID_ID3D12Device,
+                        &mut device as *mut *mut _ as *mut *mut _,
+                    )
+                };
+                if !winerror::SUCCEEDED(hr) {
+                    continue;
+                }
+
+                unsafe { ComPtr::<d3d12::ID3D12Device>::new(device) }
             };
 
-            if winerror::SUCCEEDED(hr) {
-                // We have found a possible adapter
-                // acquire the device information
-                let mut desc: dxgi1_2::DXGI_ADAPTER_DESC2 = unsafe { std::mem::uninitialized() };
-                unsafe { adapter.GetDesc2(&mut desc); }
+            // We have found a possible adapter
+            // acquire the device information
+            let mut desc: dxgi1_2::DXGI_ADAPTER_DESC2 = unsafe { std::mem::uninitialized() };
+            unsafe { adapter.GetDesc2(&mut desc); }
 
-                let device_name = {
-                    let len = desc.Description.iter().take_while(|&&c| c != 0).count();
-                    let name = <OsString as OsStringExt>::from_wide(&desc.Description[..len]);
-                    name.to_string_lossy().into_owned()
+            let device_name = {
+                let len = desc.Description.iter().take_while(|&&c| c != 0).count();
+                let name = <OsString as OsStringExt>::from_wide(&desc.Description[..len]);
+                name.to_string_lossy().into_owned()
+            };
+
+            let info = hal::AdapterInfo {
+                name: device_name,
+                vendor: desc.VendorId as usize,
+                device: desc.DeviceId as usize,
+                software_rendering: false, // TODO: check for WARP adapter (software rasterizer)?
+            };
+
+            let mut features: d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS = unsafe { mem::zeroed() };
+            assert_eq!(winerror::S_OK, unsafe {
+                device.CheckFeatureSupport(d3d12::D3D12_FEATURE_D3D12_OPTIONS,
+                    &mut features as *mut _ as *mut _,
+                    mem::size_of::<d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS>() as _)
+            });
+
+            let mut features_architecture: d3d12::D3D12_FEATURE_DATA_ARCHITECTURE = unsafe { mem::zeroed() };
+            assert_eq!(winerror::S_OK, unsafe {
+                device.CheckFeatureSupport(d3d12::D3D12_FEATURE_ARCHITECTURE,
+                    &mut features_architecture as *mut _ as *mut _,
+                    mem::size_of::<d3d12::D3D12_FEATURE_DATA_ARCHITECTURE>() as _)
+            });
+
+            let heterogeneous_resource_heaps = features.ResourceHeapTier != d3d12::D3D12_RESOURCE_HEAP_TIER_1;
+
+            let uma = features_architecture.UMA == TRUE;
+            let cc_uma = features_architecture.CacheCoherentUMA == TRUE;
+
+            let (memory_architecture, heap_properties) = match (uma, cc_uma) {
+                (true, true)  => (MemoryArchitecture::CacheCoherentUMA, HEAPS_CCUMA),
+                (true, false) => (MemoryArchitecture::UMA, HEAPS_UMA),
+                (false, _)    => (MemoryArchitecture::NUMA, HEAPS_NUMA),
+            };
+
+            // https://msdn.microsoft.com/en-us/library/windows/desktop/dn788678(v=vs.85).aspx
+            let base_memory_types = match memory_architecture {
+                MemoryArchitecture::NUMA => [
+                    // DEFAULT
+                    hal::MemoryType {
+                        id: 0,
+                        properties: Properties::DEVICE_LOCAL,
+                        heap_index: 0,
+                    },
+                    // UPLOAD
+                    hal::MemoryType {
+                        id: 1,
+                        properties: Properties::CPU_VISIBLE | Properties::COHERENT,
+                        heap_index: 1,
+                    },
+                    // READBACK
+                    hal::MemoryType {
+                        id: 2,
+                        properties: Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
+                        heap_index: 1,
+                    },
+                ],
+                MemoryArchitecture::UMA => [
+                    // DEFAULT
+                    hal::MemoryType {
+                        id: 0,
+                        properties: Properties::DEVICE_LOCAL,
+                        heap_index: 0,
+                    },
+                    // UPLOAD
+                    hal::MemoryType {
+                        id: 1,
+                        properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT,
+                        heap_index: 0,
+                    },
+                    // READBACK
+                    hal::MemoryType {
+                        id: 2,
+                        properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
+                        heap_index: 0,
+                    },
+                ],
+                MemoryArchitecture::CacheCoherentUMA => [
+                    // DEFAULT
+                    hal::MemoryType {
+                        id: 0,
+                        properties: Properties::DEVICE_LOCAL,
+                        heap_index: 0,
+                    },
+                    // UPLOAD
+                    hal::MemoryType {
+                        id: 1,
+                        properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
+                        heap_index: 0,
+                    },
+                    // READBACK
+                    hal::MemoryType {
+                        id: 2,
+                        properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
+                        heap_index: 0,
+                    },
+                ],
+            };
+
+            let memory_types = if heterogeneous_resource_heaps {
+                base_memory_types.to_vec()
+            } else {
+                // the bit pattern of ID becomes 0bTTII, where
+                // TT=1 for buffers, TT=2 for images, and TT=3 for targets
+                // TT=0 is reserved for future use, helps to avoid ambiguity
+                // and II is the same `id` as the `base_memory_types` have
+                let mut types = Vec::new();
+                for &tt in &[1, 2, 3] {
+                    types.extend(base_memory_types
+                        .iter()
+                        .map(|&mt| hal::MemoryType {
+                            id: mt.id + (tt << 2),
+                            .. mt
+                        })
+                    );
+                }
+                types
+            };
+
+            let memory_heaps = {
+                // Get the IDXGIAdapter3 from the created device to query video memory information.
+                let adapter_id = unsafe { device.GetAdapterLuid() };
+                let adapter = {
+                    let mut adapter: *mut dxgi1_4::IDXGIAdapter3 = ptr::null_mut();
+                    unsafe {
+                        assert_eq!(winerror::S_OK, self.factory.as_mut().EnumAdapterByLuid(
+                            adapter_id,
+                            &dxgi1_4::IID_IDXGIAdapter3,
+                            &mut adapter as *mut *mut _ as *mut *mut _,
+                        ));
+                        ComPtr::new(adapter)
+                    }
                 };
 
-                let info = hal::AdapterInfo {
-                    name: device_name,
-                    vendor: desc.VendorId as usize,
-                    device: desc.DeviceId as usize,
-                    software_rendering: false, // TODO: check for WARP adapter (software rasterizer)?
+                let query_memory = |segment: dxgi1_4::DXGI_MEMORY_SEGMENT_GROUP| unsafe {
+                    let mut mem_info: dxgi1_4::DXGI_QUERY_VIDEO_MEMORY_INFO = mem::uninitialized();
+                    assert_eq!(winerror::S_OK, adapter.QueryVideoMemoryInfo(
+                        0,
+                        segment,
+                        &mut mem_info,
+                    ));
+                    mem_info.Budget
                 };
 
-                let physical_device = PhysicalDevice {
-                    adapter,
-                    factory: self.factory.clone(),
-                };
+                let local = query_memory(dxgi1_4::DXGI_MEMORY_SEGMENT_GROUP_LOCAL);
+                match memory_architecture {
+                    MemoryArchitecture::NUMA => {
+                        let non_local = query_memory(dxgi1_4::DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
+                        vec![local, non_local]
+                    },
+                    _ => vec![local],
+                }
+            };
 
-                let queue_families = vec![
-                    QueueFamily::Present,
-                    QueueFamily::Normal(QueueType::General),
-                    QueueFamily::Normal(QueueType::Compute),
-                    QueueFamily::Normal(QueueType::Transfer),
-                ];
+            let physical_device = PhysicalDevice {
+                adapter,
+                factory: self.factory.clone(),
+                features: Features { // TODO
+                    indirect_execution: true,
+                    draw_instanced: true,
+                    draw_instanced_base: true,
+                    draw_indexed_base: true,
+                    draw_indexed_instanced: true,
+                    draw_indexed_instanced_base_vertex: true,
+                    draw_indexed_instanced_base: true,
+                    instance_rate: false,
+                    vertex_base: false,
+                    srgb_color: false,
+                    constant_buffer: false,
+                    unordered_access_view: false,
+                    separate_blending_slots: false,
+                    copy_buffer: false,
+                    sampler_anisotropy: false,
+                    sampler_border_color: false,
+                    sampler_lod_bias: false,
+                    sampler_objects: false,
+                    precise_occlusion_query: true,
+                    pipeline_statistics_query: true,
+                },
+                limits: Limits { // TODO
+                    max_texture_size: 0,
+                    max_patch_size: 0,
+                    max_viewports: 0,
+                    max_compute_group_count: [
+                        d3d12::D3D12_CS_THREAD_GROUP_MAX_X  as _,
+                        d3d12::D3D12_CS_THREAD_GROUP_MAX_Y  as _,
+                        d3d12::D3D12_CS_THREAD_GROUP_MAX_Z  as _,
+                    ],
+                    max_compute_group_size: [
+                        d3d12::D3D12_CS_THREAD_GROUP_MAX_THREADS_PER_GROUP as _,
+                        1, //TODO
+                        1, //TODO
+                    ],
+                    min_buffer_copy_offset_alignment: d3d12::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as _,
+                    min_buffer_copy_pitch_alignment: d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as _,
+                    min_uniform_buffer_offset_alignment: 256, // Required alignment for CBVs
+                },
+                private_caps: Capabilities {
+                    heterogeneous_resource_heaps,
+                    memory_architecture,
+                },
+                heap_properties,
+                memory_properties: hal::MemoryProperties {
+                    memory_types,
+                    memory_heaps,
+                },
+            };
 
-                adapters.push(hal::Adapter {
-                    info,
-                    physical_device,
-                    queue_families
-                });
-            }
+            let queue_families = vec![
+                QueueFamily::Present,
+                QueueFamily::Normal(QueueType::General),
+                QueueFamily::Normal(QueueType::Compute),
+                QueueFamily::Normal(QueueType::Transfer),
+            ];
 
-            cur_index += 1;
+            adapters.push(hal::Adapter {
+                info,
+                physical_device,
+                queue_families
+            });
         }
         adapters
     }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -542,7 +542,7 @@ impl hal::Instance for Instance {
 
             // We have found a possible adapter
             // acquire the device information
-            let mut desc: dxgi1_2::DXGI_ADAPTER_DESC2 = unsafe { std::mem::uninitialized() };
+            let mut desc: dxgi1_2::DXGI_ADAPTER_DESC2 = unsafe { mem::zeroed() };
             unsafe { adapter.GetDesc2(&mut desc); }
 
             let device_name = {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -59,6 +59,18 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn format_properties(&self, _: format::Format) -> format::Properties {
         unimplemented!()
     }
+
+    fn memory_properties(&self) -> hal::MemoryProperties {
+        unimplemented!()
+    }
+
+    fn get_features(&self) -> hal::Features {
+        unimplemented!()
+    }
+
+    fn get_limits(&self) -> hal::Limits {
+        unimplemented!()
+    }
 }
 
 /// Dummy command queue doing nothing.
@@ -72,14 +84,6 @@ impl queue::RawCommandQueue<Backend> for RawCommandQueue {
 /// Dummy device doing nothing.
 pub struct Device;
 impl hal::Device<Backend> for Device {
-    fn get_features(&self) -> &hal::Features {
-        unimplemented!()
-    }
-
-    fn get_limits(&self) -> &hal::Limits {
-        unimplemented!()
-    }
-
     fn create_command_pool(&self, _: &QueueFamily, _: pool::CommandPoolCreateFlags) -> RawCommandPool {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -150,14 +150,6 @@ impl Device {
 }
 
 impl d::Device<B> for Device {
-    fn get_features(&self) -> &c::Features {
-        &self.share.features
-    }
-
-    fn get_limits(&self) -> &c::Limits {
-        &self.share.limits
-    }
-
     fn allocate_memory(
         &self, mem_type: &c::MemoryType, _size: u64,
     ) -> Result<n::Memory, d::OutOfMemory> {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -72,7 +72,6 @@ struct PrivateCapabilities {
 pub struct Device {
     pub(crate) device: metal::Device,
     private_caps: PrivateCapabilities,
-    limits: hal::Limits,
     queue: Arc<command::QueueInner>,
 }
 unsafe impl Send for Device {}
@@ -92,8 +91,6 @@ impl PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(self, mut families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>) -> hal::Gpu<Backend> {
-        use self::memory::Properties;
-
         assert_eq!(families.len(), 1);
         let mut queue_group = hal::queue::RawQueueGroup::new(families.remove(0).0);
         let queue_raw = command::CommandQueue::new(&self.0);
@@ -125,6 +122,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn memory_properties(&self) -> hal::MemoryProperties {
+        use hal::memory::Properties;
+
         let memory_types = vec![
             hal::MemoryType {
                 id: 0,
@@ -171,7 +170,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
             max_compute_group_count: [0; 3], // TODO
             max_compute_group_size: [0; 3], // TODO
-        },
+        }
     }
 }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -55,9 +55,6 @@ impl Device {
 }
 
 impl d::Device<B> for Device {
-    fn get_features(&self) -> &Features { &self.features }
-    fn get_limits(&self) -> &Limits { &self.limits }
-
     fn allocate_memory(&self, memory_type: &MemoryType, size: u64) -> Result<n::Memory, d::OutOfMemory> {
         let info = vk::MemoryAllocateInfo {
             s_type: vk::StructureType::MemoryAllocateInfo,

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -2,11 +2,34 @@
 //!
 //! Physical devices are the main entry point for opening a [Device](../struct.Device).
 
-use {format, Backend, Gpu};
+use {format, memory, Backend, Gpu, Features, Limits};
 
 /// Scheduling hint for devices about the priority of a queue.
 /// Values ranging from `0.0` (low) to `1.0` (high).
 pub type QueuePriority = f32;
+
+///
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct MemoryType {
+    /// Id of the memory type.
+    pub id: usize,
+    /// Properties of the associated memory.
+    pub properties: memory::Properties,
+    /// Index to the underlying memory heap in `Gpu::memory_heaps`
+    pub heap_index: usize,
+}
+
+/// Types of memory supported by this adapter and available memory.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct MemoryProperties {
+    /// Each memory type is associated with one heap of `memory_heaps`.
+    /// Multiple types can point to the same heap.
+    pub memory_types: Vec<MemoryType>,
+    /// Memory heaps with their size in bytes.
+    pub memory_heaps: Vec<u64>,
+}
 
 /// Represents a physical or virtual device, which is capable of running the backend.
 pub trait PhysicalDevice<B: Backend>: Sized {
@@ -29,6 +52,16 @@ pub trait PhysicalDevice<B: Backend>: Sized {
 
     ///
     fn format_properties(&self, format::Format) -> format::Properties;
+
+    ///
+    fn memory_properties(&self) -> MemoryProperties;
+
+    /// Returns the features of this `Device`. This usually depends on the graphics API being
+    /// used.
+    fn get_features(&self) -> Features;
+
+    /// Returns the limits of this `Device`.
+    fn get_limits(&self) -> Limits;
 }
 
 /// Information about a backend adapter.

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -3,7 +3,6 @@
 use std::error::Error;
 use std::fmt;
 
-use memory;
 use {IndexType, Backend};
 
 /// Error creating a buffer.
@@ -140,24 +139,4 @@ pub struct IndexBufferView<'a, B: Backend> {
     pub offset: u64,
     ///
     pub index_type: IndexType,
-}
-
-/// Retrieve the complete memory requirements for this buffer,
-/// taking usage and device limits into account
-pub fn complete_requirements<B: Backend>(
-    device: &B::Device,
-    buffer: &B::UnboundBuffer,
-    usage: Usage,
-) -> memory::Requirements {
-    use std::cmp::max;
-    use device::Device;
-
-    let mut requirements = device.get_buffer_requirements(buffer);
-    if usage.can_transfer() {
-        let limits = device.get_limits();
-        requirements.alignment = max(
-            limits.min_buffer_copy_offset_alignment as u64,
-            requirements.alignment);
-    }
-    requirements
 }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 use {buffer, format, image, mapping, pass, pso, query};
 use pool::{CommandPool, CommandPoolCreateFlags};
 use queue::QueueGroup;
-use {Backend, Features, Limits, MemoryType};
+use {Backend, MemoryType};
 use memory::Requirements;
 use window::{Backbuffer, SwapchainConfig};
 
@@ -114,13 +114,6 @@ pub struct FramebufferError;
 /// benefit from the backends that support synchronization of the `Device`.
 ///
 pub trait Device<B: Backend> {
-    /// Returns the features of this `Device`. This usually depends on the graphics API being
-    /// used.
-    fn get_features(&self) -> &Features;
-
-    /// Returns the limits of this `Device`.
-    fn get_limits(&self) -> &Limits;
-
     /// Allocates a memory segment of a specified type.
     ///
     /// There is only a limited amount of allocations allowed depending on the implementation!

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -21,7 +21,10 @@ use std::error::Error;
 use std::fmt::{self, Debug};
 use std::hash::Hash;
 
-pub use self::adapter::{Adapter, AdapterInfo, PhysicalDevice, QueuePriority};
+pub use self::adapter::{
+    Adapter, AdapterInfo, MemoryProperties, MemoryType,
+    PhysicalDevice, QueuePriority,
+};
 pub use self::device::Device;
 pub use self::pool::CommandPool;
 pub use self::pso::{DescriptorPool};
@@ -200,18 +203,6 @@ pub enum IndexType {
     U32,
 }
 
-///
-#[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct MemoryType {
-    /// Id of the memory type.
-    pub id: usize,
-    /// Properties of the associated memory.
-    pub properties: memory::Properties,
-    /// Index to the underlying memory heap in `Gpu::memory_heaps`
-    pub heap_index: usize,
-}
-
 /// Basic backend instance trait.
 pub trait Instance {
     /// Associated backend type of this instance.
@@ -293,11 +284,4 @@ pub struct Gpu<B: Backend> {
     /// Raw queue groups. Each element in this vector
     /// matches the corresponding argument in `Adapter::open`.
     pub queue_groups: Vec<queue::RawQueueGroup<B>>,
-    /// Types of memory.
-    ///
-    /// Each memory type is associated with one heap of `memory_heaps`.
-    /// Multiple types can point to the same heap.
-    pub memory_types: Vec<MemoryType>,
-    /// Memory heaps with their size in bytes.
-    pub memory_heaps: Vec<u64>,
 }

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -127,7 +127,10 @@ pub mod shade;
 pub mod macros;
 
 use std::collections::VecDeque;
-use hal::{Capability, CommandQueue, QueueFamily, Surface, Swapchain, Device as Device_};
+use hal::{
+    Capability, CommandQueue, PhysicalDevice, QueueFamily, Surface, Swapchain,
+    Device as Device_,
+};
 use hal::format::RenderFormat;
 use hal::pool::CommandPoolCreateFlags;
 use memory::Typed;
@@ -217,11 +220,10 @@ impl<B: Backend, C> Context<B, C>
     where
         Cf: RenderFormat,
     {
+        let memory_properties = adapter.physical_device.memory_properties();
         let hal::Gpu {
             device,
             mut queue_groups,
-            memory_types,
-            memory_heaps,
         } = adapter.open_with(|family| {
             let ty = family.queue_type();
             if Graphics::supported_by(ty) && Compute::supported_by(ty) &&
@@ -275,7 +277,11 @@ impl<B: Backend, C> Context<B, C>
                 }
             }).collect();
 
-        let (device, garbage) = Device::new(device, memory_types, memory_heaps);
+        let (device, garbage) = Device::new(
+            device,
+            memory_properties.memory_types,
+            memory_properties.memory_heaps,
+        );
 
         let context = Context {
             surface,


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/gfx/issues/1671 https://github.com/gfx-rs/gfx/issues/1657 (set to 11.0)

Implements 2nd approach (open device -> query information -> close device) for dx12. For other backends only code has been shifted around.

Main motivation for this is vulkan portability, it doesn't provide new features.