### PR TITLE
[gl] Clear render pass start/always soft reset command buffers

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -313,9 +313,11 @@ impl RawCommandBuffer {
 
 impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     fn begin(&mut self) {
-        // Implicit buffer reset when individual reset is set.
         if self.individual_reset {
+            // Implicit buffer reset when individual reset is set.
             self.reset(false);
+        } else {
+            self.soft_reset();
         }
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -75,7 +75,7 @@ pub enum Command {
     },
     SetScissors(BufferSlice),
     SetBlendColor(command::ColorValue),
-    ClearColor(n::ImageView, command::ClearColor),
+    ClearColor(command::ClearColor),
     BindFrameBuffer(FrameBufferTarget, n::FrameBuffer),
     BindTargetView(FrameBufferTarget, AttachmentPoint, n::ImageView),
     SetDrawColorBuffers(usize),
@@ -375,13 +375,22 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         _render_pass: &n::RenderPass,
         _frame_buffer: &n::FrameBuffer,
         _render_area: command::Rect,
-        _clear_values: T,
+        clear_values: T,
         _first_subpass: command::SubpassContents,
     ) where
         T: IntoIterator,
         T::Item: Borrow<command::ClearValue>,
     {
-        unimplemented!()
+        for clear_value in clear_values.into_iter().map(|cv| *cv.borrow()) {
+            match clear_value {
+                command::ClearValue::Color(value) => {
+                    self.push_cmd(Command::ClearColor(value));
+                }
+                command::ClearValue::DepthStencil(_) => {
+                    unimplemented!();
+                }
+            }
+        }
     }
 
     fn next_subpass(&mut self, _contents: command::SubpassContents) {
@@ -407,7 +416,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         self.push_cmd(Command::BindFrameBuffer(gl::DRAW_FRAMEBUFFER, fbo));
         self.push_cmd(Command::BindTargetView(gl::DRAW_FRAMEBUFFER, gl::COLOR_ATTACHMENT0, view));
         self.push_cmd(Command::SetDrawColorBuffers(1));
-        self.push_cmd(Command::ClearColor(view, value));
+        self.push_cmd(Command::ClearColor(value));
     }
 
     fn clear_depth_stencil_image(

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -423,23 +423,21 @@ impl CommandQueue {
             com::Command::SetBlendColor(color) => {
                 state::set_blend_color(&self.share.context, color);
             }
-            com::Command::ClearColor(_texture, c) => {
+            com::Command::ClearColor(c) => unsafe {
                 //TODO: check texture?
                 let gl = &self.share.context;
                 state::unlock_color_mask(gl);
                 if self.share.private_caps.clear_buffer {
                     // Render target view bound to the framebuffer at attachment slot 0.
-                    unsafe {
-                        match c {
-                            hal::command::ClearColor::Float(v) => {
-                                gl.ClearBufferfv(gl::COLOR, 0, &v[0]);
-                            }
-                            hal::command::ClearColor::Int(v) => {
-                                gl.ClearBufferiv(gl::COLOR, 0, &v[0]);
-                            }
-                            hal::command::ClearColor::Uint(v) => {
-                                gl.ClearBufferuiv(gl::COLOR, 0, &v[0]);
-                            }
+                    match c {
+                        hal::command::ClearColor::Float(v) => {
+                            gl.ClearBufferfv(gl::COLOR, 0, &v[0]);
+                        }
+                        hal::command::ClearColor::Int(v) => {
+                            gl.ClearBufferiv(gl::COLOR, 0, &v[0]);
+                        }
+                        hal::command::ClearColor::Uint(v) => {
+                            gl.ClearBufferuiv(gl::COLOR, 0, &v[0]);
                         }
                     }
                 } else {
@@ -450,10 +448,8 @@ impl CommandQueue {
                         [0.0, 0.0, 0.0, 0.0]
                     };
 
-                    unsafe {
-                        gl.ClearColor(v[0], v[1], v[2], v[3]);
-                        gl.Clear(gl::COLOR_BUFFER_BIT);
-                    }
+                    gl.ClearColor(v[0], v[1], v[2], v[3]);
+                    gl.Clear(gl::COLOR_BUFFER_BIT);
                 }
             }
             com::Command::BindFrameBuffer(point, frame_buffer) => {


### PR DESCRIPTION
Cherry pick the first two commits from #1701 to reduce noise in the diff there. I think these commits are probably fine to merge in their current state.

- Clear during `begin_renderpass`
- Always `soft_reset` during `RawCommandBuffer::begin` to reset the command buffer state