### PR TITLE
Implement std::error::Error on FrameBufferError

### DIFF
--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -95,6 +95,19 @@ pub enum ShaderError {
 #[derive(Clone, Debug, PartialEq)]
 pub struct FramebufferError;
 
+impl fmt::Display for FramebufferError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl Error for FramebufferError {
+    fn description(&self) -> &str {
+        "Error creating framebuffer"
+    }
+}
+
+
 /// # Overview
 ///
 /// A `Device` is responsible for creating and managing resources for the physical device


### PR DESCRIPTION
Fixes #1892

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
