### PR TITLE
[gl] Make hal/quad example work on GL backend

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -82,6 +82,8 @@ pub enum Command {
     SetPatchSize(gl::types::GLint),
     BindProgram(gl::types::GLuint),
     BindBlendSlot(ColorSlot, pso::ColorBlendDesc),
+    BindAttribute(n::AttributeDesc),
+    UnbindAttribute(n::AttributeDesc),
 }
 
 pub type FrameBufferTarget = gl::types::GLenum;
@@ -556,7 +558,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
             patch_size,
             program,
             ref blend_targets,
-            ..
+            ref attributes,
         } = pipeline;
 
         if self.cache.primitive != Some(primitive) {
@@ -573,6 +575,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         if self.cache.program != Some(program) {
             self.cache.program = Some(program);
             self.push_cmd(Command::BindProgram(program));
+        }
+
+        for attribute in attributes {
+            self.push_cmd(Command::BindAttribute(*attribute));
         }
 
         self.update_blend_targets(blend_targets);

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -361,7 +361,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<memory::Barrier<'a, Backend>>,
     {
-        unimplemented!()
+        // TODO
     }
 
     fn fill_buffer(&mut self, _buffer: &n::Buffer, _range: Range<u64>, _data: u32) {
@@ -400,7 +400,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
     fn end_renderpass(&mut self) {
-        unimplemented!()
+        // TODO
     }
 
     fn clear_color_image(
@@ -587,7 +587,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<n::DescriptorSet>,
     {
-        unimplemented!()
+        // TODO
     }
 
     fn bind_compute_pipeline(&mut self, _pipeline: &n::ComputePipeline) {

--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -1,5 +1,6 @@
 use gl::{self, types as t};
 use hal::{buffer, image as i, Primitive};
+use hal::format::{Format};
 
 pub fn _image_kind_to_gl(kind: i::Kind) -> t::GLenum {
     match kind {
@@ -58,4 +59,42 @@ pub fn primitive_to_gl_primitive(primitive: Primitive) -> t::GLenum {
         Primitive::TriangleStripAdjacency => gl::TRIANGLE_STRIP_ADJACENCY,
         Primitive::PatchList(_) => gl::PATCHES,
     }
+}
+
+pub fn format_to_gl_format(format: Format) -> Option<(gl::types::GLint, gl::types::GLenum)> {
+    use hal::format::Format::*;
+    // TODO: Add more formats and error handling for `None`
+    let format = match format {
+        R8Uint => (1, gl::UNSIGNED_BYTE),
+        R8Int => (1, gl::BYTE),
+        Rg8Uint => (2, gl::UNSIGNED_BYTE),
+        Rg8Int => (2, gl::BYTE),
+        Rgba8Uint => (4, gl::UNSIGNED_BYTE),
+        Rgba8Int => (4, gl::BYTE),
+        R16Uint => (1, gl::UNSIGNED_SHORT),
+        R16Int => (1, gl::SHORT),
+        R16Float => (1, gl::HALF_FLOAT),
+        Rg16Uint => (2, gl::UNSIGNED_SHORT),
+        Rg16Int => (2, gl::SHORT),
+        Rg16Float => (2, gl::HALF_FLOAT),
+        Rgba16Uint => (4, gl::UNSIGNED_SHORT),
+        Rgba16Int => (4, gl::SHORT),
+        Rgba16Float => (4, gl::HALF_FLOAT),
+        R32Uint => (1, gl::UNSIGNED_INT),
+        R32Int => (1, gl::INT),
+        R32Float => (1, gl::FLOAT),
+        Rg32Uint => (2, gl::UNSIGNED_INT),
+        Rg32Int => (2, gl::INT),
+        Rg32Float => (2, gl::FLOAT),
+        Rgb32Uint => (3, gl::UNSIGNED_INT),
+        Rgb32Int => (3, gl::INT),
+        Rgb32Float => (3, gl::FLOAT),
+        Rgba32Uint => (4, gl::UNSIGNED_INT),
+        Rgba32Int => (4, gl::INT),
+        Rgba32Float => (4, gl::FLOAT),
+        
+        _ => return None,
+    };
+
+    Some(format)
 }

--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -1,6 +1,7 @@
 use gl::{self, types as t};
 use hal::{buffer, image as i, Primitive};
-use hal::format::{Format};
+use hal::format::Format;
+use native::VertexAttribFunction;
 
 pub fn _image_kind_to_gl(kind: i::Kind) -> t::GLenum {
     match kind {
@@ -61,37 +62,39 @@ pub fn primitive_to_gl_primitive(primitive: Primitive) -> t::GLenum {
     }
 }
 
-pub fn format_to_gl_format(format: Format) -> Option<(gl::types::GLint, gl::types::GLenum)> {
+pub fn format_to_gl_format(format: Format) -> Option<(gl::types::GLint, gl::types::GLenum, VertexAttribFunction)> {
     use hal::format::Format::*;
+    use gl::*;
+    use native::VertexAttribFunction::*;
     // TODO: Add more formats and error handling for `None`
     let format = match format {
-        R8Uint => (1, gl::UNSIGNED_BYTE),
-        R8Int => (1, gl::BYTE),
-        Rg8Uint => (2, gl::UNSIGNED_BYTE),
-        Rg8Int => (2, gl::BYTE),
-        Rgba8Uint => (4, gl::UNSIGNED_BYTE),
-        Rgba8Int => (4, gl::BYTE),
-        R16Uint => (1, gl::UNSIGNED_SHORT),
-        R16Int => (1, gl::SHORT),
-        R16Float => (1, gl::HALF_FLOAT),
-        Rg16Uint => (2, gl::UNSIGNED_SHORT),
-        Rg16Int => (2, gl::SHORT),
-        Rg16Float => (2, gl::HALF_FLOAT),
-        Rgba16Uint => (4, gl::UNSIGNED_SHORT),
-        Rgba16Int => (4, gl::SHORT),
-        Rgba16Float => (4, gl::HALF_FLOAT),
-        R32Uint => (1, gl::UNSIGNED_INT),
-        R32Int => (1, gl::INT),
-        R32Float => (1, gl::FLOAT),
-        Rg32Uint => (2, gl::UNSIGNED_INT),
-        Rg32Int => (2, gl::INT),
-        Rg32Float => (2, gl::FLOAT),
-        Rgb32Uint => (3, gl::UNSIGNED_INT),
-        Rgb32Int => (3, gl::INT),
-        Rgb32Float => (3, gl::FLOAT),
-        Rgba32Uint => (4, gl::UNSIGNED_INT),
-        Rgba32Int => (4, gl::INT),
-        Rgba32Float => (4, gl::FLOAT),
+        R8Uint => (1, UNSIGNED_BYTE, Integer),
+        R8Int => (1, BYTE, Integer),
+        Rg8Uint => (2, UNSIGNED_BYTE, Integer),
+        Rg8Int => (2, BYTE, Integer),
+        Rgba8Uint => (4, UNSIGNED_BYTE, Integer),
+        Rgba8Int => (4, BYTE, Integer),
+        R16Uint => (1, UNSIGNED_SHORT, Integer),
+        R16Int => (1, SHORT, Integer),
+        R16Float => (1, HALF_FLOAT, Float),
+        Rg16Uint => (2, UNSIGNED_SHORT, Integer),
+        Rg16Int => (2, SHORT, Integer),
+        Rg16Float => (2, HALF_FLOAT, Float),
+        Rgba16Uint => (4, UNSIGNED_SHORT, Integer),
+        Rgba16Int => (4, SHORT, Integer),
+        Rgba16Float => (4, HALF_FLOAT, Float),
+        R32Uint => (1, UNSIGNED_INT, Integer),
+        R32Int => (1, INT, Integer),
+        R32Float => (1, FLOAT, Float),
+        Rg32Uint => (2, UNSIGNED_INT, Integer),
+        Rg32Int => (2, INT, Integer),
+        Rg32Float => (2, FLOAT, Float),
+        Rgb32Uint => (3, UNSIGNED_INT, Integer),
+        Rgb32Int => (3, INT, Integer),
+        Rgb32Float => (3, FLOAT, Float),
+        Rgba32Uint => (4, UNSIGNED_INT, Integer),
+        Rgba32Int => (4, INT, Integer),
+        Rgba32Float => (4, FLOAT, Float),
         
         _ => return None,
     };

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -359,6 +359,16 @@ impl d::Device<B> for Device {
                     primitive: conv::primitive_to_gl_primitive(desc.input_assembler.primitive),
                     patch_size,
                     blend_targets: desc.blender.targets.clone(),
+                    attributes: desc.attributes
+                        .iter()
+                        .map(|&a| n::AttributeDesc {
+                            location: a.location,
+                            offset: a.element.offset,
+                            binding: a.binding + 1,
+                            size: 2, // TODO
+                            stride: 16, // TODO
+                        })
+                        .collect::<Vec<_>>(),
                 })
              })
              .collect()

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -367,7 +367,7 @@ impl d::Device<B> for Device {
                         .map(|&a| n::AttributeDesc {
                             location: a.location,
                             offset: a.element.offset,
-                            binding: a.binding + 1,
+                            binding: a.binding,
                             size: 2, // TODO
                             stride: 16, // TODO
                         })

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -362,14 +362,18 @@ impl d::Device<B> for Device {
                     primitive: conv::primitive_to_gl_primitive(desc.input_assembler.primitive),
                     patch_size,
                     blend_targets: desc.blender.targets.clone(),
+                    vertex_buffers: desc.vertex_buffers.clone(),
                     attributes: desc.attributes
                         .iter()
-                        .map(|&a| n::AttributeDesc {
-                            location: a.location,
-                            offset: a.element.offset,
-                            binding: a.binding,
-                            size: 2, // TODO
-                            stride: 16, // TODO
+                        .map(|&a| {
+                            let (size, format) = conv::format_to_gl_format(a.element.format).unwrap();
+                            n::AttributeDesc {
+                                location: a.location,
+                                offset: a.element.offset,
+                                binding: a.binding,
+                                size,
+                                format,
+                            }
                         })
                         .collect::<Vec<_>>(),
                 })

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -205,7 +205,9 @@ impl d::Device<B> for Device {
     fn allocate_memory(
         &self, _mem_type: c::MemoryTypeId, _size: u64,
     ) -> Result<n::Memory, d::OutOfMemory> {
-        unimplemented!()
+        Ok(n::Memory {
+            properties: memory::Properties::CPU_VISIBLE | memory::Properties::CPU_CACHED
+        })
     }
 
     fn create_command_pool(
@@ -635,7 +637,7 @@ impl d::Device<B> for Device {
     }
 
     fn update_descriptor_sets(&self, _: &[pso::DescriptorSetWrite<B>]) {
-        unimplemented!()
+        // TODO
     }
 
     fn acquire_mapping_raw(&self, buffer: &n::Buffer, read: Option<Range<u64>>)

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -134,4 +134,12 @@ pub struct AttributeDesc {
     pub(crate) binding: gl::types::GLuint,
     pub(crate) size: gl::types::GLint,
     pub(crate) format: gl::types::GLenum,
+    pub(crate) vertex_attrib_fn: VertexAttribFunction,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum VertexAttribFunction {
+    Float, // glVertexAttribPointer
+    Integer, // glVertexAttribIPointer
+    Double, // glVertexAttribLPointer
 }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -41,6 +41,7 @@ pub struct GraphicsPipeline {
     pub(crate) patch_size: Option<gl::types::GLint>,
     pub(crate) blend_targets: Vec<pso::ColorBlendDesc>,
     pub(crate) attributes: Vec<AttributeDesc>,
+    pub(crate) vertex_buffers: Vec<pso::VertexBufferDesc>,
 }
 
 #[derive(Clone, Debug, Copy)]
@@ -132,5 +133,5 @@ pub struct AttributeDesc {
     pub(crate) offset: u32,
     pub(crate) binding: gl::types::GLuint,
     pub(crate) size: gl::types::GLint,
-    pub(crate) stride: gl::types::GLsizei,
+    pub(crate) format: gl::types::GLenum,
 }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -4,7 +4,6 @@ use gl;
 use Backend;
 use std::cell::Cell;
 
-
 pub type RawBuffer   = gl::types::GLuint;
 pub type Shader      = gl::types::GLuint;
 pub type Program     = gl::types::GLuint;
@@ -41,6 +40,7 @@ pub struct GraphicsPipeline {
     pub(crate) primitive: gl::types::GLenum,
     pub(crate) patch_size: Option<gl::types::GLint>,
     pub(crate) blend_targets: Vec<pso::ColorBlendDesc>,
+    pub(crate) attributes: Vec<AttributeDesc>,
 }
 
 #[derive(Clone, Debug, Copy)]
@@ -125,3 +125,12 @@ pub struct PipelineLayout;
 #[derive(Debug)]
 // No inter-queue synchronization required for GL.
 pub struct Semaphore;
+
+#[derive(Debug, Clone, Copy)]
+pub struct AttributeDesc {
+    pub(crate) location: gl::types::GLuint,
+    pub(crate) offset: u32,
+    pub(crate) binding: gl::types::GLuint,
+    pub(crate) size: gl::types::GLint,
+    pub(crate) stride: gl::types::GLsizei,
+}

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -472,8 +472,19 @@ impl CommandQueue {
             com::Command::BindProgram(program) => unsafe {
                 self.share.context.UseProgram(program);
             }
-            com::Command::BindBlendSlot(slot, blend) => {
-                state::bind_blend_slot(&self.share.context, slot, &blend);
+            com::Command::BindBlendSlot(slot, ref blend) => {
+                state::bind_blend_slot(&self.share.context, slot, blend);
+            }
+            com::Command::BindAttribute(ref attribute) => unsafe {
+                let gl = &self.share.context;
+                gl.BindBuffer(gl::ARRAY_BUFFER, attribute.binding);
+                gl.VertexAttribPointer(attribute.location, attribute.size, gl::FLOAT, gl::FALSE,
+                    attribute.stride, attribute.offset as *const gl::types::GLvoid);
+                gl.EnableVertexAttribArray(attribute.location);
+                gl.BindBuffer(gl::ARRAY_BUFFER, 0);
+            }
+            com::Command::UnbindAttribute(ref attribute) => unsafe {
+                self.share.context.DisableVertexAttribArray(attribute.location);
             }
             /*
             com::Command::BindConstantBuffer(pso::ConstantBufferParam(buffer, _, slot)) => unsafe {

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -475,9 +475,9 @@ impl CommandQueue {
             com::Command::BindBlendSlot(slot, ref blend) => {
                 state::bind_blend_slot(&self.share.context, slot, blend);
             }
-            com::Command::BindAttribute(ref attribute) => unsafe {
+            com::Command::BindAttribute(ref attribute, handle) => unsafe {
                 let gl = &self.share.context;
-                gl.BindBuffer(gl::ARRAY_BUFFER, attribute.binding);
+                gl.BindBuffer(gl::ARRAY_BUFFER, handle);
                 gl.VertexAttribPointer(attribute.location, attribute.size, gl::FLOAT, gl::FALSE,
                     attribute.stride, attribute.offset as *const gl::types::GLvoid);
                 gl.EnableVertexAttribArray(attribute.location);

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -486,6 +486,21 @@ impl CommandQueue {
             com::Command::UnbindAttribute(ref attribute) => unsafe {
                 self.share.context.DisableVertexAttribArray(attribute.location);
             }
+            com::Command::CopyBufferToTexture(buffer, image, ref region) => unsafe {
+                let gl = &self.share.context;
+                gl.ActiveTexture(gl::TEXTURE0);
+                gl.BindBuffer(gl::PIXEL_UNPACK_BUFFER, buffer);
+                gl.BindTexture(gl::TEXTURE_2D, image);
+                let &hal::command::BufferImageCopy {
+                    ref image_layers,
+                    ref image_offset,
+                    ref image_extent,
+                    ..
+                } = region;
+                gl.TexSubImage2D(gl::TEXTURE_2D, image_layers.level as _, image_offset.x, image_offset.y,
+                    image_extent.width as _, image_extent.height as _, gl::RGBA, gl::UNSIGNED_BYTE, 0 as *const _);
+                gl.BindBuffer(gl::PIXEL_UNPACK_BUFFER, 0);
+            }
             /*
             com::Command::BindConstantBuffer(pso::ConstantBufferParam(buffer, _, slot)) => unsafe {
                 self.share.context.BindBufferBase(gl::UNIFORM_BUFFER, slot as gl::types::GLuint, buffer);

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -475,11 +475,11 @@ impl CommandQueue {
             com::Command::BindBlendSlot(slot, ref blend) => {
                 state::bind_blend_slot(&self.share.context, slot, blend);
             }
-            com::Command::BindAttribute(ref attribute, handle) => unsafe {
+            com::Command::BindAttribute(ref attribute, handle, stride) => unsafe {
                 let gl = &self.share.context;
                 gl.BindBuffer(gl::ARRAY_BUFFER, handle);
-                gl.VertexAttribPointer(attribute.location, attribute.size, gl::FLOAT, gl::FALSE,
-                    attribute.stride, attribute.offset as *const gl::types::GLvoid);
+                gl.VertexAttribPointer(attribute.location, attribute.size, attribute.format, gl::FALSE,
+                    stride, attribute.offset as *const gl::types::GLvoid);
                 gl.EnableVertexAttribArray(attribute.location);
                 gl.BindBuffer(gl::ARRAY_BUFFER, 0);
             }
@@ -487,6 +487,7 @@ impl CommandQueue {
                 self.share.context.DisableVertexAttribArray(attribute.location);
             }
             com::Command::CopyBufferToTexture(buffer, image, ref region) => unsafe {
+                // TODO: Fix format and active texture
                 let gl = &self.share.context;
                 gl.ActiveTexture(gl::TEXTURE0);
                 gl.BindBuffer(gl::PIXEL_UNPACK_BUFFER, buffer);


### PR DESCRIPTION
This adds basic functionality to run the hal/quad example on the GL backend. Windows seems to work fine. OS X fails because the varying name doesn't match across vertex/fragment shaders, although I think this is supposed to work on 4.10.

~~WIP because there are a few format-related attribute arguments hardcoded (element type/size/stride) at the moment, but I'll probably wait for #1700 to fix them.~~