### PR TITLE
[gl] Use primitive from graphics pipeline

### DIFF
--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -1,5 +1,5 @@
 use gl::{self, types as t};
-use hal::{buffer, image as i};
+use hal::{buffer, image as i, Primitive};
 
 pub fn _image_kind_to_gl(kind: i::Kind) -> t::GLenum {
     match kind {
@@ -42,5 +42,20 @@ pub fn buffer_usage_to_gl_target(usage: buffer::Usage) -> Option<t::GLenum> {
         Usage::VERTEX => Some(gl::ARRAY_BUFFER),
         Usage::INDIRECT => unimplemented!(),
         _ => None
+    }
+}
+
+pub fn primitive_to_gl_primitive(primitive: Primitive) -> t::GLenum {
+    match primitive {
+        Primitive::PointList => gl::POINTS,
+        Primitive::LineList => gl::LINES,
+        Primitive::LineStrip => gl::LINE_STRIP,
+        Primitive::TriangleList => gl::TRIANGLES,
+        Primitive::TriangleStrip => gl::TRIANGLE_STRIP,
+        Primitive::LineListAdjacency => gl::LINES_ADJACENCY,
+        Primitive::LineStripAdjacency => gl::LINE_STRIP_ADJACENCY,
+        Primitive::TriangleListAdjacency => gl::TRIANGLES_ADJACENCY,
+        Primitive::TriangleStripAdjacency => gl::TRIANGLE_STRIP_ADJACENCY,
+        Primitive::PatchList(_) => gl::PATCHES,
     }
 }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use gl;
 use gl::types::{GLint, GLenum, GLfloat};
-use hal::{self as c, device as d, image as i, memory, pass, pso, buffer, mapping, query};
+use hal::{self as c, device as d, image as i, memory, pass, pso, buffer, mapping, query, Primitive};
 use hal::format::{Format, Swizzle};
 use hal::pool::CommandPoolCreateFlags;
 use spirv_cross::{glsl, spirv, ErrorCode as SpirvErrorCode};
@@ -347,8 +347,15 @@ impl d::Device<B> for Device {
                     name
                 };
 
+                let patch_size = match desc.input_assembler.primitive {
+                    Primitive::PatchList(size) => Some(size as _),
+                    _ => None
+                };
+
                 Ok(n::GraphicsPipeline {
                     program,
+                    primitive: conv::primitive_to_gl_primitive(desc.input_assembler.primitive),
+                    patch_size,
                 })
              })
              .collect()

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -38,6 +38,8 @@ impl Fence {
 #[derive(Clone, Debug, Copy)]
 pub struct GraphicsPipeline {
     pub(crate) program: Program,
+    pub(crate) primitive: gl::types::GLenum,
+    pub(crate) patch_size: Option<gl::types::GLint>,
 }
 
 #[derive(Clone, Debug, Copy)]

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -463,6 +463,9 @@ impl CommandQueue {
             com::Command::SetDrawColorBuffers(num) => {
                 state::bind_draw_color_buffers(&self.share.context, num);
             }
+            com::Command::SetPatchSize(num) => unsafe {
+                &self.share.context.PatchParameteri(gl::PATCH_VERTICES, num);
+            }
             /*
             com::Command::BindProgram(program) => unsafe {
                 self.share.context.UseProgram(program);
@@ -533,12 +536,6 @@ impl CommandQueue {
                     state::bind_blend(&self.share.context, color);
                 }else if false {
                     error!("Separate blending slots are not supported");
-                }
-            },
-            com::Command::SetPatches(num) => {
-                let gl = &self.share.context;
-                unsafe {
-                    gl.PatchParameteri(gl::PATCH_VERTICES, num as gl::types::GLint);
                 }
             },
             com::Command::CopyBuffer(src, dst, src_offset, dst_offset, size) => {


### PR DESCRIPTION
Use the primitive from the graphics pipeline for `Draw` and `DrawIndexed` commands.