### PR TITLE
 [vk] careful depth clamping check 

### DIFF
--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -141,7 +141,7 @@ impl Rasterizer {
         polygon_mode: PolygonMode::Fill,
         cull_face: None,
         front_face: FrontFace::CounterClockwise,
-        depth_clamping: true,
+        depth_clamping: false,
         depth_bias: None,
         conservative: false,
     };


### PR DESCRIPTION
Follow-up to #1846

Fixes Vulkan validation warning:
> vkCreateGraphicsPipelines(): the depthClamp device feature is disabled: the depthClampEnable member of the VkPipelineRasterizationStateCreateInfo structure must be set to VK_FALSE. The spec valid usage text states 'If the depth clamping feature is not enabled, depthClampEnable must be VK_FALSE' (https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#VUID-VkPipelineRasterizationStateCreateInfo-depthClampEnable-00782)

Also enables framebuffer images to be used as clear/transfer/blit destinations.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
