### PR TITLE
[metal] Re-usable command buffers

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1107,7 +1107,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn dispatch_indirect(&mut self, buffer: &n::Buffer, offset: u64) {
+    fn dispatch_indirect(&mut self, buffer: &n::Buffer, offset: pso::BufferOffset) {
         self.set_compute_bind_point();
         unsafe {
             self.raw.ExecuteIndirect(
@@ -1124,7 +1124,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn fill_buffer(
         &mut self,
         buffer: &n::Buffer,
-        range: Range<u64>,
+        range: Range<pso::BufferOffset>,
         data: u32,
     ) {
         assert!(buffer.clear_uav.is_some(), "Buffer needs to be created with usage `TRANSFER_DST`");
@@ -1168,7 +1168,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn update_buffer(
         &mut self,
         _buffer: &n::Buffer,
-        _offset: u64,
+        _offset: pso::BufferOffset,
         _data: &[u8],
     ) {
         unimplemented!()
@@ -1436,7 +1436,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn draw_indirect(
         &mut self,
         buffer: &n::Buffer,
-        offset: u64,
+        offset: pso::BufferOffset,
         draw_count: u32,
         stride: u32,
     ) {
@@ -1457,7 +1457,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn draw_indexed_indirect(
         &mut self,
         buffer: &n::Buffer,
-        offset: u64,
+        offset: pso::BufferOffset,
         draw_count: u32,
         stride: u32,
     ) {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -401,11 +401,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn fill_buffer(&mut self, _: &(), _: Range<u64>, _: u32) {
+    fn fill_buffer(&mut self, _: &(), _: Range<pso::BufferOffset>, _: u32) {
         unimplemented!()
     }
 
-    fn update_buffer(&mut self, _: &(), _: u64, _: &[u8]) {
+    fn update_buffer(&mut self, _: &(), _: pso::BufferOffset, _: &[u8]) {
         unimplemented!()
     }
 
@@ -553,7 +553,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn dispatch_indirect(&mut self, _: &(), _: u64) {
+    fn dispatch_indirect(&mut self, _: &(), _: pso::BufferOffset) {
         unimplemented!()
     }
 
@@ -621,14 +621,14 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn draw_indirect(&mut self, _: &(), _: u64, _: u32, _: u32) {
+    fn draw_indirect(&mut self, _: &(), _: pso::BufferOffset, _: u32, _: u32) {
         unimplemented!()
     }
 
     fn draw_indexed_indirect(
         &mut self,
         _: &(),
-        _: u64,
+        _: pso::BufferOffset,
         _: u32,
         _: u32,
     ) {

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -56,7 +56,7 @@ impl BufferSlice {
 #[derive(Clone, Debug)]
 pub enum Command {
     Dispatch(u32, u32, u32),
-    DispatchIndirect(gl::types::GLuint, u64),
+    DispatchIndirect(gl::types::GLuint, pso::BufferOffset),
     Draw {
         primitive: gl::types::GLenum,
         vertices: Range<hal::VertexCount>,
@@ -66,7 +66,7 @@ pub enum Command {
         primitive: gl::types::GLenum,
         index_type: gl::types::GLenum,
         index_count: hal::IndexCount,
-        index_buffer_offset: u64,
+        index_buffer_offset: pso::BufferOffset,
         base_vertex: hal::VertexOffset,
         instances: Range<hal::InstanceCount>,
     },
@@ -525,11 +525,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         // TODO
     }
 
-    fn fill_buffer(&mut self, _buffer: &n::Buffer, _range: Range<u64>, _data: u32) {
+    fn fill_buffer(&mut self, _buffer: &n::Buffer, _range: Range<pso::BufferOffset>, _data: u32) {
         unimplemented!()
     }
 
-    fn update_buffer(&mut self, _buffer: &n::Buffer, _offset: u64, _data: &[u8]) {
+    fn update_buffer(&mut self, _buffer: &n::Buffer, _offset: pso::BufferOffset, _data: &[u8]) {
         unimplemented!()
     }
 
@@ -858,7 +858,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         self.push_cmd(Command::Dispatch(x, y, z));
     }
 
-    fn dispatch_indirect(&mut self, buffer: &n::Buffer, offset: u64) {
+    fn dispatch_indirect(&mut self, buffer: &n::Buffer, offset: pso::BufferOffset) {
         self.push_cmd(Command::DispatchIndirect(buffer.raw, offset));
     }
 
@@ -1010,7 +1010,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     fn draw_indirect(
         &mut self,
         _buffer: &n::Buffer,
-        _offset: u64,
+        _offset: pso::BufferOffset,
         _draw_count: u32,
         _stride: u32,
     ) {
@@ -1020,7 +1020,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     fn draw_indexed_indirect(
         &mut self,
         _buffer: &n::Buffer,
-        _offset: u64,
+        _offset: pso::BufferOffset,
         _draw_count: u32,
         _stride: u32,
     ) {

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -698,10 +698,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
         let needed_length = vbs.0.iter().map(|vb| vb.1).max().unwrap() + 1;
 
-        self.cache.vertex_buffers.resize(needed_length, 0);
+        self.cache.vertex_buffers.resize(needed_length as usize, 0);
 
         for vb in vbs.0 {
-            self.cache.vertex_buffers[vb.1] = vb.0.raw;
+            self.cache.vertex_buffers[vb.1 as usize] = vb.0.raw;
         }
     }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -19,6 +19,7 @@ mod window;
 mod command;
 mod native;
 mod conversions;
+mod soft;
 
 pub use command::{CommandQueue, CommandPool};
 pub use device::{Device, LanguageVersion, PhysicalDevice};

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -81,9 +81,7 @@ unsafe impl Sync for ComputePipeline {}
 #[derive(Debug)]
 pub struct Image {
     pub(crate) raw: metal::Texture,
-    pub(crate) bytes_per_block: u8,
-    // Dimension of a texel block (compressed formats).
-    pub(crate) block_dim: (u8, u8),
+    pub(crate) format_desc: hal::format::FormatDesc,
 }
 
 unsafe impl Send for Image {}
@@ -311,10 +309,8 @@ unsafe impl Sync for UnboundBuffer {}
 
 #[derive(Debug)]
 pub struct UnboundImage {
-    pub desc: metal::TextureDescriptor,
-    pub bytes_per_block: u8,
-    // Dimension of a texel block (compressed formats).
-    pub block_dim: (u8, u8),
+    pub(crate) texture_desc: metal::TextureDescriptor,
+    pub(crate) format_desc: hal::format::FormatDesc,
 }
 unsafe impl Send for UnboundImage {}
 unsafe impl Sync for UnboundImage {}

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -1,0 +1,93 @@
+use command::IndexBuffer;
+
+use hal;
+use metal;
+
+use std::ops::Range;
+
+
+pub enum RenderCommand {
+    SetViewport(metal::MTLViewport),
+    SetScissor(metal::MTLScissorRect),
+    BindBuffer {
+        stage: hal::pso::Stage,
+        index: usize,
+        buffer: Option<metal::Buffer>,
+        offset: hal::pso::BufferOffset,
+    },
+    BindTexture {
+        stage: hal::pso::Stage,
+        index: usize,
+        texture: Option<metal::Texture>,
+    },
+    BindSampler {
+        stage: hal::pso::Stage,
+        index: usize,
+        sampler: Option<metal::SamplerState>,
+    },
+    BindPipeline(metal::RenderPipelineState, Option<metal::DepthStencilState>),
+    Draw {
+        primitive_type: metal::MTLPrimitiveType,
+        vertices: Range<hal::VertexCount>,
+        instances: Range<hal::InstanceCount>
+    },
+    DrawIndexed {
+        index: IndexBuffer,
+        primitive_type: metal::MTLPrimitiveType,
+        indices: Range<hal::IndexCount>,
+        base_vertex: hal::VertexOffset,
+        instances: Range<hal::InstanceCount>,
+    }
+}
+
+pub enum BlitCommand {
+    CopyBuffer {
+        src: metal::Buffer,
+        dst: metal::Buffer,
+        region: hal::command::BufferCopy,
+    },
+    CopyBufferToImage {
+        src: metal::Buffer,
+        dst: metal::Texture,
+        dst_desc: hal::format::FormatDesc,
+        region: hal::command::BufferImageCopy,
+    },
+    CopyImageToBuffer {
+        src: metal::Texture,
+        src_desc: hal::format::FormatDesc,
+        dst: metal::Buffer,
+        region: hal::command::BufferImageCopy,  
+    },
+}
+
+pub enum ComputeCommand {
+    BindBuffer {
+        index: usize,
+        buffer: Option<metal::Buffer>,
+        offset: hal::pso::BufferOffset,
+    },
+    BindTexture {
+        index: usize,
+        texture: Option<metal::Texture>,
+    },
+    BindSampler {
+        index: usize,
+        sampler: Option<metal::SamplerState>,
+    },
+    BindPipeline(metal::ComputePipelineState),
+    Dispatch {
+        wg_size: metal::MTLSize,
+        wg_count: metal::MTLSize,
+    },
+    DispatchIndirect {
+        wg_size: metal::MTLSize,
+        buffer: metal::Buffer,
+        offset: hal::pso::BufferOffset,
+    },
+}
+
+pub enum Pass {
+    Render(metal::RenderPassDescriptor, Vec<RenderCommand>),
+    Blit(Vec<BlitCommand>),
+    Compute(Vec<ComputeCommand>),
+}

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -99,8 +99,9 @@ impl Device {
         surface: &mut Surface,
         config: SwapchainConfig,
     ) -> (Swapchain, Backbuffer<Backend>) {
-        let (mtl_format, cv_format, bytes_per_block) = match config.color_format {
-            format::Format::Rgba8Srgb => (MTLPixelFormat::RGBA8Unorm_sRGB, kCVPixelFormatType_32RGBA, 4),
+        let format_desc = config.color_format.base_format().0.desc();
+        let (mtl_format, cv_format) = match config.color_format {
+            format::Format::Rgba8Srgb => (MTLPixelFormat::RGBA8Unorm_sRGB, kCVPixelFormatType_32RGBA),
             _ => panic!("unsupported backbuffer format"), // TODO: more formats
         };
 
@@ -148,8 +149,7 @@ impl Device {
                 ];
                 native::Image {
                     raw: mapped_texture,
-                    bytes_per_block,
-                    block_dim: (1, 1),
+                    format_desc,
                 }
             }).collect();
 

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -2,8 +2,7 @@ use {Backend, QueueFamily};
 use {native, conversions};
 use device::{Device, PhysicalDevice};
 
-use std::cell::RefCell;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 
 use hal::{self, format, image};
 use hal::{Backbuffer, SwapchainConfig};
@@ -19,6 +18,7 @@ use core_graphics::base::CGFloat;
 use core_graphics::geometry::CGRect;
 use cocoa::foundation::{NSRect};
 use io_surface::{self, IOSurface};
+
 
 pub struct Surface(pub(crate) Arc<SurfaceInner>);
 

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -103,7 +103,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         let flags = if release_resources {
             vk::COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT
         } else {
-            vk::CommandBufferResetFlags ::empty()
+            vk::CommandBufferResetFlags::empty()
         };
 
         assert_eq!(Ok(()),

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -235,7 +235,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn fill_buffer(
         &mut self,
         buffer: &n::Buffer,
-        range: Range<u64>,
+        range: Range<pso::BufferOffset>,
         data: u32,
     ) {
         unsafe {
@@ -252,7 +252,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn update_buffer(
         &mut self,
         buffer: &n::Buffer,
-        offset: u64,
+        offset: pso::BufferOffset,
         data: &[u8],
     ) {
         unsafe {
@@ -634,7 +634,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn dispatch_indirect(&mut self, buffer: &n::Buffer, offset: u64) {
+    fn dispatch_indirect(&mut self, buffer: &n::Buffer, offset: pso::BufferOffset) {
         unsafe {
             self.device.0.cmd_dispatch_indirect(
                 self.raw,
@@ -787,7 +787,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn draw_indirect(
         &mut self,
         buffer: &n::Buffer,
-        offset: u64,
+        offset: pso::BufferOffset,
         draw_count: u32,
         stride: u32,
     ) {
@@ -805,7 +805,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn draw_indexed_indirect(
         &mut self,
         buffer: &n::Buffer,
-        offset: u64,
+        offset: pso::BufferOffset,
         draw_count: u32,
         stride: u32,
     ) {

--- a/src/hal/src/command/compute.rs
+++ b/src/hal/src/command/compute.rs
@@ -1,6 +1,7 @@
 use std::borrow::Borrow;
 
 use Backend;
+use pso::BufferOffset;
 use queue::capability::{Compute, Supports};
 use super::{CommandBuffer, RawCommandBuffer, Shot, Level};
 
@@ -29,7 +30,7 @@ impl<'a, B: Backend, C: Supports<Compute>, S: Shot, L: Level> CommandBuffer<'a, 
     }
 
     ///
-    pub fn dispatch_indirect(&mut self, buffer: &B::Buffer, offset: u64) {
+    pub fn dispatch_indirect(&mut self, buffer: &B::Buffer, offset: BufferOffset) {
         self.raw.dispatch_indirect(buffer, offset)
     }
 

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -99,7 +99,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     fn fill_buffer(
         &mut self,
         buffer: &B::Buffer,
-        range: Range<u64>,
+        range: Range<pso::BufferOffset>,
         data: u32,
     );
 
@@ -107,7 +107,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     fn update_buffer(
         &mut self,
         buffer: &B::Buffer,
-        offset: u64,
+        offset: pso::BufferOffset,
         data: &[u8],
     );
 
@@ -362,7 +362,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     fn dispatch(&mut self, x: u32, y: u32, z: u32);
 
     ///
-    fn dispatch_indirect(&mut self, buffer: &B::Buffer, offset: u64);
+    fn dispatch_indirect(&mut self, buffer: &B::Buffer, offset: pso::BufferOffset);
 
     ///
     fn copy_buffer<T>(
@@ -427,7 +427,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     fn draw_indirect(
         &mut self,
         buffer: &B::Buffer,
-        offset: u64,
+        offset: pso::BufferOffset,
         draw_count: u32,
         stride: u32,
     );
@@ -436,7 +436,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     fn draw_indexed_indirect(
         &mut self,
         buffer: &B::Buffer,
-        offset: u64,
+        offset: pso::BufferOffset,
         draw_count: u32,
         stride: u32,
     );

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -43,11 +43,11 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
         self.0.draw_indexed(indices, base_vertex, instances)
     }
     ///
-    pub fn draw_indirect(&mut self, buffer: &B::Buffer, offset: u64, draw_count: u32, stride: u32) {
+    pub fn draw_indirect(&mut self, buffer: &B::Buffer, offset: pso::BufferOffset, draw_count: u32, stride: u32) {
         self.0.draw_indirect(buffer, offset, draw_count, stride)
     }
     ///
-    pub fn draw_indexed_indirect(&mut self, buffer: &B::Buffer, offset: u64, draw_count: u32, stride: u32) {
+    pub fn draw_indexed_indirect(&mut self, buffer: &B::Buffer, offset: pso::BufferOffset, draw_count: u32, stride: u32) {
         self.0.draw_indexed_indirect(buffer, offset, draw_count, stride)
     }
 

--- a/src/hal/src/command/transfer.rs
+++ b/src/hal/src/command/transfer.rs
@@ -4,7 +4,7 @@ use Backend;
 use {format, image};
 use device::Extent;
 use memory::Barrier;
-use pso::PipelineStage;
+use pso::{BufferOffset, PipelineStage};
 use queue::capability::{Supports, Transfer};
 use super::{CommandBuffer, RawCommandBuffer, Shot, Level};
 
@@ -26,11 +26,11 @@ pub struct Offset {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BufferCopy {
     /// Buffer region source offset.
-    pub src: u64,
+    pub src: BufferOffset,
     /// Buffer region destination offset.
-    pub dst: u64,
+    pub dst: BufferOffset,
     /// Region size.
-    pub size: u64,
+    pub size: BufferOffset,
 }
 
 ///
@@ -58,7 +58,7 @@ pub struct ImageCopy {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BufferImageCopy {
     /// Buffer ofset in bytes.
-    pub buffer_offset: u64,
+    pub buffer_offset: BufferOffset,
     /// Width of a buffer 'row' in texels.
     pub buffer_width: u32,
     /// Height of a buffer 'image slice' in texels.
@@ -90,7 +90,7 @@ impl<'a, B: Backend, C: Supports<Transfer>, S: Shot, L: Level> CommandBuffer<'a,
     pub fn fill_buffer(
         &mut self,
         buffer: &B::Buffer,
-        range: Range<u64>,
+        range: Range<BufferOffset>,
         data: u32,
     ) {
         self.raw.fill_buffer(buffer, range, data)
@@ -113,7 +113,7 @@ impl<'a, B: Backend, C: Supports<Transfer>, S: Shot, L: Level> CommandBuffer<'a,
     pub fn update_buffer(
         &mut self,
         buffer: &B::Buffer,
-        offset: u64,
+        offset: BufferOffset,
         data: &[u8],
     ) {
         self.raw.update_buffer(buffer, offset, data)

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -93,6 +93,8 @@ pub enum ShaderError {
     MissingEntryPoint(String),
     /// Mismatch of interface (e.g missing push constants).
     InterfaceMismatch(String),
+    /// Shader stage is not supported.
+    UnsupportedStage(pso::Stage),
 }
 
 /// An error from creating a framebuffer.

--- a/src/hal/src/pso/input_assembler.rs
+++ b/src/hal/src/pso/input_assembler.rs
@@ -14,7 +14,7 @@ pub type ElemStride = u32;
 /// The number of instances between each subsequent attribute value
 pub type InstanceRate = u8;
 /// An offset inside a vertex buffer, in bytes.
-pub type BufferOffset = usize;
+pub type BufferOffset = u64;
 
 /// A struct element descriptor.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -57,7 +57,6 @@ struct TestResults {
 
 #[derive(Default)]
 struct Disabilities {
-    no_command_buffer_reuse: bool,
 }
 
 
@@ -108,7 +107,7 @@ impl Harness {
     fn run<I: hal::Instance>(
         &self,
         instance: I,
-        disabilities: Disabilities,
+        _disabilities: Disabilities,
     ) -> usize {
         use hal::{PhysicalDevice};
 
@@ -186,11 +185,6 @@ impl Harness {
                     println!("FAIL {:?}", guard.row(row));
                     results.fail += 1;
                 }
-
-                if disabilities.no_command_buffer_reuse {
-                    println!("Command buffer re-use is not ready, exiting");
-                    return results.fail;
-                }
             }
         }
 
@@ -232,7 +226,6 @@ fn main() {
         println!("Warding Metal:");
         let instance = gfx_backend_metal::Instance::create("warden", 1);
         num_failures += harness.run(instance, Disabilities {
-            no_command_buffer_reuse: true,
             .. Disabilities::default()
         });
     }


### PR DESCRIPTION
Fixes #1848
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds (on Metal, while GL has an unrelated error to be investigated)
- [x] tested examples with the following backends: Metal
