### PR TITLE
[Vulkan] Surface extension detection failure on newer Rust and 1.1 capable drivers

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -162,8 +162,9 @@ impl Instance {
                 instance_extensions
                     .iter()
                     .find(|inst_ext| unsafe {
-                        CStr::from_ptr(inst_ext.extension_name.as_ptr()) ==
-                            CStr::from_ptr(ext.as_ptr() as *const _)
+                        let inst_ext_name = std::slice::from_raw_parts(inst_ext.extension_name.as_ptr(), ext.len());
+                        let surf_ext_name = std::slice::from_raw_parts(ext.as_ptr() as *const i8, ext.len());
+                        (surf_ext_name == inst_ext_name)
                     })
                     .map(|_| ext)
                     .or_else(|| {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(libc)]
-
 #[macro_use]
 extern crate log;
 extern crate ash;
@@ -8,7 +6,6 @@ extern crate gfx_hal as hal;
 #[macro_use]
 extern crate lazy_static;
 extern crate smallvec;
-extern crate libc;
 
 #[cfg(windows)]
 extern crate winapi;
@@ -165,8 +162,8 @@ impl Instance {
                 instance_extensions
                     .iter()
                     .find(|inst_ext| unsafe {
-                        let _inst_ext = inst_ext.extension_name.as_ptr();
-                        std::slice::from_raw_parts(_inst_ext, libc::strlen(_inst_ext)) == std::slice::from_raw_parts(ext.as_ptr() as *const i8, ext.len())
+                        CStr::from_ptr(inst_ext.extension_name.as_ptr()) == 
+                        CStr::from_bytes_with_nul_unchecked(std::slice::from_raw_parts(ext.as_ptr(), ext.len()+1))
                     })
                     .map(|_| ext)
                     .or_else(|| {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(libc)]
+
 #[macro_use]
 extern crate log;
 extern crate ash;
@@ -6,6 +8,7 @@ extern crate gfx_hal as hal;
 #[macro_use]
 extern crate lazy_static;
 extern crate smallvec;
+extern crate libc;
 
 #[cfg(windows)]
 extern crate winapi;
@@ -162,9 +165,8 @@ impl Instance {
                 instance_extensions
                     .iter()
                     .find(|inst_ext| unsafe {
-                        let inst_ext_name = std::slice::from_raw_parts(inst_ext.extension_name.as_ptr(), ext.len());
-                        let surf_ext_name = std::slice::from_raw_parts(ext.as_ptr() as *const i8, ext.len());
-                        (surf_ext_name == inst_ext_name)
+                        let _inst_ext = inst_ext.extension_name.as_ptr();
+                        std::slice::from_raw_parts(_inst_ext, libc::strlen(_inst_ext)) == std::slice::from_raw_parts(ext.as_ptr() as *const i8, ext.len())
                     })
                     .map(|_| ext)
                     .or_else(|| {


### PR DESCRIPTION
Fixes #1884
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:

Our fix for extension list check 
