### PR TITLE
Re-enable glsl-to-spirv by default in Warden

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
   # (assuming it will have libsdl2-dev and Rust by then)
   # see https://docs.travis-ci.com/user/trusty-ci-environment/
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && make travis-sdl2 && export CXX=g++-5 && export CC=gcc-5; fi
-  - if [[ $TRAVIS_OS_NAME == osx ]]; then brew update && brew install sdl2 && brew upgrade cmake && export CXX=clang++ && export CC=clang && export MACOSX_DEPLOYMENT_TARGET=10.7; fi
+  - if [[ $TRAVIS_OS_NAME == osx ]]; then brew update && brew install sdl2 && brew upgrade cmake && export CXX=clang++ && export CC=clang && export MACOSX_DEPLOYMENT_TARGET=10.9; fi
 
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ FEATURES_RENDER:=
 FEATURES_EXTRA:=mint serialize
 FEATURES_HAL:=
 FEATURES_HAL2:=
-FEATURES_WARDEN:=gl
 CMD_QUAD_RENDER:=cargo check
 CMD_CHECK_XCB:=
 
@@ -30,7 +29,6 @@ else
 	ifeq ($(UNAME_S),Linux)
 		EXCLUDES+= --exclude gfx-backend-metal
 		FEATURES_HAL=vulkan
-		FEATURES_WARDEN+= glsl-to-spirv
 		CMD_CHECK_XCB=cd src/backend/vulkan && cargo check --features xcb
 	endif
 	ifeq ($(UNAME_S),Darwin)
@@ -57,6 +55,7 @@ check:
 	cd examples/hal && cargo check --features "$(FEATURES_HAL)"
 	cd examples/hal && cargo check --features "$(FEATURES_HAL2)"
 	cd examples/render/quad_render && $(CMD_QUAD_RENDER)
+	cd src/warden && cargo check --no-default-features
 	cd src/warden && cargo check --features "env_logger gl gl-headless $(FEATURES_HAL) $(FEATURES_HAL2)"
 
 test:
@@ -64,11 +63,11 @@ test:
 	cd src/render && cargo test --features "$(FEATURES_RENDER) $(FEATURES_EXTRA)"
 
 reftests:
-	cd src/warden && cargo test --features "$(FEATURES_WARDEN)"
-	cd src/warden && cargo run --features "$(FEATURES_WARDEN) $(FEATURES_HAL) $(FEATURES_HAL2)" -- local
+	cd src/warden && cargo test --features "gl"
+	cd src/warden && cargo run --features "gl $(FEATURES_HAL) $(FEATURES_HAL2)" -- local
 
 reftests-ci:
-	cd src/warden && cargo run --features "$(FEATURES_WARDEN)" -- ci #TODO: "gl-headless"
+	cd src/warden && cargo run --features "gl" -- ci #TODO: "gl-headless"
 
 travis-sdl2:
 	#TODO

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1"
 log = "0.4"
 lazy_static = "0.2"
 shared_library = "0.1"
-ash = "=0.20.2"
+ash = "0.20.2"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.10", optional = true }

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -17,7 +17,7 @@ name = "gfx_warden"
 path = "src/lib.rs"
 
 [features]
-default = [] #TODO: "glsl-to-spirv"
+default = ["glsl-to-spirv"]
 vulkan = ["gfx-backend-vulkan"]
 dx12 = ["gfx-backend-dx12"]
 metal = ["gfx-backend-metal"]


### PR DESCRIPTION
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds (might be temporarily impossible, WIP)
- [ ] tested examples with the following backends:

r? @grovesNL (trying your change, may still fail the CI)