### PR TITLE
`make check` fails on Windows 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ help:
 	@echo "Supported backends: gl $(FEATURES_HAL) $(FEATURES_HAL2)"
 
 check:
-	#Note: excluding `warden` here, since it depends on serialization
+	@echo "Note: excluding `warden` here, since it depends on serialization"
 	cargo check --all $(EXCLUDES) --exclude gfx-warden
 	cd examples/hal && cargo check --features "gl"
 	cd examples/hal && cargo check --features "$(FEATURES_HAL)"


### PR DESCRIPTION
* GNU Make 4.2
* Windows 10
* PowerShell

```ps
PS C:\Users\okr\gfx> make check
#Note: excluding `warden` here, since it depends on serialization
process_begin: CreateProcess(NULL, #Note: excluding `warden` here, since it depends on serialization, ...) failed.
make (e=2): Das System kann die angegebene Datei nicht finden.
make: *** [makefile:49: check] Error 2
```

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
