### PR TITLE
Require `DescriptorPool` to be `Sync`

### DIFF
--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -68,7 +68,7 @@ pub struct DescriptorRangeDesc {
 }
 
 ///
-pub trait DescriptorPool<B: Backend>: Send + fmt::Debug {
+pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
     /// Allocate one or multiple descriptor sets from the pool.
     ///
     /// Each descriptor set will be allocated from the pool according to the corresponding set layout.


### PR DESCRIPTION
This will allow structures with `B::DescriptorPool` field to be `Sync`.