### PR TITLE
Convert HAL features to bitflags, move legacy out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,4 +75,4 @@ script:
   - export LIBRARY_PATH=$HOME/deps/usr/lib/x86_64-linux-gnu
   - export LD_LIBRARY_PATH=$LIBRARY_PATH
   - make all
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then make reftests-ci; fi
+  #- if [[ $TRAVIS_OS_NAME == "linux" ]]; then make reftests-ci; fi # TODO

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,4 +75,4 @@ script:
   - export LIBRARY_PATH=$HOME/deps/usr/lib/x86_64-linux-gnu
   - export LD_LIBRARY_PATH=$LIBRARY_PATH
   - make all
-  #- if [[ $TRAVIS_OS_NAME == "linux" ]]; then make reftests-ci; fi # compute fail
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then make reftests-ci; fi

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ test:
 	cd src/render && cargo test --features "$(FEATURES_RENDER) $(FEATURES_EXTRA)"
 
 reftests:
+	cd src/warden && cargo test --features "gl glsl-to-spirv"
 	cd src/warden && cargo run --bin reftest --features "gl glsl-to-spirv $(FEATURES_HAL) $(FEATURES_HAL2)"
 
 reftests-ci:

--- a/reftests/suite.ron
+++ b/reftests/suite.ron
@@ -1,16 +1,19 @@
 {
 	"basic": {
 		"render-pass-clear": (
+			features: (bits: 0),
 			jobs: ["empty"],
 			expect: ImageRow("image.color", 0, [204,204,204,255]),
 		),
 		"pass-through": (
+			features: (bits: 0),
 			jobs: ["pass-through"],
 			expect: ImageRow("image.color", 0, [0,255,0,255]),
 		),
 	},
 	"compute": {
 		"fill": (
+			features: (bits: 0),
 			jobs: ["fill"],
 			expect: Buffer("buffer.output", [1, 0, 0, 0]),
 		),

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -795,12 +795,12 @@ impl hal::Instance for Instance {
                     max_patch_size: 0,
                     max_viewports: 0,
                     max_compute_group_count: [
-                        d3d12::D3D12_CS_THREAD_GROUP_MAX_X  as _,
-                        d3d12::D3D12_CS_THREAD_GROUP_MAX_Y  as _,
-                        d3d12::D3D12_CS_THREAD_GROUP_MAX_Z  as _,
+                        d3d12::D3D12_CS_THREAD_GROUP_MAX_X,
+                        d3d12::D3D12_CS_THREAD_GROUP_MAX_Y,
+                        d3d12::D3D12_CS_THREAD_GROUP_MAX_Z,
                     ],
                     max_compute_group_size: [
-                        d3d12::D3D12_CS_THREAD_GROUP_MAX_THREADS_PER_GROUP as _,
+                        d3d12::D3D12_CS_THREAD_GROUP_MAX_THREADS_PER_GROUP,
                         1, //TODO
                         1, //TODO
                     ],

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -319,8 +319,8 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
         &mut self,
         submission: hal::queue::RawSubmission<Backend, IC>,
         fence: Option<&native::Fence>,
-    ) where 
-        IC: IntoIterator, 
+    ) where
+        IC: IntoIterator,
         IC::Item: Borrow<command::CommandBuffer>,
     {
         // TODO: semaphores
@@ -780,54 +780,16 @@ impl hal::Instance for Instance {
 
             let physical_device = PhysicalDevice {
                 adapter,
-                features: Features {
-                    // TODO: `true` values should be correct, `false` needs to be checked
+                features:
+                    // TODO: add more features, based on
                     // https://msdn.microsoft.com/de-de/library/windows/desktop/mt186615(v=vs.85).aspx
-                    robust_buffer_access: false,
-                    full_draw_index_u32: false,
-                    image_cube_array: true,
-                    independent_blending: false,
-                    geometry_shader: true,
-                    tessellation_shader: true,
-                    sample_rate_shading: false,
-                    dual_src_blending: false,
-                    logic_op: false, // Optional on feature level 11_0
-                    multi_draw_indirect: true,
-                    draw_indirect_first_instance: false,
-                    depth_clamp: false,
-                    depth_bias_clamp: false,
-                    non_fill_polygon_mode: false,
-                    depth_bounds: false,
-                    line_width: false,
-                    point_size: false,
-                    alpha_to_one: false,
-                    multi_viewports: false,
-                    sampler_anisotropy: false,
-                    format_etc2: false,
-                    format_astc_ldr: false,
-                    format_bc: true,
-                    precise_occlusion_query: false,
-                    pipeline_statistics_query: false,
-                    vertex_stores_and_atomics: false,
-                    fragment_stores_and_atomics: false,
-
-                    indirect_execution: true,
-                    draw_instanced: true,
-                    draw_instanced_base: true,
-                    draw_indexed_base: true,
-                    draw_indexed_instanced: true,
-                    draw_indexed_instanced_base_vertex: true,
-                    draw_indexed_instanced_base: true,
-                    instance_rate: true,
-                    vertex_base: true,
-                    srgb_color: true,
-                    constant_buffer: true,
-                    unordered_access_view: true,
-                    copy_buffer: true,
-                    sampler_objects: true,
-                    sampler_lod_bias: true,
-                    sampler_border_color: true,
-                },
+                    Features::IMAGE_CUBE_ARRAY |
+                    Features::GEOMETRY_SHADER |
+                    Features::TESSELLATION_SHADER |
+                    //logic_op: false, // Optional on feature level 11_0
+                    Features::MULTI_DRAW_INDIRECT |
+                    Features::FORMAT_BC |
+                    Features::INSTANCE_RATE,
                 limits: Limits { // TODO
                     max_texture_size: 0,
                     max_patch_size: 0,

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -18,6 +18,7 @@ name = "gfx_backend_gl"
 default = ["glutin"]
 
 [dependencies]
+bitflags = "1"
 log = "0.3"
 gfx_gl = "0.3.1"
 gfx-hal = { path = "../../hal", version = "0.1" }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -472,7 +472,7 @@ impl RawCommandBuffer {
 }
 
 impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
-    fn begin(&mut self, flags: hal::command::CommandBufferFlags) { // TODO: Implement flags!
+    fn begin(&mut self, _flags: hal::command::CommandBufferFlags) { // TODO: Implement flags!
         if self.individual_reset {
             // Implicit buffer reset when individual reset is set.
             self.reset(false);
@@ -1046,10 +1046,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
     fn execute_commands<I>(
         &mut self,
-        buffers: I,
+        _buffers: I,
     ) where
         I: IntoIterator,
-        I::Item: Borrow<RawCommandBuffer> 
+        I::Item: Borrow<RawCommandBuffer>
     {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -231,7 +231,7 @@ impl Device {
             (1, 20) => glsl::Version::V1_20,
             (1, 10) => glsl::Version::V1_10,
             other if other > (4, 60) => glsl::Version::V4_60,
-            other => panic!("GLSL version is note recognized: {:?}", other),
+            other => panic!("GLSL version is not recognized: {:?}", other),
         };
         compile_options.vertex.invert_y = true;
         debug!("SPIR-V options {:?}", compile_options);

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -145,7 +145,7 @@ pub struct PlatformName {
 }
 
 impl PlatformName {
-    fn get(gl: &gl::Gl) -> PlatformName {
+    fn get(gl: &gl::Gl) -> Self {
         PlatformName {
             vendor: get_string(gl, gl::VENDOR),
             renderer: get_string(gl, gl::RENDERER),
@@ -154,6 +154,8 @@ impl PlatformName {
 }
 
 /// Private capabilities that don't need to be exposed.
+/// The affect the implementation code paths but not the
+/// provided API surface.
 #[derive(Debug)]
 pub struct PrivateCaps {
     /// VAO support
@@ -190,39 +192,40 @@ pub struct Info {
     pub extensions: HashSet<&'static str>,
 }
 
-/*
-pub struct LegacyFeatures {
-    /// Support indirect drawing and dispatching.
-    pub const indirect_execution = 0x01 << 48;
-    /// Support instanced drawing.
-    pub const draw_instanced = 0x02 << 48;
-    /// Support offsets for instanced drawing with base instance.
-    pub const draw_instanced_base = 0x00000000;
-    /// Support indexed drawing with base vertex.
-    pub const draw_indexed_base = 0x00000000;
-    /// Support indexed, instanced drawing.
-    pub const draw_indexed_instanced = 0x00000000;
-    /// Support indexed, instanced drawing with base vertex only.
-    pub const draw_indexed_instanced_base_vertex = 0x00000000;
-    /// Support indexed, instanced drawing with base vertex and instance.
-    pub const draw_indexed_instanced_base = 0x00000000;
-    /// Support base vertex offset for indexed drawing.
-    pub const vertex_base = 0x00000000;
-    /// Support sRGB textures and rendertargets.
-    pub const srgb_color = 0x00000000;
-    /// Support constant buffers.
-    pub const constant_buffer = 0x00000000;
-    /// Support unordered-access views.
-    pub const unordered_access_view = 0x00000000;
-    /// Support accelerated buffer copy.
-    pub const copy_buffer = 0x00000000;
-    /// Support separation of textures and samplers.
-    pub const sampler_objects = 0x00000000;
-    /// Support sampler LOD bias.
-    pub const sampler_lod_bias = 0x00000000;
-    /// Support setting border texel colors.
-    pub const sampler_border_color = 0x00000000;
-}*/
+bitflags! {
+    pub struct LegacyFeatures: u16 {
+        /// Support indirect drawing and dispatching.
+        const INDIRECT_EXECUTION = 0x0001;
+        /// Support instanced drawing.
+        const DRAW_INSTANCED = 0x0002;
+        /// Support offsets for instanced drawing with base instance.
+        const DRAW_INSTANCED_BASE = 0x0004;
+        /// Support indexed drawing with base vertex.
+        const DRAW_INDEXED_BASE = 0x0008;
+        /// Support indexed, instanced drawing.
+        const DRAW_INDEXED_INSTANCED = 0x0010;
+        /// Support indexed, instanced drawing with base vertex only.
+        const DRAW_INDEXED_INSTANCED_BASE_VERTEX = 0x0020;
+        /// Support indexed, instanced drawing with base vertex and instance.
+        const DRAW_INDEXED_INSTANCED_BASE = 0x0040;
+        /// Support base vertex offset for indexed drawing.
+        const VERTEX_BASE = 0x0080;
+        /// Support sRGB textures and rendertargets.
+        const SRGB_COLOR = 0x0100;
+        /// Support constant buffers.
+        const CONSTANT_BUFFER = 0x0200;
+        /// Support unordered-access views.
+        const UNORDERED_ACCESS_VIEW = 0x0400;
+        /// Support accelerated buffer copy.
+        const COPY_BUFFER = 0x0800;
+        /// Support separation of textures and samplers.
+        const SAMPLER_OBJECTS = 0x1000;
+        /// Support sampler LOD bias.
+        const SAMPLER_LOD_BIAS = 0x2000;
+        /// Support setting border texel colors.
+        const SAMPLER_BORDER_COLOR = 0x4000;
+    }
+}
 
 #[derive(Copy, Clone)]
 pub enum Requirement {
@@ -288,7 +291,7 @@ impl Info {
 
 /// Load the information pertaining to the driver and the corresponding device
 /// capabilities.
-pub fn query_all(gl: &gl::Gl) -> (Info, Features, Limits, PrivateCaps) {
+pub fn query_all(gl: &gl::Gl) -> (Info, Features, LegacyFeatures, Limits, PrivateCaps) {
     use self::Requirement::*;
     let info = Info::get(gl);
     let tessellation_supported =           info.is_supported(&[Core(4,0),
@@ -326,71 +329,97 @@ pub fn query_all(gl: &gl::Gl) -> (Info, Features, Limits, PrivateCaps) {
         min_uniform_buffer_offset_alignment: 1, // TODO
 
     };
-    let features = Features {
-        robust_buffer_access: false,
-        full_draw_index_u32: false,
-        image_cube_array: false,
-        independent_blending: false,
-        geometry_shader: false,
-        tessellation_shader: false,
-        sample_rate_shading: false,
-        dual_src_blending: false,
-        logic_op: false, // Optional on feature level 11_0
-        multi_draw_indirect: false,
-        draw_indirect_first_instance: false,
-        depth_clamp: false,
-        depth_bias_clamp: false,
-        non_fill_polygon_mode: false,
-        depth_bounds: false,
-        line_width: false,
-        point_size: false,
-        alpha_to_one: false,
-        multi_viewports: false,
-        sampler_anisotropy:                 info.is_supported(&[Core(4,6),
-                                                                Ext ("GL_ARB_texture_filter_anisotropic"),
-                                                                Ext ("GL_EXT_texture_filter_anisotropic")]),
-        format_etc2: false,
-        format_astc_ldr: false,
-        format_bc: false,
-        precise_occlusion_query: false,
-        pipeline_statistics_query: false,
-        vertex_stores_and_atomics: false,
-        fragment_stores_and_atomics: false,
+    let mut features = Features::empty();
+    let mut legacy = LegacyFeatures::empty();
 
-        indirect_execution:                 info.is_supported(&[Core(4,3),
-                                                                Es  (3,1)]), // TODO: extension
-        draw_instanced:                     info.is_supported(&[Core(3,1),
-                                                                Es  (3,0),
-                                                                Ext ("GL_ARB_draw_instanced")]),
-        draw_instanced_base:                info.is_supported(&[Core(4,2),
-                                                                Ext ("GL_ARB_base_instance")]),
-        draw_indexed_base:                  info.is_supported(&[Core(3,2)]), // TODO: extension
-        draw_indexed_instanced:             info.is_supported(&[Core(3,1),
-                                                                Es  (3,0)]), // TODO: extension
-        draw_indexed_instanced_base_vertex: info.is_supported(&[Core(3,2)]), // TODO: extension
-        draw_indexed_instanced_base:        info.is_supported(&[Core(4,2)]), // TODO: extension
-        instance_rate:                      info.is_supported(&[Core(3,3),
-                                                                Es  (3,0),
-                                                                Ext ("GL_ARB_instanced_arrays")]),
-        vertex_base:                        info.is_supported(&[Core(3,2),
-                                                                Es  (3,2),
-                                                                Ext ("GL_ARB_draw_elements_base_vertex")]),
-        srgb_color:                         info.is_supported(&[Core(3,2),
-                                                                Ext ("GL_ARB_framebuffer_sRGB")]),
-        constant_buffer:                    info.is_supported(&[Core(3,1),
-                                                                Es  (3,0),
-                                                                Ext ("GL_ARB_uniform_buffer_object")]),
-        unordered_access_view:              info.is_supported(&[Core(4,0)]), // TODO: extension
-        copy_buffer:                        info.is_supported(&[Core(3,1),
-                                                                Es  (3,0),
-                                                                Ext ("GL_ARB_copy_buffer"),
-                                                                Ext ("GL_NV_copy_buffer")]),
-        sampler_objects:                    info.is_supported(&[Core(3,3),
-                                                                Es  (3,0),
-                                                                Ext ("GL_ARB_sampler_objects")]),
-        sampler_lod_bias:                   info.is_supported(&[Core(3,3)]), // TODO: extension
-        sampler_border_color:               info.is_supported(&[Core(3,3)]), // TODO: extensions
-    };
+    if info.is_supported(&[
+        Core(4, 6),
+        Ext("GL_ARB_texture_filter_anisotropic"),
+        Ext("GL_EXT_texture_filter_anisotropic"),
+    ]) {
+        features |= Features::SAMPLER_ANISOTROPY;
+    }
+    if info.is_supported(&[
+        Core(3, 3),
+        Es(3, 0),
+        Ext("GL_ARB_instanced_arrays"),
+    ]) {
+        features |= Features::INSTANCE_RATE;
+    }
+
+    if info.is_supported(&[Core(4, 3), Es(3, 1)]) { // TODO: extension
+        legacy |= LegacyFeatures::INDIRECT_EXECUTION;
+    }
+    if info.is_supported(&[
+        Core(3, 1),
+        Es(3, 0),
+        Ext("GL_ARB_draw_instanced"),
+    ]) {
+        legacy |= LegacyFeatures::DRAW_INSTANCED;
+    }
+    if info.is_supported(&[
+        Core(4, 2),
+        Ext("GL_ARB_base_instance"),
+    ]) {
+        legacy |= LegacyFeatures::DRAW_INSTANCED_BASE;
+    }
+    if info.is_supported(&[Core(3, 2)]) { // TODO: extension
+        legacy |= LegacyFeatures::DRAW_INDEXED_BASE;
+    }
+    if info.is_supported(&[Core(3, 1), Es(3, 0)]) { // TODO: extension
+        legacy |= LegacyFeatures::DRAW_INDEXED_INSTANCED;
+    }
+    if info.is_supported(&[Core(3, 2)]) { // TODO: extension
+        legacy |= LegacyFeatures::DRAW_INDEXED_INSTANCED_BASE_VERTEX;
+    }
+    if info.is_supported(&[Core(4, 2)]) { // TODO: extension
+        legacy |= LegacyFeatures::DRAW_INDEXED_INSTANCED_BASE;
+    }
+    if info.is_supported(&[
+        Core(3, 2),
+        Es(3, 2),
+        Ext("GL_ARB_draw_elements_base_vertex"),
+    ]) {
+        legacy |= LegacyFeatures::VERTEX_BASE;
+    }
+    if info.is_supported(&[
+        Core(3, 2),
+        Ext("GL_ARB_framebuffer_sRGB"),
+    ]) {
+        legacy |= LegacyFeatures::SRGB_COLOR;
+    }
+    if info.is_supported(&[
+        Core(3, 1),
+        Es(3, 0),
+        Ext("GL_ARB_uniform_buffer_object"),
+    ]) {
+        legacy |= LegacyFeatures::CONSTANT_BUFFER;
+    }
+    if info.is_supported(&[Core(4, 0)]) { // TODO: extension
+        legacy |= LegacyFeatures::UNORDERED_ACCESS_VIEW;
+    }
+    if info.is_supported(&[
+        Core(3, 1),
+        Es(3, 0),
+        Ext("GL_ARB_copy_buffer"),
+        Ext("GL_NV_copy_buffer"),
+    ]) {
+        legacy |= LegacyFeatures::COPY_BUFFER;
+    }
+    if info.is_supported(&[
+        Core(3, 3),
+        Es(3, 0),
+        Ext("GL_ARB_sampler_objects"),
+    ]) {
+        legacy |= LegacyFeatures::SAMPLER_OBJECTS;
+    }
+    if info.is_supported(&[Core(3, 3)]) { // TODO: extension
+        legacy |= LegacyFeatures::SAMPLER_LOD_BIAS;
+    }
+    if info.is_supported(&[Core(3, 3)]) { // TODO: extension
+        legacy |= LegacyFeatures::SAMPLER_BORDER_COLOR;
+    }
+
     let private = PrivateCaps {
         vertex_array:                       info.is_supported(&[Core(3,0),
                                                                 Es  (3,0),
@@ -418,7 +447,7 @@ pub fn query_all(gl: &gl::Gl) -> (Info, Features, Limits, PrivateCaps) {
                                             info.is_supported(&[Ext ("GL_EXT_texture_filter_anisotropic")]),
     };
 
-    (info, features, limits, private)
+    (info, features, legacy, limits, private)
 }
 
 #[cfg(test)]

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -190,6 +190,40 @@ pub struct Info {
     pub extensions: HashSet<&'static str>,
 }
 
+/*
+pub struct LegacyFeatures {
+    /// Support indirect drawing and dispatching.
+    pub const indirect_execution = 0x01 << 48;
+    /// Support instanced drawing.
+    pub const draw_instanced = 0x02 << 48;
+    /// Support offsets for instanced drawing with base instance.
+    pub const draw_instanced_base = 0x00000000;
+    /// Support indexed drawing with base vertex.
+    pub const draw_indexed_base = 0x00000000;
+    /// Support indexed, instanced drawing.
+    pub const draw_indexed_instanced = 0x00000000;
+    /// Support indexed, instanced drawing with base vertex only.
+    pub const draw_indexed_instanced_base_vertex = 0x00000000;
+    /// Support indexed, instanced drawing with base vertex and instance.
+    pub const draw_indexed_instanced_base = 0x00000000;
+    /// Support base vertex offset for indexed drawing.
+    pub const vertex_base = 0x00000000;
+    /// Support sRGB textures and rendertargets.
+    pub const srgb_color = 0x00000000;
+    /// Support constant buffers.
+    pub const constant_buffer = 0x00000000;
+    /// Support unordered-access views.
+    pub const unordered_access_view = 0x00000000;
+    /// Support accelerated buffer copy.
+    pub const copy_buffer = 0x00000000;
+    /// Support separation of textures and samplers.
+    pub const sampler_objects = 0x00000000;
+    /// Support sampler LOD bias.
+    pub const sampler_lod_bias = 0x00000000;
+    /// Support setting border texel colors.
+    pub const sampler_border_color = 0x00000000;
+}*/
+
 #[derive(Copy, Clone)]
 pub enum Requirement {
     Core(u32,u32),

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -193,6 +193,8 @@ pub struct Info {
 }
 
 bitflags! {
+    /// Flags for features that are required for Vulkan but may not
+    /// be supported by legacy backends (GL/DX11).
     pub struct LegacyFeatures: u16 {
         /// Support indirect drawing and dispatching.
         const INDIRECT_EXECUTION = 0x0001;

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -182,6 +182,11 @@ impl PhysicalDevice {
             queue_families: vec![QueueFamily(queue_type)],
         }
     }
+
+    /// Get GL-specific legacy feature flags.
+    pub fn legacy_features(&self) -> &info::LegacyFeatures {
+        &self.0.legacy_features
+    }
 }
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -4,6 +4,8 @@
 #![allow(missing_docs, missing_copy_implementations)]
 
 #[macro_use]
+extern crate bitflags;
+#[macro_use]
 extern crate log;
 extern crate gfx_gl as gl;
 extern crate gfx_hal as hal;
@@ -103,6 +105,7 @@ struct Share {
     context: gl::Gl,
     info: Info,
     features: hal::Features,
+    legacy_features: info::LegacyFeatures,
     limits: hal::Limits,
     private_caps: info::PrivateCaps,
     // Indicates if there is an active logical device.
@@ -131,11 +134,13 @@ impl PhysicalDevice {
     {
         let gl = gl::Gl::load_with(fn_proc);
         // query information
-        let (info, features, limits, private_caps) = info::query_all(&gl);
+        let (info, features, legacy_features, limits, private_caps) = info::query_all(&gl);
         info!("Vendor: {:?}", info.platform_name.vendor);
         info!("Renderer: {:?}", info.platform_name.renderer);
         info!("Version: {:?}", info.version);
         info!("Shading Language: {:?}", info.shading_language);
+        info!("Features: {:?}", features);
+        info!("Legacy Features: {:?}", legacy_features);
         debug!("Loaded Extensions:");
         for extension in info.extensions.iter() {
             debug!("- {}", *extension);
@@ -157,6 +162,7 @@ impl PhysicalDevice {
             context: gl,
             info,
             features,
+            legacy_features,
             limits,
             private_caps,
             open: Cell::new(false),
@@ -191,7 +197,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
         // initialize permanent states
         let gl = &self.0.context;
-        if self.0.features.srgb_color {
+        if self.0.legacy_features.contains(info::LegacyFeatures::SRGB_COLOR) {
             unsafe {
                 gl.Enable(gl::FRAMEBUFFER_SRGB);
             }

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -78,7 +78,9 @@ impl pool::RawCommandPool<Backend> for RawCommandPool {
         }
     }
 
-    fn allocate(&mut self, num: usize, level: hal::command::RawLevel) -> Vec<RawCommandBuffer> { // TODO: Implement secondary buffers
+    fn allocate(
+        &mut self, num: usize, _level: hal::command::RawLevel
+    ) -> Vec<RawCommandBuffer> { // TODO: Implement secondary buffers
         (0..num).map(|_|
                 RawCommandBuffer::new(
                     self.fbo,

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -495,6 +495,9 @@ impl CommandQueue {
             com::Command::UnbindAttribute(ref attribute) => unsafe {
                 self.share.context.DisableVertexAttribArray(attribute.location);
             }*/
+            com::Command::CopyBufferToBuffer(_src, _dst, ref _r) => unsafe {
+                unimplemented!(); //TODO
+            }
             com::Command::CopyBufferToTexture(buffer, texture, ref r) => unsafe {
                 // TODO: Fix format and active texture
                 assert_eq!(r.image_offset.z, 0);

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -7,6 +7,7 @@ use gl;
 use smallvec::SmallVec;
 
 use {command as com, native, state, window};
+use info::LegacyFeatures;
 use {Backend, Share};
 
 pub type ArrayBuffer = gl::types::GLuint;
@@ -205,7 +206,7 @@ impl CommandQueue {
         }
 
         // Reset indirect draw buffer
-        if self.share.features.indirect_execution {
+        if self.share.legacy_features.contains(LegacyFeatures::INDIRECT_EXECUTION) {
             unsafe { gl.BindBuffer(gl::DRAW_INDIRECT_BUFFER, 0) };
         }
 
@@ -259,7 +260,7 @@ impl CommandQueue {
 //          com::Command::BindVertexBuffers(_data_ptr) =>
             com::Command::Draw { primitive, ref vertices, ref instances } => {
                 let gl = &self.share.context;
-                let features = &self.share.features;
+                let legacy = &self.share.legacy_features;
                 if instances == &(0u32..1) {
                     unsafe {
                         gl.DrawArrays(
@@ -268,7 +269,7 @@ impl CommandQueue {
                             (vertices.end - vertices.start) as _,
                         );
                     }
-                } else if features.draw_instanced {
+                } else if legacy.contains(LegacyFeatures::DRAW_INSTANCED) {
                     if instances.start == 0 {
                         unsafe {
                             gl.DrawArraysInstanced(
@@ -278,7 +279,7 @@ impl CommandQueue {
                                 instances.end as _,
                             );
                         }
-                    } else if features.draw_instanced_base {
+                    } else if legacy.contains(LegacyFeatures::DRAW_INSTANCED_BASE) {
                         unsafe {
                             gl.DrawArraysInstancedBaseInstance(
                                 primitive,
@@ -297,7 +298,7 @@ impl CommandQueue {
             }
             com::Command::DrawIndexed { primitive, index_type, index_count, index_buffer_offset, base_vertex, ref instances } => {
                 let gl = &self.share.context;
-                let features = &self.share.features;
+                let legacy = &self.share.legacy_features;
                 let offset = index_buffer_offset as *const gl::types::GLvoid;
 
                 if instances == &(0u32..1) {
@@ -310,7 +311,7 @@ impl CommandQueue {
                                 offset,
                             );
                         }
-                    } else if features.draw_indexed_base {
+                    } else if legacy.contains(LegacyFeatures::DRAW_INDEXED_BASE) {
                         unsafe {
                             gl.DrawElementsBaseVertex(
                                 primitive,
@@ -323,7 +324,7 @@ impl CommandQueue {
                     } else {
                         error!("Base vertex with indexed drawing not supported");
                     }
-                } else if features.draw_indexed_instanced {
+                } else if legacy.contains(LegacyFeatures::DRAW_INDEXED_INSTANCED) {
                     if base_vertex == 0 && instances.start == 0 {
                         unsafe {
                             gl.DrawElementsInstanced(
@@ -334,7 +335,7 @@ impl CommandQueue {
                                 instances.end as _,
                             );
                         }
-                    } else if instances.start == 0 && features.draw_indexed_instanced_base_vertex {
+                    } else if instances.start == 0 && legacy.contains(LegacyFeatures::DRAW_INDEXED_INSTANCED_BASE_VERTEX) {
                         unsafe {
                             gl.DrawElementsInstancedBaseVertex(
                                 primitive,
@@ -347,7 +348,7 @@ impl CommandQueue {
                         }
                     } else if instances.start == 0 {
                         error!("Base vertex with instanced indexed drawing is not supported");
-                    } else if features.draw_indexed_instanced_base {
+                    } else if legacy.contains(LegacyFeatures::DRAW_INDEXED_INSTANCED_BASE) {
                         unsafe {
                             gl.DrawElementsInstancedBaseVertexBaseInstance(
                                 primitive,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -203,7 +203,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn get_features(&self) -> hal::Features {
-        unimplemented!()
+        hal::Features::empty() //TODO
     }
 
     fn get_limits(&self) -> hal::Limits {
@@ -370,7 +370,7 @@ impl Device {
                 height: p.work_group_size.y as _,
                 depth : p.work_group_size.z as _,
             }),
-            // this can only happen if the shader came directly from the user 
+            // this can only happen if the shader came directly from the user
             None => (ep.entry, metal::MTLSize { width: 0, height: 0, depth: 0 }),
         };
         let mtl_function = get_final_function(&lib, name, ep.specialization)

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -216,8 +216,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             min_buffer_copy_pitch_alignment: 4, // TODO: made this up
             min_uniform_buffer_offset_alignment: 1, // TODO
 
-            max_compute_group_count: [0; 3], // TODO
-            max_compute_group_size: [0; 3], // TODO
+            max_compute_group_count: [16; 3], // TODO
+            max_compute_group_size: [64; 3], // TODO
         }
     }
 }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -22,7 +22,7 @@ extern crate glsl_to_spirv;
 use ash::{Entry, LoadingError};
 use ash::extensions as ext;
 use ash::version::{EntryV1_0, DeviceV1_0, InstanceV1_0, V1_0};
-use ash::vk::{self, VK_TRUE};
+use ash::vk;
 
 use hal::{format, memory, queue};
 use hal::{Features, Limits, PatchSize, QueueType};
@@ -468,54 +468,91 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
     fn get_features(&self) -> Features {
         let features = self.instance.0.get_physical_device_features(self.handle);
+        let mut bits = Features::empty();
 
-        Features {
-            robust_buffer_access: features.robust_buffer_access == VK_TRUE,
-            full_draw_index_u32: features.full_draw_index_uint32 == VK_TRUE,
-            image_cube_array: features.image_cube_array == VK_TRUE,
-            independent_blending: features.independent_blend == VK_TRUE,
-            geometry_shader: features.geometry_shader == VK_TRUE,
-            tessellation_shader: features.tessellation_shader == VK_TRUE,
-            sample_rate_shading: features.sample_rate_shading == VK_TRUE,
-            dual_src_blending: features.dual_src_blend == VK_TRUE,
-            logic_op: features.logic_op == VK_TRUE,
-            multi_draw_indirect: features.multi_draw_indirect == VK_TRUE,
-            draw_indirect_first_instance: features.draw_indirect_first_instance == VK_TRUE,
-            depth_clamp: features.depth_clamp == VK_TRUE,
-            depth_bias_clamp: features.depth_bias_clamp == VK_TRUE,
-            non_fill_polygon_mode: features.depth_bounds == VK_TRUE,
-            depth_bounds: features.depth_bounds == VK_TRUE,
-            line_width: features.wide_lines == VK_TRUE,
-            point_size: features.large_points == VK_TRUE,
-            alpha_to_one: features.alpha_to_one == VK_TRUE,
-            multi_viewports: features.multi_viewport == VK_TRUE,
-            sampler_anisotropy: features.sampler_anisotropy == VK_TRUE,
-            format_etc2: features.texture_compression_etc2 == VK_TRUE,
-            format_astc_ldr: features.texture_compression_astc_ldr == VK_TRUE,
-            format_bc: features.texture_compression_bc == VK_TRUE,
-            precise_occlusion_query: features.occlusion_query_precise == VK_TRUE,
-            pipeline_statistics_query: features.pipeline_statistics_query == VK_TRUE,
-            vertex_stores_and_atomics: features.vertex_pipeline_stores_and_atomics == VK_TRUE,
-            fragment_stores_and_atomics: features.fragment_stores_and_atomics == VK_TRUE,
-
-            indirect_execution: true,
-            draw_instanced: true,
-            draw_instanced_base: true,
-            draw_indexed_base: true,
-            draw_indexed_instanced: true,
-            draw_indexed_instanced_base_vertex: true,
-            draw_indexed_instanced_base: true,
-            instance_rate: false,
-            vertex_base: true,
-            srgb_color: true,
-            constant_buffer: true,
-            unordered_access_view: true,
-            copy_buffer: true,
-            sampler_objects: true,
-            sampler_lod_bias: true,
-            sampler_border_color: true,
+        if features.robust_buffer_access != 0 {
+            bits |= Features::ROBUST_BUFFER_ACCESS;
         }
+        if features.full_draw_index_uint32 != 0 {
+            bits |= Features::FULL_DRAW_INDEX_U32;
+        }
+        if features.image_cube_array != 0 {
+            bits |= Features::IMAGE_CUBE_ARRAY;
+        }
+        if features.independent_blend != 0 {
+            bits |= Features::INDEPENDENT_BLENDING;
+        }
+        if features.geometry_shader != 0 {
+            bits |= Features::GEOMETRY_SHADER;
+        }
+        if features.tessellation_shader != 0 {
+            bits |= Features::TESSELLATION_SHADER;
+        }
+        if features.sample_rate_shading != 0 {
+            bits |= Features::SAMPLE_RATE_SHADING;
+        }
+        if features.dual_src_blend != 0 {
+            bits |= Features::DUAL_SRC_BLENDING;
+        }
+        if features.logic_op != 0 {
+            bits |= Features::LOGIC_OP;
+        }
+        if features.multi_draw_indirect != 0 {
+            bits |= Features::MULTI_DRAW_INDIRECT;
+        }
+        if features.draw_indirect_first_instance != 0 {
+            bits |= Features::DRAW_INDIRECT_FIRST_INSTANCE;
+        }
+        if features.depth_clamp != 0 {
+            bits |= Features::DEPTH_CLAMP;
+        }
+        if features.depth_bias_clamp != 0 {
+            bits |= Features::DEPTH_BIAS_CLAMP;
+        }
+        if features.depth_bounds != 0 {
+            bits |= Features::DEPTH_BOUNDS;
+        }
+        if features.wide_lines != 0 {
+            bits |= Features::LINE_WIDTH;
+        }
+        if features.large_points != 0 {
+            bits |= Features::POINT_SIZE;
+        }
+        if features.alpha_to_one != 0 {
+            bits |= Features::ALPHA_TO_ONE;
+        }
+        if features.multi_viewport != 0 {
+            bits |= Features::MULTI_VIEWPORTS;
+        }
+        if features.sampler_anisotropy != 0 {
+            bits |= Features::SAMPLER_ANISOTROPY;
+        }
+        if features.texture_compression_etc2 != 0 {
+            bits |= Features::FORMAT_ETC2;
+        }
+        if features.texture_compression_astc_ldr != 0 {
+            bits |= Features::FORMAT_ASTC_LDR;
+        }
+        if features.texture_compression_bc != 0 {
+            bits |= Features::FORMAT_BC;
+        }
+        if features.occlusion_query_precise != 0 {
+            bits |= Features::PRECISE_OCCLUSION_QUERY;
+        }
+        if features.pipeline_statistics_query != 0 {
+            bits |= Features::PIPELINE_STATISTICS_QUERY;
+        }
+        if features.vertex_pipeline_stores_and_atomics != 0 {
+            bits |= Features::VERTEX_STORES_AND_ATOMICS;
+        }
+        if features.fragment_stores_and_atomics != 0 {
+            bits |= Features::FRAGMENT_STORES_AND_ATOMICS;
+        }
+        //TODO: cover more features
+
+        bits
     }
+
     fn get_limits(&self) -> Limits {
         let limits = &self.properties.limits;
         let max_group_count = limits.max_compute_work_group_count;

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -217,7 +217,7 @@ bitflags! {
 }
 
 /// Limits of the device.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Limits {
     /// Maximum supported texture size.
@@ -227,9 +227,9 @@ pub struct Limits {
     /// Maximum number of viewports.
     pub max_viewports: usize,
     ///
-    pub max_compute_group_count: [usize; 3],
+    pub max_compute_group_count: [u32; 3],
     ///
-    pub max_compute_group_size: [usize; 3],
+    pub max_compute_group_size: [u32; 3],
 
     /// The alignment of the start of the buffer used as a GPU copy source, in bytes, non-zero.
     pub min_buffer_copy_offset_alignment: usize,

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -79,112 +79,141 @@ pub type ColorSlot = u8;
 /// Slot for a sampler.
 pub type SamplerSlot = u8;
 
-/// Features that the device supports.
-/// These only include features of the core interface and not API extensions.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Features {
-    // Core features
+bitflags! {
+    /// Features that the device supports.
+    /// These only include features of the core interface and not API extensions.
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct Features: u64 {
+        /// Bit mask of Vulkan Core features.
+        const CORE_MASK   = 0x0FFF_FFFF_FFFF_FFFF;
+        /// Bit mask of Vulkan Portability features.
+        const PORTABILITY_MASK  = 0xF000_0000_0000_0000;
 
-    /// Support for robust buffer access.
-    /// Buffer access by SPIR-V shaders is checked against the buffer/image boundaries.
-    pub robust_buffer_access: bool,
-    /// Support the full 32-bit range of indexed for draw calls.
-    /// If not supported, the maximum index value is determined by `Limits::max_draw_index_value`.
-    pub full_draw_index_u32: bool,
-    /// Support cube array image views.
-    pub image_cube_array: bool,
-    /// Support different color blending settings per attachments on graphics pipeline creation.
-    pub independent_blending: bool,
-    /// Support geometry shader.
-    pub geometry_shader: bool,
-    /// Support tessellation shaders.
-    pub tessellation_shader: bool,
-    /// Support per-sample shading and multisample interpolation.
-    pub sample_rate_shading: bool,
-    /// Support dual source blending.
-    pub dual_src_blending: bool,
-    /// Support logic operations.
-    pub logic_op: bool,
-    /// Support multiple draws per indirect call.
-    pub multi_draw_indirect: bool,
-    /// Support indirect drawing with first instance value.
-    /// If not supported the first instance value **must** be 0.
-    pub draw_indirect_first_instance: bool,
-    /// Support depth clamping.
-    pub depth_clamp: bool,
-    /// Support depth bias clamping.
-    pub depth_bias_clamp: bool,
-    /// Support non-fill polygon modes.
-    pub non_fill_polygon_mode: bool,
-    /// Support depth bounds test.
-    pub depth_bounds: bool,
-    /// Support lines with width other than 1.0.
-    pub line_width: bool,
-    /// Support points with size greater than 1.0.
-    pub point_size: bool,
-    /// Support replacing alpha values with 1.0.
-    pub alpha_to_one: bool,
-    /// Support multiple viewports and scissors.
-    pub multi_viewports: bool,
-    /// Support anisotropic filtering.
-    pub sampler_anisotropy: bool,
-    /// Support ETC2 texture compression formats.
-    pub format_etc2: bool,
-    /// Support ASTC (LDR) texture compression formats.
-    pub format_astc_ldr: bool,
-    /// Support BC texture compression formats.
-    pub format_bc: bool,
-    /// Support precise occlusion queries, returning the actual number of samples.
-    /// If not supported, queries return a non-zero value when at least **one** sample passes.
-    pub precise_occlusion_query: bool,
-    /// Support query of pipeline statistics.
-    pub pipeline_statistics_query: bool,
-    /// Support unordered access stores and atomic ops in the vertex, geometry
-    /// and tessellation shader stage.
-    /// If not supported, the shader resources **must** be annotated as read-only.
-    pub vertex_stores_and_atomics: bool,
-    /// Support unordered access stores and atomic ops in the fragment shader stage
-    /// If not supported, the shader resources **must** be annotated as read-only.
-    pub fragment_stores_and_atomics: bool,
+        /// Support for robust buffer access.
+        /// Buffer access by SPIR-V shaders is checked against the buffer/image boundaries.
+        const ROBUST_BUFFER_ACCESS = 0x000_0000_0000_0001;
+        /// Support the full 32-bit range of indexed for draw calls.
+        /// If not supported, the maximum index value is determined by `Limits::max_draw_index_value`.
+        const FULL_DRAW_INDEX_U32 = 0x000_0000_0000_0002;
+        /// Support cube array image views.
+        const IMAGE_CUBE_ARRAY = 0x000_0000_0000_0004;
+        /// Support different color blending settings per attachments on graphics pipeline creation.
+        const INDEPENDENT_BLENDING = 0x000_0000_0000_0008;
+        /// Support geometry shader.
+        const GEOMETRY_SHADER = 0x000_0000_0000_0010;
+        /// Support tessellation shaders.
+        const TESSELLATION_SHADER = 0x000_0000_0000_0020;
+        /// Support per-sample shading and multisample interpolation.
+        const SAMPLE_RATE_SHADING = 0x000_0000_0000_0040;
+        /// Support dual source blending.
+        const DUAL_SRC_BLENDING = 0x000_0000_0000_0080;
+        /// Support logic operations.
+        const LOGIC_OP = 0x000_0000_0000_0100;
+        /// Support multiple draws per indirect call.
+        const MULTI_DRAW_INDIRECT = 0x000_0000_0000_0200;
+        /// Support indirect drawing with first instance value.
+        /// If not supported the first instance value **must** be 0.
+        const DRAW_INDIRECT_FIRST_INSTANCE = 0x00_0000_0000_0400;
+        /// Support depth clamping.
+        const DEPTH_CLAMP = 0x000_0000_0000_0800;
+        /// Support depth bias clamping.
+        const DEPTH_BIAS_CLAMP = 0x000_0000_0000_1000;
+        /// Support non-fill polygon modes.
+        const NON_FILL_POLYGON_MODE = 0x000_0000_0000_2000;
+        /// Support depth bounds test.
+        const DEPTH_BOUNDS = 0x000_0000_0000_4000;
+        /// Support lines with width other than 1.0.
+        const LINE_WIDTH = 0x000_0000_0000_8000;
+        /// Support points with size greater than 1.0.
+        const POINT_SIZE = 0x000_0000_0001_0000;
+        /// Support replacing alpha values with 1.0.
+        const ALPHA_TO_ONE = 0x000_0000_0002_0000;
+        /// Support multiple viewports and scissors.
+        const MULTI_VIEWPORTS = 0x000_0000_0004_0000;
+        /// Support anisotropic filtering.
+        const SAMPLER_ANISOTROPY = 0x000_0000_0008_0000;
+        /// Support ETC2 texture compression formats.
+        const FORMAT_ETC2 = 0x000_0000_0010_0000;
+        /// Support ASTC (LDR) texture compression formats.
+        const FORMAT_ASTC_LDR = 0x000_0000_0020_0000;
+        /// Support BC texture compression formats.
+        const FORMAT_BC = 0x000_0000_0040_0000;
+        /// Support precise occlusion queries, returning the actual number of samples.
+        /// If not supported, queries return a non-zero value when at least **one** sample passes.
+        const PRECISE_OCCLUSION_QUERY = 0x000_0000_0080_0000;
+        /// Support query of pipeline statistics.
+        const PIPELINE_STATISTICS_QUERY = 0x000_0000_0100_0000;
+        /// Support unordered access stores and atomic ops in the vertex, geometry
+        /// and tessellation shader stage.
+        /// If not supported, the shader resources **must** be annotated as read-only.
+        const VERTEX_STORES_AND_ATOMICS = 0x000_0000_0200_0000;
+        /// Support unordered access stores and atomic ops in the fragment shader stage
+        /// If not supported, the shader resources **must** be annotated as read-only.
+        const FRAGMENT_STORES_AND_ATOMICS = 0x000_0000_0400_0000;
+        ///
+        const SHADER_TESSELLATION_AND_GEOMETRY_POINT_SIZE = 0x000_0000_0800_0000;
+        ///
+        const SHADER_IMAGE_GATHER_EXTENDED = 0x000_0000_1000_0000;
+        ///
+        const SHADER_STORAGE_IMAGE_EXTENDED_FORMATS = 0x000_0000_2000_0000;
+        ///
+        const SHADER_STORAGE_IMAGE_MULTISAMPLE = 0x000_0000_4000_0000;
+        ///
+        const SHADER_STORAGE_IMAGE_READ_WITHOUT_FORMAT = 0x000_0000_8000_0000;
+        ///
+        const SHADER_STORAGE_IMAGE_WRITE_WITHOUT_FORMAT = 0x000_0001_0000_0000;
+        ///
+        const SHADER_UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING = 0x000_0002_0000_0000;
+        ///
+        const SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING = 0x000_0004_0000_0000;
+        ///
+        const SHADER_STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING = 0x000_0008_0000_0000;
+        ///
+        const SHADER_STORAGE_IMAGE_ARRAY_DYNAMIC_INDEXING = 0x000_0010_0000_0000;
+        ///
+        const SHADER_CLIP_DISTANCE = 0x000_0020_0000_0000;
+        ///
+        const SHADER_CULL_DISTANCE = 0x000_0040_0000_0000;
+        ///
+        const SHADER_FLOAT64 = 0x000_0080_0000_0000;
+        ///
+        const SHADER_INT64 = 0x000_0100_0000_0000;
+        ///
+        const SHADER_INT16 = 0x000_0200_0000_0000;
+        ///
+        const SHADER_RESOURCE_RESIDENCY = 0x000_0400_0000_0000;
+        ///
+        const SHADER_RESOURCE_MIN_LOD = 0x000_0800_0000_0000;
+        ///
+        const SPARSE_BINDING = 0x000_1000_0000_0000;
+        ///
+        const SPARSE_RESIDENCY_BUFFER = 0x000_2000_0000_0000;
+        ///
+        const SHADER_RESIDENCY_IMAGE_2D = 0x000_4000_0000_0000;
+        ///
+        const SHADER_RESIDENSY_IMAGE_3D = 0x000_8000_0000_0000;
+        ///
+        const SPARSE_RESIDENCY_2_SAMPLES = 0x001_0000_0000_0000;
+        ///
+        const SPARSE_RESIDENCY_4_SAMPLES = 0x002_0000_0000_0000;
+        ///
+        const SPARSE_RESIDENCY_8_SAMPLES = 0x004_0000_0000_0000;
+        ///
+        const SPARSE_RESIDENCY_16_SAMPLES = 0x008_0000_0000_0000;
+        ///
+        const SPARSE_RESIDENCY_ALIASED = 0x010_0000_0000_0000;
+        ///
+        const VARIABLE_MULTISAMPLE_RATE = 0x020_0000_0000_0000;
+        ///
+        const INHERITED_QUERIES = 0x040_0000_0000_0000;
 
-    // Legacy features
-
-    /// Support indirect drawing and dispatching.
-    pub indirect_execution: bool,
-    /// Support instanced drawing.
-    pub draw_instanced: bool,
-    /// Support offsets for instanced drawing with base instance.
-    pub draw_instanced_base: bool,
-    /// Support indexed drawing with base vertex.
-    pub draw_indexed_base: bool,
-    /// Support indexed, instanced drawing.
-    pub draw_indexed_instanced: bool,
-    /// Support indexed, instanced drawing with base vertex only.
-    pub draw_indexed_instanced_base_vertex: bool,
-    /// Support indexed, instanced drawing with base vertex and instance.
-    pub draw_indexed_instanced_base: bool,
-    /// Support base vertex offset for indexed drawing.
-    pub vertex_base: bool,
-    /// Support sRGB textures and rendertargets.
-    pub srgb_color: bool,
-    /// Support constant buffers.
-    pub constant_buffer: bool,
-    /// Support unordered-access views.
-    pub unordered_access_view: bool,
-    /// Support accelerated buffer copy.
-    pub copy_buffer: bool,
-    /// Support separation of textures and samplers.
-    pub sampler_objects: bool,
-    /// Support sampler LOD bias.
-    pub sampler_lod_bias: bool,
-    /// Support setting border texel colors.
-    pub sampler_border_color: bool,
-
-    // Extension features
-
-    /// Support manually specified vertex attribute rates (divisors).
-    pub instance_rate: bool,
+        /// Support triangle fan primitive topology.
+        const TRIANGLE_FAN = 0x1000_0000_0000_0000;
+        /// Support separate stencil reference values for front and back sides.
+        const SEPARATE_STENCIL_REF_VALUES = 0x2000_0000_0000_0000;
+        /// Support manually specified vertex attribute rates (divisors).
+        const INSTANCE_RATE = 0x8000_0000_0000_0000;
+    }
 }
 
 /// Limits of the device.

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -56,3 +56,7 @@ path = "../../src/backend/gl"
 version = "0.1"
 features = ["glutin"]
 optional = true
+
+[[example]]
+name = "basic"
+required-features = ["gl", "glsl-to-spirv"]

--- a/src/warden/examples/basic.rs
+++ b/src/warden/examples/basic.rs
@@ -1,5 +1,4 @@
-#[cfg(feature = "vulkan")]
-extern crate gfx_backend_vulkan as back;
+extern crate gfx_backend_gl as gl;
 extern crate gfx_hal as hal;
 extern crate gfx_warden as warden;
 extern crate ron;
@@ -7,19 +6,22 @@ extern crate serde;
 
 use std::fs::File;
 use std::io::Read;
+use std::path::PathBuf;
 
+use hal::Instance;
 use ron::de::Deserializer;
 use serde::de::Deserialize;
 
 
 fn main() {
+    let base_path = PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../reftests",
+    ));
+
     let raw_scene = {
-        let path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../reftests/scenes/basic.ron",
-        );
         let mut raw_data = Vec::new();
-        File::open(path)
+        File::open(base_path.join("scenes/basic.ron"))
             .unwrap()
             .read_to_end(&mut raw_data)
             .unwrap();
@@ -28,16 +30,20 @@ fn main() {
             .unwrap()
     };
 
-    #[cfg(feature = "vulkan")]
-    {
-        use hal::Instance;
-        let instance = back::Instance::create("warden", 1);
-        let adapters = instance.enumerate_adapters();
-        let mut scene = warden::gpu::Scene::<back::Backend>::new(&adapters[0], &raw_scene, "");
-        scene.run(Some("empty"));
-        let guard = scene.fetch_image("im-color");
-        println!("row: {:?}", guard.row(0));
-    }
+    let events_loop = gl::glutin::EventsLoop::new();
+    let window = gl::glutin::GlWindow::new(
+        gl::glutin::WindowBuilder::new(),
+        gl::glutin::ContextBuilder::new()
+            .with_gl_profile(gl::glutin::GlProfile::Core),
+        &events_loop,
+        ).unwrap();
+    let instance = gl::Surface::from_window(window);
 
-    let _ = raw_scene;
+    let adapter = instance.enumerate_adapters().swap_remove(0);
+    let mut scene = warden::gpu::Scene::<gl::Backend, _>
+        ::new(adapter, &raw_scene, base_path.join("data"))
+        .unwrap();
+    scene.run(Some("empty"));
+    let guard = scene.fetch_image("image.color");
+    println!("row: {:?}", guard.row(0));
 }

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -120,7 +120,7 @@ impl Harness {
             let mut scene = warden::gpu::Scene::<I::Backend, _>::new(
                 adapter,
                 &tg.scene,
-                &self.base_path.join("data"),
+                self.base_path.join("data"),
             ).unwrap();
 
             for (test_name, test) in &tg.tests {
@@ -225,6 +225,6 @@ fn main() {
         num_failures += harness.run(instance);
     }
     let _ = harness;
-    num_failures += 0;
+    num_failures += 0; // mark as mutated
     process::exit(num_failures as _);
 }

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -109,7 +109,9 @@ fn align(x: usize, y: usize) -> usize {
 }
 
 impl<B: hal::Backend> Scene<B, hal::General> {
-    pub fn new(adapter: hal::Adapter<B>, raw: &raw::Scene, data_path: &PathBuf) -> Result<Self, Error> {
+    pub fn new(
+        adapter: hal::Adapter<B>, raw: &raw::Scene, data_path: PathBuf
+    ) -> Result<Self, Error> {
         info!("creating Scene from {:?}", data_path);
         let memory_types = adapter
             .physical_device


### PR DESCRIPTION
The main reasoning behind using bitflags is not as much an economy of space but the ability to check for intersections and do mathematical set-related operations for Warden. As such, I want to specify which features are affected by a test, so that the framework can skip backends that we know (at run-time) are not capable of running this test. This is way better than current crashing on, say, GL compute.

Requesting early feedback since converting all the backends is considerable amount of work.