### PR TITLE
gl: Add an accessor to the `GlWindow` underlying a `Surface`.

### DIFF
--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -82,6 +82,10 @@ impl Surface {
             window: Starc::new(window)
         }
     }
+    
+    pub fn window(&self) -> &glutin::GlWindow {
+        &self.window
+    }
 
     fn swapchain_formats(&self) -> Vec<f::Format> {
         let pixel_format = self.window.get_pixel_format();


### PR DESCRIPTION
There is no way currently to access a `GlWindow`'s methods after a `Surface` has been created for it.