### PR TITLE
[0.17/gl] improved texture copies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,21 @@ skip_branch_with_pr: true
 branches:
   except:
     - staging.tmp
+
 environment:
   RUST_BACKTRACE: full
   matrix:
-  - channel: stable
-    target: x86_64-pc-windows-msvc
-  - channel: stable
-    target: x86_64-pc-windows-gnu
-  - channel: nightly
-    target: x86_64-pc-windows-msvc
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+    - channel: stable
+      target: x86_64-pc-windows-gnu
+    - channel: nightly
+      target: x86_64-pc-windows-msvc
+matrix:
+  fast_finish: true
+  allow_failures:
+    - channel: nightly
+
 install:
 - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
 - rustup-init -yv --default-toolchain %channel% --default-host %target%

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_gl"
-version = "0.15.1"
+version = "0.15.2"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
Related to #1881
Forces the texture-to-buffer copies to go through FBO path if only a sub-texture is needed instead of panicing.