### PR TITLE
Implement method to get a unique device identifier.

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -135,6 +135,8 @@ fn main() {
             surface.supports_queue_family(family)
         }).unwrap();
 
+    println!("Device ID: {:?}", device.id());
+
     let mut command_pool = device.create_command_pool_typed(&queue_group, pool::CommandPoolCreateFlags::empty(), 16);
     let mut queue = &mut queue_group.queues[0];
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2381,4 +2381,8 @@ impl d::Device<B> for Device {
         }
         Ok(())
     }
+
+    fn id(&self) -> d::DeviceId {
+        self.id
+    }
 }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -345,6 +345,10 @@ impl hal::Device<Backend> for Device {
     fn wait_idle(&self) -> Result<(), error::HostExecutionError> {
         unimplemented!()
     }
+
+    fn id(&self) -> device::DeviceId {
+        unimplemented!()
+    }
 }
 
 #[derive(Debug)]

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -25,3 +25,4 @@ gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 glutin = { version = "0.12", optional = true }
 spirv_cross = "0.6"
+rand = "0.4"

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -6,6 +6,8 @@ use std::ops::Range;
 use std::{ptr, mem, slice};
 use std::sync::{Arc, Mutex};
 
+use rand::{Rng, thread_rng};
+
 use gl;
 use gl::types::{GLint, GLenum, GLfloat, GLuint};
 
@@ -103,6 +105,7 @@ pub struct UnboundImage {
 #[derive(Debug)]
 pub struct Device {
     share: Starc<Share>,
+    id: d::DeviceId,
 }
 
 impl Drop for Device {
@@ -116,6 +119,7 @@ impl Device {
     pub(crate) fn new(share: Starc<Share>) -> Self {
         Device {
             share: share,
+            id: d::DeviceId(thread_rng().gen::<usize>()),
         }
     }
 
@@ -1067,6 +1071,10 @@ impl d::Device<B> for Device {
     fn wait_idle(&self) -> Result<(), error::HostExecutionError> {
         unsafe { self.share.context.Finish(); }
         Ok(())
+    }
+
+    fn id(&self) -> d::DeviceId {
+        self.id
     }
 }
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -11,6 +11,7 @@ extern crate gfx_gl as gl;
 extern crate gfx_hal as hal;
 extern crate smallvec;
 extern crate spirv_cross;
+extern crate rand;
 #[cfg(feature = "glutin")]
 pub extern crate glutin;
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -178,14 +178,14 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             max_samplers_per_stage: 31,
         };
 
-        let id = DeviceId(self.raw.registry_id());
+        let device_id = DeviceId(self.raw.registry_id() as usize);
 
         let device = Device {
             device: self.raw.clone(),
             private_caps,
             queue,
             memory_types: self.memory_types,
-            id,
+            id: device_id,
         };
 
         let mut queues = HashMap::new();

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::{cmp, mem, ptr, slice};
 
 use hal::{self, error, image, pass, format, mapping, memory, buffer, pso, query};
-use hal::device::{BindError, OutOfMemory, FramebufferError, ShaderError, Extent};
+use hal::device::{BindError, DeviceId, OutOfMemory, FramebufferError, ShaderError, Extent};
 use hal::memory::Properties;
 use hal::pool::CommandPoolCreateFlags;
 use hal::pso::{DescriptorType, DescriptorSetLayoutBinding, AttributeDesc, DepthTest, StencilTest};
@@ -113,6 +113,7 @@ pub struct Device {
     private_caps: PrivateCapabilities,
     queue: Arc<command::QueueInner>,
     memory_types: [hal::MemoryType; 3],
+    id: DeviceId,
 }
 unsafe impl Send for Device {}
 unsafe impl Sync for Device {}
@@ -177,11 +178,14 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             max_samplers_per_stage: 31,
         };
 
+        let id = DeviceId(self.raw.registry_id());
+
         let device = Device {
             device: self.raw.clone(),
             private_caps,
             queue,
             memory_types: self.memory_types,
+            id,
         };
 
         let mut queues = HashMap::new();
@@ -1409,6 +1413,10 @@ impl hal::Device<Backend> for Device {
 
     fn wait_idle(&self) -> Result<(), error::HostExecutionError> {
         unimplemented!()
+    }
+
+    fn id(&self) -> DeviceId {
+        self.id
     }
 }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1546,6 +1546,10 @@ impl d::Device<B> for Device {
             .map_err(From::from)
             .map_err(From::<result::Error>::from)
     }
+
+    fn id(&self) -> d::DeviceId {
+        self._id
+    }
 }
 
 #[test]

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -101,6 +101,12 @@ pub enum ShaderError {
 #[derive(Clone, Debug, PartialEq)]
 pub struct FramebufferError;
 
+/// A locally unique identifier for the Device.
+/// Note that this value will change each time the program is run.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DeviceId(pub usize);
+
 /// # Overview
 ///
 /// A `Device` is responsible for creating and managing resources for the physical device
@@ -576,4 +582,7 @@ pub trait Device<B: Backend>: Any + Send + Sync {
     ///
     /// Host access to all queues needs to be **externally** sycnhronized!
     fn wait_idle(&self) -> Result<(), HostExecutionError>;
+
+    /// Get a locally unique identifier for this device
+    fn id(&self) -> DeviceId;
 }


### PR DESCRIPTION
Note that the GL implementation just creates a random number and the
Metal api function registryID was only available since High Sierra and I
don't know if we care about that or not.

Fixes #1766
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
    Vulkan
    dx12
    OpenGL
