### PR TITLE
hal: Support various range types as function parameters

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -29,6 +29,7 @@ use hal::pso::{PipelineStage, ShaderStageFlags, Specialization};
 use hal::queue::Submission;
 
 use std::io::Cursor;
+use std::ops::Range;
 
 const ENTRY_NAME: &str = "main";
 
@@ -421,7 +422,7 @@ fn main() {
         )
     );
 
-    device.update_descriptor_sets(&[
+    device.update_descriptor_sets::<Range<_>>(&[
         pso::DescriptorSetWrite {
             set: &desc_sets[0],
             binding: 0,

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -9,6 +9,7 @@ use hal::{
     adapter, buffer, command, device, format, image, mapping,
     memory, pass, pool, pso, query, queue,
 };
+use hal::range::RangeArg;
 
 /// Dummy backend.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -161,7 +162,7 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_buffer_view(&self, _: &(), _: Option<format::Format>, _: Range<u64>) -> Result<(), buffer::ViewError> {
+    fn create_buffer_view<R: RangeArg<u64>>(&self, _: &(), _: Option<format::Format>, _: R) -> Result<(), buffer::ViewError> {
         unimplemented!()
     }
 
@@ -196,7 +197,7 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn update_descriptor_sets(&self, _: &[pso::DescriptorSetWrite<Backend>]) {
+    fn update_descriptor_sets<R: RangeArg<u64>>(&self, _: &[pso::DescriptorSetWrite<Backend, R>]) {
         unimplemented!()
     }
 
@@ -227,7 +228,7 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn map_memory(&self, _: &(), _: Range<u64>) -> Result<*mut u8, mapping::Error> {
+    fn map_memory<R: RangeArg<u64>>(&self, _: &(), _: R) -> Result<*mut u8, mapping::Error> {
         unimplemented!()
     }
 
@@ -235,18 +236,20 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn flush_mapped_memory_ranges<'a, I>(&self, _: I)
+    fn flush_mapped_memory_ranges<'a, I, R>(&self, _: I)
     where
         I: IntoIterator,
-        I::Item: Borrow<(&'a (), Range<u64>)>,
+        I::Item: Borrow<(&'a (), R)>,
+        R: RangeArg<u64>,
     {
         unimplemented!()
     }
 
-    fn invalidate_mapped_memory_ranges<'a, I>(&self, _: I)
+    fn invalidate_mapped_memory_ranges<'a, I, R>(&self, _: I)
     where
         I: IntoIterator,
-        I::Item: Borrow<(&'a (), Range<u64>)>,
+        I::Item: Borrow<(&'a (), R)>,
+        R: RangeArg<u64>,
     {
         unimplemented!()
     }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -109,6 +109,8 @@ pub enum ShaderModule {
 pub struct Memory {
     pub(crate) properties: Properties,
     pub(crate) first_bound_buffer: Cell<RawBuffer>,
+    /// Allocation size
+    pub(crate) size: u64,
 }
 
 impl Memory {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -234,14 +234,16 @@ pub enum DescriptorSetBinding {
 #[derive(Debug)]
 pub struct Memory {
     pub(crate) heap: MemoryHeap,
+    pub(crate) size: u64,
     pub(crate) allocations: Arc<Mutex<MemoryAllocations>>,
     pub(crate) mapping: Mutex<Option<MemoryMapping>>,
 }
 
 impl Memory {
-    pub(crate) fn new(heap: MemoryHeap) -> Self {
+    pub(crate) fn new(heap: MemoryHeap, size: u64) -> Self {
         Memory {
             heap,
+            size,
             allocations: Arc::new(Mutex::new(MemoryAllocations {
                 starts: BTreeMap::new(),
                 ends: BTreeMap::new(),
@@ -290,7 +292,7 @@ impl MemoryAllocations {
 
 #[derive(Debug)]
 pub(crate) enum MemoryHeap {
-    Emulated { memory_type: usize, size: u64 },
+    Emulated { memory_type: usize },
     Native(metal::Heap),
 }
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -49,6 +49,7 @@ pub mod pool;
 pub mod pso;
 pub mod query;
 pub mod queue;
+pub mod range;
 pub mod window;
 
 #[doc(hidden)]

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -1,11 +1,12 @@
 //! Descriptor sets and layouts.
 
 use std::fmt;
-use std::ops::Range;
 
 use {Backend};
 use image::ImageLayout;
-use super::ShaderStageFlags;
+use pso::ShaderStageFlags;
+use range::RangeArg;
+
 
 ///
 // TODO: Grasping and remembering the differences between these
@@ -82,21 +83,21 @@ pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
 }
 
 #[allow(missing_docs)] //TODO
-pub struct DescriptorSetWrite<'a, 'b, B: Backend> {
+pub struct DescriptorSetWrite<'a, 'b, B: Backend, R: RangeArg<u64>> {
     pub set: &'a B::DescriptorSet,
     pub binding: usize,
     pub array_offset: usize,
-    pub write: DescriptorWrite<'b, B>,
+    pub write: DescriptorWrite<'b, B, R>,
 }
 
 #[allow(missing_docs)] //TODO
-pub enum DescriptorWrite<'a, B: Backend> {
+pub enum DescriptorWrite<'a, B: Backend, R: RangeArg<u64>> {
     Sampler(Vec<&'a B::Sampler>),
     SampledImage(Vec<(&'a B::ImageView, ImageLayout)>),
     StorageImage(Vec<(&'a B::ImageView, ImageLayout)>),
     InputAttachment(Vec<(&'a B::ImageView, ImageLayout)>),
-    UniformBuffer(Vec<(&'a B::Buffer, Range<u64>)>),
-    StorageBuffer(Vec<(&'a B::Buffer, Range<u64>)>),
+    UniformBuffer(Vec<(&'a B::Buffer, R)>),
+    StorageBuffer(Vec<(&'a B::Buffer, R)>),
     UniformTexelBuffer(Vec<&'a B::BufferView>),
     StorageTexelBuffer(Vec<&'a B::BufferView>),
 }

--- a/src/hal/src/range.rs
+++ b/src/hal/src/range.rs
@@ -1,0 +1,59 @@
+//! Generic range type abstraction
+
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+
+/// Abstracts the std range types.
+///
+/// Based upon the nightly `RangeArgument` trait.
+pub trait RangeArg<T> {
+    /// Start index bound.
+    fn start(&self) -> Option<&T>;
+    /// End index bound.
+    fn end(&self) -> Option<&T>;
+}
+
+impl<T> RangeArg<T> for Range<T> {
+    fn start(&self) -> Option<&T> {
+        Some(&self.start)
+    }
+    fn end(&self) -> Option<&T> {
+        Some(&self.end)
+    }
+}
+
+impl<T> RangeArg<T> for RangeTo<T> {
+    fn start(&self) -> Option<&T> {
+        None
+    }
+    fn end(&self) -> Option<&T> {
+        Some(&self.end)
+    }
+}
+
+impl<T> RangeArg<T> for RangeFrom<T> {
+    fn start(&self) -> Option<&T> {
+        Some(&self.start)
+    }
+    fn end(&self) -> Option<&T> {
+        None
+    }
+}
+
+impl<T> RangeArg<T> for RangeFull {
+    fn start(&self) -> Option<&T> {
+        None
+    }
+    fn end(&self) -> Option<&T> {
+        None
+    }
+}
+
+impl<T> RangeArg<T> for (Option<T>, Option<T>) {
+    fn start(&self) -> Option<&T> {
+        self.0.as_ref()
+    }
+    fn end(&self) -> Option<&T> {
+        self.1.as_ref()
+    }
+}
+

--- a/src/hal/src/range.rs
+++ b/src/hal/src/range.rs
@@ -56,4 +56,3 @@ impl<T> RangeArg<T> for (Option<T>, Option<T>) {
         self.1.as_ref()
     }
 }
-

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use hal::{self, Device as CoreDevice, MemoryType, MemoryTypeId};
 use hal::memory::{Properties};
+use hal::range::RangeArg;
 
 use memory::{self, Allocator, Typed};
 use handle::{self, GarbageSender};


### PR DESCRIPTION
Adds the Range abstraction discussed in #1749 
Supporting `..`, `a..`, `..b`, `a..b` and `(Option<_>, Option<_>)` (covering all prior mentioned cases).

**WIP**: Update gl, d3d12, metal and higher level crates

Fixes #1749 