### PR TITLE
[vk] Add BlendConstants to DynamicState

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -295,7 +295,7 @@ impl d::Device<B> for Device {
         let mut info_specializations       = Vec::with_capacity(descs.len() * NUM_STAGES);
         let mut specialization_data        = Vec::with_capacity(descs.len() * NUM_STAGES);
 
-        let dynamic_states = [vk::DynamicState::Viewport, vk::DynamicState::Scissor];
+        let dynamic_states = [vk::DynamicState::Viewport, vk::DynamicState::Scissor, vk::DynamicState::BlendConstants];
         let mut c_strings = Vec::new(); // hold the C strings temporarily
         let mut make_stage = |stage, source: &pso::EntryPoint<'a, B>| {
             let string = CString::new(source.entry).unwrap();


### PR DESCRIPTION
Fixes the following error:
```
ERROR:: [DS] Object: 0x7f2b421a6e00 | vkCmdSetBlendConstants(): pipeline was created without VK_DYNAMIC_STATE_BLEND_CONSTANTS flag. The spec valid usage text states 'The currently bound graphics pipeline must have been created with the VK_DYNAMIC_STATE_BLEND_CONSTANTS dynamic state enabled' (https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#VUID-vkCmdSetBlendConstants-None-00612).
```
This is just a workaround. The ultimate solution should be passing these dynamic states at creation.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
