### PR TITLE
vk: Update to winapi 0.3

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -29,9 +29,7 @@ winit = { version = "0.10", optional = true }
 glsl-to-spirv = { version = "0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
-kernel32-sys = "0.2"
-user32-sys = "0.2"
+winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 x11 = { version = "2.15", features = ["xlib"]}

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -6,10 +6,7 @@ extern crate gfx_hal as hal;
 #[macro_use]
 extern crate lazy_static;
 extern crate smallvec;
-#[cfg(windows)]
-extern crate kernel32;
-#[cfg(windows)]
-extern crate user32;
+
 #[cfg(windows)]
 extern crate winapi;
 #[cfg(feature = "winit")]
@@ -18,6 +15,7 @@ extern crate winit;
 extern crate x11;
 #[cfg(all(unix, not(target_os = "android"), feature = "xcb"))]
 extern crate xcb;
+
 #[cfg(feature = "glsl-to-spirv")]
 extern crate glsl_to_spirv;
 

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -214,9 +214,10 @@ impl Instance {
         };
 
         let (width, height) = unsafe {
-            use winapi::RECT;
-            use user32::GetClientRect;
+            use winapi::shared::windef::RECT;
+            use winapi::um::winuser::GetClientRect;
             use std::mem::zeroed;
+
             let mut rect: RECT = zeroed();
             if GetClientRect(hwnd as *mut _, &mut rect as *mut RECT) == 0 {
                 panic!("GetClientRect failed");
@@ -258,9 +259,10 @@ impl Instance {
         }
         #[cfg(windows)]
         {
-            use kernel32;
+            use winapi::um::libloaderapi::GetModuleHandleW;
             use winit::os::windows::WindowExt;
-            let hinstance = unsafe { kernel32::GetModuleHandleW(ptr::null()) };
+
+            let hinstance = unsafe { GetModuleHandleW(ptr::null()) };
             let hwnd = window.get_hwnd();
             self.create_surface_from_hwnd(hinstance as *mut _, hwnd as *mut _)
         }


### PR DESCRIPTION
PR checklist:
- [x] `make reftests` succeeds (might be temporarily impossible, WIP)
- [x] tested examples with the following backends: vulkan (quad, compute seems to crash but unrelated?)
