### PR TITLE
[pre-ll] Update glutin, winit, gfx_gl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,16 @@ name = "gfx_app"
 
 [dependencies]
 log = "0.4"
-env_logger = "0.4"
-glutin = "0.12"
-winit = "0.10"
+env_logger = "0.5"
+glutin = "0.13"
+winit = "0.11"
 gfx_core = { path = "src/core", version = "0.8" }
 gfx = { path = "src/render", version = "0.17" }
 gfx_macros = { path = "src/macros", version = "0.2" }
-gfx_device_gl = { path = "src/backend/gl", version = "0.15" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.20" }
-gfx_window_glfw = { path = "src/window/glfw", version = "0.16", optional = true }
-gfx_window_sdl = { path = "src/window/sdl", version = "0.8", optional = true }
+gfx_device_gl = { path = "src/backend/gl", version = "0.16" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.21" }
+gfx_window_glfw = { path = "src/window/glfw", version = "0.17", optional = true }
+gfx_window_sdl = { path = "src/window/sdl", version = "0.9", optional = true }
 
 [dependencies.gfx_device_vulkan]
 path = "src/backend/vulkan"
@@ -42,7 +42,7 @@ optional = true
 
 [dependencies.gfx_window_vulkan]
 path = "src/window/vulkan"
-version = "0.4"
+version = "0.5"
 optional = true
 
 [dependencies.gfx_device_metal]
@@ -52,12 +52,12 @@ optional = true
 
 [dependencies.gfx_window_metal]
 path = "src/window/metal"
-version = "0.4"
+version = "0.5"
 optional = true
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.7" }
-gfx_window_dxgi = { path = "src/window/dxgi", version = "0.11" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.12" }
 
 [[example]]
 name = "blend"
@@ -124,8 +124,8 @@ name = "render_target"
 path = "examples/render_target/main.rs"
 
 [dev-dependencies]
-cgmath = "0.15"
-gfx_gl = "0.4"
+cgmath = "0.16"
+gfx_gl = "0.5"
 rand = "0.4"
 genmesh = "0.5"
 noise = "0.2" #TODO: update

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_gl"
-version = "0.15.0"
+version = "0.16.0"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,5 +29,5 @@ name = "gfx_device_gl"
 
 [dependencies]
 log = "0.4"
-gfx_gl = "0.4"
+gfx_gl = "0.5"
 gfx_core = { path = "../../core", version = "0.8" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ A: Sized + ApplicationBase<gfx_device_gl::Resources, gfx_device_gl::CommandBuffe
     use gfx::traits::Device;
     use glutin::GlContext;
 
-    env_logger::init().unwrap();
+    env_logger::init();
     #[cfg(target_os = "emscripten")]
     let gl_version = glutin::GlRequest::Specific(
         glutin::Api::WebGl, (2, 0),
@@ -209,7 +209,7 @@ A: Sized + ApplicationBase<gfx_device_dx11::Resources, D3D11CommandBuffer>
 {
     use gfx::traits::{Device, Factory};
 
-    env_logger::init().unwrap();
+    env_logger::init();
     let mut events_loop = winit::EventsLoop::new();
     let (mut window, device, mut factory, main_color) =
         gfx_window_dxgi::init::<ColorFormat>(wb, &events_loop).unwrap();
@@ -289,7 +289,7 @@ A: Sized + ApplicationBase<gfx_device_metal::Resources, gfx_device_metal::Comman
     use gfx::traits::{Device, Factory};
     use gfx::texture::Size;
 
-    env_logger::init().unwrap();
+    env_logger::init();
     let mut events_loop = winit::EventsLoop::new();
     let (window, mut device, mut factory, main_color) = gfx_window_metal::init::<ColorFormat>(wb, &events_loop)
                                                                                 .unwrap();
@@ -348,7 +348,7 @@ A: Sized + ApplicationBase<gfx_device_vulkan::Resources, gfx_device_vulkan::Comm
     use gfx::traits::{Device, Factory};
     use gfx::texture::Size;
 
-    env_logger::init().unwrap();
+    env_logger::init();
     let mut events_loop = winit::EventsLoop::new();
     let (mut win, mut factory) = gfx_window_vulkan::init::<ColorFormat>(wb, &events_loop);
     let (width, height) = win.get_size();

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.11.0"
+version = "0.12.0"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,6 +29,6 @@ name = "gfx_window_dxgi"
 [dependencies]
 log = "0.4"
 winapi = { version = "0.3" , features = ["d3d11", "dxgi"] }
-winit = "0.10"
+winit = "0.11"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.7" }

--- a/src/window/glfw/Cargo.toml
+++ b/src/window/glfw/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glfw"
-version = "0.16.0"
+version = "0.17.0"
 description = "GLFW window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -30,7 +30,7 @@ name = "gfx_window_glfw"
 [dependencies]
 glfw = "0.20"
 gfx_core = { path = "../../core", version = "0.8" }
-gfx_device_gl = { path = "../../backend/gl", version = "0.15" }
+gfx_device_gl = { path = "../../backend/gl", version = "0.16" }
 
 # Currently there is an issue with cargo and dev-dependencies:
 # https://github.com/rust-lang/cargo/issues/860

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.20.0"
+version = "0.21.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,9 +28,9 @@ documentation = "https://docs.rs/gfx_window_glutin"
 name = "gfx_window_glutin"
 
 [dependencies]
-glutin = "0.12"
+glutin = "0.13"
 gfx_core = { path = "../../core", version = "0.8" }
-gfx_device_gl = { path = "../../backend/gl", version = "0.15" }
+gfx_device_gl = { path = "../../backend/gl", version = "0.16" }
 
 [features]
 headless = []

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_metal"
-version = "0.4.0"
+version = "0.5.0"
 description = "Metal window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -30,7 +30,7 @@ name = "gfx_window_metal"
 log = "0.4"
 cocoa = "0.9"
 objc = "0.2"
-winit = "0.10"
+winit = "0.11"
 metal-rs = "0.4"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.3" }

--- a/src/window/sdl/Cargo.toml
+++ b/src/window/sdl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_sdl"
-version = "0.8.0"
+version = "0.9.0"
 description = "SDL2 window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -30,7 +30,7 @@ name = "gfx_window_sdl"
 log = "0.4"
 sdl2 = "0.31"
 gfx_core = { path = "../../core", version = "0.8" }
-gfx_device_gl = { path = "../../backend/gl", version = "0.15" }
+gfx_device_gl = { path = "../../backend/gl", version = "0.16" }
 # Currently there is an issue with cargo and dev-dependencies:
 # https://github.com/rust-lang/cargo/issues/860
 # TODO: move gfx to [dev-dependencies] once it gets resolved.

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_window_vulkan"
-version = "0.4.0"
+version = "0.5.0"
 description = "Vulkan window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/gfx_window_vulkan"
 name = "gfx_window_vulkan"
 
 [dependencies]
-winit = "0.10"
+winit = "0.11"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.2" }


### PR DESCRIPTION
Dependency update for glutin/winit + gfx_gl

* gfx_device_gl -> `0.16`
  - gfx_gl -> `0.5`
* gfx_window_dxgi -> `0.12`
  - winit -> `0.11`
* gfx_window_glfw -> `0.17`
  - gfx_device_gl -> `0.16`
* gfx_window_glutin -> `0.21`
  - glutin -> `0.13`
  - gfx_device_gl -> `0.16`
* gfx_window_metal -> `0.5`
  - winit -> `0.11`
* gfx_window_sdl -> `0.9`
  - gfx_device_gl -> `0.16`
* gfx_window_vulkan -> `0.5`
  - winit -> `0.11`

Also update gfx_app's dev-dependencies

PR checklist:
- ~`make` succeeds (on *nix)~ _pre-ll_
- ~`make reftests` succeeds~ _pre-ll_
- [x] tested examples with the following backends: gl
