### PR TITLE
Tweak surface presentation support

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -186,7 +186,7 @@ pub struct PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
-        &self, families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>
+        &self, families: Vec<(&QueueFamily, Vec<hal::QueuePriority>)>
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
         let lock = self.is_open.try_lock();
         let mut open_guard = match lock {
@@ -245,7 +245,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
         let queue_groups = families
             .into_iter()
-            .map(|(family, priorities)| {
+            .map(|(&family, priorities)| {
                 let mut group = hal::backend::RawQueueGroup::new(family);
 
                 let create_idle_event = || unsafe {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -56,7 +56,7 @@ impl hal::Backend for Backend {
 pub struct PhysicalDevice;
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
-        &self, _: Vec<(QueueFamily, Vec<hal::QueuePriority>)>
+        &self, _: Vec<(&QueueFamily, Vec<hal::QueuePriority>)>
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
         unimplemented!()
     }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -182,7 +182,7 @@ impl PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
-        &self, families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>,
+        &self, families: Vec<(&QueueFamily, Vec<hal::QueuePriority>)>,
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
         // Can't have multiple logical devices at the same time
         // as they would share the same context.
@@ -225,7 +225,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 .into_iter()
                 .map(|(proto_family, priorities)| {
                     assert_eq!(priorities.len(), 1);
-                    let mut family = hal::backend::RawQueueGroup::new(proto_family);
+                    let mut family = hal::backend::RawQueueGroup::new(*proto_family);
                     let queue = queue::CommandQueue::new(&self.0, vao);
                     family.add_queue(queue);
                     (QueueFamilyId(0), family)
@@ -282,7 +282,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct QueueFamily;
 
 impl hal::QueueFamily for QueueFamily {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -154,12 +154,12 @@ impl PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
-        &self, mut families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>,
+        &self, mut families: Vec<(&QueueFamily, Vec<hal::QueuePriority>)>,
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
         // TODO: Handle opening a physical device multiple times
 
         assert_eq!(families.len(), 1);
-        let family = families.remove(0).0;
+        let family = *families.remove(0).0;
         let id = family.id();
 
         let mut queue_group = hal::backend::RawQueueGroup::new(family);

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -39,7 +39,7 @@ use cocoa::foundation::NSAutoreleasePool;
 use core_graphics::geometry::CGRect;
 
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct QueueFamily {}
 
 impl hal::QueueFamily for QueueFamily {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -287,7 +287,7 @@ impl hal::Instance for Instance {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct QueueFamily {
     properties: vk::QueueFamilyProperties,
     device: vk::PhysicalDevice,
@@ -315,7 +315,7 @@ pub struct PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
-        &self, families: Vec<(QueueFamily, Vec<hal::QueuePriority>)>
+        &self, families: Vec<(&QueueFamily, Vec<hal::QueuePriority>)>
     ) -> Result<hal::Gpu<Backend>, DeviceCreationError> {
         let family_infos = families
             .iter()
@@ -388,7 +388,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             .into_iter()
             .map(|(family, priorities)| {
                 let family_index = family.index;
-                let mut family_raw = hal::backend::RawQueueGroup::new(family);
+                let mut family_raw = hal::backend::RawQueueGroup::new(family.clone());
                 for id in 0 .. priorities.len() {
                     let queue_raw = unsafe {
                         device_arc.0.get_device_queue(family_index, id as _)

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -60,10 +60,10 @@ pub trait PhysicalDevice<B: Backend>: Sized {
     ///
     /// # let physical_device: empty::PhysicalDevice = return;
     /// # let family: empty::QueueFamily = return;
-    /// let gpu = physical_device.open(vec![(family, vec![1.0; 1])]);
+    /// let gpu = physical_device.open(vec![(&family, vec![1.0; 1])]);
     /// # }
     /// ```
-    fn open(&self, Vec<(B::QueueFamily, Vec<QueuePriority>)>) -> Result<Gpu<B>, DeviceCreationError>;
+    fn open(&self, Vec<(&B::QueueFamily, Vec<QueuePriority>)>) -> Result<Gpu<B>, DeviceCreationError>;
 
     ///
     fn format_properties(&self, Option<format::Format>) -> format::Properties;
@@ -146,7 +146,7 @@ impl<B: Backend> Adapter<B> {
             .next();
 
         let (id, family) = match requested_family {
-            Some(family) => (family.id(), vec![(family, vec![1.0; count])]),
+            Some(ref family) => (family.id(), vec![(family, vec![1.0; count])]),
             _ => return Err(DeviceCreationError::InitializationFailed),
         };
 


### PR DESCRIPTION
Make it possible to query whether queue supports presentation on surface after queues creation

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds (might be temporarily impossible, WIP)
- [ ] tested examples with the following backends:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/1811)
<!-- Reviewable:end -->
