### PR TITLE
Make exposed objects send+sync.

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -274,6 +274,7 @@ pub struct CommandBuffer {
 }
 
 unsafe impl Send for CommandBuffer { }
+unsafe impl Sync for CommandBuffer { }
 
 impl CommandBuffer {
     pub(crate) fn new(

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -184,6 +184,9 @@ pub struct PhysicalDevice {
     is_open: Arc<Mutex<bool>>,
 }
 
+unsafe impl Send for PhysicalDevice { }
+unsafe impl Sync for PhysicalDevice { }
+
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
         &self, families: Vec<(&QueueFamily, Vec<hal::QueuePriority>)>
@@ -334,7 +337,9 @@ pub struct CommandQueue {
     idle_fence: *mut d3d12::ID3D12Fence,
     idle_event: winnt::HANDLE,
 }
-unsafe impl Send for CommandQueue {} //blocked by ComPtr
+
+unsafe impl Send for CommandQueue {}
+unsafe impl Sync for CommandQueue {}
 
 impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
     unsafe fn submit_raw<IC>(
@@ -580,6 +585,9 @@ impl Drop for Device {
 pub struct Instance {
     pub(crate) factory: ComPtr<dxgi1_4::IDXGIFactory4>,
 }
+
+unsafe impl Send for Instance { }
+unsafe impl Sync for Instance { }
 
 impl Instance {
     pub fn create(_: &str, _: u32) -> Instance {

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -226,6 +226,7 @@ pub struct Semaphore {
     #[derivative(Debug="ignore")]
     pub(crate) raw: ComPtr<d3d12::ID3D12Fence>,
 }
+
 unsafe impl Send for Semaphore {}
 unsafe impl Sync for Semaphore {}
 
@@ -239,6 +240,9 @@ pub struct Memory {
     // Buffer containing the whole memory for mapping (only for host visible heaps)
     pub(crate) resource: Option<*mut d3d12::ID3D12Resource>,
 }
+
+unsafe impl Send for Memory {}
+unsafe impl Sync for Memory {}
 
 #[derive(Debug)]
 pub struct DescriptorRange {

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -48,6 +48,7 @@ impl RawCommandPool {
 }
 
 unsafe impl Send for RawCommandPool { }
+unsafe impl Sync for RawCommandPool { }
 
 impl pool::RawCommandPool<Backend> for RawCommandPool {
     fn reset(&mut self) {

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -46,6 +46,9 @@ pub struct Surface {
     pub(crate) height: u32,
 }
 
+unsafe impl Send for Surface { }
+unsafe impl Sync for Surface { }
+
 impl hal::Surface<Backend> for Surface {
     fn supports_queue_family(&self, _queue_family: &QueueFamily) -> bool { true }
     fn kind(&self) -> i::Kind {
@@ -110,3 +113,6 @@ impl hal::Swapchain<Backend> for Swapchain {
         hal::Frame::new(index as usize)
     }
 }
+
+unsafe impl Send for Swapchain { }
+unsafe impl Sync for Swapchain { }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::iter::repeat;
 use std::ops::Range;
 use std::{ptr, mem, slice};
-use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 use gl;
@@ -18,7 +17,7 @@ use hal::range::RangeArg;
 
 use spirv_cross::{glsl, spirv, ErrorCode as SpirvErrorCode};
 
-use {Backend as B, Share, Surface, Swapchain};
+use {Backend as B, Share, Surface, Swapchain, Starc};
 use {conv, native as n, state};
 use info::LegacyFeatures;
 use pool::{BufferMemory, OwnedBuffer, RawCommandPool};
@@ -101,8 +100,9 @@ pub struct UnboundImage {
 }
 
 /// GL device.
+#[derive(Debug)]
 pub struct Device {
-    share: Rc<Share>,
+    share: Starc<Share>,
 }
 
 impl Drop for Device {
@@ -113,7 +113,7 @@ impl Drop for Device {
 
 impl Device {
     /// Create a new `Device`.
-    pub(crate) fn new(share: Rc<Share>) -> Self {
+    pub(crate) fn new(share: Starc<Share>) -> Self {
         Device {
             share: share,
         }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -118,6 +118,9 @@ pub struct Memory {
     pub(crate) size: u64,
 }
 
+unsafe impl Send for Memory {}
+unsafe impl Sync for Memory {}
+
 impl Memory {
     pub fn can_upload(&self) -> bool {
         self.properties.contains(Properties::CPU_VISIBLE)

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1,6 +1,6 @@
 use std::{mem, ptr, slice};
 use std::borrow::{Borrow, BorrowMut};
-use std::rc::Rc;
+use Starc;
 
 use hal;
 use hal::error;
@@ -58,14 +58,14 @@ impl State {
 }
 
 pub struct CommandQueue {
-    pub(crate) share: Rc<Share>,
+    pub(crate) share: Starc<Share>,
     vao: ArrayBuffer,
     state: State,
 }
 
 impl CommandQueue {
     /// Create a new command queue.
-    pub(crate) fn new(share: &Rc<Share>, vao: ArrayBuffer) -> Self {
+    pub(crate) fn new(share: &Starc<Share>, vao: ArrayBuffer) -> Self {
         CommandQueue {
             share: share.clone(),
             vao,

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -48,7 +48,7 @@ use hal::{self, format as f, image};
 use {Backend as B, Device, PhysicalDevice, QueueFamily};
 
 use glutin::{self, GlContext};
-use std::rc::Rc;
+use Starc;
 
 fn get_window_dimensions(window: &glutin::GlWindow) -> image::Dimensions {
     let (width, height) = window.get_inner_size().unwrap();
@@ -59,7 +59,7 @@ fn get_window_dimensions(window: &glutin::GlWindow) -> image::Dimensions {
 
 pub struct Swapchain {
     // Underlying window, required for presentation
-    pub(crate) window: Rc<glutin::GlWindow>,
+    pub(crate) window: Starc<glutin::GlWindow>,
 }
 
 impl hal::Swapchain<B> for Swapchain {
@@ -73,13 +73,13 @@ impl hal::Swapchain<B> for Swapchain {
 // we could spawn window + GL context when a swapchain is requested
 // and actually respect the swapchain configuration provided by the user.
 pub struct Surface {
-    window: Rc<glutin::GlWindow>,
+    window: Starc<glutin::GlWindow>,
 }
 
 impl Surface {
     pub fn from_window(window: glutin::GlWindow) -> Self {
         Surface {
-            window: Rc::new(window)
+            window: Starc::new(window)
         }
     }
 
@@ -175,6 +175,9 @@ pub fn config_context(
 
 
 pub struct Headless(pub glutin::HeadlessContext);
+
+unsafe impl Send for Headless {}
+unsafe impl Sync for Headless {}
 
 impl hal::Instance for Headless {
     type Backend = B;

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -225,6 +225,9 @@ impl CommandBufferInner {
 unsafe impl Send for CommandBuffer {
 }
 
+unsafe impl Sync for CommandBuffer {
+}
+
 enum EncoderState {
     None,
     Blit(metal::BlitCommandEncoder),
@@ -303,7 +306,7 @@ impl RawCommandQueue<Backend> for CommandQueue {
             let swapchain = swapchain.borrow_mut();
             let (surface, io_surface) = swapchain.present();
             unsafe {
-                let render_layer_borrow = surface.render_layer.borrow_mut();
+                let render_layer_borrow = surface.render_layer.lock().unwrap();
                 let render_layer = *render_layer_borrow;
                 msg_send![render_layer, setContents: io_surface.obj];
             }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -121,6 +121,8 @@ pub struct PhysicalDevice {
     raw: metal::Device,
     memory_types: [hal::MemoryType; 3],
 }
+unsafe impl Send for PhysicalDevice {}
+unsafe impl Sync for PhysicalDevice {}
 
 impl PhysicalDevice {
     pub(crate) fn new(raw: metal::Device) -> Self {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -21,14 +21,13 @@ mod native;
 mod conversions;
 
 pub use command::{CommandQueue, CommandPool};
-pub use device::LanguageVersion;
+pub use device::{Device, LanguageVersion, PhysicalDevice};
 pub use window::{Surface, Swapchain};
 
 pub type GraphicsCommandPool = CommandPool;
 
 use std::mem;
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 use std::os::raw::c_void;
 
 use hal::queue::QueueFamilyId;
@@ -93,9 +92,9 @@ impl Instance {
             msg_send![view_layer, addSublayer: render_layer];
 
             msg_send![view, retain];
-            window::Surface(Rc::new(window::SurfaceInner {
+            window::Surface(Arc::new(window::SurfaceInner {
                 nsview: view,
-                render_layer: RefCell::new(render_layer),
+                render_layer: Mutex::new(render_layer),
             }))
         }
     }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -255,6 +255,9 @@ impl Memory {
     }
 }
 
+unsafe impl Send for Memory {}
+unsafe impl Sync for Memory {}
+
 #[derive(Debug)]
 pub(crate) struct MemoryMapping {
     pub(crate) range: Range<u64>,

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -2,6 +2,8 @@
 //!
 //! Physical devices are the main entry point for opening a [Device](../struct.Device).
 
+use std::any::Any;
+
 use {format, memory, Backend, Gpu, Features, Limits};
 use error::DeviceCreationError;
 use queue::{Capability, QueueGroup};
@@ -43,7 +45,7 @@ pub struct MemoryProperties {
 }
 
 /// Represents a physical or virtual device, which is capable of running the backend.
-pub trait PhysicalDevice<B: Backend>: Sized {
+pub trait PhysicalDevice<B: Backend>: Any + Send + Sync {
     /// Create a new logical device.
     ///
     /// # Errors

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::borrow::Borrow;
 use std::ops::Range;
 
@@ -75,7 +76,7 @@ pub enum Level {
 }
 
 ///
-pub trait RawCommandBuffer<B: Backend>: Clone + Send {
+pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     ///
     fn begin(&mut self, flags: CommandBufferFlags);
 

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -4,6 +4,7 @@
 //! includes several items to facilitate this.
 
 use std::{fmt, mem, slice};
+use std::any::Any;
 use std::borrow::Borrow;
 use std::error::Error;
 use std::ops::Range;
@@ -118,7 +119,7 @@ pub struct FramebufferError;
 /// are not enforced at the HAL level due to OpenGL constraint (to be revised). Users can still
 /// benefit from the backends that support synchronization of the `Device`.
 ///
-pub trait Device<B: Backend> {
+pub trait Device<B: Backend>: Any + Send + Sync {
     /// Allocates a memory segment of a specified type.
     ///
     /// There is only a limited amount of allocations allowed depending on the implementation!

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -297,7 +297,7 @@ pub enum IndexType {
 }
 
 /// Basic backend instance trait.
-pub trait Instance {
+pub trait Instance: Any + Send + Sync {
     /// Associated backend type of this instance.
     type Backend: Backend;
     /// Enumerate all available adapters.
@@ -306,7 +306,7 @@ pub trait Instance {
 
 /// Different types of a specific API.
 #[allow(missing_docs)]
-pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any {
+pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any + Send + Sync {
     //type Instance:          Instance<Self>;
     type PhysicalDevice:      PhysicalDevice<Self>;
     type Device:              Device<Self>;
@@ -322,7 +322,7 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any {
     type RenderPass:          Debug + Any + Send + Sync;
     type Framebuffer:         Debug + Any + Send + Sync;
 
-    type Memory:              Debug + Any;
+    type Memory:              Debug + Any + Send + Sync;
     type CommandPool:         pool::RawCommandPool<Self>;
 
     type UnboundBuffer:       Debug + Any + Send + Sync;

--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -6,6 +6,8 @@ use command::{
     SubpassCommandBuffer, CommandBufferFlags, Shot, RawLevel
 };
 use queue::capability::{Supports, Graphics};
+
+use std::any::Any;
 use std::marker::PhantomData;
 
 bitflags!(
@@ -21,7 +23,7 @@ bitflags!(
 );
 
 /// The allocated command buffers are associated with the creating command queue.
-pub trait RawCommandPool<B: Backend>: Send {
+pub trait RawCommandPool<B: Backend>: Any + Send + Sync {
     /// Reset the command pool and the corresponding command buffers.
     ///
     /// # Synchronization: You may _not_ free the pool if a command buffer is still in use (pool memory still in use)

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -5,6 +5,7 @@ use backend::RawQueueGroup;
 use queue::{CommandQueue, QueueType};
 use queue::capability::{Capability, Graphics, Compute};
 
+use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -12,7 +13,7 @@ use std::marker::PhantomData;
 /// General information about a queue family, available upon adapter discovery.
 ///
 /// *Note*: A backend can expose multiple queue families with the same properties.
-pub trait QueueFamily: Debug {
+pub trait QueueFamily: Debug + Any + Send + Sync {
     /// Returns the type of queues.
     fn queue_type(&self) -> QueueType;
     /// Returns maximum number of queues created from this family.

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -11,6 +11,7 @@ pub mod capability;
 pub mod family;
 pub mod submission;
 
+use std::any::Any;
 use std::borrow::{Borrow, BorrowMut};
 use std::marker::PhantomData;
 
@@ -43,7 +44,7 @@ pub enum QueueType {
 
 /// `RawCommandQueue` are abstractions to the internal GPU execution engines.
 /// Commands are executed on the the device by submitting command buffers to queues.
-pub trait RawCommandQueue<B: Backend> {
+pub trait RawCommandQueue<B: Backend>: Any + Send + Sync {
     /// Submit command buffers to queue for execution.
     /// `fence` will be signalled after submission and _must_ be unsignalled.
     ///
@@ -52,12 +53,14 @@ pub trait RawCommandQueue<B: Backend> {
     /// Each queue implements safe wrappers according to their supported functionalities!
     unsafe fn submit_raw<IC>(&mut self, RawSubmission<B, IC>, Option<&B::Fence>)
     where
+        Self: Sized,
         IC: IntoIterator,
         IC::Item: Borrow<B::CommandBuffer>;
 
     ///
     fn present<IS, IW>(&mut self, swapchains: IS, wait_semaphores: IW)
     where
+        Self: Sized,
         IS: IntoIterator,
         IS::Item: BorrowMut<B::Swapchain>,
         IW: IntoIterator,

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -54,6 +54,7 @@ use image;
 use format::{self, Format};
 use queue::CommandQueue;
 
+use std::any::Any;
 use std::borrow::{Borrow, BorrowMut};
 use std::ops::Range;
 
@@ -95,7 +96,7 @@ pub struct SurfaceCapabilities {
 }
 
 /// A `Surface` abstracts the surface of a native window, which will be presented
-pub trait Surface<B: Backend> {
+pub trait Surface<B: Backend>: Any + Send + Sync {
     /// Retrieve the surface image kind.
     fn kind(&self) -> image::Kind;
 
@@ -235,7 +236,7 @@ pub enum Backbuffer<B: Backend> {
 
 /// The `Swapchain` is the backend representation of the surface.
 /// It consists of multiple buffers, which will be presented on the surface.
-pub trait Swapchain<B: Backend> : Sized {
+pub trait Swapchain<B: Backend>: Any + Send + Sync {
     /// Acquire a new frame for rendering. This needs to be called before presenting.
     ///
     /// # Synchronization
@@ -271,7 +272,7 @@ pub trait Swapchain<B: Backend> : Sized {
     )
     where
         &'a mut Self: BorrowMut<B::Swapchain>,
-        Self: 'a,
+        Self: Sized + 'a,
         IW: IntoIterator,
         IW::Item: Borrow<B::Semaphore>,
     {


### PR DESCRIPTION
Place `Send + Sync` bound on everything in `Backend`.
Add `single-threaded` feature that removes `Send + Sync` bounds from some objects of `Backend`.
OpenGL backend requires `single-threaded` feature.

Some types from metal backend weren't `Send` or `Sync`.
Either their public methods takes `&mut self` and they don't share internal state.
Or metal docs says that they are internally synchronised.
The only exception is `RawCommandBuffer`. But it already was `Send` making use of it unsafe. Adding `Sync` can't make things to worse.

Let IC checks vulkan and dx12 as I can't compile them.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/1820)
<!-- Reviewable:end -->
