### PR TITLE
[RFC] Refactor queue creation

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -18,9 +18,9 @@ extern crate winit;
 extern crate image;
 
 use hal::{buffer, command, device as d, format as f, image as i, memory as m, pass, pso, pool};
-use hal::{Device, Instance, PhysicalDevice, QueueFamily, Surface, Swapchain};
+use hal::{Device, Instance, PhysicalDevice, Surface, Swapchain};
 use hal::{
-    DescriptorPool, Gpu, FrameSync, Primitive,
+    DescriptorPool, FrameSync, Primitive,
     Backbuffer, SwapchainConfig,
 };
 use hal::format::{AsFormat, ChannelType, Rgba8Srgb as ColorFormat, Swizzle};
@@ -129,14 +129,13 @@ fn main() {
         .get_limits();
 
     // Build a new device and associated command queues
-    let Gpu { device, mut queue_groups } =
-        adapter.open_with(|family| {
-            if family.supports_graphics() && surface.supports_queue_family(family) {
+    let (device, mut queue_group) =
+        adapter.open_with::<_, hal::Graphics>(|family| {
+            if surface.supports_queue_family(family) {
                 Some(1)
             } else { None }
         }).unwrap();
 
-    let mut queue_group = hal::QueueGroup::<_, hal::Graphics>::new(queue_groups.remove(0));
     let mut command_pool = device.create_command_pool_typed(&queue_group, pool::CommandPoolCreateFlags::empty(), 16);
     let mut queue = &mut queue_group.queues[0];
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -15,10 +15,11 @@ use hal::{self, buffer, device as d, format, image, mapping, memory, pass, pso, 
 use hal::format::AspectFlags;
 use hal::memory::Requirements;
 use hal::pool::CommandPoolCreateFlags;
+use hal::queue::QueueFamilyId;
 
 use {
     conv, free_list, native as n, root_constants, shade, window as w,
-    Backend as B, Device, QueueFamily, MAX_VERTEX_BUFFERS, NUM_HEAP_PROPERTIES,
+    Backend as B, Device, QUEUE_FAMILIES, MAX_VERTEX_BUFFERS, NUM_HEAP_PROPERTIES,
 };
 use pool::RawCommandPool;
 use root_constants::RootConstant;
@@ -717,9 +718,9 @@ impl d::Device<B> for Device {
     }
 
     fn create_command_pool(
-        &self, family: &QueueFamily, _create_flags: CommandPoolCreateFlags
+        &self, family: QueueFamilyId, _create_flags: CommandPoolCreateFlags
     ) -> RawCommandPool {
-        let list_type = family.native_type();
+        let list_type = QUEUE_FAMILIES[family.0].native_type();
         // create command allocator
         let mut command_allocator: *mut d3d12::ID3D12CommandAllocator = ptr::null_mut();
         let hr = unsafe {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -23,7 +23,7 @@ mod shade;
 mod window;
 
 use hal::{format, memory, Features, Limits, QueueType};
-use hal::queue::{QueueFamilyId, Queues};
+use hal::queue::{QueueFamily as HalQueueFamily, QueueFamilyId, Queues};
 
 use winapi::shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, winerror};
 use winapi::shared::minwindef::TRUE;
@@ -126,6 +126,16 @@ impl hal::QueueFamily for QueueFamily {
             QueueFamily::Normal(_) => MAX_QUEUES,
         }
     }
+    fn id(&self) -> QueueFamilyId {
+        // This must match the order exposed by `QUEUE_FAMILIES`
+        QueueFamilyId(match *self {
+            QueueFamily::Present => 0,
+            QueueFamily::Normal(QueueType::General) => 1,
+            QueueFamily::Normal(QueueType::Compute) => 2,
+            QueueFamily::Normal(QueueType::Transfer) => 3,
+            _ => unreachable!(),
+        })
+    }
 }
 
 impl QueueFamily {
@@ -137,17 +147,6 @@ impl QueueFamily {
             QueueType::Compute => d3d12::D3D12_COMMAND_LIST_TYPE_COMPUTE,
             QueueType::Transfer => d3d12::D3D12_COMMAND_LIST_TYPE_COPY,
         }
-    }
-
-    fn id(&self) -> QueueFamilyId {
-        // This must match the order exposed by `QUEUE_FAMILIES`
-        QueueFamilyId(match *self {
-            QueueFamily::Present => 0,
-            QueueFamily::Normal(QueueType::General) => 1,
-            QueueFamily::Normal(QueueType::Compute) => 2,
-            QueueFamily::Normal(QueueType::Transfer) => 3,
-            _ => unreachable!(),
-        })
     }
 }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -90,7 +90,7 @@ impl queue::RawCommandQueue<Backend> for RawCommandQueue {
 /// Dummy device doing nothing.
 pub struct Device;
 impl hal::Device<Backend> for Device {
-    fn create_command_pool(&self, _: &QueueFamily, _: pool::CommandPoolCreateFlags) -> RawCommandPool {
+    fn create_command_pool(&self, _: queue::QueueFamilyId, _: pool::CommandPoolCreateFlags) -> RawCommandPool {
         unimplemented!()
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -316,6 +316,9 @@ impl queue::QueueFamily for QueueFamily {
     fn max_queues(&self) -> usize {
         unimplemented!()
     }
+    fn id(&self) -> queue::QueueFamilyId {
+        unimplemented!()
+    }
 }
 
 /// Dummy subpass command buffer.

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -8,12 +8,15 @@ use std::sync::{Arc, Mutex};
 
 use gl;
 use gl::types::{GLint, GLenum, GLfloat, GLuint};
+
 use hal::{self as c, device as d, image as i, memory, pass, pso, buffer, mapping, query, Primitive};
 use hal::format::{Format, Swizzle};
 use hal::pool::CommandPoolCreateFlags;
+use hal::queue::QueueFamilyId;
+
 use spirv_cross::{glsl, spirv, ErrorCode as SpirvErrorCode};
 
-use {Backend as B, QueueFamily, Share, Surface, Swapchain};
+use {Backend as B, Share, Surface, Swapchain};
 use {conv, native as n, state};
 use pool::{BufferMemory, OwnedBuffer, RawCommandPool};
 
@@ -239,7 +242,7 @@ impl d::Device<B> for Device {
 
     fn create_command_pool(
         &self,
-        _family: &QueueFamily,
+        _family: QueueFamilyId,
         flags: CommandPoolCreateFlags,
     ) -> RawCommandPool {
         let fbo = create_fbo_internal(&self.share.context);

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -228,7 +228,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                     let mut family = hal::backend::RawQueueGroup::new(proto_family);
                     let queue = queue::CommandQueue::new(&self.0, vao);
                     family.add_queue(queue);
-                    (QueueFamilyId(1), family)
+                    (QueueFamilyId(0), family)
                 })
                 .collect()),
         })
@@ -288,4 +288,5 @@ pub struct QueueFamily(hal::QueueType);
 impl hal::QueueFamily for QueueFamily {
     fn queue_type(&self) -> hal::QueueType { self.0 }
     fn max_queues(&self) -> usize { 1 }
+    fn id(&self) -> QueueFamilyId { QueueFamilyId(0) }
 }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -15,6 +15,8 @@ pub extern crate glutin;
 use std::cell::Cell;
 use std::rc::Rc;
 
+use hal::queue::{Queues, QueueFamilyId};
+
 pub use self::device::Device;
 pub use self::info::{Info, PlatformName, Version};
 
@@ -219,16 +221,16 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
         Ok(hal::Gpu {
             device: Device::new(self.0.clone()),
-            queue_groups: families
+            queues: Queues::new(families
                 .into_iter()
                 .map(|(proto_family, priorities)| {
                     assert_eq!(priorities.len(), 1);
-                    let mut family = hal::queue::RawQueueGroup::new(proto_family);
+                    let mut family = hal::backend::RawQueueGroup::new(proto_family);
                     let queue = queue::CommandQueue::new(&self.0, vao);
                     family.add_queue(queue);
-                    family
+                    (QueueFamilyId(1), family)
                 })
-                .collect(),
+                .collect()),
         })
     }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -14,6 +14,7 @@ use hal::device::{WaitFor, BindError, OutOfMemory, FramebufferError, ShaderError
 use hal::memory::Properties;
 use hal::pool::CommandPoolCreateFlags;
 use hal::pso::{DescriptorSetWrite, DescriptorType, DescriptorSetLayoutBinding, AttributeDesc, DepthTest, StencilTest, StencilFace};
+use hal::queue::QueueFamilyId;
 
 use cocoa::foundation::{NSRange, NSUInteger};
 use metal::{self, MTLFeatureSet, MTLLanguageVersion, MTLArgumentAccess, MTLDataType, MTLPrimitiveType, MTLPrimitiveTopologyClass};
@@ -569,7 +570,7 @@ impl Device {
 
 impl hal::Device<Backend> for Device {
     fn create_command_pool(
-        &self, _family: &QueueFamily, flags: CommandPoolCreateFlags
+        &self, _family: QueueFamilyId, flags: CommandPoolCreateFlags
     ) -> command::CommandPool {
         command::CommandPool {
             queue: self.queue.clone(),

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -14,7 +14,7 @@ use hal::device::{WaitFor, BindError, OutOfMemory, FramebufferError, ShaderError
 use hal::memory::Properties;
 use hal::pool::CommandPoolCreateFlags;
 use hal::pso::{DescriptorSetWrite, DescriptorType, DescriptorSetLayoutBinding, AttributeDesc, DepthTest, StencilTest, StencilFace};
-use hal::queue::QueueFamilyId;
+use hal::queue::{QueueFamily as HalQueueFamily, QueueFamilyId, Queues};
 
 use cocoa::foundation::{NSRange, NSUInteger};
 use metal::{self, MTLFeatureSet, MTLLanguageVersion, MTLArgumentAccess, MTLDataType, MTLPrimitiveType, MTLPrimitiveTopologyClass};
@@ -155,7 +155,10 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         // TODO: Handle opening a physical device multiple times
 
         assert_eq!(families.len(), 1);
-        let mut queue_group = hal::queue::RawQueueGroup::new(families.remove(0).0);
+        let family = families.remove(0).0;
+        let id = family.id();
+
+        let mut queue_group = hal::backend::RawQueueGroup::new(family);
         let queue_raw = command::CommandQueue::new(&self.0);
         let queue = queue_raw.0.clone();
         queue_group.add_queue(queue_raw);
@@ -174,9 +177,12 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             queue,
         };
 
+        let mut queues = HashMap::new();
+        queues.insert(id, queue_group);
+
         Ok(hal::Gpu {
             device,
-            queue_groups: vec![queue_group],
+            queues: Queues::new(queues),
         })
     }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -31,6 +31,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::os::raw::c_void;
 
+use hal::queue::QueueFamilyId;
+
 use objc::runtime::{Object, Class};
 use cocoa::base::YES;
 use cocoa::foundation::NSAutoreleasePool;
@@ -43,6 +45,7 @@ pub struct QueueFamily {}
 impl hal::QueueFamily for QueueFamily {
     fn queue_type(&self) -> hal::QueueType { hal::QueueType::General }
     fn max_queues(&self) -> usize { 1 }
+    fn id(&self) -> QueueFamilyId { QueueFamilyId(0) }
 }
 
 pub struct Instance {}

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1,7 +1,7 @@
 use ash::vk;
 use ash::extensions as ext;
 use ash::version::DeviceV1_0;
-use hal::{buffer, device as d, format, image, mapping, pass, pso, query};
+use hal::{buffer, device as d, format, image, mapping, pass, pso, query, queue};
 use hal::{Backbuffer, MemoryTypeId, SwapchainConfig};
 use hal::memory::Requirements;
 use hal::pool::CommandPoolCreateFlags;
@@ -14,8 +14,7 @@ use std::collections::VecDeque;
 use std::ffi::CString;
 use std::ops::Range;
 
-use {Backend as B, Device, QueueFamily};
-use {conv, window as w};
+use {Backend as B, Device};use {conv, window as w};
 use pool::RawCommandPool;
 
 
@@ -73,7 +72,7 @@ impl d::Device<B> for Device {
     }
 
     fn create_command_pool(
-        &self, family: &QueueFamily, create_flags: CommandPoolCreateFlags
+        &self, family: queue::QueueFamilyId, create_flags: CommandPoolCreateFlags
     ) -> RawCommandPool {
         let mut flags = vk::CommandPoolCreateFlags::empty();
         if create_flags.contains(CommandPoolCreateFlags::TRANSIENT) {
@@ -87,7 +86,7 @@ impl d::Device<B> for Device {
             s_type: vk::StructureType::CommandPoolCreateInfo,
             p_next: ptr::null(),
             flags,
-            queue_family_index: family.index,
+            queue_family_index: family.0 as _,
         };
 
         let command_pool_raw = unsafe {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -300,8 +300,8 @@ impl hal::queue::QueueFamily for QueueFamily {
     fn max_queues(&self) -> usize {
         self.properties.queue_count as _
     }
-    fn id(&self) -> QueueFamilyId {
-        QueueFamilyId(self.index as _)
+    fn id(&self) -> queue::QueueFamilyId {
+        queue::QueueFamilyId(self.index as _)
     }
 }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -300,6 +300,9 @@ impl hal::queue::QueueFamily for QueueFamily {
     fn max_queues(&self) -> usize {
         self.properties.queue_count as _
     }
+    fn id(&self) -> QueueFamilyId {
+        QueueFamilyId(self.index as _)
+    }
 }
 
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -374,7 +374,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             .into_iter()
             .map(|(family, priorities)| {
                 let family_index = family.index;
-                let mut family_raw = queue::family::RawQueueGroup::new(family);
+                let mut family_raw = hal::backend::RawQueueGroup::new(family);
                 for id in 0 .. priorities.len() {
                     let queue_raw = unsafe {
                         device_arc.0.get_device_queue(family_index, id as _)

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -24,7 +24,7 @@ use ash::extensions as ext;
 use ash::version::{EntryV1_0, DeviceV1_0, InstanceV1_0, V1_0};
 use ash::vk;
 
-use hal::{format, memory};
+use hal::{format, memory, queue};
 use hal::{Features, Limits, PatchSize, QueueType};
 use hal::adapter::DeviceCreationError;
 
@@ -370,11 +370,11 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         };
 
         let device_arc = device.raw.clone();
-        let queue_groups = families
+        let queues = families
             .into_iter()
             .map(|(family, priorities)| {
                 let family_index = family.index;
-                let mut family_raw = hal::queue::RawQueueGroup::new(family);
+                let mut family_raw = queue::family::RawQueueGroup::new(family);
                 for id in 0 .. priorities.len() {
                     let queue_raw = unsafe {
                         device_arc.0.get_device_queue(family_index, id as _)
@@ -384,13 +384,13 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                         device: device_arc.clone(),
                     });
                 }
-                family_raw
+                (queue::QueueFamilyId(family_index as _), family_raw)
             })
             .collect();
 
         Ok(hal::Gpu {
             device,
-            queue_groups,
+            queues: queue::Queues::new(queues),
         })
     }
 

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -3,6 +3,7 @@
 //! Physical devices are the main entry point for opening a [Device](../struct.Device).
 
 use {format, memory, Backend, Gpu, Features, Limits};
+use queue::{Capability, QueueGroup};
 
 /// Scheduling hint for devices about the priority of a queue.
 /// Values ranging from `0.0` (low) to `1.0` (high).
@@ -143,7 +144,7 @@ pub struct Adapter<B: Backend> {
 
 impl<B: Backend> Adapter<B> {
     /// Open the physical device with active queue families
-    /// specified by a selector function.
+    /// specified by a selector function with a specified queue capability.
     ///
     /// Selector returns `Some(count)` for the `count` number of queues
     /// to be created for a given queue family.
@@ -159,22 +160,39 @@ impl<B: Backend> Adapter<B> {
     /// let gpu = adapter.open_with(|_| Some(1));
     /// # }
     /// ```
-    pub fn open_with<F>(mut self, selector: F) -> Result<Gpu<B>, DeviceCreationError>
-    where F: Fn(&B::QueueFamily) -> Option<usize>
+    ///
+    /// # Return
+    ///
+    /// Returns the same errors as `open` and `InitializationFailed` if no suitable
+    /// queue family could be found.
+    pub fn open_with<F, C>(mut self, selector: F) -> Result<(B::Device, QueueGroup<B, C>), DeviceCreationError>
+    where
+        F: Fn(&B::QueueFamily) -> Option<usize>,
+        C: Capability,
     {
         use queue::QueueFamily;
 
-        let requested_families = self.queue_families
+        let requested_family = self.queue_families
             .drain(..)
             .flat_map(|family| {
-                selector(&family)
-                    .map(|count| {
-                        assert!(count != 0 && count <= family.max_queues());
-                        (family, vec![1.0; count])
-                    })
+                if C::supported_by(family.queue_type()) {
+                    selector(&family)
+                        .map(|count| {
+                            assert!(count != 0 && count <= family.max_queues());
+                            (family, vec![1.0; count])
+                        })
+                } else {
+                    None
+                }
             })
-            .collect();
+            .next();
 
-        self.physical_device.open(requested_families)
+        let (id, family) = match requested_family {
+            Some((family, priorities)) => (family.id(), vec![(family, priorities)]),
+            _ => return Err(DeviceCreationError::InitializationFailed),
+        };
+
+        let Gpu { device, mut queues } = self.physical_device.open(family)?;
+        Ok((device, queues.take(id).unwrap()))
     }
 }

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -153,11 +153,12 @@ impl<B: Backend> Adapter<B> {
     ///
     /// ```no_run
     /// # extern crate gfx_backend_empty as empty;
-    /// # extern crate gfx_hal;
+    /// # extern crate gfx_hal as hal;
+    /// use hal::General;
     /// # fn main() {
     ///
-    /// # let adapter: gfx_hal::Adapter<empty::Backend> = return;
-    /// let gpu = adapter.open_with(|_| Some(1));
+    /// # let adapter: hal::Adapter<empty::Backend> = return;
+    /// let gpu = adapter.open_with::<_, General>(|_| Some(1));
     /// # }
     /// ```
     ///

--- a/src/hal/src/backend.rs
+++ b/src/hal/src/backend.rs
@@ -1,0 +1,51 @@
+//! Functionality only required for backend implementations.
+
+use Backend;
+use queue::{QueueFamily, QueueFamilyId, Queues};
+use window::Frame;
+
+use std::collections::HashMap;
+
+/// Bare-metal queue group.
+///
+/// Denotes all queues created from one queue family.
+pub struct RawQueueGroup<B: Backend> {
+    pub family: B::QueueFamily,
+    pub queues: Vec<B::CommandQueue>,
+}
+
+impl<B: Backend> RawQueueGroup<B> {
+    /// Create a new, empty queue group for a queue family.
+    pub fn new(family: B::QueueFamily) -> Self {
+        RawQueueGroup {
+            family,
+            queues: Vec::new(),
+        }
+    }
+
+    /// Add a command queue to the group.
+    ///
+    /// The queue needs to be created from this queue family.
+    ///
+    /// # Panics
+    ///
+    /// Panics if more command queues are added the exposed by the queue family.
+    pub fn add_queue(&mut self, queue: B::CommandQueue) {
+        assert!(self.queues.len() < self.family.max_queues());
+        self.queues.push(queue);
+    }
+}
+
+impl Frame {
+    /// Create a new frame.
+    pub fn new(id: usize) -> Self {
+        Frame(id)
+    }
+}
+
+impl<B: Backend> Queues<B> {
+    /// Create a new collection of queues.
+    pub fn new(queues: HashMap<QueueFamilyId, RawQueueGroup<B>>) -> Self {
+        Queues(queues)
+    }
+}

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -9,7 +9,7 @@ use std::error::Error;
 use std::ops::Range;
 use {buffer, format, image, mapping, pass, pso, query};
 use pool::{CommandPool, CommandPoolCreateFlags};
-use queue::QueueGroup;
+use queue::{QueueFamilyId, QueueGroup};
 use {Backend, MemoryTypeId};
 use memory::Requirements;
 use window::{Backbuffer, SwapchainConfig};
@@ -131,7 +131,7 @@ pub trait Device<B: Backend> {
     /// Creates a new command pool for a given queue family.
     ///
     /// *Note*: the family has to be associated by one as the `Gpu::queue_groups`.
-    fn create_command_pool(&self, &B::QueueFamily, CommandPoolCreateFlags) -> B::CommandPool;
+    fn create_command_pool(&self, QueueFamilyId, CommandPoolCreateFlags) -> B::CommandPool;
 
     /// Creates a strongly typed command pool wrapper.
     fn create_command_pool_typed<C>(
@@ -140,7 +140,7 @@ pub trait Device<B: Backend> {
         flags: CommandPoolCreateFlags,
         max_buffers: usize,
     ) -> CommandPool<B, C> {
-        let raw = self.create_command_pool(&group.family, flags);
+        let raw = self.create_command_pool(group.family, flags);
         CommandPool::new(raw, max_buffers)
     }
 

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -140,7 +140,7 @@ pub trait Device<B: Backend> {
         flags: CommandPoolCreateFlags,
         max_buffers: usize,
     ) -> CommandPool<B, C> {
-        let raw = self.create_command_pool(group.family, flags);
+        let raw = self.create_command_pool(group.family(), flags);
         CommandPool::new(raw, max_buffers)
     }
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -51,6 +51,8 @@ pub mod query;
 pub mod queue;
 pub mod window;
 
+#[doc(hidden)]
+pub mod backend;
 
 /// Draw vertex count.
 pub type VertexCount = u32;

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -281,7 +281,6 @@ pub type SubmissionResult<T> = Result<T, SubmissionError>;
 pub struct Gpu<B: Backend> {
     /// Logical device.
     pub device: B::Device,
-    /// Raw queue groups. Each element in this vector
-    /// matches the corresponding argument in `Adapter::open`.
-    pub queue_groups: Vec<queue::RawQueueGroup<B>>,
+    ///
+    pub queues: queue::Queues<B>,
 }

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -1,0 +1,106 @@
+//! Queue family and groups.
+
+use Backend;
+use queue::{CommandQueue, QueueType};
+use queue::capability::{Capability, Graphics, Compute};
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+
+/// General information about a queue family, available upon adapter discovery.
+///
+/// *Note*: A backend can expose multiple queue families with the same properties.
+pub trait QueueFamily: Debug {
+    /// Returns the type of queues.
+    fn queue_type(&self) -> QueueType;
+    /// Returns maximum number of queues created from this family.
+    fn max_queues(&self) -> usize;
+    /// Returns true if the queue supports graphics operations.
+    fn supports_graphics(&self) -> bool {
+        Graphics::supported_by(self.queue_type())
+    }
+    /// Returns true if the queue supports graphics operations.
+    fn supports_compute(&self) -> bool {
+        Compute::supported_by(self.queue_type())
+    }
+}
+
+/// Identifier for a queue family of a physical device.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct QueueFamilyId(pub usize);
+
+// Only needed for backend implementations.
+#[doc(hidden)]
+pub struct RawQueueGroup<B: Backend> {
+    pub family: B::QueueFamily,
+    pub queues: Vec<B::CommandQueue>,
+}
+
+impl<B: Backend> RawQueueGroup<B> {
+    #[doc(hidden)]
+    pub fn new(family: B::QueueFamily) -> Self {
+        RawQueueGroup {
+            family,
+            queues: Vec::new(),
+        }
+    }
+    #[doc(hidden)]
+    pub fn add_queue(&mut self, queue: B::CommandQueue) {
+        assert!(self.queues.len() < self.family.max_queues());
+        self.queues.push(queue);
+    }
+}
+
+
+/// Strong-typed group of queues of the same queue family.
+pub struct QueueGroup<B: Backend, C> {
+    pub(crate) family: QueueFamilyId,
+    /// Command queues created in this family.
+    pub queues: Vec<CommandQueue<B, C>>,
+}
+
+impl<B: Backend, C: Capability> QueueGroup<B, C> {
+    /// Create a new strongly typed queue group from a raw one.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the family doesn't expose required queue capabilities.
+    fn new(id: QueueFamilyId, raw: RawQueueGroup<B>) -> Self {
+        assert!(C::supported_by(raw.family.queue_type()));
+        QueueGroup {
+            family: id,
+            queues: raw.queues
+                .into_iter()
+                .map(|q| CommandQueue(q, PhantomData))
+                .collect(),
+        }
+    }
+}
+
+/// Contains a list of all instantiated queue queues, grouped by their
+/// associated queue family.
+pub struct Queues<B: Backend>(HashMap<QueueFamilyId, RawQueueGroup<B>>);
+
+impl<B: Backend> Queues<B> {
+    #[doc(hidden)]
+    pub fn new(queues: HashMap<QueueFamilyId, RawQueueGroup<B>>) -> Self {
+        Queues(queues)
+    }
+
+    /// Removes the queue family with the passed id from the queue list and
+    /// returns the queue group.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the family doesn't expose required queue capabilities.
+    pub fn take<C: Capability>(&mut self, id: QueueFamilyId) -> Option<QueueGroup<B, C>> {
+        self.0.remove(&id).map(|group| QueueGroup::new(id, group))
+    }
+
+    /// Removes the queue family with the passed id from the queue list and
+    /// returns the command queues.
+    pub fn take_raw(&mut self, id: QueueFamilyId) -> Option<Vec<B::CommandQueue>> {
+        self.0.remove(&id).map(|group| group.queues)
+    }
+}

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -25,6 +25,8 @@ pub trait QueueFamily: Debug {
     fn supports_compute(&self) -> bool {
         Compute::supported_by(self.queue_type())
     }
+    ///
+    fn id(&self) -> QueueFamilyId;
 }
 
 /// Identifier for a queue family of a physical device.

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -8,15 +8,18 @@
 !*/
 
 pub mod capability;
+pub mod family;
 pub mod submission;
 
 use Backend;
-use std::fmt::Debug;
 use std::marker::PhantomData;
 
 pub use self::capability::{
     Capability, Supports,
     Compute, Graphics, General, Transfer,
+};
+pub use self::family::{
+    QueueFamily, QueueFamilyId, QueueGroup, Queues,
 };
 pub use self::submission::{RawSubmission, Submission};
 
@@ -32,76 +35,6 @@ pub enum QueueType {
     Compute,
     ///
     Transfer,
-}
-
-/// General information about a queue family, available upon adapter discovery.
-///
-/// *Note*: A backend can expose multiple queue families with the same properties.
-pub trait QueueFamily: Debug {
-    /// Returns the type of queues.
-    fn queue_type(&self) -> QueueType;
-    /// Returns maximum number of queues created from this family.
-    fn max_queues(&self) -> usize;
-    /// Returns true if the queue supports graphics operations.
-    fn supports_graphics(&self) -> bool {
-        Graphics::supported_by(self.queue_type())
-    }
-    /// Returns true if the queue supports graphics operations.
-    fn supports_compute(&self) -> bool {
-        Compute::supported_by(self.queue_type())
-    }
-}
-
-/// `RawQueueGroup` denotes a group of command queues provided by the backend
-/// with the same properties/type.
-pub struct RawQueueGroup<B: Backend> {
-    family: B::QueueFamily,
-    queues: Vec<B::CommandQueue>,
-}
-
-//TODO: this is not a very sound structure, unfortunately.
-impl<B: Backend> RawQueueGroup<B> {
-    #[doc(hidden)]
-    pub fn new(family: B::QueueFamily) -> Self {
-        RawQueueGroup {
-            family,
-            queues: Vec::new(),
-        }
-    }
-    #[doc(hidden)]
-    pub fn add_queue(&mut self, queue: B::CommandQueue) {
-        assert!(self.queues.len() < self.family.max_queues());
-        self.queues.push(queue);
-    }
-    ///
-    pub fn family(&self) -> &B::QueueFamily {
-        &self.family
-    }
-}
-
-/// Stronger-typed queue family.
-pub struct QueueGroup<B: Backend, C> {
-    pub(crate) family: B::QueueFamily,
-    /// Command queues created in this family.
-    pub queues: Vec<CommandQueue<B, C>>,
-}
-
-impl<B: Backend, C: Capability> QueueGroup<B, C> {
-    /// Create a new strongly typed queue group from a raw one.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the family doesn't expose required queue capabilities.
-    pub fn new(raw: RawQueueGroup<B>) -> Self {
-        assert!(C::supported_by(raw.family.queue_type()));
-        QueueGroup {
-            family: raw.family,
-            queues: raw.queues
-                .into_iter()
-                .map(|q| CommandQueue(q, PhantomData))
-                .collect(),
-        }
-    }
 }
 
 /// `RawCommandQueue` are abstractions to the internal GPU execution engines.

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -119,14 +119,9 @@ pub trait Surface<B: Backend> {
 /// Handle to a backbuffer of the swapchain.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Frame(usize);
+pub struct Frame(pub(crate) usize);
 
 impl Frame {
-    #[doc(hidden)]
-    pub fn new(id: usize) -> Self {
-        Frame(id)
-    }
-
     /// Retrieve frame id.
     ///
     /// The can be used to access the currently used backbuffer image

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::slice;
 
 use hal::{self, buffer, format as f, image as i, memory, pso};
-use hal::{Device, DescriptorPool, PhysicalDevice, QueueFamily};
+use hal::{Device, DescriptorPool, PhysicalDevice};
 
 use raw;
 
@@ -104,12 +104,7 @@ impl<B: hal::Backend> Scene<B> {
             .get_limits();
 
         // initialize graphics
-        let hal::Gpu { device, mut queue_groups } =
-            adapter.open_with(|family| {
-                if family.supports_graphics() {
-                    Some(1)
-                } else { None }
-            })?;
+        let (device, queue_group) = adapter.open_with(|_| Some(1))?;
 
         let upload_type: hal::MemoryTypeId = memory_types
             .iter()
@@ -129,7 +124,6 @@ impl<B: hal::Backend> Scene<B> {
         info!("upload memory: {:?}", upload_type);
         info!("download memory: {:?}", &download_type);
 
-        let queue_group = hal::QueueGroup::<_, hal::Graphics>::new(queue_groups.remove(0));
         let mut command_pool = device.create_command_pool_typed(
             &queue_group,
             hal::pool::CommandPoolCreateFlags::empty(),


### PR DESCRIPTION
Identify queue families by handle and use actual queue families only for device creation.
It hides the `RawQueueGroup` as implementation detail and gives the user a bit more contol over selecting the queue groups after creation.

Removes also the `open_with` function for now, as it's a bit awkward to use imo as we give up information about the order of queue families. I'm looking into replacing it with an alternative for single queue family selection using a filter, which is probably more common and sound.

Use-case scenario:
```rust
let adapter = instance.enumerate_adapters();
let (family_ids, families) = adapters.find_families(..);
let Gpu { device, queues } = adapter.open(families);
let main_queue = queues.take::<Graphics>(family_id[0]);
let compute_queue = queues.take::<Compute>(family_id[1]);

let graphics_pool = device.create_command_pool(main_queue.family());
```

Other motivation is implementation of portability layer to query queues from `(family_id, queue_id)`.

**WIP**: Backend implementations missing
  