### PR TITLE
[gl] Generate GLSL with SPIRV-Cross

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ matrix:
   include:
     - os: linux
       rust: stable
+      compiler: gcc
     - os: linux
       rust: nightly
+      compiler: gcc
     - os: osx
       rust: stable
       osx_image: xcode9
@@ -40,7 +42,7 @@ before_install:
   # Will no longer be needed when Trusty build environment goes out of beta at Travis CI
   # (assuming it will have libsdl2-dev and Rust by then)
   # see https://docs.travis-ci.com/user/trusty-ci-environment/
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && make travis-sdl2; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && make travis-sdl2 && export CXX=g++-5 && export CC=gcc-5; fi
   - if [[ $TRAVIS_OS_NAME == osx ]]; then brew update && brew install sdl2 && brew upgrade cmake && export CXX=clang++ && export CC=clang && export MACOSX_DEPLOYMENT_TARGET=10.7; fi
 
 addons:
@@ -48,6 +50,8 @@ addons:
     sources:
       # install a newer cmake since at this time Travis only has version 2.8.7
       - george-edison55-precise-backports
+      - llvm-toolchain-precise-3.8
+      - ubuntu-toolchain-r-test
     packages:
       - xdotool
       - cmake
@@ -61,6 +65,8 @@ addons:
       - libosmesa6-dev
       - libxi-dev
       - libxrandr-dev
+      - g++-5
+      - gcc
 
 script:
   - if [[ $TRAVIS_RUST_VERSION == "nightly" && $TRAVIS_BRANCH == "staging" ]]; then exit; fi

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -153,19 +153,6 @@ fn main() {
         ).expect("Error on creating shader lib");
     */
 
-    #[cfg(feature = "gl")]
-    let vs_module = device
-        .create_shader_module_from_source(
-            include_bytes!("shader/quad_150.glslv"),
-            pso::Stage::Vertex,
-        ).unwrap();
-    #[cfg(feature = "gl")]
-    let fs_module = device
-        .create_shader_module_from_source(
-            include_bytes!("shader/quad_150.glslf"),
-            pso::Stage::Fragment,
-        ).unwrap();
-
     let set_layout = device.create_descriptor_set_layout(&[
             pso::DescriptorSetLayoutBinding {
                 binding: 0,

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -23,3 +23,4 @@ gfx_gl = "0.3.1"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.4"
 glutin = { version = "0.11", optional = true }
+spirv_cross = "0.4.3"

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -653,10 +653,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     
     fn push_graphics_constants(
         &mut self,
-        layout: &n::PipelineLayout,
-        stages: pso::ShaderStageFlags,
-        offset: u32,
-        constants: &[u32],
+        _layout: &n::PipelineLayout,
+        _stages: pso::ShaderStageFlags,
+        _offset: u32,
+        _constants: &[u32],
     ) {
         unimplemented!()
     }
@@ -686,9 +686,9 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     
     fn push_compute_constants(
         &mut self,
-        layout: &n::PipelineLayout,
-        offset: u32,
-        constants: &[u32],
+        _layout: &n::PipelineLayout,
+        _offset: u32,
+        _constants: &[u32],
     ) {
         unimplemented!()
     }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -8,6 +8,7 @@ extern crate log;
 extern crate gfx_gl as gl;
 extern crate gfx_hal as hal;
 extern crate smallvec;
+extern crate spirv_cross;
 #[cfg(feature = "glutin")]
 pub extern crate glutin;
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -85,9 +85,10 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
     }
 }
 
-#[derive(Clone, Copy, Debug, Hash)]
-pub struct ShaderModule {
-    pub(crate) raw: Shader,
+#[derive(Clone, Debug, Hash)]
+pub enum ShaderModule {
+    Raw(Shader),
+    Spirv(Vec<u8>),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Adds SPIRV-Cross GLSL compilation and fixed some trivial warnings. Most of the implementation is taken from DX12 backend for now.