### PR TITLE
dx12: Fix compute descriptor tables

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -516,7 +516,7 @@ impl CommandBuffer {
                 )
             },
             |slot, gpu| unsafe {
-                cmd_buffer.clone().SetGraphicsRootDescriptorTable(slot, gpu);
+                cmd_buffer.clone().SetComputeRootDescriptorTable(slot, gpu);
             },
         );
     }


### PR DESCRIPTION
(Required for fixing `gfx_ocean`)