### PR TITLE
Combined image samplers

### DIFF
--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -426,7 +426,7 @@ pub fn map_image_resource_state(access: image::Access, layout: image::ImageLayou
     state
 }
 
-pub fn map_descriptor_range(bind: &DescriptorSetLayoutBinding, register_space: u32) -> D3D12_DESCRIPTOR_RANGE {
+pub fn map_descriptor_range(bind: &DescriptorSetLayoutBinding, register_space: u32, sampler: bool) -> D3D12_DESCRIPTOR_RANGE {
     D3D12_DESCRIPTOR_RANGE {
         RangeType: match bind.ty {
             pso::DescriptorType::Sampler => D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER,
@@ -434,6 +434,11 @@ pub fn map_descriptor_range(bind: &DescriptorSetLayoutBinding, register_space: u
             pso::DescriptorType::StorageBuffer |
             pso::DescriptorType::StorageImage => D3D12_DESCRIPTOR_RANGE_TYPE_UAV,
             pso::DescriptorType::UniformBuffer => D3D12_DESCRIPTOR_RANGE_TYPE_CBV,
+            pso::DescriptorType::CombinedImageSampler => if sampler {
+                D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER
+            } else {
+                D3D12_DESCRIPTOR_RANGE_TYPE_SRV
+            },
             _ => panic!("unsupported binding type {:?}", bind.ty)
         },
         NumDescriptors: bind.count as _,

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -158,6 +158,7 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
                         }
                         pso::DescriptorType::UniformTexelBuffer |
                         pso::DescriptorType::StorageTexelBuffer |
+                        pso::DescriptorType::CombinedImageSampler |
                         pso::DescriptorType::InputAttachment => unimplemented!()
                     };
                     (layout.binding, binding)

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -401,6 +401,7 @@ pub fn map_descriptor_type(ty: pso::DescriptorType) -> vk::DescriptorType {
         Dt::UniformBuffer      => vk::DescriptorType::UniformBuffer,
         Dt::StorageBuffer      => vk::DescriptorType::StorageBuffer,
         Dt::InputAttachment    => vk::DescriptorType::InputAttachment,
+        Dt::CombinedImageSampler => vk::DescriptorType::CombinedImageSampler,
     }
 }
 

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -34,6 +34,9 @@ pub enum DescriptorType {
     /// Allows unfiltered loads of pixel local data in the fragment shader.
     InputAttachment,
 
+    ///
+    CombinedImageSampler,
+
     // TODO: Dynamic descriptors
 }
 
@@ -117,4 +120,5 @@ pub enum DescriptorWrite<'a, B: Backend, R: RangeArg<u64>> {
     StorageBuffer(Vec<(&'a B::Buffer, R)>),
     UniformTexelBuffer(Vec<&'a B::BufferView>),
     StorageTexelBuffer(Vec<&'a B::BufferView>),
+    CombinedImageSampler(Vec<(&'a B::Sampler, &'a B::ImageView, ImageLayout)>),
 }


### PR DESCRIPTION
Add support for combined image samplers (vulkan and dx12 only). Missing register space adjustment for sampler part, not able in spirv-cross atm.

Fix a bunch of other bugs on the go:
* dx12: vertex attributes check to conservative
* dx12: clear values where stencil and color/depth are cleared at the same time
* dx12: buffer copy allows to specify 0 for row length and height if they shall match image extents
* dx12: typo in descriptor size for SrvCbvUav

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds (might be temporarily impossible, WIP)
- [ ] tested examples with the following backends:
