### PR TITLE
Add TRANSFER_SRC usage flag for swapchain images

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1423,7 +1423,7 @@ impl d::Device<B> for Device {
                 height: surface.height,
             },
             image_array_layers: 1,
-            image_usage: vk::IMAGE_USAGE_COLOR_ATTACHMENT_BIT | vk::IMAGE_USAGE_TRANSFER_DST_BIT,
+            image_usage: vk::IMAGE_USAGE_COLOR_ATTACHMENT_BIT | vk::IMAGE_USAGE_TRANSFER_SRC_BIT | vk::IMAGE_USAGE_TRANSFER_DST_BIT,
             image_sharing_mode: vk::SharingMode::Exclusive,
             queue_family_index_count: 0,
             p_queue_family_indices: ptr::null(),


### PR DESCRIPTION
Fixes #1872 
PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends:
  - hal/quad (vulkan)