### PR TITLE
dx12: Fix tier1 resource creation

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -709,8 +709,20 @@ impl hal::Instance for Instance {
                 // `device::MEM_TYPE_IMAGE_SHIFT`, `device::MEM_TYPE_TARGET_SHIFT`)
                 // denote the usage group.
                 let mut types = Vec::new();
-                for _ in 0..3 {
-                    types.extend(base_memory_types.iter());
+                for i in 0..4 {
+                    types.extend(base_memory_types
+                        .iter()
+                        .map(|mem_type| {
+                            let mut ty = mem_type.clone();
+
+                            // Images and RenderTargets are not host visible as we can't create
+                            // a corresponding buffer for mapping
+                            if i >= 2 {
+                                ty.properties.remove(Properties::CPU_VISIBLE);
+                            }
+                            ty
+                        })
+                    );
                 }
                 types
             };

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -236,8 +236,8 @@ pub struct Memory {
     pub(crate) heap: ComPtr<d3d12::ID3D12Heap>,
     pub(crate) type_id: usize,
     pub(crate) size: u64,
-    // Buffer containing the whole memory for mapping
-    pub(crate) resource: *mut d3d12::ID3D12Resource,
+    // Buffer containing the whole memory for mapping (only for host visible heaps)
+    pub(crate) resource: Option<*mut d3d12::ID3D12Resource>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Tier1 devices expose 3 memory type groups (buffer only, image only and target only). We can only create a buffer for mapping in the first group. This PR fixes the exposed memory types and only creates buffers if possible (tier2 or tier1 buffer only and cpu visible).

The remaining issue are exposed image memory types, which should be only device local for tier1 (will be addressed in a followup). Vulkan requires us to expose at least one host-visible memory type for images supporting linear tiling. But we can circumvent this by not exposing any format supporting linear tiling at all for heap tier1 hardware..

Fixes #1756 
cc @Rhuagh @AlphaModder 

NOTE: This PR is written against the generic range type PR.