### PR TITLE
[gl] Warden on CI, basic texture to buffer copies and memory mapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
   # Do not run bors builds against the nightly compiler.
   # We want to find out about nightly bugs, so they're done in master, but we don't block on them.
   - if [[ $TRAVIS_RUST_VERSION == "nightly" && $TRAVIS_BRANCH == "staging" ]]; then exit; fi
+  #- if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then sudo add-apt-repository ppa:xorg-edgers/ppa -y && sudo apt-get update -q && sudo apt-get install libosmesa6-dev -y; fi
   # Extract SDL2 .deb into a cached directory (see cache section above and LIBRARY_PATH exports below)
   # Will no longer be needed when Trusty build environment goes out of beta at Travis CI
   # (assuming it will have libsdl2-dev and Rust by then)
@@ -74,4 +75,4 @@ script:
   - export LIBRARY_PATH=$HOME/deps/usr/lib/x86_64-linux-gnu
   - export LD_LIBRARY_PATH=$LIBRARY_PATH
   - make all
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then make reftests-software; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then make reftests-ci; fi

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ check:
 	cd examples/hal && cargo check --features "$(FEATURES_HAL)"
 	cd examples/hal && cargo check --features "$(FEATURES_HAL2)"
 	cd examples/render/quad_render && $(CMD_QUAD_RENDER)
-	cd src/warden && cargo check --features "gl $(FEATURES_HAL) $(FEATURES_HAL2)" #TODO: run
+	cd src/warden && cargo check --features "gl gl-soft $(FEATURES_HAL) $(FEATURES_HAL2)"
 
 test:
 	cargo test --all $(EXCLUDES)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ check:
 	cd examples/hal && cargo check --features "$(FEATURES_HAL)"
 	cd examples/hal && cargo check --features "$(FEATURES_HAL2)"
 	cd examples/render/quad_render && $(CMD_QUAD_RENDER)
-	cd src/warden && cargo check --features "gl gl-soft $(FEATURES_HAL) $(FEATURES_HAL2)"
+	cd src/warden && cargo check --features "ci gl gl-headless $(FEATURES_HAL) $(FEATURES_HAL2)"
 
 test:
 	cargo test --all $(EXCLUDES)
@@ -58,8 +58,8 @@ test:
 reftests:
 	cd src/warden && cargo run --bin reftest --features "$(FEATURES_HAL) $(FEATURES_HAL2)"
 
-reftests-software:
-	cd src/warden && cargo run #TODO: --features "gl-soft"
+reftests-ci:
+	cd src/warden && cargo run --features "ci gl" #TODO: "gl-headless"
 
 travis-sdl2:
 	#TODO

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -83,8 +83,11 @@ pub enum Command {
     BindProgram(gl::types::GLuint),
     BindBlendSlot(ColorSlot, pso::ColorBlendDesc),
     BindAttribute(n::AttributeDesc, gl::types::GLuint, gl::types::GLsizei, n::VertexAttribFunction),
-    UnbindAttribute(n::AttributeDesc),
-    CopyBufferToTexture(n::RawBuffer, gl::types::GLuint, command::BufferImageCopy),
+    //UnbindAttribute(n::AttributeDesc),
+    CopyBufferToTexture(n::RawBuffer, n::Texture, command::BufferImageCopy),
+    CopyBufferToSurface(n::RawBuffer, n::Surface, command::BufferImageCopy),
+    CopyTextureToBuffer(n::Texture, n::RawBuffer, command::BufferImageCopy),
+    CopySurfaceToBuffer(n::Surface, n::RawBuffer, command::BufferImageCopy),
 }
 
 pub type FrameBufferTarget = gl::types::GLenum;
@@ -334,7 +337,7 @@ impl RawCommandBuffer {
                 &mut self.memory,
                 &mut self.buf,
                 Command::BindAttribute(*attribute, handle, desc.stride as _, attribute.vertex_attrib_fn)
-            ); 
+            );
         }
     }
 }
@@ -501,7 +504,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         let needed_length = vbs.0.iter().map(|vb| vb.1).max().unwrap() + 1;
 
         self.cache.vertex_buffers.resize(needed_length, 0);
-        
+
         for vb in vbs.0 {
             self.cache.vertex_buffers[vb.1] = vb.0.raw;
         }
@@ -689,34 +692,46 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
          T: IntoIterator,
          T::Item: Borrow<command::BufferImageCopy>,
      {
-        let image_raw = match dst {
-            &n::Image::Surface(s) => s,
-            &n::Image::Texture(t) => t
-        };
+        let old_offset = self.buf.offset;
 
-        let mut no_commands_submitted = true;
-
-        for region in regions.into_iter() {
-            no_commands_submitted = false;
-            self.push_cmd(Command::CopyBufferToTexture(src.raw, image_raw, region.borrow().clone()));
+        for region in regions {
+            let r = region.borrow().clone();
+            let cmd = match *dst {
+                n::Image::Surface(s) => Command::CopyBufferToSurface(src.raw, s, r),
+                n::Image::Texture(t) => Command::CopyBufferToTexture(src.raw, t, r),
+            };
+            self.push_cmd(cmd);
         }
 
-        if no_commands_submitted {
+        if self.buf.offset == old_offset {
             error!("At least one region must be specified");
         }
     }
 
     fn copy_image_to_buffer<T>(
         &mut self,
-        _src: &n::Image,
-        _src_layout: image::ImageLayout,
-        _dst: &n::Buffer,
-        _regions: T,
+        src: &n::Image,
+        _: image::ImageLayout,
+        dst: &n::Buffer,
+        regions: T,
     ) where
         T: IntoIterator,
         T::Item: Borrow<command::BufferImageCopy>,
     {
-        unimplemented!()
+        let old_offset = self.buf.offset;
+
+        for region in regions {
+            let r = region.borrow().clone();
+            let cmd = match *src {
+                n::Image::Surface(s) => Command::CopySurfaceToBuffer(s, dst.raw, r),
+                n::Image::Texture(t) => Command::CopyTextureToBuffer(t, dst.raw, r),
+            };
+            self.push_cmd(cmd);
+        }
+
+        if self.buf.offset == old_offset {
+            error!("At least one region must be specified");
+        }
     }
 
     fn draw(
@@ -807,7 +822,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     ) {
         unimplemented!()
     }
-    
+
     fn push_graphics_constants(
         &mut self,
         _layout: &n::PipelineLayout,
@@ -840,7 +855,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     ) {
         unimplemented!()
     }
-    
+
     fn push_compute_constants(
         &mut self,
         _layout: &n::PipelineLayout,
@@ -869,7 +884,7 @@ fn push_cmd_internal(id: &u64, memory: &mut Arc<Mutex<pool::BufferMemory>>, buff
     };
 
     cmd_buffer.push(cmd);
-    
+
     buffer.append(BufferSlice {
         offset: cmd_buffer.len() as u32 - 1,
         size: 1,

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -406,7 +406,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     fn begin_renderpass<T>(
         &mut self,
         _render_pass: &n::RenderPass,
-        _frame_buffer: &n::FrameBuffer,
+        frame_buffer: &n::FrameBuffer,
         _render_area: command::Rect,
         clear_values: T,
         _first_subpass: command::SubpassContents,
@@ -414,6 +414,8 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<command::ClearValue>,
     {
+        self.push_cmd(Command::BindFrameBuffer(gl::DRAW_FRAMEBUFFER, *frame_buffer));
+
         for clear_value in clear_values.into_iter().map(|cv| *cv.borrow()) {
             match clear_value {
                 command::ClearValue::Color(value) => {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -647,7 +647,7 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn invalidate_mapped_memory_ranges<'a, I>(&self, ranges: I)
+    fn invalidate_mapped_memory_ranges<'a, I>(&self, _ranges: I)
     where
         I: IntoIterator,
         I::Item: Borrow<(&'a n::Memory, Range<u64>)>,
@@ -900,8 +900,10 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn destroy_fence(&self, _: n::Fence) {
-        unimplemented!()
+    fn destroy_fence(&self, fence: n::Fence) {
+        unsafe {
+            self.share.context.DeleteSync(fence.0.get());
+        }
     }
 
     fn destroy_semaphore(&self, _: n::Semaphore) {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1,4 +1,5 @@
 use std::borrow::Borrow;
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::iter::repeat;
 use std::ops::Range;
@@ -233,7 +234,8 @@ impl d::Device<B> for Device {
     ) -> Result<n::Memory, d::OutOfMemory> {
         // TODO
         Ok(n::Memory {
-            properties: memory::Properties::CPU_VISIBLE | memory::Properties::CPU_CACHED
+            properties: memory::Properties::CPU_VISIBLE | memory::Properties::CPU_CACHED,
+            first_bound_buffer: Cell::new(0),
         })
     }
 
@@ -569,23 +571,23 @@ impl d::Device<B> for Device {
     }
 
     fn bind_buffer_memory(
-        &self, memory: &n::Memory, _offset: u64, unbound: UnboundBuffer,
+        &self, memory: &n::Memory, offset: u64, unbound: UnboundBuffer,
     ) -> Result<n::Buffer, d::BindError> {
         let gl = &self.share.context;
         let target = unbound.target;
+
+        if offset == 0 {
+            memory.first_bound_buffer.set(unbound.name);
+        } else {
+            assert_ne!(0, memory.first_bound_buffer.get());
+        }
 
         let cpu_can_read = memory.can_download();
         let cpu_can_write = memory.can_upload();
 
         if self.share.private_caps.buffer_storage {
             //TODO: gl::DYNAMIC_STORAGE_BIT | gl::MAP_PERSISTENT_BIT
-            let mut flags = 0;
-            if cpu_can_read {
-                flags |= gl::MAP_READ_BIT;
-            }
-            if cpu_can_write {
-                flags |= gl::MAP_WRITE_BIT;
-            }
+            let flags = memory.map_flags();
             //TODO: use *Named calls to avoid binding
             unsafe {
                 gl.BindBuffer(target, unbound.name);
@@ -626,17 +628,55 @@ impl d::Device<B> for Device {
         Ok(n::Buffer {
             raw: unbound.name,
             target,
-            cpu_can_read,
-            cpu_can_write,
         })
     }
 
-    fn map_memory(&self, _: &n::Memory, _: Range<u64>) -> Result<*mut u8, mapping::Error> {
-        unimplemented!()
+    fn map_memory(
+        &self, memory: &n::Memory, range: Range<u64>
+    ) -> Result<*mut u8, mapping::Error> {
+        let gl = &self.share.context;
+        let buffer = match memory.first_bound_buffer.get() {
+            0 => panic!("No buffer has been bound yet, can't map memory!"),
+            other => other,
+        };
+
+        assert!(self.share.private_caps.buffer_role_change);
+        let target = gl::PIXEL_PACK_BUFFER;
+        let access = memory.map_flags();
+
+        let ptr = unsafe {
+            gl.BindBuffer(target, buffer);
+            let ptr = gl.MapBufferRange(target, range.start as _, (range.end - range.start) as _, access);
+            gl.BindBuffer(target, 0);
+            ptr as *mut _
+        };
+
+        if let Err(err) = self.share.check() {
+            panic!("Error mapping memory: {:?} for memory {:?} with range {:?}",
+                err, memory, range);
+        }
+
+        Ok(ptr)
     }
 
-    fn unmap_memory(&self, _: &n::Memory) {
-        unimplemented!()
+    fn unmap_memory(&self, memory: &n::Memory) {
+        let gl = &self.share.context;
+        let buffer = match memory.first_bound_buffer.get() {
+            0 => panic!("No buffer has been bound yet, can't map memory!"),
+            other => other,
+        };
+        let target = gl::PIXEL_PACK_BUFFER;
+
+        unsafe {
+            gl.BindBuffer(target, buffer);
+            gl.UnmapBuffer(target);
+            gl.BindBuffer(target, 0);
+        }
+
+        if let Err(err) = self.share.check() {
+            panic!("Error unmapping memory: {:?} for memory {:?}",
+                err, memory);
+        }
     }
 
     fn flush_mapped_memory_ranges<'a, I>(&self, _: I)
@@ -843,8 +883,8 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn free_memory(&self, _: n::Memory) {
-        unimplemented!()
+    fn free_memory(&self, _memory: n::Memory) {
+        // nothing to do
     }
 
     fn create_query_pool(&self, _ty: query::QueryType, _count: u32) -> () {
@@ -876,8 +916,10 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn destroy_buffer(&self, _: n::Buffer) {
-        unimplemented!()
+    fn destroy_buffer(&self, buffer: n::Buffer) {
+        unsafe {
+            self.share.context.DeleteBuffers(1, &buffer.raw);
+        }
     }
     fn destroy_buffer_view(&self, _: n::BufferView) {
         unimplemented!()

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -1,8 +1,11 @@
+use std::cell::Cell;
+
 use hal::{self, image as i, pass, pso};
 use hal::memory::Properties;
+
 use gl;
 use Backend;
-use std::cell::Cell;
+
 
 pub type RawBuffer   = gl::types::GLuint;
 pub type Shader      = gl::types::GLuint;
@@ -16,8 +19,6 @@ pub type Sampler     = gl::types::GLuint;
 pub struct Buffer {
     pub(crate) raw: RawBuffer,
     pub(crate) target: gl::types::GLenum,
-    pub(crate) cpu_can_read: bool,
-    pub(crate) cpu_can_write: bool,
 }
 
 #[derive(Debug)]
@@ -98,14 +99,27 @@ pub enum ShaderModule {
 #[derive(Debug)]
 pub struct Memory {
     pub(crate) properties: Properties,
+    pub(crate) first_bound_buffer: Cell<RawBuffer>,
 }
 
 impl Memory {
     pub fn can_upload(&self) -> bool {
         self.properties.contains(Properties::CPU_VISIBLE)
     }
+
     pub fn can_download(&self) -> bool {
         self.properties.contains(Properties::CPU_VISIBLE | Properties::CPU_CACHED)
+    }
+
+    pub fn map_flags(&self) -> gl::types::GLenum {
+        let mut flags = 0;
+        if self.can_download() {
+            flags |= gl::MAP_READ_BIT;
+        }
+        if self.can_upload() {
+            flags |= gl::MAP_WRITE_BIT;
+        }
+        flags
     }
 }
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -24,7 +24,7 @@ pub struct Buffer {
 pub struct BufferView;
 
 #[derive(Debug)]
-pub struct Fence(pub Cell<gl::types::GLsync>);
+pub struct Fence(pub(crate) Cell<gl::types::GLsync>);
 unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}
 

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -499,6 +499,7 @@ impl CommandQueue {
             }*/
             com::Command::CopyBufferToTexture(buffer, texture, ref r) => unsafe {
                 // TODO: Fix format and active texture
+                assert_eq!(r.image_offset.z, 0);
                 let gl = &self.share.context;
                 gl.ActiveTexture(gl::TEXTURE0);
                 gl.BindBuffer(gl::PIXEL_UNPACK_BUFFER, buffer);
@@ -517,6 +518,7 @@ impl CommandQueue {
             com::Command::CopyTextureToBuffer(texture, buffer, ref r) => unsafe {
                 // TODO: Fix format and active texture
                 // TODO: handle partial copies gracefully
+                assert_eq!(r.image_offset, hal::command::Offset { x: 0, y: 0, z: 0 });
                 let gl = &self.share.context;
                 gl.ActiveTexture(gl::TEXTURE0);
                 gl.BindBuffer(gl::PIXEL_PACK_BUFFER, buffer);

--- a/src/hal/src/command/transfer.rs
+++ b/src/hal/src/command/transfer.rs
@@ -10,7 +10,7 @@ use super::{CommandBuffer, RawCommandBuffer};
 
 
 ///
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Offset {
     ///

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -18,12 +18,13 @@ path = "src/lib.rs"
 
 [features]
 default = []
+ci = []
 logger = ["env_logger"]
 vulkan = ["gfx-backend-vulkan"]
 dx12 = ["gfx-backend-dx12"]
 metal = ["gfx-backend-metal"]
 gl = ["gfx-backend-gl"]
-gl-soft = ["gl"]
+gl-headless = ["gfx-backend-gl"]
 
 #TODO: keep Warden backend-agnostic?
 


### PR DESCRIPTION
It's super annoying that GL doesn't have `GetTexSubImage`, which would make total sense in terms of API symmetry...

~~Next steps would be implementing the memory mapping.~~
Note:
We should probably use headless GL on CI. However, Travis Ubuntu 14.04 image only has an old "libosmesa6-dev" package that is not compatible with our `osmesa-sys`. Working around that doesn't appear to be trivial (but it is time consuming), and neither glutin or glium work on Linux CI either :/.
Fortunately, our headed GL context seems to be fine, so we are using that now.