### PR TITLE
vk: Fix shader module code length

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -710,7 +710,7 @@ impl d::Device<B> for Device {
             s_type: vk::StructureType::ShaderModuleCreateInfo,
             p_next: ptr::null(),
             flags: vk::ShaderModuleCreateFlags::empty(),
-            code_size: spirv_data.len(),
+            code_size: spirv_data.len() / 4,
             p_code: spirv_data as *const _ as *const u32,
         };
 


### PR DESCRIPTION
Casting from &[u8] to &[u32] requires adjusting the length.