### PR TITLE
API refactor (memory, offsets, wg counts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test:
 
 reftests:
 	cd src/warden && cargo test --features "gl"
-	cd src/warden && cargo run --features "gl $(FEATURES_HAL) $(FEATURES_HAL2)" -- local
+	cd src/warden && cargo run --features "$(FEATURES_HAL) $(FEATURES_HAL2)" -- local #TODO: gl
 
 reftests-ci:
 	cd src/warden && cargo run --features "gl" -- ci #TODO: "gl-headless"

--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -13,7 +13,6 @@ extern crate gfx_backend_vulkan as back;
 extern crate gfx_backend_metal as back;
 
 use std::str::FromStr;
-use std::ops::Range;
 
 use hal::{
     Backend, Compute, Device, DescriptorPool, Instance, PhysicalDevice, QueueFamily,
@@ -118,26 +117,24 @@ fn main() {
         let mut command_buffer = command_pool.acquire_command_buffer(false);
         command_buffer.copy_buffer(&staging_buffer, &device_buffer, &[command::BufferCopy { src: 0, dst: 0, size: stride * numbers.len() as u64}]);
         command_buffer.pipeline_barrier(
-            Range { start: pso::PipelineStage::TRANSFER, end: pso::PipelineStage::COMPUTE_SHADER },
-                &[memory::Barrier::Buffer {
-                    states: Range {
-                        start: buffer::Access::TRANSFER_WRITE,
-                        end: buffer::Access::SHADER_READ | buffer::Access::SHADER_WRITE
-                    },
-                    target: &device_buffer
-                }]);
+            pso::PipelineStage::TRANSFER .. pso::PipelineStage::COMPUTE_SHADER,
+            memory::Dependencies::empty(),
+            Some(memory::Barrier::Buffer {
+                states: buffer::Access::TRANSFER_WRITE .. buffer::Access::SHADER_READ | buffer::Access::SHADER_WRITE,
+                target: &device_buffer
+            }),
+        );
         command_buffer.bind_compute_pipeline(&pipeline);
         command_buffer.bind_compute_descriptor_sets(&pipeline_layout, 0, &[desc_set]);
-        command_buffer.dispatch(numbers.len() as u32, 1, 1);
+        command_buffer.dispatch([numbers.len() as u32, 1, 1]);
         command_buffer.pipeline_barrier(
-            Range { start: pso::PipelineStage::COMPUTE_SHADER, end: pso::PipelineStage::TRANSFER },
-                &[memory::Barrier::Buffer {
-                    states: Range {
-                        start: buffer::Access::SHADER_READ | buffer::Access::SHADER_WRITE,
-                        end: buffer::Access::TRANSFER_READ
-                    },
-                    target: &device_buffer
-                }]);
+            pso::PipelineStage::COMPUTE_SHADER .. pso::PipelineStage::TRANSFER,
+            memory::Dependencies::empty(),
+            Some(memory::Barrier::Buffer {
+                states: buffer::Access::SHADER_READ | buffer::Access::SHADER_WRITE .. buffer::Access::TRANSFER_READ,
+                target: &device_buffer
+            }),
+        );
         command_buffer.copy_buffer(&device_buffer, &staging_buffer, &[command::BufferCopy { src: 0, dst: 0, size: stride * numbers.len() as u64}]);
         command_buffer.finish()
     }));

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -51,7 +51,7 @@ const QUAD: [Vertex; 6] = [
 ];
 
 const COLOR_RANGE: i::SubresourceRange = i::SubresourceRange {
-    aspects: f::AspectFlags::COLOR,
+    aspects: f::Aspects::COLOR,
     levels: 0 .. 1,
     layers: 0 .. 1,
 };
@@ -469,7 +469,11 @@ fn main() {
                 target: &image_logo,
                 range: COLOR_RANGE.clone(),
             };
-            cmd_buffer.pipeline_barrier(PipelineStage::TOP_OF_PIPE .. PipelineStage::TRANSFER, &[image_barrier]);
+            cmd_buffer.pipeline_barrier(
+                PipelineStage::TOP_OF_PIPE .. PipelineStage::TRANSFER,
+                m::Dependencies::empty(),
+                &[image_barrier],
+            );
 
             cmd_buffer.copy_buffer_to_image(
                 &image_upload_buffer,
@@ -480,11 +484,11 @@ fn main() {
                     buffer_width: row_pitch / (image_stride as u32),
                     buffer_height: height as u32,
                     image_layers: i::SubresourceLayers {
-                        aspects: f::AspectFlags::COLOR,
+                        aspects: f::Aspects::COLOR,
                         level: 0,
                         layers: 0 .. 1,
                     },
-                    image_offset: command::Offset { x: 0, y: 0, z: 0 },
+                    image_offset: i::Offset { x: 0, y: 0, z: 0 },
                     image_extent: d::Extent { width, height, depth: 1 },
                 }]);
 
@@ -494,7 +498,11 @@ fn main() {
                 target: &image_logo,
                 range: COLOR_RANGE.clone(),
             };
-            cmd_buffer.pipeline_barrier(PipelineStage::TRANSFER .. PipelineStage::FRAGMENT_SHADER, &[image_barrier]);
+            cmd_buffer.pipeline_barrier(
+                PipelineStage::TRANSFER .. PipelineStage::FRAGMENT_SHADER,
+                m::Dependencies::empty(),
+                &[image_barrier],
+            );
 
             cmd_buffer.finish()
         };

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -104,7 +104,7 @@ fn main() {
     ).unwrap();
 
     let image_range = gfx::image::SubresourceRange {
-        aspects: f::AspectFlags::COLOR,
+        aspects: f::Aspects::COLOR,
         levels: 0 .. 1,
         layers: 0 .. 1,
     };
@@ -226,11 +226,11 @@ fn main() {
             buffer_width: row_pitch / image_stride as u32,
             buffer_height: height as u32,
             image_layers: gfx::image::SubresourceLayers {
-                aspects: f::AspectFlags::COLOR,
+                aspects: f::Aspects::COLOR,
                 level: 0,
                 layers: 0 .. 1,
             },
-            image_offset: command::Offset { x: 0, y: 0, z: 0 },
+            image_offset: i::Offset { x: 0, y: 0, z: 0 },
             image_extent: d::Extent { width, height, depth: 1 },
         }]);
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -12,7 +12,7 @@ use winapi::shared::{dxgi, dxgi1_2, dxgi1_4, dxgiformat, dxgitype, winerror};
 use wio::com::ComPtr;
 
 use hal::{self, buffer, device as d, error, format, image, mapping, memory, pass, pso, query};
-use hal::format::AspectFlags;
+use hal::format::Aspects;
 use hal::memory::Requirements;
 use hal::pool::CommandPoolCreateFlags;
 use hal::queue::{RawCommandQueue, QueueFamilyId};
@@ -93,7 +93,8 @@ pub struct UnboundImage {
     requirements: memory::Requirements,
     kind: image::Kind,
     usage: image::Usage,
-    aspects: AspectFlags,
+    aspects: Aspects,
+    //TODO: use hal::format::FormatDesc
     bytes_per_block: u8,
     // Dimension of a texel block (compressed formats).
     block_dim: (u8, u8),
@@ -1635,9 +1636,9 @@ impl d::Device<B> for Device {
             block_dim: image.block_dim,
             num_levels: image.num_levels,
             num_layers: image.num_layers,
-            clear_cv: if image.aspects.contains(AspectFlags::COLOR) && image.usage.contains(Usage::COLOR_ATTACHMENT) {
+            clear_cv: if image.aspects.contains(Aspects::COLOR) && image.usage.contains(Usage::COLOR_ATTACHMENT) {
                 let range = image::SubresourceRange {
-                    aspects: AspectFlags::COLOR,
+                    aspects: Aspects::COLOR,
                     levels: 0 .. 1, //TODO?
                     layers: 0 .. image.num_layers,
                 };
@@ -1645,9 +1646,9 @@ impl d::Device<B> for Device {
             } else {
                 None
             },
-            clear_dv: if image.aspects.contains(AspectFlags::DEPTH) && image.usage.contains(Usage::DEPTH_STENCIL_ATTACHMENT) {
+            clear_dv: if image.aspects.contains(Aspects::DEPTH) && image.usage.contains(Usage::DEPTH_STENCIL_ATTACHMENT) {
                 let range = image::SubresourceRange {
-                    aspects: AspectFlags::DEPTH,
+                    aspects: Aspects::DEPTH,
                     levels: 0 .. 1, //TODO?
                     layers: 0 .. image.num_layers,
                 };
@@ -1655,9 +1656,9 @@ impl d::Device<B> for Device {
             } else {
                 None
             },
-            clear_sv: if image.aspects.contains(AspectFlags::STENCIL) && image.usage.contains(Usage::DEPTH_STENCIL_ATTACHMENT) {
+            clear_sv: if image.aspects.contains(Aspects::STENCIL) && image.usage.contains(Usage::DEPTH_STENCIL_ATTACHMENT) {
                 let range = image::SubresourceRange {
-                    aspects: AspectFlags::STENCIL,
+                    aspects: Aspects::STENCIL,
                     levels: 0 .. 1, //TODO?
                     layers: 0 .. image.num_layers,
                 };

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -169,7 +169,7 @@ unsafe impl Sync for Image { }
 
 impl Image {
     /// Get `SubresourceRange` of the whole image.
-    pub fn to_subresource_range(&self, aspects: format::AspectFlags) -> image::SubresourceRange {
+    pub fn to_subresource_range(&self, aspects: format::Aspects) -> image::SubresourceRange {
         image::SubresourceRange {
             aspects,
             levels: 0 .. self.num_levels,

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -393,19 +393,23 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn pipeline_barrier<'a, T>(&mut self, _: Range<pso::PipelineStage>, _: T)
-    where
+    fn pipeline_barrier<'a, T>(
+        &mut self,
+        _: Range<pso::PipelineStage>,
+        _: memory::Dependencies,
+        _: T,
+    ) where
         T: IntoIterator,
         T::Item: Borrow<memory::Barrier<'a, Backend>>,
     {
         unimplemented!()
     }
 
-    fn fill_buffer(&mut self, _: &(), _: Range<pso::BufferOffset>, _: u32) {
+    fn fill_buffer(&mut self, _: &(), _: Range<buffer::Offset>, _: u32) {
         unimplemented!()
     }
 
-    fn update_buffer(&mut self, _: &(), _: pso::BufferOffset, _: &[u8]) {
+    fn update_buffer(&mut self, _: &(), _: buffer::Offset, _: &[u8]) {
         unimplemented!()
     }
 
@@ -549,11 +553,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn dispatch(&mut self, _: u32, _: u32, _: u32) {
+    fn dispatch(&mut self, _: hal::WorkGroupCount) {
         unimplemented!()
     }
 
-    fn dispatch_indirect(&mut self, _: &(), _: pso::BufferOffset) {
+    fn dispatch_indirect(&mut self, _: &(), _: buffer::Offset) {
         unimplemented!()
     }
 
@@ -621,14 +625,14 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn draw_indirect(&mut self, _: &(), _: pso::BufferOffset, _: u32, _: u32) {
+    fn draw_indirect(&mut self, _: &(), _: buffer::Offset, _: u32, _: u32) {
         unimplemented!()
     }
 
     fn draw_indexed_indirect(
         &mut self,
         _: &(),
-        _: pso::BufferOffset,
+        _: buffer::Offset,
         _: u32,
         _: u32,
     ) {
@@ -700,7 +704,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 // Dummy descriptor pool.
 #[derive(Debug)]
 pub struct DescriptorPool;
-impl hal::DescriptorPool<Backend> for DescriptorPool {
+impl pso::DescriptorPool<Backend> for DescriptorPool {
     fn reset(&mut self) {
         unimplemented!()
     }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use hal::{self, format, image as i, pass, pso};
+use hal::{format, image as i, pass, pso};
 use hal::memory::Properties;
 
 use gl;
@@ -90,7 +90,7 @@ pub struct DescriptorSet;
 #[derive(Debug)]
 pub struct DescriptorPool {}
 
-impl hal::DescriptorPool<Backend> for DescriptorPool {
+impl pso::DescriptorPool<Backend> for DescriptorPool {
     fn allocate_sets<I>(&mut self, layouts: I) -> Vec<DescriptorSet>
     where
         I: IntoIterator,

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -369,12 +369,12 @@ impl CommandQueue {
                     error!("Instanced indexed drawing is not supported");
                 }
             }
-            com::Command::Dispatch(x, y, z) => {
+            com::Command::Dispatch(count) => {
                 // Capability support is given by which queue types will be exposed.
                 // If there is no compute support, this pattern should never be reached
                 // because no queue with compute capability can be created.
                 let gl = &self.share.context;
-                unsafe { gl.DispatchCompute(x, y, z) };
+                unsafe { gl.DispatchCompute(count[0], count[1], count[2]) };
             }
             com::Command::DispatchIndirect(buffer, offset) => {
                 // Capability support is given by which queue types will be exposed.
@@ -384,7 +384,7 @@ impl CommandQueue {
                 unsafe {
                     gl.BindBuffer(gl::DRAW_INDIRECT_BUFFER, buffer);
                     // TODO: possible integer conversion issue
-                    gl.DispatchComputeIndirect(offset as gl::types::GLintptr);
+                    gl.DispatchComputeIndirect(offset as _);
                 }
             }
             com::Command::SetViewports { viewport_ptr, depth_range_ptr } => {
@@ -529,7 +529,7 @@ impl CommandQueue {
             com::Command::CopyTextureToBuffer(texture, buffer, ref r) => unsafe {
                 // TODO: Fix format and active texture
                 // TODO: handle partial copies gracefully
-                assert_eq!(r.image_offset, hal::command::Offset { x: 0, y: 0, z: 0 });
+                assert_eq!(r.image_offset, hal::image::Offset { x: 0, y: 0, z: 0 });
                 let gl = &self.share.context;
                 gl.ActiveTexture(gl::TEXTURE0);
                 gl.BindBuffer(gl::PIXEL_PACK_BUFFER, buffer);

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -13,7 +13,7 @@ pub enum RenderCommand {
         stage: hal::pso::Stage,
         index: usize,
         buffer: Option<metal::Buffer>,
-        offset: hal::pso::BufferOffset,
+        offset: hal::buffer::Offset,
     },
     BindTexture {
         stage: hal::pso::Stage,
@@ -56,7 +56,7 @@ pub enum BlitCommand {
         src: metal::Texture,
         src_desc: hal::format::FormatDesc,
         dst: metal::Buffer,
-        region: hal::command::BufferImageCopy,  
+        region: hal::command::BufferImageCopy,
     },
 }
 
@@ -64,7 +64,7 @@ pub enum ComputeCommand {
     BindBuffer {
         index: usize,
         buffer: Option<metal::Buffer>,
-        offset: hal::pso::BufferOffset,
+        offset: hal::buffer::Offset,
     },
     BindTexture {
         index: usize,
@@ -82,7 +82,7 @@ pub enum ComputeCommand {
     DispatchIndirect {
         wg_size: metal::MTLSize,
         buffer: metal::Buffer,
-        offset: hal::pso::BufferOffset,
+        offset: hal::buffer::Offset,
     },
 }
 

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -74,16 +74,16 @@ pub fn map_image_layout(layout: image::ImageLayout) -> vk::ImageLayout {
     }
 }
 
-pub fn map_image_aspects(aspects: format::AspectFlags) -> vk::ImageAspectFlags {
-    use self::format::AspectFlags;
+pub fn map_image_aspects(aspects: format::Aspects) -> vk::ImageAspectFlags {
+    use self::format::Aspects;
     let mut flags = vk::ImageAspectFlags::empty();
-    if aspects.contains(AspectFlags::COLOR) {
+    if aspects.contains(Aspects::COLOR) {
         flags |= vk::IMAGE_ASPECT_COLOR_BIT;
     }
-    if aspects.contains(AspectFlags::DEPTH) {
+    if aspects.contains(Aspects::DEPTH) {
         flags |= vk::IMAGE_ASPECT_DEPTH_BIT;
     }
-    if aspects.contains(AspectFlags::STENCIL) {
+    if aspects.contains(Aspects::STENCIL) {
         flags |= vk::IMAGE_ASPECT_STENCIL_BIT;
     }
     flags
@@ -118,7 +118,7 @@ pub fn map_clear_stencil(stencil: command::StencilValue) -> vk::ClearDepthStenci
     }
 }
 
-pub fn map_offset(offset: command::Offset) -> vk::Offset3D {
+pub fn map_offset(offset: image::Offset) -> vk::Offset3D {
     vk::Offset3D {
         x: offset.x,
         y: offset.y,
@@ -146,7 +146,7 @@ pub fn map_subresource_layers(
 }
 
 pub fn map_subresource_with_layers(
-    aspects: format::AspectFlags,
+    aspects: format::Aspects,
     (mip_level, base_layer): image::Subresource,
     layers: image::Layer,
 ) -> vk::ImageSubresourceLayers {

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1002,14 +1002,6 @@ impl d::Device<B> for Device {
         swizzle: format::Swizzle,
         range: image::SubresourceRange,
     ) -> Result<n::ImageView, image::ViewError> {
-        let subresource_range = vk::ImageSubresourceRange {
-            aspect_mask: conv::map_image_aspects(range.aspects),
-            base_mip_level: range.levels.start as _,
-            level_count: (range.levels.end - range.levels.start) as _,
-            base_array_layer: range.layers.start as _,
-            layer_count: (range.layers.end - range.layers.start) as _,
-        };
-
         let info = vk::ImageViewCreateInfo {
             s_type: vk::StructureType::ImageViewCreateInfo,
             p_next: ptr::null(),
@@ -1018,7 +1010,7 @@ impl d::Device<B> for Device {
             view_type: vk::ImageViewType::Type2d, // TODO
             format: conv::map_format(format),
             components: conv::map_swizzle(swizzle),
-            subresource_range,
+            subresource_range: conv::map_subresource_range(&range),
         };
 
         let view = unsafe {

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -1,6 +1,6 @@
 use ash::vk;
 use ash::version::DeviceV1_0;
-use hal;
+use hal::pso;
 use hal::image::SubresourceRange;
 use std::borrow::Borrow;
 use std::sync::Arc;
@@ -88,7 +88,7 @@ pub struct DescriptorPool {
     pub(crate) device: Arc<RawDevice>,
 }
 
-impl hal::DescriptorPool<Backend> for DescriptorPool {
+impl pso::DescriptorPool<Backend> for DescriptorPool {
     fn allocate_sets<I>(&mut self, layouts: I) -> Vec<DescriptorSet>
     where
         I: IntoIterator,

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use {IndexType, Backend};
 
 
-/// An offset inside a vertex buffer, in bytes.
+/// An offset inside a buffer, in bytes.
 pub type Offset = u64;
 
 /// Error creating a buffer.

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -5,6 +5,10 @@ use std::fmt;
 
 use {IndexType, Backend};
 
+
+/// An offset inside a vertex buffer, in bytes.
+pub type Offset = u64;
+
 /// Error creating a buffer.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum CreationError {

--- a/src/hal/src/command/compute.rs
+++ b/src/hal/src/command/compute.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 
-use Backend;
-use pso::BufferOffset;
+use {Backend, WorkGroupCount};
+use buffer::Offset;
 use queue::capability::{Compute, Supports};
 use super::{CommandBuffer, RawCommandBuffer, Shot, Level};
 
@@ -25,12 +25,12 @@ impl<'a, B: Backend, C: Supports<Compute>, S: Shot, L: Level> CommandBuffer<'a, 
     }
 
     ///
-    pub fn dispatch(&mut self, x: u32, y: u32, z: u32) {
-        self.raw.dispatch(x, y, z)
+    pub fn dispatch(&mut self, count: WorkGroupCount) {
+        self.raw.dispatch(count)
     }
 
     ///
-    pub fn dispatch_indirect(&mut self, buffer: &B::Buffer, offset: BufferOffset) {
+    pub fn dispatch_indirect(&mut self, buffer: &B::Buffer, offset: Offset) {
         self.raw.dispatch_indirect(buffer, offset)
     }
 

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -8,9 +8,9 @@ use device::Extent;
 use query::{Query, QueryControl, QueryId};
 use queue::capability::{Graphics, GraphicsOrCompute, Supports};
 use super::{
-    CommandBuffer, RawCommandBuffer, RenderPassInlineEncoder,
-    RenderPassSecondaryEncoder, Shot, Level, Primary,
-    ClearColorRaw, Offset,
+    CommandBuffer, RawCommandBuffer,
+    RenderPassInlineEncoder, RenderPassSecondaryEncoder,
+    Shot, Level, Primary, ClearColorRaw,
 };
 
 
@@ -151,11 +151,11 @@ pub struct ImageResolve {
     ///
     pub src_subresource: image::SubresourceLayers,
     ///
-    pub src_offset: Offset,
+    pub src_offset: image::Offset,
     ///
     pub dst_subresource: image::SubresourceLayers,
     ///
-    pub dst_offset: Offset,
+    pub dst_offset: image::Offset,
     ///
     pub extent: Extent,
 }
@@ -167,11 +167,11 @@ pub struct ImageBlit {
     ///
     pub src_subresource: image::SubresourceLayers,
     ///
-    pub src_bounds: Range<Offset>,
+    pub src_bounds: Range<image::Offset>,
     ///
     pub dst_subresource: image::SubresourceLayers,
     ///
-    pub dst_bounds: Range<Offset>,
+    pub dst_bounds: Range<image::Offset>,
 }
 
 impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a, B, C, S, L> {

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -1,8 +1,9 @@
 use std::borrow::Borrow;
 use std::ops::{Range, Deref, DerefMut};
 use std::marker::PhantomData;
-use {pso, Backend, IndexCount, InstanceCount, VertexCount, VertexOffset};
-use buffer::IndexBufferView;
+
+use {buffer, pso};
+use {Backend, IndexCount, InstanceCount, VertexCount, VertexOffset};
 use queue::{Supports, Graphics};
 use super::{
     ColorValue, StencilValue, Rect, Viewport,
@@ -43,16 +44,16 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
         self.0.draw_indexed(indices, base_vertex, instances)
     }
     ///
-    pub fn draw_indirect(&mut self, buffer: &B::Buffer, offset: pso::BufferOffset, draw_count: u32, stride: u32) {
+    pub fn draw_indirect(&mut self, buffer: &B::Buffer, offset: buffer::Offset, draw_count: u32, stride: u32) {
         self.0.draw_indirect(buffer, offset, draw_count, stride)
     }
     ///
-    pub fn draw_indexed_indirect(&mut self, buffer: &B::Buffer, offset: pso::BufferOffset, draw_count: u32, stride: u32) {
+    pub fn draw_indexed_indirect(&mut self, buffer: &B::Buffer, offset: buffer::Offset, draw_count: u32, stride: u32) {
         self.0.draw_indexed_indirect(buffer, offset, draw_count, stride)
     }
 
     /// Bind index buffer view.
-    pub fn bind_index_buffer(&mut self, ibv: IndexBufferView<B>) {
+    pub fn bind_index_buffer(&mut self, ibv: buffer::IndexBufferView<B>) {
         self.0.bind_index_buffer(ibv)
     }
 

--- a/src/hal/src/format.rs
+++ b/src/hal/src/format.rs
@@ -4,7 +4,7 @@
 bitflags!(
     ///
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct AspectFlags: u8 {
+    pub struct Aspects: u8 {
         /// Color aspect.
         const COLOR = 0x1;
         /// Depth aspect.
@@ -31,7 +31,7 @@ pub struct FormatDesc {
     /// For uncompressed formats these are always (1, 1).
     pub dim: (u8, u8),
     /// Format aspects
-    pub aspects: AspectFlags,
+    pub aspects: Aspects,
 }
 
 /// Description of the bits distribution of a format.
@@ -203,7 +203,7 @@ macro_rules! surface_types {
                 match *self {
                     $( SurfaceType::$name => FormatDesc {
                         bits: $total,
-                        aspects: $(AspectFlags::$aspect)|*,
+                        aspects: $(Aspects::$aspect)|*,
                         dim: $dim,
                     }, )*
                 }
@@ -545,7 +545,7 @@ impl Format {
     }
 
     /// Retuns aspect flags of the format.
-    pub fn aspect_flags(self) -> AspectFlags {
+    pub fn aspects(self) -> Aspects {
         self.base_format()
             .0
             .desc()
@@ -554,17 +554,17 @@ impl Format {
 
     /// Returns if the format has a color aspect.
     pub fn is_color(self) -> bool {
-        self.aspect_flags().contains(AspectFlags::COLOR)
+        self.aspects().contains(Aspects::COLOR)
     }
 
     /// Returns if the format has a depth aspect.
     pub fn is_depth(self) -> bool {
-        self.aspect_flags().contains(AspectFlags::DEPTH)
+        self.aspects().contains(Aspects::DEPTH)
     }
 
     /// Returns if the format has a stencil aspect.
     pub fn is_stencil(self) -> bool {
-        self.aspect_flags().contains(AspectFlags::STENCIL)
+        self.aspects().contains(Aspects::STENCIL)
     }
 }
 

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -11,7 +11,7 @@ use std::error::Error;
 use std::fmt;
 use std::ops::Range;
 
-use format::{self, AspectFlags};
+use format;
 use pso::Comparison;
 
 
@@ -21,6 +21,18 @@ pub type Layer = u16;
 pub type Level = u8;
 /// Maximum accessible mipmap level of a image.
 pub const MAX_LEVEL: Level = 15;
+
+///
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Offset {
+    ///
+    pub x: i32,
+    ///
+    pub y: i32,
+    ///
+    pub z: i32,
+}
 
 /// Pure texture object creation error.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -354,7 +366,7 @@ bitflags!(
         const TRANSIENT_ATTACHMENT = 0x40;
         ///
         const INPUT_ATTACHMENT = 0x80;
-        
+
     }
 );
 
@@ -588,7 +600,7 @@ pub type Subresource = (Level, Layer);
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SubresourceLayers {
     /// Included aspects: color/depth/stencil
-    pub aspects: AspectFlags,
+    pub aspects: format::Aspects,
     /// Selected mipmap level
     pub level: Level,
     /// Included array levels
@@ -600,7 +612,7 @@ pub struct SubresourceLayers {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SubresourceRange {
     /// Included aspects: color/depth/stencil
-    pub aspects: AspectFlags,
+    pub aspects: format::Aspects,
     /// Included mipmap levels
     pub levels: Range<Level>,
     /// Included array levels

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -29,6 +29,7 @@ pub use self::adapter::{
 };
 pub use self::device::Device;
 pub use self::pool::CommandPool;
+pub use self::pso::DescriptorPool;
 pub use self::queue::{
     CommandQueue, QueueGroup, QueueFamily, QueueType, Submission,
     Capability, Supports, General, Graphics, Compute, Transfer,

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -18,8 +18,10 @@ extern crate serde;
 
 use std::any::Any;
 use std::error::Error;
-use std::fmt::{self, Debug};
+use std::fmt;
 use std::hash::Hash;
+
+//TODO: reconsider what is publicly exported
 
 pub use self::adapter::{
     Adapter, AdapterInfo, MemoryProperties, MemoryType, MemoryTypeId,
@@ -27,7 +29,6 @@ pub use self::adapter::{
 };
 pub use self::device::Device;
 pub use self::pool::CommandPool;
-pub use self::pso::{DescriptorPool};
 pub use self::queue::{
     CommandQueue, QueueGroup, QueueFamily, QueueType, Submission,
     Capability, Supports, General, Graphics, Compute, Transfer,
@@ -66,6 +67,8 @@ pub type IndexCount = u32;
 pub type InstanceCount = u32;
 /// Number of vertices in a patch
 pub type PatchSize = u8;
+/// Number of work groups.
+pub type WorkGroupCount = [u32; 3];
 
 /// Slot for an attribute.
 pub type AttributeSlot = u8;
@@ -228,17 +231,17 @@ pub struct Limits {
     /// Maximum number of viewports.
     pub max_viewports: usize,
     ///
-    pub max_compute_group_count: [u32; 3],
+    pub max_compute_group_count: WorkGroupCount,
     ///
     pub max_compute_group_size: [u32; 3],
 
     /// The alignment of the start of the buffer used as a GPU copy source, in bytes, non-zero.
-    pub min_buffer_copy_offset_alignment: usize,
+    pub min_buffer_copy_offset_alignment: buffer::Offset,
     /// The alignment of the row pitch of the texture data stored in a buffer that is
     /// used in a GPU copy operation, in bytes, non-zero.
-    pub min_buffer_copy_pitch_alignment: usize,
+    pub min_buffer_copy_pitch_alignment: buffer::Offset,
     /// The alignment of the start of buffer used for uniform buffer updates, in bytes, non-zero.
-    pub min_uniform_buffer_offset_alignment: usize,
+    pub min_uniform_buffer_offset_alignment: buffer::Offset,
 }
 
 /// Describes what geometric primitives are created from vertex data.
@@ -306,7 +309,7 @@ pub trait Instance: Any + Send + Sync {
 
 /// Different types of a specific API.
 #[allow(missing_docs)]
-pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any + Send + Sync {
+pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send + Sync {
     //type Instance:          Instance<Self>;
     type PhysicalDevice:      PhysicalDevice<Self>;
     type Device:              Device<Self>;
@@ -318,31 +321,31 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + Debug + Any + Send + Sy
     type CommandQueue:        queue::RawCommandQueue<Self>;
     type CommandBuffer:       command::RawCommandBuffer<Self>;
 
-    type ShaderModule:        Debug + Any + Send + Sync;
-    type RenderPass:          Debug + Any + Send + Sync;
-    type Framebuffer:         Debug + Any + Send + Sync;
+    type ShaderModule:        fmt::Debug + Any + Send + Sync;
+    type RenderPass:          fmt::Debug + Any + Send + Sync;
+    type Framebuffer:         fmt::Debug + Any + Send + Sync;
 
-    type Memory:              Debug + Any + Send + Sync;
+    type Memory:              fmt::Debug + Any + Send + Sync;
     type CommandPool:         pool::RawCommandPool<Self>;
 
-    type UnboundBuffer:       Debug + Any + Send + Sync;
-    type Buffer:              Debug + Any + Send + Sync;
-    type BufferView:          Debug + Any + Send + Sync;
-    type UnboundImage:        Debug + Any + Send + Sync;
-    type Image:               Debug + Any + Send + Sync;
-    type ImageView:           Debug + Any + Send + Sync;
-    type Sampler:             Debug + Any + Send + Sync;
+    type UnboundBuffer:       fmt::Debug + Any + Send + Sync;
+    type Buffer:              fmt::Debug + Any + Send + Sync;
+    type BufferView:          fmt::Debug + Any + Send + Sync;
+    type UnboundImage:        fmt::Debug + Any + Send + Sync;
+    type Image:               fmt::Debug + Any + Send + Sync;
+    type ImageView:           fmt::Debug + Any + Send + Sync;
+    type Sampler:             fmt::Debug + Any + Send + Sync;
 
-    type ComputePipeline:     Debug + Any + Send + Sync;
-    type GraphicsPipeline:    Debug + Any + Send + Sync;
-    type PipelineLayout:      Debug + Any + Send + Sync;
-    type DescriptorPool:      DescriptorPool<Self>;
-    type DescriptorSet:       Debug + Any + Send + Sync;
-    type DescriptorSetLayout: Debug + Any + Send + Sync;
+    type ComputePipeline:     fmt::Debug + Any + Send + Sync;
+    type GraphicsPipeline:    fmt::Debug + Any + Send + Sync;
+    type PipelineLayout:      fmt::Debug + Any + Send + Sync;
+    type DescriptorPool:      pso::DescriptorPool<Self>;
+    type DescriptorSet:       fmt::Debug + Any + Send + Sync;
+    type DescriptorSetLayout: fmt::Debug + Any + Send + Sync;
 
-    type Fence:               Debug + Any + Send + Sync;
-    type Semaphore:           Debug + Any + Send + Sync;
-    type QueryPool:           Debug + Any + Send + Sync;
+    type Fence:               fmt::Debug + Any + Send + Sync;
+    type Semaphore:           fmt::Debug + Any + Send + Sync;
+    type QueryPool:           fmt::Debug + Any + Send + Sync;
 }
 
 #[allow(missing_docs)]

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -62,9 +62,24 @@ bitflags!(
     }
 );
 
+bitflags!(
+    /// Barrier dependency flags.
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct Dependencies: u32 {
+        ///
+        const BY_REGION    = 0x1;
+        ///
+        const VIEW_LOCAL   = 0x2;
+        ///
+        const DEVICE_GROUP = 0x4;
+    }
+);
+
 #[allow(missing_docs)] //TODO
 #[derive(Clone, Debug)]
 pub enum Barrier<'a, B: Backend> {
+    AllBuffers(Range<buffer::Access>),
+    AllImages(Range<image::Access>),
     Buffer {
         states: Range<buffer::State>,
         target: &'a B::Buffer,

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -66,12 +66,10 @@ bitflags!(
     /// Barrier dependency flags.
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct Dependencies: u32 {
-        ///
+        /// Specifies the memory dependency to be framebuffer-local.
         const BY_REGION    = 0x1;
-        ///
-        const VIEW_LOCAL   = 0x2;
-        ///
-        const DEVICE_GROUP = 0x4;
+        //const VIEW_LOCAL   = 0x2;
+        //const DEVICE_GROUP = 0x4;
     }
 );
 

--- a/src/hal/src/pso/input_assembler.rs
+++ b/src/hal/src/pso/input_assembler.rs
@@ -1,6 +1,7 @@
 //! Input Assembler(IA) stage description.
 
 use format;
+use buffer::Offset;
 use {Backend, Primitive};
 
 /// Shader binding location.
@@ -13,8 +14,6 @@ pub type ElemOffset = u32;
 pub type ElemStride = u32;
 /// The number of instances between each subsequent attribute value
 pub type InstanceRate = u8;
-/// An offset inside a vertex buffer, in bytes.
-pub type BufferOffset = u64;
 
 /// A struct element descriptor.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -85,7 +84,7 @@ impl InputAssemblerDesc {
 #[derive(Clone, Debug)]
 pub struct VertexBufferSet<'a, B: Backend>(
     /// Array of buffer handles with offsets in them
-    pub Vec<(&'a B::Buffer, BufferOffset)>,
+    pub Vec<(&'a B::Buffer, Offset)>,
 );
 
 impl<'a, B: Backend> VertexBufferSet<'a, B> {

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -183,7 +183,7 @@ impl<B: Backend> Device<B> {
         use image::Usage;
         use hal::image::ImageLayout;
 
-        let aspects = format.aspect_flags();
+        let aspects = format.aspects();
         let image = self.raw.create_image(kind, mip_levels, format, usage)?;
         let (image, memory) = allocator.allocate_image(self, usage, image);
         let origin = image::Origin::User(memory);
@@ -265,7 +265,7 @@ impl<B: Backend> Device<B> {
     pub fn create_descriptors<D>(&mut self, count: usize) -> Vec<(D, D::Data)>
         where D: pso::Descriptors<B>
     {
-        use hal::DescriptorPool as CDP;
+        use hal::pso::DescriptorPool as CDP;
 
         let bindings = &D::layout_bindings()[..];
         let layout = self.create_descriptor_set_layout(bindings);

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -7,8 +7,8 @@ use std::collections::{HashMap, HashSet};
 
 use hal::{self, buffer as b, image as i, CommandPool};
 use hal::command::CommandBuffer;
-use hal::format::AspectFlags;
-use hal::memory::Barrier;
+use hal::format::Aspects;
+use hal::memory::{Barrier, Dependencies};
 use hal::pso::PipelineStage;
 
 use memory::{Provider, Dependency, cast_slice};
@@ -211,7 +211,7 @@ impl<'a, B: Backend, C> Encoder<'a, B, C>
             }
         }
         let stage_transition = self.pipeline_stage..self.pipeline_stage;
-        self.buffer.pipeline_barrier(stage_transition, barriers);
+        self.buffer.pipeline_barrier(stage_transition, Dependencies::empty(), barriers);
     }
 
     fn init_image<'b>(
@@ -324,7 +324,7 @@ impl<'a, B: Backend, C> Encoder<'a, B, C>
         }
         let current_stage = mem::replace(&mut self.pipeline_stage, stage);
         if (current_stage != stage) || !barriers.is_empty() {
-            self.buffer.pipeline_barrier(current_stage..stage, barriers);
+            self.buffer.pipeline_barrier(current_stage..stage, Dependencies::empty(), barriers);
         }
     }
 
@@ -348,7 +348,7 @@ impl<'a, B: Backend, C> Encoder<'a, B, C>
             }
         }
         let stage_transition = self.pipeline_stage..PipelineStage::BOTTOM_OF_PIPE;
-        self.buffer.pipeline_barrier(stage_transition, barriers);
+        self.buffer.pipeline_barrier(stage_transition, Dependencies::empty(), barriers);
     }
 
     // TODO: fill buffer
@@ -616,7 +616,7 @@ impl<'a, B: Backend, C> Encoder<'a, B, C>
         let layout = self.require_clear_state(image);
         //TODO
         let range = i::SubresourceRange {
-            aspects: AspectFlags::COLOR,
+            aspects: Aspects::COLOR,
             levels: 0 .. 1,
             layers: 0 .. 1,
         };
@@ -644,7 +644,7 @@ impl<'a, B: Backend, C> Encoder<'a, B, C>
         let layout = self.require_clear_state(image);
         //TODO
         let range = i::SubresourceRange {
-            aspects: AspectFlags::DEPTH | AspectFlags::STENCIL,
+            aspects: Aspects::DEPTH | Aspects::STENCIL,
             levels: 0 .. 1,
             layers: 0 .. 1,
         };

--- a/src/render/src/image.rs
+++ b/src/render/src/image.rs
@@ -1,7 +1,7 @@
 use hal;
 use memory::Memory;
 
-pub use hal::format::AspectFlags;
+pub use hal::format::Aspects;
 pub use hal::image::{
     CreationError, Kind, AaMode, Size, Level, Layer, Dimensions,
     SamplerInfo, ViewError, Usage,
@@ -11,7 +11,7 @@ pub use hal::image::{
 #[allow(missing_docs)]
 #[derive(Debug)]
 pub struct Info {
-    pub aspects: AspectFlags,
+    pub aspects: Aspects,
     pub usage: Usage,
     pub kind: Kind,
     pub mip_levels: Level,

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -256,7 +256,7 @@ impl<B: Backend, C> Context<B, C>
                 let handle = handle::inner::Image::without_garbage(
                     raw,
                     image::Info {
-                        aspects: format::AspectFlags::COLOR,
+                        aspects: format::Aspects::COLOR,
                         usage: image::Usage::TRANSFER_SRC | image::Usage::COLOR_ATTACHMENT,
                         kind: surface.kind(),
                         mip_levels: 1,

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -154,9 +154,9 @@ impl Harness {
                 let mut max_compute_groups = [0; 3];
                 for job_name in &test.jobs {
                     if let warden::raw::Job::Compute { dispatch, .. } = tg.scene.jobs[job_name] {
-                         max_compute_groups[0] = max_compute_groups[0].max(dispatch.0);
-                         max_compute_groups[1] = max_compute_groups[1].max(dispatch.1);
-                         max_compute_groups[2] = max_compute_groups[2].max(dispatch.2);
+                        for (max, count) in max_compute_groups.iter_mut().zip(dispatch.iter()) {
+                            *max = (*max).max(*count);
+                        }
                     }
                 }
                 if  max_compute_groups[0] > limits.max_compute_group_size[0] ||

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -137,10 +137,10 @@ fn default_instance_range() -> Range<hal::InstanceCount> {
 pub enum DrawCommand {
     BindIndexBuffer {
         buffer: String,
-        offset: u64,
+        offset: hal::buffer::Offset,
         index_type: hal::IndexType,
     },
-    BindVertexBuffers(Vec<(String, hal::pso::BufferOffset)>),
+    BindVertexBuffers(Vec<(String, hal::buffer::Offset)>),
     BindPipeline(String),
     BindDescriptorSets {
         layout: String,
@@ -179,7 +179,7 @@ pub enum Job {
     Compute {
         pipeline: String,
         descriptor_sets: Vec<String>,
-        dispatch: (u32, u32, u32),
+        dispatch: hal::WorkGroupCount,
     },
 }
 


### PR DESCRIPTION
Improved API consistency.
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan,GL
