### PR TITLE
Move the portable branch into main repository

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -13,6 +13,7 @@ workspace = "../../.."
 
 [features]
 default = ["winit"]
+portable = []
 
 [lib]
 name = "gfx_backend_vulkan"

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -1,6 +1,5 @@
 use std::{cmp, ptr};
 use std::ops::Range;
-use std::sync::Arc;
 use smallvec::SmallVec;
 use ash::vk;
 use ash::version::DeviceV1_0;
@@ -10,12 +9,14 @@ use hal::{IndexCount, InstanceCount, VertexCount, VertexOffset};
 use hal::buffer::IndexBufferView;
 use hal::image::{AspectFlags, ImageLayout, SubresourceRange};
 use {conv, native as n};
-use {Backend, RawDevice};
+use {Backend, DeviceRef};
 
+#[repr(C)]
 #[derive(Clone)]
+#[cfg_attr(feature = "portable", derive(Copy, Debug))]
 pub struct CommandBuffer {
     pub raw: vk::CommandBuffer,
-    pub device: Arc<RawDevice>,
+    pub device: DeviceRef,
 }
 
 fn map_subpass_contents(contents: com::SubpassContents) -> vk::SubpassContents {

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -12,7 +12,7 @@ use std::collections::VecDeque;
 use std::ffi::CString;
 use std::ops::Range;
 
-use {Backend as B, Device, QueueFamily};
+use {Backend as B, Device, DeviceRef, QueueFamily};
 use {conv, memory, window as w};
 use pool::RawCommandPool;
 
@@ -51,6 +51,15 @@ impl Device {
             },
             Err(string) => Err(d::ShaderError::CompilationFailed(string)),
         }
+    }
+
+    #[cfg(feature = "portable")]
+    pub(crate) fn get_ref(&self) -> DeviceRef {
+        unsafe { mem::transmute(&*self.raw) }
+    }
+    #[cfg(not(feature = "portable"))]
+    pub (crate) fn get_ref(&self) -> DeviceRef {
+        self.raw.clone()
     }
 }
 
@@ -111,7 +120,7 @@ impl d::Device<B> for Device {
 
         RawCommandPool {
             raw: command_pool_raw,
-            device: self.raw.clone(),
+            device: self.get_ref(),
         }
     }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -283,6 +283,7 @@ impl hal::Instance for Instance {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "portable", derive(Clone))]
 pub struct QueueFamily {
     properties: vk::QueueFamilyProperties,
     device: vk::PhysicalDevice,
@@ -299,6 +300,7 @@ impl hal::queue::QueueFamily for QueueFamily {
 }
 
 
+#[cfg_attr(feature = "portable", derive(Clone))]
 pub struct PhysicalDevice {
     instance: Arc<RawInstance>,
     handle: vk::PhysicalDevice,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -393,7 +393,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             },
         };
 
-        let device_arc = device.raw.clone();
+        let device_ref = device.get_ref();
         let queue_groups = families
             .into_iter()
             .map(|(family, priorities)| {
@@ -401,11 +401,11 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 let mut family_raw = hal::queue::RawQueueGroup::new(family);
                 for id in 0 .. priorities.len() {
                     let queue_raw = unsafe {
-                        device_arc.0.get_device_queue(family_index, id as _)
+                        device_ref.0.get_device_queue(family_index, id as _)
                     };
                     family_raw.add_queue(CommandQueue {
                         raw: Arc::new(queue_raw),
-                        device: device_arc.clone(),
+                        device: device_ref.clone(),
                     });
                 }
                 family_raw
@@ -478,12 +478,16 @@ impl Drop for RawDevice {
     }
 }
 
-// Need to explicitly synchronize on submission and present.
-pub type RawCommandQueue = Arc<vk::Queue>;
+#[cfg(feature = "portable")]
+type DeviceRef = &'static RawDevice;
 
+#[cfg(not(feature = "portable"))]
+type DeviceRef = Arc<RawDevice>;
+
+// Need to explicitly synchronize on submission and present.
 pub struct CommandQueue {
-    raw: RawCommandQueue,
-    device: Arc<RawDevice>,
+    raw: Arc<vk::Queue>,
+    device: DeviceRef,
 }
 
 impl hal::queue::RawCommandQueue<Backend> for CommandQueue {

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -1,17 +1,16 @@
 use std::ptr;
-use std::sync::Arc;
 use ash::vk;
 use ash::version::DeviceV1_0;
 use smallvec::SmallVec;
 
 use command::{CommandBuffer, SubpassCommandBuffer};
 use hal::pool;
-use {Backend, RawDevice};
+use {Backend, DeviceRef};
 
 
 pub struct RawCommandPool {
     pub(crate) raw: vk::CommandPool,
-    pub(crate) device: Arc<RawDevice>,
+    pub(crate) device: DeviceRef,
 }
 
 impl pool::RawCommandPool<Backend> for RawCommandPool {
@@ -62,7 +61,7 @@ pub struct SubpassCommandPool {
     _pool: vk::CommandPool,
     _command_buffers: Vec<SubpassCommandBuffer>,
     _next_buffer: usize,
-    _device: Arc<RawDevice>,
+    _device: DeviceRef,
 }
 
 impl pool::SubpassCommandPool<Backend> for SubpassCommandPool { }


### PR DESCRIPTION
Currently, `gfx/portability` uses `kvark/gfx` with the `portable` branch for obtaining the gfx repository. Moving this over to the main repository would make rebasing easier and centralizes information.

🔔 **NOTE** Don't merge this right now, as it would be merged into the master branch. Once we have a consensus on this change I will setup a new branch and redirect the PR.