### PR TITLE
Warden and GL improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,3 +74,4 @@ script:
   - export LIBRARY_PATH=$HOME/deps/usr/lib/x86_64-linux-gnu
   - export LD_LIBRARY_PATH=$LIBRARY_PATH
   - make all
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then make reftests-software; fi

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ test:
 reftests:
 	cd src/warden && cargo run --bin reftest --features "$(FEATURES_HAL) $(FEATURES_HAL2)"
 
+reftests-software:
+	cd src/warden && cargo run #TODO: --features "gl-soft"
+
 travis-sdl2:
 	#TODO
 	#if [ -e $(SDL2_CONFIG) ]; then exit 1; fi

--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -3,13 +3,13 @@
 		"im-color": Image(
 			kind: D2(1, 1, Single),
 			num_levels: 1,
-			format: (R8_G8_B8_A8, Unorm),
+			format: Rgba8Unorm,
 			usage: (bits: 4),
 		),
 		"pass": RenderPass(
 			attachments: {
 				"c": (
-					format: (R8_G8_B8_A8, Unorm),
+					format: Some(Rgba8Unorm),
 					ops: (load: Clear, store: Store),
 					layouts: (start: General, end: General),
 				),
@@ -24,7 +24,7 @@
 		),
 		"im-color-view": ImageView(
 			image: "im-color",
-			format: (R8_G8_B8_A8, Unorm),
+			format: Rgba8Unorm,
 			range: (
 				aspects: (bits: 1),
 				levels: (start: 0, end: 1),

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::{ffi, fmt, mem, str};
 use gl;
@@ -153,6 +152,8 @@ pub struct PrivateCaps {
     pub vertex_array: bool,
     /// FBO support
     pub framebuffer: bool,
+    /// FBO support to call `glFramebufferTexture`
+    pub framebuffer_texture: bool,
     /// Can bind a buffer to a different target than was
     /// used upon the buffer creation/initialization
     pub buffer_role_change: bool,
@@ -333,6 +334,7 @@ pub fn query_all(gl: &gl::Gl) -> (Info, Features, Limits, PrivateCaps) {
         framebuffer:                        info.is_supported(&[Core(3,0),
                                                                 Es  (2,0),
                                                                 Ext ("GL_ARB_framebuffer_object")]),
+        framebuffer_texture:                info.is_supported(&[Core(3,0)]), //TODO: double check
         buffer_role_change:                 !info.version.is_embedded,
         image_storage:                      info.is_supported(&[Core(3,2),
                                                                 Ext ("GL_ARB_texture_storage")]),

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -23,6 +23,7 @@ vulkan = ["gfx-backend-vulkan"]
 dx12 = ["gfx-backend-dx12"]
 metal = ["gfx-backend-metal"]
 gl = ["gfx-backend-gl"]
+gl-soft = ["gl"]
 
 #TODO: keep Warden backend-agnostic?
 

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -50,7 +50,7 @@ pub struct Image<B: hal::Backend> {
     #[allow(dead_code)]
     memory: B::Memory,
     kind: i::Kind,
-    format: hal::format::Format,
+    format: f::Format,
     stable_state: i::State,
 }
 


### PR DESCRIPTION
This PR makes a few steps towards #583 goal of getting Warden running on CI:
  - it splits the `gl` feature on Warden in to pure "gl" and software CI-compatible "gl-soft"
  - makes Warden parse all the inputs before any backends are initialized, allowing us to at least stop breaking the test formatting (enabled on CI here)
  - updates reftest RON files
  - makes GL backend `create_framebuffer` to be compatible with OsMesa GL 2.1 context
  