### PR TITLE
[hal] Update winit and glutin, bump version

### DIFF
--- a/examples/hal/Cargo.toml
+++ b/examples/hal/Cargo.toml
@@ -24,7 +24,7 @@ path = "compute/main.rs"
 env_logger = "0.4"
 image = "0.15"
 log = "0.3"
-winit = "0.7"
+winit = "0.9"
 gfx-hal = { path = "../../src/hal", version = "0.1" }
 
 [dependencies.gfx-backend-gl]

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -81,7 +81,7 @@ fn main() {
         back::glutin::GlWindow::new(wb, builder, &events_loop).unwrap()
     };
 
-    let window_size = window.get_inner_size_pixels().unwrap();
+    let window_size = window.get_inner_size().unwrap();
     let pixel_width = window_size.0 as u16;
     let pixel_height = window_size.1 as u16;
 

--- a/examples/render/quad_render/Cargo.toml
+++ b/examples/render/quad_render/Cargo.toml
@@ -10,10 +10,10 @@ path = "main.rs"
 
 [dependencies]
 env_logger = "0.4"
-glutin = { version = "0.9", optional = true }
+glutin = { version = "0.11", optional = true }
 image = "0.15"
 log = "0.3"
-winit = "0.7"
+winit = "0.9"
 gfx-hal = { path = "../../../src/hal", version = "0.1" }
 gfx-render = { path = "../../../src/render", version = "0.1" }
 

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -54,7 +54,7 @@ fn main() {
         .with_title("quad".to_string())
         .build(&events_loop)
         .unwrap();
-    let window_size = window.get_inner_size_pixels().unwrap();
+    let window_size = window.get_inner_size().unwrap();
     let pixel_width = window_size.0 as u16;
     let pixel_height = window_size.1 as u16;
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -25,5 +25,5 @@ log = "0.3"
 smallvec = "0.4"
 spirv_cross = "0.4.2"
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgiformat","dxgitype","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
-winit = { version = "0.7", optional = true }
+winit = { version = "0.9", optional = true }
 wio = { git = "https://github.com/msiglreith/wio-rs.git", branch = "stable" }

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -22,4 +22,4 @@ log = "0.3"
 gfx_gl = "0.3.1"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.4"
-glutin = { version = "0.9", optional = true }
+glutin = { version = "0.11", optional = true }

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -20,7 +20,7 @@ name = "gfx_backend_metal"
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.1" }
 log = "0.3"
-winit = { version = "0.7", optional = true }
+winit = { version = "0.9", optional = true }
 metal-rs = "0.6"
 foreign-types = "0.3"
 objc = "0.2"

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -25,7 +25,7 @@ shared_library = "0.1"
 ash = "0.20.2"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.4"
-winit = { version = "0.7", optional = true }
+winit = { version = "0.9", optional = true }
 glsl-to-spirv = { version = "0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -270,7 +270,7 @@ impl core::WindowExt<device_dx12::Backend> for Window {
         let mut instance = device_dx12::Instance::create();
         let adapters = instance.enumerate_adapters();
         let surface = {
-            let (width, height) = self.0.get_inner_size_pixels().unwrap();
+            let (width, height) = self.0.get_inner_size().unwrap();
             Surface12 {
                 factory: instance.factory.clone(),
                 wnd_handle: self.0.get_hwnd() as *mut _,


### PR DESCRIPTION
Update winit to the latest version, which introduced the Clone implementation for EventsLoopProxy. This winit feature is required to run Webrender tests/examples and servo in the future with gfx-hal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/1686)
<!-- Reviewable:end -->
