### PR TITLE
[RFC] Expose raw, union-based clearing API for portability

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -642,26 +642,25 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }));
 
         let mut clear_iter = clear_values.into_iter();
-        let attachment_clears = render_pass.attachments.iter().enumerate().map(|(i, attachment)| {
-            AttachmentClear {
-                subpass_id: render_pass.subpasses.iter().position(|sp| sp.is_using(i)),
-                value: if attachment.ops.load == pass::AttachmentLoadOp::Clear {
-                    Some(*clear_iter.next().unwrap().borrow())
-                } else {
-                    None
-                },
-                stencil_value: if attachment.stencil_ops.load == pass::AttachmentLoadOp::Clear {
-                    let clear = clear_iter.next().expect("Must provide an addition DepthStencil clear value");
-                    Some(unsafe { clear.borrow().depth_stencil.stencil })
-                } else {
-                    None
-                },
-            }
-        }).collect();
-
-        if let Some(_) = clear_iter.next() {
-            panic!("Too many clear values provided");
-        }
+        let attachment_clears = render_pass.attachments
+            .iter()
+            .enumerate()
+            .map(|(i, attachment)| {
+                AttachmentClear {
+                    subpass_id: render_pass.subpasses.iter().position(|sp| sp.is_using(i)),
+                    value: if attachment.ops.load == pass::AttachmentLoadOp::Clear {
+                        Some(*clear_iter.next().unwrap().borrow())
+                    } else {
+                        None
+                    },
+                    stencil_value: if attachment.stencil_ops.load == pass::AttachmentLoadOp::Clear {
+                        let clear = clear_iter.next().expect("Must provide an addition DepthStencil clear value");
+                        Some(unsafe { clear.borrow().depth_stencil.stencil })
+                    } else {
+                        None
+                    },
+                }
+            }).collect();
 
         self.pass_cache = Some(RenderPassCache {
             render_pass: render_pass.clone(),

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -378,22 +378,22 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn clear_color_image(
+    fn clear_color_image_raw(
         &mut self,
         _: &(),
         _: image::ImageLayout,
         _: image::SubresourceRange,
-        _: command::ClearColor,
+        _: command::ClearColorRaw,
     ) {
         unimplemented!()
     }
 
-    fn clear_depth_stencil_image(
+    fn clear_depth_stencil_image_raw(
         &mut self,
         _: &(),
         _: image::ImageLayout,
         _: image::SubresourceRange,
-        _: command::ClearDepthStencil,
+        _: command::ClearDepthStencilRaw,
     ) {
         unimplemented!()
     }
@@ -457,7 +457,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
 
-    fn begin_renderpass<T>(
+    fn begin_renderpass_raw<T>(
         &mut self,
         _: &(),
         _: &(),
@@ -466,7 +466,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         _: command::SubpassContents,
     ) where
         T: IntoIterator,
-        T::Item: Borrow<command::ClearValue>,
+        T::Item: Borrow<command::ClearValueRaw>,
     {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -2,7 +2,7 @@
 
 use gl;
 
-use hal::{self, command, image, memory, pso, query, ColorSlot};
+use hal::{self, command, image, memory, pass, pso, query, ColorSlot};
 use hal::buffer::IndexBufferView;
 use hal::format::ChannelType;
 
@@ -88,6 +88,10 @@ pub enum Command {
     /// Clear depth-stencil drawbuffer of bound framebuffer.
     ClearBufferDepthStencil(Option<command::DepthValue>, Option<command::StencilValue>),
 
+    /// Set list of color attachments for drawing.
+    /// The buffer slice contains a list of `GLenum`.
+    DrawBuffers(BufferSlice),
+
     BindFrameBuffer(FrameBufferTarget, n::FrameBuffer),
     BindTargetView(FrameBufferTarget, AttachmentPoint, n::ImageView),
     SetDrawColorBuffers(usize),
@@ -105,6 +109,20 @@ pub enum Command {
 pub type FrameBufferTarget = gl::types::GLenum;
 pub type AttachmentPoint = gl::types::GLenum;
 pub type DrawBuffer = gl::types::GLint;
+
+#[derive(Clone)]
+struct AttachmentClear {
+    subpass_id: Option<pass::SubpassId>,
+    value: Option<command::ClearValueRaw>,
+    stencil_value: Option<command::StencilValue>,
+}
+
+#[derive(Clone)]
+pub struct RenderPassCache {
+    render_pass: n::RenderPass,
+    framebuffer: n::FrameBuffer,
+    attachment_clears: Vec<AttachmentClear>,
+}
 
 // Cache current states of the command buffer
 #[derive(Clone)]
@@ -195,6 +213,10 @@ pub struct RawCommandBuffer {
     /// etc.) so that rendering to it can occur immediately.
     pub display_fb: n::FrameBuffer,
     cache: Cache,
+
+    pass_cache: Option<RenderPassCache>,
+    cur_subpass: usize,
+
     limits: Limits,
     active_attribs: usize,
 }
@@ -230,6 +252,8 @@ impl RawCommandBuffer {
             fbo,
             display_fb: 0 as n::FrameBuffer,
             cache: Cache::new(),
+            pass_cache: None,
+            cur_subpass: !0,
             limits,
             active_attribs: 0,
         }
@@ -240,6 +264,8 @@ impl RawCommandBuffer {
     pub(crate) fn soft_reset(&mut self) {
         self.buf = BufferSlice::new();
         self.cache = Cache::new();
+        self.pass_cache = None;
+        self.cur_subpass = !0;
     }
 
     fn push_cmd(&mut self, cmd: Command) {
@@ -353,6 +379,96 @@ impl RawCommandBuffer {
             );
         }
     }
+
+    fn begin_subpass(&mut self) {
+        // Split processing and command recording due to borrowchk.
+        let (draw_buffers, clear_cmds) = {
+            let state = self.pass_cache.as_ref().unwrap();
+            let subpass = &state.render_pass.subpasses[self.cur_subpass];
+
+            // See `begin_renderpass_cache` for clearing strategy
+
+            // Bind draw buffers for mapping color output locations with
+            // framebuffer attachments.
+            let draw_buffers = if state.framebuffer == n::DEFAULT_FRAMEBUFFER {
+                // The default framebuffer is created by the driver
+                // We don't have influence on its layout and we treat it as single image.
+                //
+                // TODO: handle case where we don't du double-buffering?
+                vec![gl::BACK]
+            } else {
+                subpass
+                    .color_attachments
+                    .iter()
+                    .map(|id| gl::COLOR_ATTACHMENT0 + *id as gl::types::GLenum)
+                    .collect::<Vec<_>>()
+            };
+
+            let clear_cmds = state
+                .render_pass
+                .attachments
+                .iter()
+                .zip(state.attachment_clears.iter())
+                .filter_map(|(attachment, clear)| {
+                    // Check if the attachment is first used in this subpass
+                    if clear.subpass_id != Some(self.cur_subpass) {
+                        return None;
+                    }
+
+                    // View format needs to be known at this point.
+                    // All attachments specified in the renderpass must have a valid,
+                    // matching image view bound in the framebuffer.
+                    let view_format = attachment.format.unwrap();
+
+                    // Clear color target
+                    if view_format.is_color() {
+                        if let Some(cv) = clear.value {
+                            let channel = view_format.base_format().1;
+
+                            let cmd = match channel {
+                                ChannelType::Unorm | ChannelType::Inorm | ChannelType::Ufloat |
+                                ChannelType::Float | ChannelType::Srgb | ChannelType::Uscaled |
+                                ChannelType::Iscaled => Command::ClearBufferColorF(0, unsafe { cv.color.float32 }),
+                                ChannelType::Uint => Command::ClearBufferColorU(0, unsafe { cv.color.uint32 }),
+                                ChannelType::Int => Command::ClearBufferColorI(0, unsafe { cv.color.int32 }),
+                            };
+
+                            return Some(cmd);
+                        }
+                    } else {
+                        // Clear depth-stencil target
+                        let depth = if view_format.is_depth() {
+                            clear.value.map(|cv| unsafe { cv.depth_stencil.depth })
+                        } else {
+                            None
+                        };
+
+                        let stencil = if view_format.is_stencil() {
+                            clear.stencil_value
+                        } else {
+                            None
+                        };
+
+                        if depth.is_some() || stencil.is_some() {
+                            return Some(Command::ClearBufferDepthStencil(depth, stencil));
+                        }
+                    }
+
+                    None
+                })
+                .collect::<Vec<_>>();
+
+            (draw_buffers, clear_cmds)
+        };
+
+        // Record commands
+        let draw_buffers = self.add(&draw_buffers);
+        self.push_cmd(Command::DrawBuffers(draw_buffers));
+
+        for cmd in clear_cmds {
+            self.push_cmd(cmd);
+        }
+    }
 }
 
 impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
@@ -418,10 +534,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
     fn begin_renderpass_raw<T>(
         &mut self,
-        _render_pass: &n::RenderPass,
-        frame_buffer: &n::FrameBuffer,
+        render_pass: &n::RenderPass,
+        framebuffer: &n::FrameBuffer,
         _render_area: command::Rect,
-        _clear_values: T,
+        clear_values: T,
         _first_subpass: command::SubpassContents,
     ) where
         T: IntoIterator,
@@ -429,7 +545,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     {
         // TODO: load ops: clearing strategy
         //  1.  < GL 3.0 / GL ES 2.0: glClear, only single color attachment?
-        //  2.  = GL ES 2.0: glBindFramebuffer + glClear (no individual color clear values?)
+        //  2.  = GL ES 2.0: glBindFramebuffer + glClear (no single draw buffer supported)
         //  3. >= GL 3.0 / GL ES 3.0: glBindFramerbuffer + glClearBuffer
         //
         // Clearing when entering a subpass:
@@ -442,7 +558,37 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         //  >= GL 4.5: Invalidate framebuffer attachment when store op is `DONT_CARE`.
 
         // 2./3.
-        self.push_cmd(Command::BindFrameBuffer(gl::DRAW_FRAMEBUFFER, *frame_buffer));
+        self.push_cmd(Command::BindFrameBuffer(gl::DRAW_FRAMEBUFFER, *framebuffer));
+
+        let attachment_clears = render_pass.attachments
+            .iter()
+            .zip(clear_values.into_iter())
+            .enumerate()
+            .map(|(i, (attachment, clear_value))| {
+                AttachmentClear {
+                    subpass_id: render_pass.subpasses.iter().position(|sp| sp.is_using(i)),
+                    value: if attachment.ops.load == pass::AttachmentLoadOp::Clear {
+                        Some(*clear_value.borrow())
+                    } else {
+                        None
+                    },
+                    stencil_value: if attachment.stencil_ops.load == pass::AttachmentLoadOp::Clear {
+                        Some(unsafe { clear_value.borrow().depth_stencil.stencil })
+                    } else {
+                        None
+                    },
+                }
+            }).collect();
+
+        self.pass_cache = Some(RenderPassCache {
+            render_pass: render_pass.clone(),
+            framebuffer: *framebuffer,
+            attachment_clears,
+        });
+
+        // Enter first subpass
+        self.cur_subpass = 0;
+        self.begin_subpass();
     }
 
     fn next_subpass(&mut self, _contents: command::SubpassContents) {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -707,7 +707,8 @@ impl d::Device<B> for Device {
         I: IntoIterator,
         I::Item: Borrow<(&'a n::Memory, Range<u64>)>,
     {
-        unimplemented!()
+        // unimplemented!()
+        warn!("memory range invalidation not implemented!");
     }
 
     fn invalidate_mapped_memory_ranges<'a, I>(&self, _ranges: I)

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -11,7 +11,7 @@ use gl;
 use gl::types::{GLint, GLenum, GLfloat, GLuint};
 
 use hal::{self as c, device as d, image as i, memory, pass, pso, buffer, mapping, query, Primitive};
-use hal::format::{Format, Swizzle};
+use hal::format::{ChannelType, Format, Swizzle};
 use hal::pool::CommandPoolCreateFlags;
 use hal::queue::QueueFamilyId;
 
@@ -94,6 +94,7 @@ pub struct UnboundBuffer {
 #[derive(Debug)]
 pub struct UnboundImage {
     raw: GLuint,
+    channel: ChannelType,
     requirements: memory::Requirements,
 }
 
@@ -740,6 +741,8 @@ impl d::Device<B> for Device {
             _ => unimplemented!()
         };
 
+        let channel = format.base_format().1;
+
         let (width, height) = match kind {
             i::Kind::D2(w, h, aa) => unsafe {
                 assert_eq!(aa, i::AaMode::Single);
@@ -762,6 +765,7 @@ impl d::Device<B> for Device {
 
         Ok(UnboundImage {
             raw: name,
+            channel,
             requirements: memory::Requirements {
                 size: width as u64 * height as u64 * bytes_per_texel as u64,
                 alignment: 1,
@@ -775,7 +779,10 @@ impl d::Device<B> for Device {
     }
 
     fn bind_image_memory(&self, _memory: &n::Memory, _offset: u64, image: UnboundImage) -> Result<n::Image, d::BindError> {
-        Ok(n::Image::Texture(image.raw))
+        Ok(n::Image {
+            kind: n::ImageKind::Texture(image.raw),
+            channel: image.channel,
+        })
     }
 
     fn create_image_view(&self,
@@ -787,8 +794,8 @@ impl d::Device<B> for Device {
         //assert_eq!(format, image.format);
         assert_eq!(swizzle, Swizzle::NO);
         //TODO: check format
-        match *image {
-            n::Image::Surface(surface) => {
+        match image.kind {
+            n::ImageKind::Surface(surface) => {
                 if range.levels.start == 0 && range.layers.start == 0 {
                     Ok(n::ImageView::Surface(surface))
                 } else if level != 0 {
@@ -797,7 +804,7 @@ impl d::Device<B> for Device {
                     Err(i::ViewError::Layer(i::LayerError::OutOfBounds(range.layers)))
                 }
             }
-            n::Image::Texture(texture) => {
+            n::ImageKind::Texture(texture) => {
                 //TODO: check that `level` exists
                 if range.layers.start == 0 {
                     Ok(n::ImageView::Texture(texture, level))

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -15,6 +15,8 @@ pub type Surface     = gl::types::GLuint;
 pub type Texture     = gl::types::GLuint;
 pub type Sampler     = gl::types::GLuint;
 
+pub const DEFAULT_FRAMEBUFFER: FrameBuffer = 0;
+
 #[derive(Debug)]
 pub struct Buffer {
     pub(crate) raw: RawBuffer,
@@ -130,15 +132,23 @@ impl Memory {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RenderPass {
     pub(crate) attachments: Vec<pass::Attachment>,
     pub(crate) subpasses: Vec<SubpassDesc>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SubpassDesc {
     pub(crate) color_attachments: Vec<usize>,
+}
+
+impl SubpassDesc {
+    /// Check if an attachment is used by this sub-pass.
+    pub(crate) fn is_using(&self, at_id: pass::AttachmentId) -> bool {
+        self.color_attachments.iter()
+            .any(|id| *id == at_id)
+    }
 }
 
 #[derive(Debug)]

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use hal::{self, image as i, pass, pso};
+use hal::{self, format, image as i, pass, pso};
 use hal::memory::Properties;
 
 use gl;
@@ -51,7 +51,14 @@ pub struct ComputePipeline {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub enum Image {
+pub struct Image {
+    pub(crate) kind: ImageKind,
+    // Required for clearing operations
+    pub(crate) channel: format::ChannelType,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum ImageKind {
     Surface(Surface),
     Texture(Texture),
 }

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -423,6 +423,7 @@ impl CommandQueue {
             com::Command::SetBlendColor(color) => {
                 state::set_blend_color(&self.share.context, color);
             }
+            /*
             com::Command::ClearColor(c) => unsafe {
                 //TODO: check texture?
                 let gl = &self.share.context;
@@ -451,6 +452,26 @@ impl CommandQueue {
                     gl.ClearColor(v[0], v[1], v[2], v[3]);
                     gl.Clear(gl::COLOR_BUFFER_BIT);
                 }
+            }
+            */
+            com::Command::ClearBufferColorF(draw_buffer, cv) => unsafe {
+                self.share.context.ClearBufferfv(gl::COLOR, draw_buffer, cv.as_ptr());
+            }
+            com::Command::ClearBufferColorU(draw_buffer, cv) => unsafe {
+                self.share.context.ClearBufferuiv(gl::COLOR, draw_buffer, cv.as_ptr());
+            }
+            com::Command::ClearBufferColorI(draw_buffer, cv) => unsafe {
+                self.share.context.ClearBufferiv(gl::COLOR, draw_buffer, cv.as_ptr());
+            }
+            com::Command::ClearBufferDepthStencil(depth, stencil) => unsafe {
+                let (target, depth, stencil) = match (depth, stencil) {
+                    (Some(depth), Some(stencil)) => (gl::DEPTH_STENCIL, depth, stencil),
+                    (Some(depth), None) => (gl::DEPTH, depth, 0),
+                    (None, Some(stencil)) => (gl::STENCIL, 0.0, stencil),
+                    _ => unreachable!(),
+                };
+
+                self.share.context.ClearBufferfi(target, 0, depth, stencil as _);
             }
             com::Command::BindFrameBuffer(point, frame_buffer) => {
                 if self.share.private_caps.framebuffer {

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -423,37 +423,6 @@ impl CommandQueue {
             com::Command::SetBlendColor(color) => {
                 state::set_blend_color(&self.share.context, color);
             }
-            /*
-            com::Command::ClearColor(c) => unsafe {
-                //TODO: check texture?
-                let gl = &self.share.context;
-                state::unlock_color_mask(gl);
-                if self.share.private_caps.clear_buffer {
-                    // Render target view bound to the framebuffer at attachment slot 0.
-                    match c {
-                        hal::command::ClearColor::Float(v) => {
-                            gl.ClearBufferfv(gl::COLOR, 0, &v[0]);
-                        }
-                        hal::command::ClearColor::Int(v) => {
-                            gl.ClearBufferiv(gl::COLOR, 0, &v[0]);
-                        }
-                        hal::command::ClearColor::Uint(v) => {
-                            gl.ClearBufferuiv(gl::COLOR, 0, &v[0]);
-                        }
-                    }
-                } else {
-                    let v = if let hal::command::ClearColor::Float(v) = c {
-                        v
-                    } else {
-                        warn!("Integer clears are not supported on GL2");
-                        [0.0, 0.0, 0.0, 0.0]
-                    };
-
-                    gl.ClearColor(v[0], v[1], v[2], v[3]);
-                    gl.Clear(gl::COLOR_BUFFER_BIT);
-                }
-            }
-            */
             com::Command::ClearBufferColorF(draw_buffer, cv) => unsafe {
                 self.share.context.ClearBufferfv(gl::COLOR, draw_buffer, cv.as_ptr());
             }
@@ -472,6 +441,13 @@ impl CommandQueue {
                 };
 
                 self.share.context.ClearBufferfi(target, 0, depth, stencil as _);
+            }
+            com::Command::DrawBuffers(draw_buffers) => unsafe {
+                let draw_buffers = Self::get::<gl::types::GLenum>(data_buf, draw_buffers);
+                self.share.context.DrawBuffers(
+                    draw_buffers.len() as _,
+                    draw_buffers.as_ptr(),
+                );
             }
             com::Command::BindFrameBuffer(point, frame_buffer) => {
                 if self.share.private_caps.framebuffer {

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -11,7 +11,7 @@ use hal::{VertexCount, VertexOffset, InstanceCount, IndexCount};
 use hal::buffer::{IndexBufferView};
 use hal::image::{ImageLayout, SubresourceRange};
 use hal::command::{
-    AttachmentClear, ClearColor, ClearDepthStencil, ClearValue,
+    AttachmentClear, ClearColorRaw, ClearDepthStencilRaw, ClearValueRaw,
     BufferImageCopy, BufferCopy, ImageCopy, ImageResolve,
     SubpassContents, RawCommandBuffer,
     ColorValue, StencilValue, Rect, Viewport,
@@ -396,22 +396,22 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
-    fn clear_color_image(
+    fn clear_color_image_raw(
         &mut self,
         _image: &native::Image,
         _layout: ImageLayout,
         _range: SubresourceRange,
-        _value: ClearColor,
+        _value: ClearColorRaw,
     ) {
         unimplemented!()
     }
 
-    fn clear_depth_stencil_image(
+    fn clear_depth_stencil_image_raw(
         &mut self,
         _image: &native::Image,
         _layout: ImageLayout,
         _range: SubresourceRange,
-        _value: ClearDepthStencil,
+        _value: ClearDepthStencilRaw,
     ) {
         unimplemented!()
     }
@@ -530,7 +530,7 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
-    fn begin_renderpass<T>(
+    fn begin_renderpass_raw<T>(
         &mut self,
         _render_pass: &native::RenderPass,
         frame_buffer: &native::FrameBuffer,
@@ -539,7 +539,7 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
         _first_subpass: SubpassContents,
     ) where
         T: IntoIterator,
-        T::Item: Borrow<ClearValue>,
+        T::Item: Borrow<ClearValueRaw>,
     {
         unsafe {
             let command_buffer = self.inner();
@@ -556,6 +556,8 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
             // FIXME: subpasses
             let pass_descriptor: metal::RenderPassDescriptor = msg_send![frame_buffer.0, copy];
             // TODO: validate number of clear colors
+            // TODO: fix clearing with unions
+            /*
             for (i, value) in clear_values.into_iter().enumerate() {
                 match *value.borrow() {
                     ClearValue::Color(ClearColor::Float(values)) => {
@@ -575,6 +577,7 @@ impl RawCommandBuffer<Backend> for CommandBuffer {
                     _ => unimplemented!(),
                 };
             }
+            */
 
             let render_encoder = command_buffer.command_buffer.new_render_command_encoder(&pass_descriptor).to_owned();
 

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -116,19 +116,6 @@ pub fn map_clear_stencil(stencil: command::StencilValue) -> vk::ClearDepthStenci
     }
 }
 
-pub fn map_clear_value(value: &command::ClearValue) -> vk::ClearValue {
-    match *value {
-        command::ClearValue::Color(cv) => {
-            let cv = map_clear_color(cv);
-            vk::ClearValue::new_color(cv)
-        },
-        command::ClearValue::DepthStencil(dsv) => {
-            let dsv = map_clear_depth_stencil(dsv);
-            vk::ClearValue::new_depth_stencil(dsv)
-        },
-    }
-}
-
 pub fn map_offset(offset: command::Offset) -> vk::Offset3D {
     vk::Offset3D {
         x: offset.x,

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -7,7 +7,7 @@ use buffer::IndexBufferView;
 use image::{ImageLayout, SubresourceRange};
 use query::{Query, QueryControl, QueryId};
 use queue::capability::{Graphics, GraphicsOrCompute, Supports};
-use super::{CommandBuffer, RawCommandBuffer, RenderPassInlineEncoder};
+use super::{ClearColorRaw, CommandBuffer, RawCommandBuffer, RenderPassInlineEncoder};
 
 
 #[allow(missing_docs)]
@@ -85,6 +85,16 @@ impl From<i32> for ClearColor {
 impl From<u32> for ClearColor {
     fn from(v: u32) -> ClearColor {
         ClearColor::Uint([v, 0, 0, 0])
+    }
+}
+
+impl From<ClearColor> for ClearColorRaw {
+    fn from(cv: ClearColor) -> Self {
+        match cv {
+            ClearColor::Float(cv) => ClearColorRaw { float32: cv },
+            ClearColor::Int(cv) => ClearColorRaw { int32: cv },
+            ClearColor::Uint(cv) => ClearColorRaw { uint32: cv },
+        }
     }
 }
 

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -11,7 +11,7 @@ mod renderpass;
 mod transfer;
 
 pub use self::graphics::*;
-pub use self::raw::RawCommandBuffer;
+pub use self::raw::{ClearValueRaw, ClearColorRaw, ClearDepthStencilRaw, RawCommandBuffer};
 pub use self::renderpass::*;
 pub use self::transfer::*;
 
@@ -50,7 +50,7 @@ impl<'a, B: Backend, C> CommandBuffer<'a, B, C> {
     }
 
     /// Downgrade a command buffer to a lesser capability type.
-    /// 
+    ///
     /// This is safe as you can't `submit` downgraded version since `submit`
     /// requires `self` by move.
     pub fn downgrade<D>(&mut self) -> &mut CommandBuffer<'a, B, D>

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -1,5 +1,7 @@
+use std::mem;
 use std::borrow::Borrow;
 use std::ops::Range;
+
 use pso;
 use {Backend, IndexCount, InstanceCount, VertexCount, VertexOffset};
 use buffer::IndexBufferView;
@@ -16,7 +18,6 @@ use super::{
 /// Unsafe variant of `ClearColor`.
 #[repr(C)]
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub union ClearColorRaw {
     ///
     pub float32: [f32; 4],
@@ -29,7 +30,6 @@ pub union ClearColorRaw {
 ///
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ClearDepthStencilRaw {
     ///
     pub depth: f32,
@@ -39,7 +39,6 @@ pub struct ClearDepthStencilRaw {
 /// Unsafe variant of `ClearValue`.
 #[repr(C)]
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub union ClearValueRaw {
     ///
     pub color: ClearColorRaw,

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -96,11 +96,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
             image,
             layout,
             range,
-            match cv {
-                ClearColor::Float(cv) => ClearColorRaw { float32: cv },
-                ClearColor::Int(cv) => ClearColorRaw { int32: cv },
-                ClearColor::Uint(cv) => ClearColorRaw { uint32: cv },
-            },
+            cv.into(),
         )
     }
 

--- a/src/hal/src/format.rs
+++ b/src/hal/src/format.rs
@@ -561,6 +561,11 @@ impl Format {
     pub fn is_depth(self) -> bool {
         self.aspect_flags().contains(AspectFlags::DEPTH)
     }
+
+    /// Returns if the format has a stencil aspect.
+    pub fn is_stencil(self) -> bool {
+        self.aspect_flags().contains(AspectFlags::STENCIL)
+    }
 }
 
 // Common vertex attribute formats


### PR DESCRIPTION
The Vulkan API uses unions for [clear value structs](https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkClearValue.html), so we don't know which enum variant to choose when implementing the portability layer.

Therefore, I added new `raw` variants for a few clear based commands using union structs for the clear values, which should be memory layout compatible with the vulkan union structs. The raw functions are only exposed by the raw command buffer interface as they don't have much use for normal gfx-rs API users.

`clear_attachments` is excluded as I quite confident that we can infer the enum variants from the associated information when calling the function in the portability layer.


**Suggestions/feedback are welcome!**

~~Only defining the API layer for now, implementation will follow for empty/(gl)/dx12/vulkan (breaking metal again..)~~