### PR TITLE
[vk] better anisotropy sampling checks

### DIFF
--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -393,7 +393,7 @@ pub fn map_image_usage(usage: image::Usage) -> vk::ImageUsageFlags {
     if usage.contains(Usage::INPUT_ATTACHMENT) {
         flags |= vk::IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     }
-    
+
     flags
 }
 
@@ -444,14 +444,14 @@ pub fn map_stage_flags(stages: pso::ShaderStageFlags) -> vk::ShaderStageFlags {
 }
 
 
-pub fn map_filter(filter: image::FilterMethod) -> (vk::Filter, vk::Filter, vk::SamplerMipmapMode, f32) {
+pub fn map_filter(filter: image::FilterMethod) -> (vk::Filter, vk::Filter, vk::SamplerMipmapMode) {
     use hal::image::FilterMethod as Fm;
     match filter {
-        Fm::Scale          => (vk::Filter::Nearest, vk::Filter::Nearest, vk::SamplerMipmapMode::Nearest, 1.0),
-        Fm::Mipmap         => (vk::Filter::Nearest, vk::Filter::Nearest, vk::SamplerMipmapMode::Linear,  1.0),
-        Fm::Bilinear       => (vk::Filter::Linear,  vk::Filter::Linear,  vk::SamplerMipmapMode::Nearest, 1.0),
-        Fm::Trilinear      => (vk::Filter::Linear,  vk::Filter::Linear,  vk::SamplerMipmapMode::Linear,  1.0),
-        Fm::Anisotropic(a) => (vk::Filter::Linear,  vk::Filter::Linear,  vk::SamplerMipmapMode::Linear,  a as f32),
+        Fm::Scale          => (vk::Filter::Nearest, vk::Filter::Nearest, vk::SamplerMipmapMode::Nearest),
+        Fm::Mipmap         => (vk::Filter::Nearest, vk::Filter::Nearest, vk::SamplerMipmapMode::Linear),
+        Fm::Bilinear       => (vk::Filter::Linear,  vk::Filter::Linear,  vk::SamplerMipmapMode::Nearest),
+        Fm::Trilinear      => (vk::Filter::Linear,  vk::Filter::Linear,  vk::SamplerMipmapMode::Linear),
+        Fm::Anisotropic(_) => (vk::Filter::Linear,  vk::Filter::Linear,  vk::SamplerMipmapMode::Linear),
     }
 }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -329,6 +329,9 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             })
             .collect::<Vec<_>>();
 
+        // enabled features mask
+        let features = Features::empty();
+
         // Create device
         let device_raw = {
             let cstrings = DEVICE_EXTENSIONS
@@ -341,7 +344,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 .map(|s| s.as_ptr())
                 .collect::<Vec<_>>();
 
-            let features = unsafe { mem::zeroed() };
+            // TODO: derive from `features`
+            let enabled_features = unsafe { mem::zeroed() };
             let info = vk::DeviceCreateInfo {
                 s_type: vk::StructureType::DeviceCreateInfo,
                 p_next: ptr::null(),
@@ -352,7 +356,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 pp_enabled_layer_names: ptr::null(),
                 enabled_extension_count: str_pointers.len() as u32,
                 pp_enabled_extension_names: str_pointers.as_ptr(),
-                p_enabled_features: &features,
+                p_enabled_features: &enabled_features,
             };
 
             unsafe {
@@ -380,7 +384,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         }).unwrap();
 
         let device = Device {
-            raw: Arc::new(RawDevice(device_raw)),
+            raw: Arc::new(RawDevice(device_raw, features)),
         };
 
         let device_arc = device.raw.clone();
@@ -572,7 +576,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 }
 
 #[doc(hidden)]
-pub struct RawDevice(pub ash::Device<V1_0>);
+pub struct RawDevice(pub ash::Device<V1_0>, Features);
 impl fmt::Debug for RawDevice {
     fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
         unimplemented!()


### PR DESCRIPTION
Fixes Vulkan validation warning:
> vkCreateSampler(): The samplerAnisotropy feature was not enabled at device-creation time, so the maxAnisotropy member of the VkSamplerCreateInfo structure must be 1.0 but is 0.000000.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
