### PR TITLE
Fix handling of optional function constants in Metal backend

### DIFF
--- a/examples/render/quad_render/Cargo.toml
+++ b/examples/render/quad_render/Cargo.toml
@@ -8,6 +8,11 @@ workspace = "../../.."
 name = "quad_render"
 path = "main.rs"
 
+[features]
+default = ["vulkan"]
+vulkan = ["gfx-backend-vulkan"]
+metal = ["gfx-backend-metal"]
+
 [dependencies]
 env_logger = "0.4"
 glutin = { version = "0.11", optional = true }
@@ -17,4 +22,8 @@ winit = "0.9"
 gfx-hal = { path = "../../../src/hal", version = "0.1" }
 gfx-render = { path = "../../../src/render", version = "0.1" }
 
-gfx-backend-vulkan = { path = "../../../src/backend/vulkan", version = "0.1" }
+gfx-backend-vulkan = { path = "../../../src/backend/vulkan", version = "0.1", optional = true }
+gfx-backend-metal = { path = "../../../src/backend/metal", optional = true }
+
+
+

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -1,6 +1,9 @@
 extern crate env_logger;
 extern crate gfx_hal as hal;
+#[cfg(feature = "vulkan")]
 extern crate gfx_backend_vulkan as back;
+#[cfg(feature = "metal")]
+extern crate gfx_backend_metal as back;
 #[macro_use]
 extern crate gfx_render as gfx;
 
@@ -48,6 +51,10 @@ gfx_graphics_pipeline! {
 
 fn main() {
     env_logger::init().unwrap();
+
+    #[cfg(feature = "metal")]
+    let mut autorelease_pool = unsafe { back::AutoreleasePool::new() };
+
     let mut events_loop = winit::EventsLoop::new();
     let window = winit::WindowBuilder::new()
         .with_dimensions(1024, 768)
@@ -256,6 +263,11 @@ fn main() {
 
         submits.push(encoder.finish());
         context.present(submits.drain(..).collect::<Vec<_>>());
+
+        #[cfg(feature = "metal")]
+        unsafe {
+            autorelease_pool.reset();
+        }
     }
 
     println!("cleanup!");


### PR DESCRIPTION
A shader with only optional function constants will be handled improperly by the current Metal backend, resulting in a crash. `MTLLibrary` distinguishes between creating a function without passing any specialization constants and creating a function with an empty list of specialization constants. If the function has only optional constants the former method produces a reflection-only function, while the latter produces a function suitable for inclusion in a PSO. This PR detects this edge case and handles it appropriately.

It also implements a few missing functions to get the `gfx_render` quad example working on Metal (the high level quad example also exercises the above edge case).