### PR TITLE
Change Subresource and ImageCopy to match Vulkan API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ help:
 	@echo "Supported backends: gl $(FEATURES_HAL) $(FEATURES_HAL2)"
 
 check:
-	@echo "Note: excluding `warden` here, since it depends on serialization"
+	@echo "Note: excluding \`warden\` here, since it depends on serialization"
 	cargo check --all $(EXCLUDES) --exclude gfx-warden
 	cd examples/hal && cargo check --features "gl"
 	cd examples/hal && cargo check --features "$(FEATURES_HAL)"

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1236,7 +1236,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         for region in regions {
             let region = region.borrow();
             debug_assert_eq!(region.src_subresource.layers.len(), region.dst_subresource.layers.len());
-            let num_layers = region.src_subresource.layers.len();
+            let num_layers = region.src_subresource.layers.len() as image::Layer;
             let src_layer_start = region.src_subresource.layers.start;
             let dst_layer_start = region.dst_subresource.layers.start;
             for layer in 0..num_layers {

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1235,11 +1235,15 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
         for region in regions {
             let region = region.borrow();
-            for layer in 0..region.num_layers {
+            debug_assert_eq!(region.src_subresource.layers.len(), region.dst_subresource.layers.len());
+            let num_layers = region.src_subresource.layers.len();
+            let src_layer_start = region.src_subresource.layers.start;
+            let dst_layer_start = region.dst_subresource.layers.start;
+            for layer in 0..num_layers {
                 *unsafe { src_image.u.SubresourceIndex_mut() } =
-                    src.calc_subresource(region.src_subresource.0 as _, (region.src_subresource.1 + layer) as _, 0);
+                    src.calc_subresource(region.src_subresource.level as _, (src_layer_start + layer) as _, 0);
                 *unsafe { dst_image.u.SubresourceIndex_mut() } =
-                    dst.calc_subresource(region.dst_subresource.0 as _, (region.dst_subresource.1 + layer) as _, 0);
+                    dst.calc_subresource(region.dst_subresource.level as _, (dst_layer_start + layer) as _, 0);
 
                 let src_box = d3d12::D3D12_BOX {
                     left: region.src_offset.x as _,

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -703,9 +703,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             .map(|region| {
                 let r = region.borrow();
                 vk::ImageCopy {
-                    src_subresource: conv::map_subresource_with_layers(r.aspects, r.src_subresource, r.num_layers),
+                    src_subresource: conv::map_subresource_layers(r.src_subresource),
                     src_offset: conv::map_offset(r.src_offset),
-                    dst_subresource: conv::map_subresource_with_layers(r.aspects, r.dst_subresource, r.num_layers),
+                    dst_subresource: conv::map_subresource_layers(r.dst_subresource),
                     dst_offset: conv::map_offset(r.dst_offset),
                     extent: conv::map_extent(r.extent),
                 }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -703,9 +703,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             .map(|region| {
                 let r = region.borrow();
                 vk::ImageCopy {
-                    src_subresource: conv::map_subresource_layers(r.src_subresource),
+                    src_subresource: conv::map_subresource_layers(&r.src_subresource),
                     src_offset: conv::map_offset(r.src_offset),
-                    dst_subresource: conv::map_subresource_layers(r.dst_subresource),
+                    dst_subresource: conv::map_subresource_layers(&r.dst_subresource),
                     dst_offset: conv::map_offset(r.dst_offset),
                     extent: conv::map_extent(r.extent),
                 }

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -145,14 +145,13 @@ pub fn map_subresource_layers(
 }
 
 pub fn map_subresource_with_layers(
-    aspects: format::Aspects,
-    (mip_level, base_layer): image::Subresource,
+    sub: image::Subresource,
     layers: image::Layer,
 ) -> vk::ImageSubresourceLayers {
     map_subresource_layers(&image::SubresourceLayers {
-        aspects,
-        level: mip_level,
-        layers: base_layer..base_layer+layers,
+        aspects: sub.aspects,
+        level: sub.level,
+        layers: sub.layer..sub.layer+layers,
     })
 }
 

--- a/src/hal/src/command/transfer.rs
+++ b/src/hal/src/command/transfer.rs
@@ -29,20 +29,16 @@ pub struct BufferCopy {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ImageCopy {
-    /// The aspect mask of what to copy: color, depth and/or stencil information.
-    pub aspects: format::Aspects,
     /// The image subresource to copy from.
-    pub src_subresource: image::Subresource,
+    pub src_subresource: image::SubresourceLayers,
     /// The source offset.
     pub src_offset: image::Offset,
-    /// he image subresource to copy to.
-    pub dst_subresource: image::Subresource,
+    /// The image subresource to copy to.
+    pub dst_subresource: image::SubresourceLayers,
     /// The destination offset.
     pub dst_offset: image::Offset,
     /// The extent of the region to copy.
     pub extent: image::Extent,
-    /// The number of layers to copy.
-    pub num_layers: image::Layer,
 }
 
 /// Bundles together all the parameters needed to copy a buffer
@@ -56,7 +52,7 @@ pub struct BufferImageCopy {
     pub buffer_width: u32,
     /// Height of a buffer 'image slice' in texels.
     pub buffer_height: u32,
-    /// The number of layers to copy.
+    /// The image subresource.
     pub image_layers: image::SubresourceLayers,
     /// The offset of the portion of the image to copy.
     pub image_offset: image::Offset,

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -628,7 +628,16 @@ bitflags!(
 pub type State = (Access, ImageLayout);
 
 /// Selector of a concrete subresource in an image.
-pub type Subresource = (Level, Layer);
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Subresource {
+    /// Included aspects: color/depth/stencil
+    pub aspects: format::Aspects,
+    /// Selected mipmap level
+    pub level: Level,
+    /// Selected array level
+    pub layer: Layer,
+}
 
 /// A subset of resource layers contained within an image's level.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/src/render/src/pso.rs
+++ b/src/render/src/pso.rs
@@ -130,7 +130,12 @@ impl<B: Backend> Bind<B> for SampledImage {
         let state = (hal::image::Access::SHADER_READ, ImageLayout::ShaderReadOnlyOptimal);
         for level in 0..levels {
             for layer in 0..layers {
-                images.push((img, (level, layer), state));
+                let subresource = hal::image::Subresource {
+                    aspects: img.info().aspects,
+                    level,
+                    layer
+                };
+                images.push((img, subresource, state));
             }
         }
     }
@@ -323,7 +328,12 @@ where
             ImageLayout::ColorAttachmentOptimal);
         for level in 0..levels {
             for layer in 0..layers {
-                images.push((img, (level, layer), state));
+                let subresource = hal::image::Subresource {
+                    aspects: img.info().aspects,
+                    level,
+                    layer
+                };
+                images.push((img, subresource, state));
             }
         }
     }


### PR DESCRIPTION
As discussed on Gitter, this changes the `Subresource` and `ImageCopy` structs to match the Vulkan API.

`Subresource` is `Copy` because it's just three ints, and because the previous `Subresource` type (a tuple of two ints), was also copy and some existing code assumes this.

I had to change the DirectX and Vulkan code blind as I can't compile them, so as well as the CI, perhaps @kvark and/or @msiglreith can take a look at that especially.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds (no, but Metal reftests didn't work before anyway)
- [ ] tested examples with the following backends:
