### PR TITLE
Fix #1833: Change getter names to follow Rust conventions

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -127,7 +127,7 @@ fn main() {
         .memory_types;
     let limits = adapter
         .physical_device
-        .get_limits();
+        .limits();
 
     // Build a new device and associated command queues
     let (device, mut queue_group) =

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -73,7 +73,7 @@ fn main() {
         println!("{:?}", adapter.info);
     }
     let adapter = adapters.remove(0);
-    let limits = adapter.physical_device.get_limits();
+    let limits = adapter.physical_device.limits();
 
     let (mut context, backbuffers) =
         gfx::Context::<back::Backend, hal::Graphics>

--- a/examples/support/deferred/main.rs
+++ b/examples/support/deferred/main.rs
@@ -224,7 +224,7 @@ impl<B: gfx::Backend> gfx_support::Application<B> for App<B> {
     {
         use gfx::traits::DeviceExt;
 
-        let (width, height, _, _) = window_targets.views[0].0.get_dimensions();
+        let (width, height, _, _) = window_targets.views[0].0.dimensions();
         let (gpos, gnormal, gdiffuse, depth_resource, depth_target) =
             create_g_buffer(width, height, device);
         let res = {
@@ -479,7 +479,7 @@ impl<B: gfx::Backend> gfx_support::Application<B> for App<B> {
             Point3::new(0.0, 0.0, 0.0),
             Vector3::unit_z(),
         );
-        let (width, height, _, _) = self.terrain.data.out_depth.get_dimensions();
+        let (width, height, _, _) = self.terrain.data.out_depth.dimensions();
         let aspect = width as f32 / height as f32;
         let proj = cgmath::perspective(Deg(60.0f32), aspect, 5.0, 100.0);
         let (cur_color, _) = self.views[frame.id()].clone();
@@ -569,7 +569,7 @@ impl<B: gfx::Backend> gfx_support::Application<B> for App<B> {
     }
 
     fn on_resize_ext(&mut self, device: &mut B::Device, window_targets: gfx_support::WindowTargets<B::Resources>) {
-        let (width, height, _, _) = window_targets.views[0].0.get_dimensions();
+        let (width, height, _, _) = window_targets.views[0].0.dimensions();
 
         let (gpos, gnormal, gdiffuse, depth_resource, depth_target) =
             create_g_buffer(width, height, device);

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -88,7 +88,7 @@ impl Device {
     }
 
     /// Return the maximum supported shader model.
-    pub fn get_shader_model(&self) -> ShaderModel {
+    pub fn shader_model(&self) -> ShaderModel {
         match self.feature_level {
             winapi::D3D_FEATURE_LEVEL_10_0 => 40,
             winapi::D3D_FEATURE_LEVEL_10_1 => 41,
@@ -794,7 +794,7 @@ impl core::Device<R> for Device {
             error!("Failed to create RTV from {:#?}, error {:x}", native_desc, hr);
             return Err(d::TargetViewError::Unsupported);
         }
-        let size = htex.get_info().kind.get_level_dimensions(desc.level);
+        let size = htex.get_info().kind.level_dimensions(desc.level);
         Ok(self.share.handles.borrow_mut().make_rtv(native::Rtv(raw_view), htex, size))
     }
 
@@ -859,7 +859,7 @@ impl core::Device<R> for Device {
             error!("Failed to create DSV from {:#?}, error {:x}", native_desc, hr);
             return Err(d::TargetViewError::Unsupported);
         }
-        let dim = htex.get_info().kind.get_level_dimensions(desc.level);
+        let dim = htex.get_info().kind.level_dimensions(desc.level);
         Ok(self.share.handles.borrow_mut().make_dsv(native::Dsv(raw_view), htex, dim))
     }
 

--- a/src/backend/dx11/src/execute.rs
+++ b/src/backend/dx11/src/execute.rs
@@ -48,7 +48,7 @@ pub fn update_texture(context: &mut ComPtr<winapi::ID3D11DeviceContext>, texture
                       face: Option<tex::CubeFace>, data: &[u8], image: &tex::RawImageInfo) {
     let subres = texture_subres(face, image);
     let dst_resource = texture.as_resource();
-    let (width, height, _, _) = kind.get_level_dimensions(image.mipmap);
+    let (width, height, _, _) = kind.level_dimensions(image.mipmap);
     let stride = image.format.0.get_total_bits() as usize;
     let row_pitch = width as usize * stride;
     let depth_pitch = height as usize * row_pitch;

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1268,7 +1268,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             Type: d3d12::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
             u: unsafe { mem::zeroed() },
         };
-        let (width, height, depth, _) = image.kind.get_dimensions();
+        let (width, height, depth, _) = image.kind.dimensions();
         for region in regions {
             let region = region.borrow();
             // Copy each layer in the region
@@ -1351,7 +1351,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             Type: d3d12::D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT,
             u: unsafe { mem::zeroed() },
         };
-        let (width, height, depth, _) = image.kind.get_dimensions();
+        let (width, height, depth, _) = image.kind.dimensions();
         for region in regions {
             let region = region.borrow();
             // Copy each layer in the region

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -505,7 +505,7 @@ impl Device {
         //TODO: use subresource range
         let handle = self.rtv_pool.lock().unwrap().alloc_handles(1).cpu;
 
-        if kind.get_dimensions().3 != image::AaMode::Single {
+        if kind.dimensions().3 != image::AaMode::Single {
             error!("No MSAA supported yet!");
         }
 
@@ -543,7 +543,7 @@ impl Device {
         //TODO: use subresource range
         let handle = self.dsv_pool.lock().unwrap().alloc_handles(1).cpu;
 
-        if kind.get_dimensions().3 != image::AaMode::Single {
+        if kind.dimensions().3 != image::AaMode::Single {
             error!("No MSAA supported yet!");
         }
 
@@ -1528,7 +1528,7 @@ impl d::Device<B> for Device {
         let bytes_per_block = (format_desc.bits / 8) as _;
         let block_dim = format_desc.dim;
 
-        let (width, height, depth, aa) = kind.get_dimensions();
+        let (width, height, depth, aa) = kind.dimensions();
         let dimension = match kind {
             image::Kind::D1(..) |
             image::Kind::D1Array(..) => d3d12::D3D12_RESOURCE_DIMENSION_TEXTURE1D,
@@ -1550,7 +1550,7 @@ impl d::Device<B> for Device {
                 None => return Err(image::CreationError::Format(format)),
             },
             SampleDesc: dxgitype::DXGI_SAMPLE_DESC {
-                Count: aa.get_num_fragments() as u32,
+                Count: aa.num_fragments() as u32,
                 Quality: 0,
             },
             Layout: d3d12::D3D12_TEXTURE_LAYOUT_UNKNOWN,
@@ -1583,7 +1583,7 @@ impl d::Device<B> for Device {
             bytes_per_block,
             block_dim,
             num_levels: mip_levels,
-            num_layers: kind.get_num_layers(),
+            num_layers: kind.num_layers(),
         })
     }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -324,8 +324,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         self.memory_properties.clone()
     }
 
-    fn get_features(&self) -> Features { self.features }
-    fn get_limits(&self) -> Limits { self.limits }
+    fn features(&self) -> Features { self.features }
+    fn limits(&self) -> Limits { self.limits }
 }
 
 #[derive(Clone)]

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -48,7 +48,7 @@ pub struct Surface {
 
 impl hal::Surface<Backend> for Surface {
     fn supports_queue_family(&self, _queue_family: &QueueFamily) -> bool { true }
-    fn get_kind(&self) -> i::Kind {
+    fn kind(&self) -> i::Kind {
         let aa = i::AaMode::Single;
         i::Kind::D2(self.width as i::Size, self.height as i::Size, aa)
     }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -69,11 +69,11 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         unimplemented!()
     }
 
-    fn get_features(&self) -> hal::Features {
+    fn features(&self) -> hal::Features {
         unimplemented!()
     }
 
-    fn get_limits(&self) -> hal::Limits {
+    fn limits(&self) -> hal::Limits {
         unimplemented!()
     }
 }
@@ -709,7 +709,7 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
 /// Dummy surface.
 pub struct Surface;
 impl hal::Surface<Backend> for Surface {
-    fn get_kind(&self) -> hal::image::Kind {
+    fn kind(&self) -> hal::image::Kind {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -273,11 +273,11 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         }
     }
 
-    fn get_features(&self) -> hal::Features {
+    fn features(&self) -> hal::Features {
         self.0.features
     }
 
-    fn get_limits(&self) -> hal::Limits {
+    fn limits(&self) -> hal::Limits {
         self.0.limits
     }
 }

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -105,7 +105,7 @@ impl Surface {
 }
 
 impl hal::Surface<B> for Surface {
-    fn get_kind(&self) -> hal::image::Kind {
+    fn kind(&self) -> hal::image::Kind {
         let (w, h, _, a) = get_window_dimensions(&self.window);
         hal::image::Kind::D2(w, h, a)
     }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -202,11 +202,11 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         }
     }
 
-    fn get_features(&self) -> hal::Features {
+    fn features(&self) -> hal::Features {
         hal::Features::empty() //TODO
     }
 
-    fn get_limits(&self) -> hal::Limits {
+    fn limits(&self) -> hal::Limits {
         hal::Limits {
             max_texture_size: 4096, // TODO: feature set
             max_patch_size: 0, // No tessellation

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -53,7 +53,7 @@ impl Swapchain {
 const kCVPixelFormatType_32RGBA: u32 = (b'R' as u32) << 24 | (b'G' as u32) << 16 | (b'B' as u32) << 8 | b'A' as u32;
 
 impl hal::Surface<Backend> for Surface {
-    fn get_kind(&self) -> image::Kind {
+    fn kind(&self) -> image::Kind {
         let (width, height) = self.pixel_dimensions();
 
         image::Kind::D2(width, height, image::AaMode::Single)

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -466,7 +466,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         }
     }
 
-    fn get_features(&self) -> Features {
+    fn features(&self) -> Features {
         let features = self.instance.0.get_physical_device_features(self.handle);
         let mut bits = Features::empty();
 
@@ -553,7 +553,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         bits
     }
 
-    fn get_limits(&self) -> Limits {
+    fn limits(&self) -> Limits {
         let limits = &self.properties.limits;
         let max_group_count = limits.max_compute_work_group_count;
         let max_group_size = limits.max_compute_work_group_size;

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -287,7 +287,7 @@ impl Instance {
 }
 
 impl hal::Surface<Backend> for Surface {
-    fn get_kind(&self) -> hal::image::Kind {
+    fn kind(&self) -> hal::image::Kind {
         use hal::image::Size;
 
         let aa = hal::image::AaMode::Single;

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -73,10 +73,10 @@ pub trait PhysicalDevice<B: Backend>: Sized {
 
     /// Returns the features of this `Device`. This usually depends on the graphics API being
     /// used.
-    fn get_features(&self) -> Features;
+    fn features(&self) -> Features;
 
     /// Returns the limits of this `Device`.
-    fn get_limits(&self) -> Limits;
+    fn limits(&self) -> Limits;
 }
 
 /// Information about a backend adapter.

--- a/src/hal/src/error.rs
+++ b/src/hal/src/error.rs
@@ -21,7 +21,7 @@ pub enum DeviceCreationError {
     /// At least one of the user requested features if not supported by the
     /// physical device.
     ///
-    /// Use [`get_features`](trait.PhysicalDevice.html#tymethod.get_features)
+    /// Use [`features`](trait.PhysicalDevice.html#tymethod.features)
     /// for checking the supported features.
     #[fail(display = "One or multiple features are not supported.")]
     MissingFeature,

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -180,7 +180,7 @@ impl From<NumSamples> for AaMode {
 
 impl AaMode {
     /// Return the number of actual data fragments stored per texel.
-    pub fn get_num_fragments(&self) -> NumFragments {
+    pub fn num_fragments(&self) -> NumFragments {
         match *self {
             AaMode::Single => 1,
             AaMode::Multi(n) => n,
@@ -189,7 +189,7 @@ impl AaMode {
     }
     /// Return true if the surface has to be resolved before sampling.
     pub fn needs_resolve(&self) -> bool {
-        self.get_num_fragments() > 1
+        self.num_fragments() > 1
     }
 }
 
@@ -266,7 +266,7 @@ pub enum Kind {
 
 impl Kind {
     /// Get texture dimensions
-    pub fn get_dimensions(&self) -> Dimensions {
+    pub fn dimensions(&self) -> Dimensions {
         let s0 = AaMode::Single;
         match *self {
             Kind::D1(w) => (w, 1, 1, s0),
@@ -279,12 +279,12 @@ impl Kind {
         }
     }
     /// Get the dimensionality of a particular mipmap level.
-    pub fn get_level_dimensions(&self, level: Level) -> Dimensions {
+    pub fn level_dimensions(&self, level: Level) -> Dimensions {
         use std::cmp::{max, min};
         // must be at least 1
         let map = |val| max(min(val, 1), val >> min(level, MAX_LEVEL));
-        let (w, h, da, _) = self.get_dimensions();
-        let dm = if self.get_num_slices().is_some() {
+        let (w, h, da, _) = self.dimensions();
+        let dm = if self.num_slices().is_some() {
             1
         } else {
             map(da)
@@ -292,9 +292,9 @@ impl Kind {
         (map(w), map(h), dm, AaMode::Single)
     }
     /// Count the number of mipmap levels.
-    pub fn get_num_levels(&self) -> Level {
+    pub fn num_levels(&self) -> Level {
         use std::cmp::max;
-        let (w, h, d, aa) = self.get_dimensions();
+        let (w, h, d, aa) = self.dimensions();
         let dominant = max(max(w, h), d);
         if aa == AaMode::Single {
             (1..).find(|level| dominant>>level <= 1).unwrap()
@@ -303,7 +303,7 @@ impl Kind {
         }
     }
     /// Return the number of slices for an array, or None for non-arrays.
-    pub fn get_num_slices(&self) -> Option<Layer> {
+    pub fn num_slices(&self) -> Option<Layer> {
         match *self {
             Kind::D1(..) | Kind::D2(..) | Kind::D3(..) | Kind::Cube(..) => None,
             Kind::D1Array(_, a) => Some(a),
@@ -314,7 +314,7 @@ impl Kind {
     /// Return the number of layers.
     ///
     /// Each cube face counts as separate layer.
-    pub fn get_num_layers(&self) -> Layer {
+    pub fn num_layers(&self) -> Layer {
         match *self {
             Kind::D1(..) | Kind::D2(..) | Kind::D3(..) => 1,
             Kind::Cube(..) => 6,

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -97,7 +97,7 @@ pub struct SurfaceCapabilities {
 /// A `Surface` abstracts the surface of a native window, which will be presented
 pub trait Surface<B: Backend> {
     /// Retrieve the surface image kind.
-    fn get_kind(&self) -> image::Kind;
+    fn kind(&self) -> image::Kind;
 
     /// Check if the queue family supports presentation for this surface.
     ///

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -219,7 +219,7 @@ impl<'a, B: Backend, C> Encoder<'a, B, C>
     ) -> Barrier<'b, B> {
         let creation_state = (hal::image::Access::empty(), i::ImageLayout::Undefined);
         let num_levels = image.info().mip_levels;
-        let num_layers = image.info().kind.get_num_layers();
+        let num_layers = image.info().kind.num_layers();
         let stable_state = image.info().stable_state;
         let states = ImageStates::new(stable_state, num_levels, num_layers);
         self.image_states.insert(image.clone(), states);
@@ -257,7 +257,7 @@ impl<'a, B: Backend, C> Encoder<'a, B, C>
     ) -> Option<Barrier<'b, B>> {
         if !self.image_states.contains_key(image) {
             let levels = image.info().mip_levels;
-            let layers = image.info().kind.get_num_layers();
+            let layers = image.info().kind.num_layers();
             let states = ImageStates::new(image.info().stable_state, levels, layers);
             self.image_states.insert(image.clone(), states);
         }
@@ -591,7 +591,7 @@ impl<'a, B: Backend, C> Encoder<'a, B, C>
 {
     fn require_clear_state(&mut self, image: &handle::raw::Image<B>) -> i::ImageLayout {
         let levels = image.info().mip_levels;
-        let layers = image.info().kind.get_num_layers();
+        let layers = image.info().kind.num_layers();
         let state = (i::Access::TRANSFER_WRITE, i::ImageLayout::TransferDstOptimal);
         let mut image_states = Vec::new();
         for level in 0..levels {

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -258,7 +258,7 @@ impl<B: Backend, C> Context<B, C>
                     image::Info {
                         aspects: format::AspectFlags::COLOR,
                         usage: image::Usage::TRANSFER_SRC | image::Usage::COLOR_ATTACHMENT,
-                        kind: surface.get_kind(),
+                        kind: surface.kind(),
                         mip_levels: 1,
                         format: Cf::SELF,
                         origin: image::Origin::Backbuffer,

--- a/src/render/src/pso.rs
+++ b/src/render/src/pso.rs
@@ -127,7 +127,7 @@ impl<B: Backend> Bind<B> for SampledImage {
     ) {
         let img = view.info();
         let levels = img.info().mip_levels;
-        let layers = img.info().kind.get_num_layers();
+        let layers = img.info().kind.num_layers();
         let state = (image::Access::SHADER_READ, ImageLayout::ShaderReadOnlyOptimal);
         for level in 0..levels {
             for layer in 0..layers {
@@ -318,7 +318,7 @@ where
     ) where 'a: 'b {
         let img = data.as_ref().info();
         let levels = img.info().mip_levels;
-        let layers = img.info().kind.get_num_layers();
+        let layers = img.info().kind.num_layers();
         // TODO: READ not always necessary
         let state = (image::Access::COLOR_ATTACHMENT_READ | image::Access::COLOR_ATTACHMENT_WRITE,
             ImageLayout::ColorAttachmentOptimal);

--- a/src/support/src/shade.rs
+++ b/src/support/src/shade.rs
@@ -43,21 +43,21 @@ impl ShadeExt for ::gfx_device_gl::Device {
 #[cfg(feature = "dx11")]
 impl ShadeExt for ::gfx_device_dx11::Device {
     fn shader_backend(&self) -> Backend {
-        Backend::Hlsl(self.get_shader_model())
+        Backend::Hlsl(self.shader_model())
     }
 }
 
 #[cfg(feature = "dx12")]
 impl ShadeExt for ::gfx_device_dx12::Device {
     fn shader_backend(&self) -> Backend {
-        Backend::Hlsl(self.get_shader_model())
+        Backend::Hlsl(self.shader_model())
     }
 }
 
 #[cfg(feature = "metal")]
 impl ShadeExt for ::gfx_device_metal::Device {
     fn shader_backend(&self) -> Backend {
-        Backend::Msl(self.get_shader_model())
+        Backend::Msl(self.shader_model())
     }
 }
 

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -120,8 +120,8 @@ impl Harness {
         for tg in &self.suite {
             let mut adapters = instance.enumerate_adapters();
             let adapter = adapters.remove(0);
-            let features = adapter.physical_device.get_features();
-            let limits = adapter.physical_device.get_limits();
+            let features = adapter.physical_device.features();
+            let limits = adapter.physical_device.limits();
             //println!("\t{:?}", adapter.info);
             println!("\tScene '{}':", tg.name);
 

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -134,7 +134,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
             .memory_types;
         let limits = adapter
             .physical_device
-            .get_limits();
+            .limits();
 
         // initialize graphics
         let (device, queue_group) = adapter.open_with(1, |_| true)?;
@@ -320,7 +320,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                             (access, layout)
                         } else {
                             // calculate required sizes
-                            let (w, h, d, aa) = kind.get_dimensions();
+                            let (w, h, d, aa) = kind.dimensions();
                             assert_eq!(aa, i::AaMode::Single);
 
                             let base_format = format.base_format();
@@ -937,7 +937,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
             .expect(&format!("Unable to find image to fetch: {}", name));
         let limits = &self.limits;
 
-        let (width, height, depth, aa) = image.kind.get_dimensions();
+        let (width, height, depth, aa) = image.kind.dimensions();
         assert_eq!(aa, i::AaMode::Single);
 
         // TODO:


### PR DESCRIPTION
Fixes #1833
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
  - Metal
