### PR TITLE
Simplify interface for Adapter::open_with

### DIFF
--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -44,7 +44,7 @@ fn main() {
 
     let memory_properties = adapter.physical_device.memory_properties();
     let (mut device, mut queue_group) = adapter
-        .open_with::<_, Compute>(|_family| Some(1))
+        .open_with::<_, Compute>(1, |_family| true)
         .unwrap();
 
     let shader = device.create_shader_module(include_bytes!("shader/collatz.spv")).unwrap();

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -131,10 +131,8 @@ fn main() {
 
     // Build a new device and associated command queues
     let (device, mut queue_group) =
-        adapter.open_with::<_, hal::Graphics>(|family| {
-            if surface.supports_queue_family(family) {
-                Some(1)
-            } else { None }
+        adapter.open_with::<_, hal::Graphics>(1, |family| {
+            surface.supports_queue_family(family)
         }).unwrap();
 
     let mut command_pool = device.create_command_pool_typed(&queue_group, pool::CommandPoolCreateFlags::empty(), 16);

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -221,10 +221,8 @@ impl<B: Backend, C> Context<B, C>
         Cf: AsFormat,
     {
         let memory_properties = adapter.physical_device.memory_properties();
-        let (device, queues) = adapter.open_with(|family| {
-            if surface.supports_queue_family(family) {
-                Some(1)
-            } else { None }
+        let (device, queues) = adapter.open_with(1, |family| {
+            surface.supports_queue_family(family)
         })?;
 
         let queue = Queue::new(queues);

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -120,7 +120,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
             .get_limits();
 
         // initialize graphics
-        let (device, queue_group) = adapter.open_with(|_| Some(1))?;
+        let (device, queue_group) = adapter.open_with(1, |_| true)?;
 
         let upload_type: hal::MemoryTypeId = memory_types
             .iter()


### PR DESCRIPTION
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftest` succeeds (for Vulkan, GL fails for the compute scene)*
- [x] tested examples with the following backends: Vulkan

\* Unrelated, but the command is actually `make reftests` (plural). The PR template should probably be updated...