### PR TITLE
Proper naming of conversion functions.

### DIFF
--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -51,15 +51,15 @@ unsafe impl<B: Backend, C, S, L> Send for Submit<B, C, S, L> {}
 /// A trait representing a command buffer that can be added to a `Submission`.
 pub unsafe trait Submittable<'a, B: Backend, C, L: Level> {
     ///
-    unsafe fn as_buffer(self) -> Cow<'a, B::CommandBuffer>;
+    unsafe fn into_buffer(self) -> Cow<'a, B::CommandBuffer>;
 }
 
 unsafe impl<'a, B: Backend, C, L: Level> Submittable<'a, B, C, L> for Submit<B, C, OneShot, L> {
-    unsafe fn as_buffer(self) -> Cow<'a, B::CommandBuffer> { Cow::Owned(self.0) }
+    unsafe fn into_buffer(self) -> Cow<'a, B::CommandBuffer> { Cow::Owned(self.0) }
 }
 
 unsafe impl<'a, B: Backend, C, L: Level> Submittable<'a, B, C, L> for &'a Submit<B, C, MultiShot, L> {
-    unsafe fn as_buffer(self) -> Cow<'a, B::CommandBuffer> { Cow::Borrowed(&self.0) }
+    unsafe fn into_buffer(self) -> Cow<'a, B::CommandBuffer> { Cow::Borrowed(&self.0) }
 }
 
 /// A convenience for not typing out the full signature of a secondary command buffer.
@@ -109,7 +109,7 @@ impl<'a, B: Backend, C, S: Shot> CommandBuffer<'a, B, C, S, Primary> {
         C: Supports<K>,
     {
         let submits = submits.into_iter().collect::<Vec<_>>();
-        self.raw.execute_commands(submits.into_iter().map(|submit| unsafe { submit.as_buffer() }));
+        self.raw.execute_commands(submits.into_iter().map(|submit| unsafe { submit.into_buffer() }));
     }
 }
 

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -221,7 +221,7 @@ impl<'a, B: Backend> RenderPassSecondaryEncoder<'a, B> {
         I::Item: Submittable<'a, B, Subpass, Secondary>,
     {
         let submits = submits.into_iter().collect::<Vec<_>>();
-        self.0.as_mut().unwrap().execute_commands(submits.into_iter().map(|submit| unsafe { submit.as_buffer() }));
+        self.0.as_mut().unwrap().execute_commands(submits.into_iter().map(|submit| unsafe { submit.into_buffer() }));
     }
 
     ///

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -489,14 +489,14 @@ pub trait Device<B: Backend> {
     {
         use std::{time, thread};
         let start = time::Instant::now();
-        fn as_ms(duration: time::Duration) -> u32 {
+        fn to_ms(duration: time::Duration) -> u32 {
             duration.as_secs() as u32 * 1000 + duration.subsec_nanos() / 1_000_000
         }
         match wait {
             WaitFor::All => {
                 for fence in fences {
                     if !self.wait_for_fence(fence.borrow(), 0) {
-                        let elapsed_ms = as_ms(start.elapsed());
+                        let elapsed_ms = to_ms(start.elapsed());
                         if elapsed_ms > timeout_ms {
                             return false;
                         }
@@ -515,7 +515,7 @@ pub trait Device<B: Backend> {
                             return true;
                         }
                     }
-                    if as_ms(start.elapsed()) >= timeout_ms {
+                    if to_ms(start.elapsed()) >= timeout_ms {
                         return false;
                     }
                     thread::sleep(time::Duration::from_millis(1));

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -89,7 +89,7 @@ impl<B: Backend, C> CommandQueue<B, C> {
         C: Supports<D>
     {
         unsafe {
-            self.0.submit_raw(submission.as_raw(), fence)
+            self.0.submit_raw(submission.to_raw(), fence)
         }
     }
 

--- a/src/hal/src/queue/submission.rs
+++ b/src/hal/src/queue/submission.rs
@@ -71,7 +71,7 @@ where
     }
 
     /// Convert strong-typed submission object into untyped equivalent.
-    pub(super) fn as_raw(&self) -> RawSubmission<B, Vec<&B::CommandBuffer>> {
+    pub(super) fn to_raw(&self) -> RawSubmission<B, Vec<&B::CommandBuffer>> {
         RawSubmission {
             cmd_buffers: self.cmd_buffers.iter().map(|b| b.deref().borrow()).collect::<Vec<_>>(),
             wait_semaphores: &self.wait_semaphores,
@@ -91,7 +91,7 @@ where
         (C, K): Upper
     {
         self.cmd_buffers.extend(submits.into_iter().map(
-            |s| { unsafe { s.as_buffer() } }
+            |s| { unsafe { s.into_buffer() } }
         ));
         Submission {
             cmd_buffers: self.cmd_buffers,


### PR DESCRIPTION
Fixes #1832
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
