### PR TITLE
Fix #1851: Crash on dx12

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -603,9 +603,8 @@ impl Instance {
 
             if winerror::SUCCEEDED(hr) {
                 unsafe { (*debug_controller).EnableDebugLayer() };
+                unsafe { (*debug_controller).Release(); }
             }
-
-            unsafe { (*debug_controller).Release(); }
         }
 
         // Create DXGI factory


### PR DESCRIPTION
Fixes #1851 
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
    - dx12

Even if we couldn't initialize debug_controller, we would always try to call Release,
sometimes on a null ptr. Now only Release the debug_controller if we could get it
successfully.