### PR TITLE
Mandatory XCB dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ FEATURES_HAL:=
 FEATURES_HAL2:=
 FEATURES_WARDEN:=gl
 CMD_QUAD_RENDER:=cargo check
-CMD_CHECK_XCB:=
 
 SDL2_DEST=$(HOME)/deps
 SDL2_CONFIG=$(SDL2_DEST)/usr/bin/sdl2-config
@@ -31,7 +30,6 @@ else
 		EXCLUDES+= --exclude gfx-backend-metal
 		FEATURES_HAL=vulkan
 		FEATURES_WARDEN+= glsl-to-spirv
-		CMD_CHECK_XCB=cd src/backend/vulkan && cargo check --features xcb
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		EXCLUDES+= --exclude gfx-backend-vulkan
@@ -52,7 +50,6 @@ help:
 check:
 	#Note: excluding `warden` here, since it depends on serialization
 	cargo check --all $(EXCLUDES) --exclude gfx-warden
-	$(CMD_CHECK_XCB)
 	cd examples/hal && cargo check --features "gl"
 	cd examples/hal && cargo check --features "$(FEATURES_HAL)"
 	cd examples/hal && cargo check --features "$(FEATURES_HAL2)"

--- a/src/backend/gl/README.md
+++ b/src/backend/gl/README.md
@@ -1,4 +1,4 @@
-# gfx_device_gl
+# gfx-backend-gl
 
 [OpenGL](https://www.khronos.org/opengl/) backend for gfx.
 
@@ -9,19 +9,6 @@ Render | Depth | Texture
 ![render_coordinates](../../../info/gl_render_coordinates.png) | ![depth_coordinates](../../../info/gl_depth_coordinates.png) | ![texture_coordinates](../../../info/gl_texture_coordinates.png)
 
 ## GLSL Mirroring
-
-PSO component | GLSL component
---------------|----------------
-`Vertex/InstanceBuffer` | a collection of vertex shader inputs
-`ConstantBuffer` | [Uniform Buffer Object](https://www.opengl.org/wiki/Uniform_Buffer_Object)
-`Global` | [Uniform](https://www.opengl.org/wiki/Uniform_(GLSL))
-`Render/BlendTarget` | fragment shader output
-`Depth/StencilTarget` | [depth](https://www.opengl.org/wiki/Depth_Test), [stencil](https://www.opengl.org/wiki/Stencil_Test)
-`UnorderedAccess` | TODO
-`Scissor` | not visible
-`BlendRef` | not visible
-
-`TextureSampler`s correspond to the following [GLSL samplers](https://www.opengl.org/wiki/Sampler_(GLSL)), when you see a *g* preceding a sampler name, it represents any of the 3 possible prefixes (nothing for float, i for signed integer, and u for unsigned integer):
 
 Texture Kind | GLSL sampler
 -------------|-------------

--- a/src/backend/metal/README.md
+++ b/src/backend/metal/README.md
@@ -1,6 +1,6 @@
-# gfx-backend-dx12
+# gfx-backend-metal
 
-DX12 backend for gfx.
+[Metal](https://developer.apple.com/metal/) backend for gfx-rs.
 
 ## Normalized Coordinates
 

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -33,4 +33,4 @@ winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 x11 = { version = "2.15", features = ["xlib"]}
-xcb = { version = "0.8", optional = true }
+xcb = { version = "0.8" }

--- a/src/backend/vulkan/README.md
+++ b/src/backend/vulkan/README.md
@@ -1,6 +1,6 @@
-# gfx_device_vulkan
+# gfx-backend-vulkan
 
-[Vulkan](https://www.khronos.org/vulkan/) backend for gfx.
+[Vulkan](https://www.khronos.org/vulkan/) backend for gfx-rs.
 
 ## Normalized Coordinates
 
@@ -10,4 +10,4 @@ Render | Depth | Texture
 
 ## Mirroring
 
-TODO
+HAL is modelled after Vulkan, so everything should be 1:1.

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -13,7 +13,7 @@ extern crate winapi;
 extern crate winit;
 #[cfg(all(unix, not(target_os = "android")))]
 extern crate x11;
-#[cfg(all(unix, not(target_os = "android"), feature = "xcb"))]
+#[cfg(all(unix, not(target_os = "android")))]
 extern crate xcb;
 
 #[cfg(feature = "glsl-to-spirv")]

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -81,7 +81,7 @@ impl Instance {
         self.create_surface_from_vk_surface_khr(surface, width, height)
     }
 
-    #[cfg(all(unix, not(target_os = "android"), feature = "xcb"))]
+    #[cfg(all(unix, not(target_os = "android")))]
     pub fn create_surface_from_xcb(
         &self, connection: *mut vk::xcb_connection_t, window: vk::xcb_window_t
     ) -> Surface {


### PR DESCRIPTION
Allows https://github.com/gfx-rs/portability/pull/30 to proceed
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
