### PR TITLE
Descriptor set updates and copies

### DIFF
--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -103,14 +103,14 @@ fn main() {
     );
 
     let desc_set = desc_pool.allocate_set(&set_layout);
-    device.update_descriptor_sets(&[
+    device.write_descriptor_sets(Some(
         pso::DescriptorSetWrite {
             set: &desc_set,
             binding: 0,
             array_offset: 0,
-            write: pso::DescriptorWrite::StorageBuffer(vec![(&device_buffer, 0..stride * numbers.len() as u64)])
+            write: pso::DescriptorWrite::StorageBuffer(&[(&device_buffer, 0..stride * numbers.len() as u64)])
         }
-    ]);
+    ));
 
     let mut command_pool = device.create_command_pool_typed(&queue_group, pool::CommandPoolCreateFlags::empty(), 16);
     let fence = device.create_fence(false);

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -431,18 +431,18 @@ fn main() {
         )
     );
 
-    device.update_descriptor_sets::<_,Range<_>>(&[
+    device.write_descriptor_sets::<_, Range<_>>(vec![
         pso::DescriptorSetWrite {
             set: &desc_set,
             binding: 0,
             array_offset: 0,
-            write: pso::DescriptorWrite::SampledImage(vec![(&image_srv, i::ImageLayout::Undefined)]),
+            write: pso::DescriptorWrite::SampledImage(&[(&image_srv, i::ImageLayout::Undefined)]),
         },
         pso::DescriptorSetWrite {
             set: &desc_set,
             binding: 1,
             array_offset: 0,
-            write: pso::DescriptorWrite::Sampler(vec![&sampler]),
+            write: pso::DescriptorWrite::Sampler(&[&sampler]),
         },
     ]);
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -214,11 +214,19 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn update_descriptor_sets<'a, I, R>(&self, _: I)
+    fn write_descriptor_sets<'a, I, R>(&self, _: I)
     where
         I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetWrite<'a, 'a, Backend, R>>,
-        R: RangeArg<u64>,
+        I::Item: Borrow<pso::DescriptorSetWrite<'a, Backend, R>>,
+        R: 'a + RangeArg<u64>,
+    {
+        unimplemented!()
+    }
+
+    fn copy_descriptor_sets<'a, I>(&self, _: I)
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorSetCopy<'a, Backend>>
     {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -889,13 +889,26 @@ impl d::Device<B> for Device {
         n::DescriptorSetLayout
     }
 
-    fn update_descriptor_sets<'a, I, R>(&self, _: I)
+    fn write_descriptor_sets<'a, I, R>(&self, writes: I)
     where
         I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetWrite<'a, 'a, B, R>>,
-        R: RangeArg<u64>,
+        I::Item: Borrow<pso::DescriptorSetWrite<'a, B, R>>,
+        R: 'a + RangeArg<u64>,
     {
-        // TODO
+        for _write in writes {
+            //unimplemented!() // not panicing because of Warden
+            error!("TODO: implement `write_descriptor_sets`");
+        }
+    }
+
+    fn copy_descriptor_sets<'a, I>(&self, copies: I)
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorSetCopy<'a, B>>,
+    {
+        for _copy in copies {
+            unimplemented!()
+        }
     }
 
     fn create_semaphore(&self) -> n::Semaphore {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -973,11 +973,11 @@ impl hal::Device<Backend> for Device {
         n::DescriptorSetLayout::ArgumentBuffer(encoder, stage_flags)
     }
 
-    fn update_descriptor_sets<'a, I, R>(&self, writes: I)
+    fn write_descriptor_sets<'a, I, R>(&self, writes: I)
     where
         I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetWrite<'a, 'a, Backend, R>>,
-        R: RangeArg<u64>,
+        I::Item: Borrow<pso::DescriptorSetWrite<'a, Backend, R>>,
+        R: 'a + RangeArg<u64>,
     {
         use hal::pso::DescriptorWrite::*;
 
@@ -986,25 +986,25 @@ impl hal::Device<Backend> for Device {
         let mut mtl_buffers = Vec::new();
         let mut mtl_offsets = Vec::new();
 
-        for write in writes.into_iter() {
-            let write = write.borrow();
-            match *write.set {
+        for write in writes {
+            let w = write.borrow();
+            match *w.set {
                 n::DescriptorSet::Emulated(ref inner) => {
                     let mut set = inner.lock().unwrap();
 
                     // Find layout entry
                     let layout = set.layout.iter()
-                        .find(|layout| layout.binding == write.binding)
+                        .find(|layout| layout.binding == w.binding)
                         .expect("invalid descriptor set binding index")
                         .clone();
 
-                    match (&write.write, set.bindings.get_mut(&write.binding)) {
+                    match (&w.write, set.bindings.get_mut(&w.binding)) {
                         (&Sampler(ref samplers), Some(&mut n::DescriptorSetBinding::Sampler(ref mut vec))) => {
-                            if write.array_offset + samplers.len() > layout.count {
+                            if w.array_offset + samplers.len() > layout.count {
                                 panic!("out of range descriptor write");
                             }
 
-                            let target_iter = vec[write.array_offset..(write.array_offset + samplers.len())].iter_mut();
+                            let target_iter = vec[w.array_offset..(w.array_offset + samplers.len())].iter_mut();
 
                             for (new, old) in samplers.iter().zip(target_iter) {
                                 *old = Some(new.0.clone());
@@ -1012,11 +1012,11 @@ impl hal::Device<Backend> for Device {
                         }
                         (&SampledImage(ref images), Some(&mut n::DescriptorSetBinding::Image(ref mut vec))) |
                         (&StorageImage(ref images), Some(&mut n::DescriptorSetBinding::Image(ref mut vec))) => {
-                            if write.array_offset + images.len() > layout.count {
+                            if w.array_offset + images.len() > layout.count {
                                 panic!("out of range descriptor write");
                             }
 
-                            let target_iter = vec[write.array_offset..(write.array_offset + images.len())].iter_mut();
+                            let target_iter = vec[w.array_offset..(w.array_offset + images.len())].iter_mut();
 
                             for (&(image, offset), old) in images.iter().zip(target_iter) {
                                 *old = Some((image.0.clone(), offset));
@@ -1024,11 +1024,11 @@ impl hal::Device<Backend> for Device {
                         }
                         (&UniformBuffer(ref buffers), Some(&mut n::DescriptorSetBinding::Buffer(ref mut vec))) |
                         (&StorageBuffer(ref buffers), Some(&mut n::DescriptorSetBinding::Buffer(ref mut vec))) => {
-                            if write.array_offset + buffers.len() > layout.count {
+                            if w.array_offset + buffers.len() > layout.count {
                                 panic!("out of range descriptor write");
                             }
 
-                            let target_iter = vec[write.array_offset..(write.array_offset + buffers.len())].iter_mut();
+                            let target_iter = vec[w.array_offset..(w.array_offset + buffers.len())].iter_mut();
 
                             for (new, old) in buffers.iter().zip(target_iter) {
                                 let (buffer, ref range) = *new;
@@ -1051,18 +1051,18 @@ impl hal::Device<Backend> for Device {
 
                     encoder.set_argument_buffer(buffer, offset);
                     //TODO: range checks, need to keep some layout metadata around
-                    assert_eq!(write.array_offset, 0); //TODO
+                    assert_eq!(w.array_offset, 0); //TODO
 
-                    match write.write {
+                    match w.write {
                         Sampler(ref samplers) => {
                             mtl_samplers.clear();
                             mtl_samplers.extend(samplers.iter().map(|sampler| &*sampler.0));
-                            encoder.set_sampler_states(&mtl_samplers, write.binding as _);
+                            encoder.set_sampler_states(&mtl_samplers, w.binding as _);
                         },
                         SampledImage(ref images) => {
                             mtl_textures.clear();
                             mtl_textures.extend(images.iter().map(|image| &*((image.0).0)));
-                            encoder.set_textures(&mtl_textures, write.binding as _);
+                            encoder.set_textures(&mtl_textures, w.binding as _);
                         },
                         UniformBuffer(ref buffers) | StorageBuffer(ref buffers) => {
                             mtl_buffers.clear();
@@ -1088,6 +1088,16 @@ impl hal::Device<Backend> for Device {
                     }
                 }
             }
+        }
+    }
+
+    fn copy_descriptor_sets<'a, I>(&self, copies: I)
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorSetCopy<'a, Backend>>,
+    {
+        for _copy in copies {
+            unimplemented!()
         }
     }
 

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -358,12 +358,17 @@ pub trait Device<B: Backend> {
     fn destroy_descriptor_set_layout(&self, B::DescriptorSetLayout);
 
     ///
-    // TODO: copies
-    fn update_descriptor_sets<'a, I, R>(&self, writes: I)
+    fn write_descriptor_sets<'a, I, R>(&self, I)
     where
         I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetWrite<'a, 'a, B, R>>,
-        R: RangeArg<u64>;
+        I::Item: Borrow<pso::DescriptorSetWrite<'a, B, R>>,
+        R: 'a + RangeArg<u64>;
+
+    ///
+    fn copy_descriptor_sets<'a, I>(&self, I)
+    where
+        I: IntoIterator,
+        I::Item: Borrow<pso::DescriptorSetCopy<'a, B>>;
 
     ///
     fn map_memory<R>(&self, &B::Memory, R) -> Result<*mut u8, mapping::Error>

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -103,22 +103,35 @@ pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
 }
 
 #[allow(missing_docs)] //TODO
-pub struct DescriptorSetWrite<'a, 'b, B: Backend, R: RangeArg<u64>> {
+pub struct DescriptorSetWrite<'a, B: Backend, R: 'a + RangeArg<u64>> {
     pub set: &'a B::DescriptorSet,
     pub binding: usize,
     pub array_offset: usize,
-    pub write: DescriptorWrite<'b, B, R>,
+    pub write: DescriptorWrite<'a, B, R>,
 }
 
 #[allow(missing_docs)] //TODO
-pub enum DescriptorWrite<'a, B: Backend, R: RangeArg<u64>> {
-    Sampler(Vec<&'a B::Sampler>),
-    SampledImage(Vec<(&'a B::ImageView, ImageLayout)>),
-    StorageImage(Vec<(&'a B::ImageView, ImageLayout)>),
-    InputAttachment(Vec<(&'a B::ImageView, ImageLayout)>),
-    UniformBuffer(Vec<(&'a B::Buffer, R)>),
-    StorageBuffer(Vec<(&'a B::Buffer, R)>),
-    UniformTexelBuffer(Vec<&'a B::BufferView>),
-    StorageTexelBuffer(Vec<&'a B::BufferView>),
-    CombinedImageSampler(Vec<(&'a B::Sampler, &'a B::ImageView, ImageLayout)>),
+#[derive(Clone, Copy)]
+pub enum DescriptorWrite<'a, B: Backend, R: 'a + RangeArg<u64>> {
+    Sampler(&'a [&'a B::Sampler]),
+    SampledImage(&'a [(&'a B::ImageView, ImageLayout)]),
+    StorageImage(&'a [(&'a B::ImageView, ImageLayout)]),
+    InputAttachment(&'a [(&'a B::ImageView, ImageLayout)]),
+    UniformBuffer(&'a [(&'a B::Buffer, R)]),
+    StorageBuffer(&'a [(&'a B::Buffer, R)]),
+    UniformTexelBuffer(&'a [&'a B::BufferView]),
+    StorageTexelBuffer(&'a [&'a B::BufferView]),
+    CombinedImageSampler(&'a [(&'a B::Sampler, &'a B::ImageView, ImageLayout)]),
+}
+
+#[allow(missing_docs)] //TODO
+#[derive(Clone, Copy)]
+pub struct DescriptorSetCopy<'a, B: Backend> {
+    pub src_set: &'a B::DescriptorSet,
+    pub src_binding: usize,
+    pub src_array_offset: usize,
+    pub dst_set: &'a B::DescriptorSet,
+    pub dst_binding: usize,
+    pub dst_array_offset: usize,
+    pub count: usize,
 }

--- a/src/render/src/pso.rs
+++ b/src/render/src/pso.rs
@@ -105,17 +105,18 @@ define_descriptors! {
 impl<B: Backend> Bind<B> for SampledImage {
     type Handle = handle::raw::ImageView<B>;
 
-    fn write<'a, I>(views: I) -> hal::pso::DescriptorWrite<'a, B, (Option<u64>, Option<u64>)>
+    fn write<'a, I>(_views: I) -> hal::pso::DescriptorWrite<'a, B, (Option<u64>, Option<u64>)>
     where
         I: IntoIterator,
         I::Item: Borrow<&'a Self::Handle>,
     {
-        hal::pso::DescriptorWrite::SampledImage(views
+        hal::pso::DescriptorWrite::SampledImage(&[])
+        /* views
             .into_iter()
             .map(|view| {
                 let layout = ImageLayout::ShaderReadOnlyOptimal;
                 (view.borrow().resource(), layout)
-            }).collect())
+            }).collect())*/
     }
 
     fn require<'a>(
@@ -139,15 +140,17 @@ impl<B: Backend> Bind<B> for SampledImage {
 impl<B: Backend> Bind<B> for Sampler {
     type Handle = handle::raw::Sampler<B>;
 
-    fn write<'a, I>(samplers: I) -> hal::pso::DescriptorWrite<'a, B, (Option<u64>, Option<u64>)>
+    fn write<'a, I>(_samplers: I) -> hal::pso::DescriptorWrite<'a, B, (Option<u64>, Option<u64>)>
     where
         I: IntoIterator,
         I::Item: Borrow<&'a Self::Handle>,
     {
-        hal::pso::DescriptorWrite::Sampler(samplers
+        hal::pso::DescriptorWrite::Sampler(&[])
+        /*
+        samplers
             .into_iter()
             .map(|sampler| sampler.borrow().resource())
-            .collect())
+            .collect())*/
     }
 
     fn require<'a>(
@@ -168,7 +171,7 @@ pub struct DescriptorSetBindRef<'a, 'b, B: Backend, T: Bind<B>> {
 
 pub struct DescriptorSetsUpdate<'a, B: Backend> {
     device: &'a mut Device<B>,
-    writes: Vec<hal::pso::DescriptorSetWrite<'a, 'a, B, (Option<u64>, Option<u64>)>>,
+    writes: Vec<hal::pso::DescriptorSetWrite<'a, B, (Option<u64>, Option<u64>)>>,
 }
 
 impl<'a, B: Backend> DescriptorSetsUpdate<'a, B> {
@@ -202,7 +205,7 @@ impl<'a, B: Backend> DescriptorSetsUpdate<'a, B> {
 
     pub fn finish(self) {
         use hal::Device;
-        self.device.raw.update_descriptor_sets(&self.writes);
+        self.device.raw.write_descriptor_sets(self.writes);
     }
 }
 


### PR DESCRIPTION
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan

This PR avoids the need to allocate vectors just for descriptor updates. It also introduces a separate `Device` entry point for descriptor copies, implemented on Vulkan only at the moment.
