### PR TITLE
Update readmes/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,42 +15,27 @@
       <img src="http://img.shields.io/crates/v/gfx-hal.svg?label=gfx-hal" alt = "gfx-hal on crates.io">
   </a-->
   <a href="https://gitter.im/gfx-rs/gfx">
-    <img src="https://img.shields.io/badge/GITTER-join%20chat-green.svg?style=flat-square" alt="Gitter Chat">
+    <img src="https://img.shields.io/badge/gitter-join%20chat-green.svg?style=flat-square" alt="Gitter Chat">
   </a>
   <br>
-  <strong><a href="http://docs.rs/gfx-hal">Documentation</a> | <a href="http://gfx-rs.github.io/">Blog</a> </strong>
+  <strong><a href="info/getting_started.md">Getting Started</a> | <a href="http://docs.rs/gfx-hal">Documentation</a> | <a href="http://gfx-rs.github.io/">Blog</a> </strong>
 </p>
 
-## gfx-rs
+# gfx-rs
 
-gfx-rs is a graphics abstraction library in Rust. It consists of the following layers/components:
-- `gfx-hal`: hardware abstraction layer - a Vulkan-ic mostly unsafe API translating to native graphics backends.
-- `gfx-backend-*`: graphics backends for various platforms, include the windowing logic.
-- `gfx-warden`: data-driven reference test framework.
+gfx-rs is a low-level, cross-platform graphics abstraction library in Rust. It consists of the following layers/components:
 
-## pre-LL
+* `gfx-hal` which is gfx's hardware abstraction layer: a Vulkan-ic mostly unsafe API which translates to native graphics backends.
+* `gfx-backend-*` which contains graphics backends for various platforms:
+  * [Vulkan](src/backend/vulkan)
+  * [DirectX 12](src/backend/dx12)
+  * [Metal](src/backend/metal)
+  * [OpenGL 2.1+/ES2+](src/backend/gl)
+* `gfx-warden` which is a data-driven reference test framework, used to verify consistency across all graphics backends.
 
-If you are looking for information about the released crates (`gfx_core`, `gfx`, `gfx_device_*`, `gfx_window_`, etc), they are being developed and published from the [pre-ll](https://github.com/gfx-rs/gfx/tree/pre-ll) branch. Code in `master` is a complete rewrite that will be shipped in different crates.
+## Example
 
-### Features
-
-Native API backends:
-- [Vulkan](src/backend/vulkan)
-- [Direct3D 12](src/backend/dx12)
-- [Metal](src/backend/metal)
-- [OpenGL 2.1+/ES2+](src/backend/gl)
-
-### Dependencies
-
-For Fedora
-``` bash
-sudo dnf install -y libX11-devel vulkan
-```
-### Usage
-
-You can run the examples this way:
-
-Note: ```dx12``` works only in windows.
+To run an example, simply use `cargo run` and specify the backend with `--features {backend}` (where `{backend}` is one of `vulkan`, `dx12`, `metal`, or `gl`). For example:
 
 ```bash
 git clone https://github.com/gfx-rs/gfx
@@ -58,10 +43,28 @@ cd gfx/examples/hal
 cargo run --bin quad --features vulkan
 cargo run --bin compute --features dx12 1 2 3 4
 ```
-The native API backend is selected by one of the features: `vulkan`, `dx12`, `metal`, or `gl`.
+
+This runs the `quad` example using the Vulkan backend, and then the `compute` example using the DirectX 12 backend.
+
+These examples assume that necessary dependencies for the graphics backend are already installed. For more information about installation and usage, refer to the [Getting Started](info/getting_started.md) guide.
+
+## Hardware Abstraction Layer
+
+The Hardware Abstraction Layer (HAL), is a thin, low-level graphics layer which translates API calls to various graphics backends, which allows for cross-platform support. The API of this layer is based on the Vulkan API, adapted to be more Rust-friendly.
+
+<p align="center"><img src="info/hal.svg" alt="Hardware Abstraction Layer (HAL)" /></p>
+
+Currently HAL has backends for Vulkan, DirectX 12, Metal, and OpenGL/OpenGL ES/WebGL.
+
+The HAL layer is consumed directly by user applications or libraries. HAL is also used in efforts such as [gfx-portability](https://github.com/gfx-rs/portability).
+
+## pre-LL
+
+If you are looking for information about the released crates (`gfx_core`, `gfx`, `gfx_device_*`, `gfx_window_`, etc), they are being developed and published from the [pre-ll](https://github.com/gfx-rs/gfx/tree/pre-ll) branch. Code in `master` is a complete rewrite that will be shipped in different crates.
 
 ## License
-[License]: #license
+
+[license]: #license
 
 This repository is currently in the process of being licensed under either of
 
@@ -70,6 +73,6 @@ This repository is currently in the process of being licensed under either of
 
 at your option. Some parts of the repository are already licensed according to those terms. See the [tracking issue](https://github.com/gfx-rs/gfx/issues/847).
 
-### Contributions
+## Contributions
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,17 +1,6 @@
 # Examples
 
-A collection of gfx examples which use the various gfx APIs.
-
-## Getting Started
-
-The gfx git repository contains a number of examples. Those examples are automatically downloaded if you clone the gfx directory by running
-
-    cd <my_dir>
-    git clone https://github.com/gfx-rs/gfx
-
-where `<my_dir>` is a directory name of your choice. Once gfx is downloaded you can build any of the gfx examples.
-
-### Why Three Example Directories?
+This directory contains a collection of examples which use the various gfx APIs.
 
 The examples are split across three directories, each pertaining to the gfx API they are using.
 
@@ -19,7 +8,7 @@ The examples are split across three directories, each pertaining to the gfx API 
 1. `examples/render` shows how to use the render crate directly.
 1. `examples/support` shows how to use the support crate, to demonstrate how you can build an application using minimal setup.
 
-*Please note that `support` is still being updated, so `support` examples will not run at the moment.*
+_Please note that `support` is still being updated, so `support` examples will not run at the moment._
 
 To run the examples, set your working directory to the examples directory and execute
 `cargo run --bin <example> --features=<backend>`, where `<example>` is the example you want to run and `<backend>` is the backend you would like to use (`vulkan`, `dx12`, `metal`, or `gl`).

--- a/info/getting_started.md
+++ b/info/getting_started.md
@@ -1,0 +1,24 @@
+# Getting Started
+
+## Dependencies
+
+For Fedora
+
+```bash
+sudo dnf install -y libX11-devel vulkan
+```
+
+## Usage
+
+The gfx repository contains a number of examples. Those examples are automatically downloaded when the repository is cloned.
+
+To run an example, simply use `cargo run` and specify the backend with `--features {backend}` (where `{backend}` is one of `vulkan`, `dx12`, `metal`, or `gl`). For example:
+
+```bash
+git clone https://github.com/gfx-rs/gfx
+cd gfx/examples/hal
+cargo run --bin quad --features vulkan
+cargo run --bin compute --features dx12 1 2 3 4
+```
+
+This would run the `quad` example using the Vulkan backend, and then the `compute` example using the Direct3D 12 backend.

--- a/info/hal.svg
+++ b/info/hal.svg
@@ -1,0 +1,32 @@
+<svg version="1.1" width="500" height="110" 
+    xmlns="http://www.w3.org/2000/svg" 
+    xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 500 110">
+    <g font-family="Arial" font-weight="bold" font-size="20">
+        <g fill="rgb(68,60,64)" transform="translate(0, 0)">
+            <g transform="translate(0, 0)">
+                <rect rx="8" ry="8" height="50" width="500"/>
+                <text text-anchor="middle" x="250" y="50" dy="-15" fill="rgb(192,100,65)" font-size="26">Hardware Abstraction Layer (HAL)</text>
+            </g>
+        </g>
+        <g fill="rgb(68,60,64)" transform="translate(0, 60)">
+            <g transform="translate(0, 0)">
+                <rect rx="8" ry="8" height="50" width="90"/>
+                <text text-anchor="middle" x="45" y="50" dy="-16" fill="rgb(192,100,65)">Vulkan</text>
+            </g>
+            <g transform="translate(97, 0)">
+                <rect rx="8" ry="8" height="50" width="116"/>
+                <text text-anchor="middle" x="58" y="50" dy="-16" fill="rgb(192,100,65)">DirectX 12</text>
+            </g>
+            <g transform="translate(220, 0)">
+                <rect rx="8" ry="8" height="50" width="90"/>
+                <text text-anchor="middle" x="45" y="50" dy="-16" fill="rgb(192,100,65)">Metal</text>
+            </g>
+            <g transform="translate(317, 0)">
+                <rect rx="8" ry="8" height="50" width="183"/>
+                <text text-anchor="middle" x="50" y="50" dy="-16" fill="rgb(192,100,65)">OpenGL</text>
+                <text text-anchor="middle" x="135" y="50" dy="-29" fill="rgb(192,100,65)" font-size="14">OpenGL ES</text>
+                <text text-anchor="middle" x="135" y="50" dy="-9" fill="rgb(192,100,65)" font-size="14">WebGL</text>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
- Reworked main README [(rendered)](https://github.com/grovesNL/gfx/blob/readme-update/README.md) slightly
- Added a note about HAL and part of the diagram from the Fosdem slides
- Split off dependency information into a new "Getting Started" page [(rendered)](https://github.com/grovesNL/gfx/blob/readme-update/info/getting_started.md), I think we could list other backend setup info here