### PR TITLE
Tweak documentation in a couple places

### DIFF
--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -5,8 +5,8 @@
 use {format, memory, Backend, Gpu, Features, Limits};
 use queue::{Capability, QueueGroup};
 
-/// Scheduling hint for devices about the priority of a queue.
-/// Values ranging from `0.0` (low) to `1.0` (high).
+/// Scheduling hint for devices about the priority of a queue.  Values range from `0.0` (low) to
+/// `1.0` (high).
 pub type QueuePriority = f32;
 
 ///
@@ -133,6 +133,10 @@ pub struct AdapterInfo {
 }
 
 /// The list of `Adapter` instances is obtained by calling `Instance::enumerate_adapters()`.
+///
+/// Given an `Adapter` a `Gpu` can be constructed by calling `PhysicalDevice::open()` on its
+/// `physical_device` field. However, if only a single queue family is needed, then the
+/// `Adapter::open_with` convenience method can be used instead.
 pub struct Adapter<B: Backend> {
     /// General information about this adapter.
     pub info: AdapterInfo,

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -65,8 +65,8 @@ impl<B: Backend, C: Capability> QueueGroup<B, C> {
     }
 }
 
-/// Contains a list of all instantiated queue queues, grouped by their
-/// associated queue family.
+/// Contains a list of all instantiated queues. Conceptually structured as a collection of
+/// `QueueGroup`s, one for each queue family.
 pub struct Queues<B: Backend>(pub(crate) HashMap<QueueFamilyId, RawQueueGroup<B>>);
 
 impl<B: Backend> Queues<B> {


### PR DESCRIPTION
These are edits to a couple parts of the documentation that annoyed me as I was reading through

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds (might be temporarily impossible, WIP)
- [x] tested examples with the following backends:
