### PR TITLE
Fix #1827: Naming / casing issues

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -538,7 +538,7 @@ fn main() {
             cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, Some(&desc_set)); //TODO
 
             {
-                let mut encoder = cmd_buffer.begin_renderpass_inline(
+                let mut encoder = cmd_buffer.begin_render_pass_inline(
                     &render_pass,
                     &framebuffers[frame.id()],
                     viewport.rect,
@@ -580,7 +580,7 @@ fn main() {
     device.destroy_fence(frame_fence);
     device.destroy_semaphore(frame_semaphore);
     device.destroy_pipeline_layout(pipeline_layout);
-    device.destroy_renderpass(render_pass);
+    device.destroy_render_pass(render_pass);
     device.free_memory(buffer_memory);
     device.free_memory(image_memory);
     device.free_memory(image_upload_memory);

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -618,7 +618,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.reset();
     }
 
-    fn begin_renderpass_raw<T>(
+    fn begin_render_pass_raw<T>(
         &mut self,
         render_pass: &n::RenderPass,
         framebuffer: &n::Framebuffer,
@@ -686,7 +686,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.bind_targets();
     }
 
-    fn end_renderpass(&mut self) {
+    fn end_render_pass(&mut self) {
         self.cur_subpass = !0;
         self.insert_subpass_barriers();
         self.pass_cache = None;

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2196,7 +2196,7 @@ impl d::Device<B> for Device {
         }
     }
 
-    fn destroy_renderpass(&self, _rp: n::RenderPass) {
+    fn destroy_render_pass(&self, _rp: n::RenderPass) {
         // Just drop
     }
 

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -56,7 +56,7 @@ impl hal::Surface<Backend> for Surface {
     fn capabilities_and_formats(
         &self, _: &PhysicalDevice,
     ) -> (hal::SurfaceCapabilities, Option<Vec<f::Format>>) {
-        let extent = hal::window::Extent2d {
+        let extent = hal::window::Extent2D {
             width: self.width,
             height: self.height,
         };

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -285,7 +285,7 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn destroy_renderpass(&self, _: ()) {
+    fn destroy_render_pass(&self, _: ()) {
         unimplemented!()
     }
 
@@ -503,7 +503,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
 
-    fn begin_renderpass_raw<T>(
+    fn begin_render_pass_raw<T>(
         &mut self,
         _: &(),
         _: &(),
@@ -521,7 +521,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn end_renderpass(&mut self) {
+    fn end_render_pass(&mut self) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -533,7 +533,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn begin_renderpass_raw<T>(
+    fn begin_render_pass_raw<T>(
         &mut self,
         render_pass: &n::RenderPass,
         framebuffer: &n::FrameBuffer,
@@ -596,7 +596,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn end_renderpass(&mut self) {
+    fn end_render_pass(&mut self) {
         // TODO
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -983,7 +983,7 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    fn destroy_renderpass(&self, _: n::RenderPass) {
+    fn destroy_render_pass(&self, _: n::RenderPass) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -112,7 +112,7 @@ impl hal::Surface<B> for Surface {
 
     fn capabilities_and_formats(&self, _: &PhysicalDevice) -> (hal::SurfaceCapabilities, Option<Vec<f::Format>>) {
         let dim = get_window_dimensions(&self.window);
-        let extent = hal::window::Extent2d {
+        let extent = hal::window::Extent2D {
             width: dim.0 as u32,
             height: dim.1 as u32,
         };
@@ -120,7 +120,7 @@ impl hal::Surface<B> for Surface {
         (hal::SurfaceCapabilities {
             image_count: if self.window.get_pixel_format().double_buffer { 2..3 } else { 1..2 },
             current_extent: Some(extent),
-            extents: extent..hal::window::Extent2d {
+            extents: extent..hal::window::Extent2D {
                 width: dim.0 as u32 + 1,
                 height: dim.1 as u32 + 1
             },

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -139,7 +139,7 @@ impl CommandBufferInner {
         }
     }
 
-    fn begin_renderpass(&mut self, encoder: metal::RenderCommandEncoder) {
+    fn begin_render_pass(&mut self, encoder: metal::RenderCommandEncoder) {
         self.stop_ecoding();
 
         self.encoder_state = EncoderState::Render(encoder);
@@ -413,7 +413,7 @@ impl CommandBuffer {
         }
     }
 
-    fn expect_renderpass(&self) -> &metal::RenderCommandEncoderRef {
+    fn expect_render_pass(&self) -> &metal::RenderCommandEncoderRef {
         if let EncoderState::Render(ref encoder) = self.inner_ref().encoder_state {
             encoder
         } else {
@@ -634,7 +634,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
-    fn begin_renderpass_raw<T>(
+    fn begin_render_pass_raw<T>(
         &mut self,
         render_pass: &native::RenderPass,
         frame_buffer: &native::FrameBuffer,
@@ -682,14 +682,14 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 .to_owned()
         };
 
-        inner.begin_renderpass(encoder);
+        inner.begin_render_pass(encoder);
     }
 
     fn next_subpass(&mut self, _contents: com::SubpassContents) {
         unimplemented!()
     }
 
-    fn end_renderpass(&mut self) {
+    fn end_render_pass(&mut self) {
         match self.inner().encoder_state {
             EncoderState::Render(ref encoder) => {
                 encoder.end_encoding();
@@ -1060,7 +1060,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         instances: Range<InstanceCount>,
     ) {
         let primitive_type = self.inner().primitive_type;
-        let encoder = self.expect_renderpass();
+        let encoder = self.expect_render_pass();
 
         unsafe {
             msg_send![encoder,
@@ -1081,7 +1081,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     ) {
         let (buffer, offset, index_type) = self.inner_ref().index_buffer.as_ref().cloned().expect("must bind index buffer");
         let primitive_type = self.inner_ref().primitive_type;
-        let encoder = self.expect_renderpass();
+        let encoder = self.expect_render_pass();
         let index_offset = match index_type {
             MTLIndexType::UInt16 => indices.start as u64 * 2,
             MTLIndexType::UInt32 => indices.start as u64 * 4,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1113,7 +1113,7 @@ impl hal::Device<Backend> for Device {
     fn destroy_shader_module(&self, _module: n::ShaderModule) {
     }
 
-    fn destroy_renderpass(&self, _pass: n::RenderPass) {
+    fn destroy_render_pass(&self, _pass: n::RenderPass) {
     }
 
     fn destroy_graphics_pipeline(&self, _pipeline: n::GraphicsPipeline) {

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use hal::{self, format, image};
 use hal::{Backbuffer, SwapchainConfig};
-use hal::window::Extent2d;
+use hal::window::Extent2D;
 
 use metal::{self, MTLPixelFormat, MTLTextureUsage};
 use objc::runtime::{Object};
@@ -65,7 +65,7 @@ impl hal::Surface<Backend> for Surface {
         let caps = hal::SurfaceCapabilities {
             image_count: 1..8,
             current_extent: None,
-            extents: Extent2d { width: 4, height: 4} .. Extent2d { width: 4096, height: 4096 },
+            extents: Extent2D { width: 4, height: 4} .. Extent2D { width: 4096, height: 4096 },
             max_image_layers: 1,
         };
         let formats = Some(vec![format::Format::Rgba8Srgb]);

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -111,10 +111,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         );
     }
 
-    fn begin_renderpass_raw<T>(
+    fn begin_render_pass_raw<T>(
         &mut self,
         render_pass: &n::RenderPass,
-        frame_buffer: &n::FrameBuffer,
+        frame_buffer: &n::Framebuffer,
         render_area: com::Rect,
         clear_values: T,
         first_subpass: com::SubpassContents,
@@ -169,7 +169,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn end_renderpass(&mut self) {
+    fn end_render_pass(&mut self) {
         unsafe {
             self.device.0.cmd_end_render_pass(self.raw);
         }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -711,7 +711,7 @@ impl d::Device<B> for Device {
         renderpass: &n::RenderPass,
         attachments: T,
         extent: d::Extent,
-    ) -> Result<n::FrameBuffer, d::FramebufferError>
+    ) -> Result<n::Framebuffer, d::FramebufferError>
     where
         T: IntoIterator,
         T::Item: Borrow<n::ImageView>,
@@ -737,7 +737,7 @@ impl d::Device<B> for Device {
             self.raw.0.create_framebuffer(&info, None)
         }.expect("error on framebuffer creation");
 
-        Ok(n::FrameBuffer { raw: framebuffer })
+        Ok(n::Framebuffer { raw: framebuffer })
     }
 
     fn create_shader_module(&self, spirv_data: &[u8]) -> Result<n::ShaderModule, d::ShaderError> {
@@ -1471,7 +1471,7 @@ impl d::Device<B> for Device {
         unsafe { self.raw.0.destroy_shader_module(module.raw, None); }
     }
 
-    fn destroy_renderpass(&self, rp: n::RenderPass) {
+    fn destroy_render_pass(&self, rp: n::RenderPass) {
         unsafe { self.raw.0.destroy_render_pass(rp.raw, None); }
     }
 
@@ -1487,7 +1487,7 @@ impl d::Device<B> for Device {
         unsafe { self.raw.0.destroy_pipeline(pipeline.0, None); }
     }
 
-    fn destroy_framebuffer(&self, fb: n::FrameBuffer) {
+    fn destroy_framebuffer(&self, fb: n::Framebuffer) {
         unsafe { self.raw.0.destroy_framebuffer(fb.raw, None); }
     }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -715,7 +715,7 @@ impl hal::Backend for Backend {
 
     type ShaderModule = native::ShaderModule;
     type RenderPass = native::RenderPass;
-    type Framebuffer = native::FrameBuffer;
+    type Framebuffer = native::Framebuffer;
 
     type UnboundBuffer = device::UnboundBuffer;
     type Buffer = native::Buffer;

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -58,7 +58,7 @@ pub struct RenderPass {
 }
 
 #[derive(Debug, Hash)]
-pub struct FrameBuffer {
+pub struct Framebuffer {
     pub(crate)  raw: vk::Framebuffer,
 }
 

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -309,7 +309,7 @@ impl hal::Surface<Backend> for Surface {
         // `0xFFFFFFFF` indicates that the extent depends on the created swapchain.
         let current_extent =
             if caps.current_extent.width != 0xFFFFFFFF && caps.current_extent.height != 0xFFFFFFFF {
-                Some(hal::window::Extent2d {
+                Some(hal::window::Extent2D {
                     width: caps.current_extent.width,
                     height: caps.current_extent.height,
                 })
@@ -317,12 +317,12 @@ impl hal::Surface<Backend> for Surface {
                 None
             };
 
-        let min_extent = hal::window::Extent2d {
+        let min_extent = hal::window::Extent2D {
             width: caps.min_image_extent.width,
             height: caps.min_image_extent.height,
         };
 
-        let max_extent = hal::window::Extent2d {
+        let max_extent = hal::window::Extent2D {
             width: caps.max_image_extent.width,
             height: caps.max_image_extent.height,
         };

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -176,7 +176,7 @@ pub struct ImageBlit {
 
 impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a, B, C, S, L> {
     ///
-    pub fn begin_renderpass_inline<T>(
+    pub fn begin_render_pass_inline<T>(
         &mut self,
         render_pass: &B::RenderPass,
         frame_buffer: &B::Framebuffer,
@@ -307,7 +307,7 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
 
 impl<'a, B: Backend, C: Supports<Graphics>, S: Shot> CommandBuffer<'a, B, C, S, Primary> {
     ///
-    pub fn begin_renderpass_secondary<T>(
+    pub fn begin_render_pass_secondary<T>(
         &mut self,
         render_pass: &B::RenderPass,
         frame_buffer: &B::Framebuffer,

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -7,12 +7,12 @@ use std::marker::PhantomData;
 mod compute;
 mod graphics;
 mod raw;
-mod renderpass;
+mod render_pass;
 mod transfer;
 
 pub use self::graphics::*;
 pub use self::raw::{ClearValueRaw, ClearColorRaw, ClearDepthStencilRaw, RawCommandBuffer, CommandBufferFlags, Level as RawLevel};
-pub use self::renderpass::*;
+pub use self::render_pass::*;
 pub use self::transfer::*;
 
 use std::borrow::{Cow};

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -249,7 +249,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     fn set_blend_constants(&mut self, ColorValue);
 
     ///
-    fn begin_renderpass<T>(
+    fn begin_render_pass<T>(
         &mut self,
         render_pass: &B::RenderPass,
         framebuffer: &B::Framebuffer,
@@ -275,7 +275,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
                 }
             });
 
-        self.begin_renderpass_raw(
+        self.begin_render_pass_raw(
             render_pass,
             framebuffer,
             render_area,
@@ -285,7 +285,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     }
 
     ///
-    fn begin_renderpass_raw<T>(
+    fn begin_render_pass_raw<T>(
         &mut self,
         render_pass: &B::RenderPass,
         framebuffer: &B::Framebuffer,
@@ -300,7 +300,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     fn next_subpass(&mut self, contents: SubpassContents);
 
     ///
-    fn end_renderpass(&mut self);
+    fn end_render_pass(&mut self);
 
     /// Bind a graphics pipeline.
     ///

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -139,7 +139,7 @@ impl<'a, B: Backend, L: Level> RenderPassInlineEncoder<'a, B, L> {
         T: IntoIterator,
         T::Item: Borrow<ClearValue>,
     {
-        cmd_buffer.raw.begin_renderpass(
+        cmd_buffer.raw.begin_render_pass(
             render_pass,
             frame_buffer,
             render_area,
@@ -181,7 +181,7 @@ impl<'a, B: Backend, L: Level> DerefMut for RenderPassInlineEncoder<'a, B, L> {
 impl<'a, B: Backend, L: Level> Drop for RenderPassInlineEncoder<'a, B, L> {
     fn drop(&mut self) {
         if let Some(ref mut b) = self.0 {
-            b.0.end_renderpass();
+            b.0.end_render_pass();
         }
     }
 }
@@ -204,7 +204,7 @@ impl<'a, B: Backend> RenderPassSecondaryEncoder<'a, B> {
         T: IntoIterator,
         T::Item: Borrow<ClearValue>,
     {
-        cmd_buffer.raw.begin_renderpass(
+        cmd_buffer.raw.begin_render_pass(
             render_pass,
             frame_buffer,
             render_area,
@@ -241,7 +241,7 @@ impl<'a, B: Backend> RenderPassSecondaryEncoder<'a, B> {
 impl<'a, B: Backend> Drop for RenderPassSecondaryEncoder<'a, B> {
     fn drop(&mut self) {
         if let Some(ref mut b) = self.0 {
-            b.end_renderpass();
+            b.end_render_pass();
         }
     }
 }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -167,7 +167,7 @@ pub trait Device<B: Backend> {
         ID::Item: Borrow<pass::SubpassDependency>;
 
     ///
-    fn destroy_renderpass(&self, B::RenderPass);
+    fn destroy_render_pass(&self, B::RenderPass);
 
     /// Create a new pipeline layout.
     ///

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -60,7 +60,7 @@ use std::ops::Range;
 ///
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Extent2d {
+pub struct Extent2D {
     ///
     pub width: u32,
     ///
@@ -81,12 +81,12 @@ pub struct SurfaceCapabilities {
     /// Current extent of the surface.
     ///
     /// `None` if the surface has no explicit size, depending on the swapchain extent.
-    pub current_extent: Option<Extent2d>,
+    pub current_extent: Option<Extent2D>,
 
     /// Range of supported extents.
     ///
     /// `current_extent` must be inside this range.
-    pub extents: Range<Extent2d>,
+    pub extents: Range<Extent2D>,
 
     /// Maximum number of layers supported for presentable images.
     ///

--- a/src/render/src/handle.rs
+++ b/src/render/src/handle.rs
@@ -52,7 +52,7 @@ impl<B: Backend> InnerGarbageCollector<B> {
             use self::Garbage::*;
             match garbage {
                 // ShaderLib(sl) => dev.destroy_shader_lib(sl),
-                RenderPass(rp) => dev.destroy_renderpass(rp),
+                RenderPass(rp) => dev.destroy_render_pass(rp),
                 PipelineLayout(pl) => dev.destroy_pipeline_layout(pl),
                 GraphicsPipeline(pl) => dev.destroy_graphics_pipeline(pl),
                 Framebuffer(fb) => dev.destroy_framebuffer(fb),

--- a/src/render/src/macros/pipeline.rs
+++ b/src/render/src/macros/pipeline.rs
@@ -148,7 +148,7 @@ macro_rules! gfx_graphics_pipeline {
                         w: extent.width as u16,
                         h: extent.height as u16
                     };
-                    cmd_buffer.begin_renderpass_inline(
+                    cmd_buffer.begin_render_pass_inline(
                         meta.render_pass.resource(),
                         self.framebuffer.resource(),
                         render_rect,

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -720,7 +720,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                         w: extent.width as _,
                         h: extent.height as _,
                     };
-                    let mut encoder = command_buf.begin_renderpass_inline(&rp.handle, fb, rect, clear_values);
+                    let mut encoder = command_buf.begin_render_pass_inline(&rp.handle, fb, rect, clear_values);
                     encoder.set_scissors(Some(rect));
                     encoder.set_viewports(Some(c::Viewport {
                         rect,


### PR DESCRIPTION
Fixes #1827
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
  - Metal

On running `make refests` I get the following:
```
Parsing test suite 'local'...
Warding Metal:
        Scene 'transfer':
                Test 'copy' ... ran: FAIL [0, 0, 0, 0]
Command buffer re-use is not ready, exiting
Warding GL:
        Scene 'transfer':
                Test 'copy' ... ran: PASS
        Scene 'compute':
                skipped 1 tests (GLSL shaders)
        Scene 'basic':
                skipped 2 tests (GLSL shaders)
        TestResults { pass: 1, skip: 3, fail: 0 }
make: *** [reftests] Error 1
```

I'm not sure what this means, but I don't think it was this that broke it. I'm assuming the message means that command buffer re-use isn't implemented yet for Metal?