### PR TITLE
hal: Allow creating multiple logical devices from a physical device

### DIFF
--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -57,7 +57,7 @@ impl hal::Backend for Backend {
 pub struct PhysicalDevice;
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
-        self, _: Vec<(QueueFamily, Vec<hal::QueuePriority>)>
+        &self, _: Vec<(QueueFamily, Vec<hal::QueuePriority>)>
     ) -> Result<hal::Gpu<Backend>, adapter::DeviceCreationError> {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -103,6 +103,12 @@ impl Device {
     }
 }
 
+impl Drop for Device {
+    fn drop(&mut self) {
+        self.share.open.set(false);
+    }
+}
+
 impl Device {
     pub fn create_shader_module_from_source(
         &self,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -148,8 +148,10 @@ impl PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
-        self, mut families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>,
+        &self, mut families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>,
     ) -> Result<hal::Gpu<Backend>, hal::adapter::DeviceCreationError> {
+        // TODO: Handle opening a physical device multiple times
+
         assert_eq!(families.len(), 1);
         let mut queue_group = hal::queue::RawQueueGroup::new(families.remove(0).0);
         let queue_raw = command::CommandQueue::new(&self.0);

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -311,7 +311,7 @@ pub struct PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
-        self, families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>
+        &self, families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>
     ) -> Result<hal::Gpu<Backend>, DeviceCreationError> {
         let family_infos = families
             .iter()

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -44,6 +44,10 @@ pub struct MemoryProperties {
 pub trait PhysicalDevice<B: Backend>: Sized {
     /// Create a new logical device.
     ///
+    /// # Errors
+    ///
+    /// - Returns `TooManyObjects` if the implementation can't create a new logical device.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -57,7 +61,7 @@ pub trait PhysicalDevice<B: Backend>: Sized {
     /// let gpu = physical_device.open(vec![(family, vec![1.0; 1])]);
     /// # }
     /// ```
-    fn open(self, Vec<(B::QueueFamily, Vec<QueuePriority>)>) -> Result<Gpu<B>, DeviceCreationError>;
+    fn open(&self, Vec<(B::QueueFamily, Vec<QueuePriority>)>) -> Result<Gpu<B>, DeviceCreationError>;
 
     ///
     fn format_properties(&self, Option<format::Format>) -> format::Properties;


### PR DESCRIPTION
Following Vulkan specification and required to get portability running with dx12.
Currently, implementation clones the adapter, but that's a hack and creating multiple devices would result in a mess as all would be the same device under the hood on dx12.