### PR TITLE
[vk] ash update, destroy buffer view

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1"
 log = "0.4"
 lazy_static = "1"
 shared_library = "0.1"
-ash = "0.21.1" # for cmd_blit_image
+ash = "0.22.1"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.11", optional = true }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -336,28 +336,28 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         vk::ClearAttachment {
                             aspect_mask: vk::IMAGE_ASPECT_COLOR_BIT,
                             color_attachment: index as _,
-                            clear_value: vk::ClearValue::new_color(conv::map_clear_color(cv)),
+                            clear_value: vk::ClearValue { color: conv::map_clear_color(cv) },
                         }
                     }
                     com::AttachmentClear::Depth(v) => {
                         vk::ClearAttachment {
                             aspect_mask: vk::IMAGE_ASPECT_DEPTH_BIT,
                             color_attachment: 0,
-                            clear_value: vk::ClearValue::new_depth_stencil(conv::map_clear_depth(v)),
+                            clear_value: vk::ClearValue { depth: conv::map_clear_depth(v) },
                         }
                     }
                     com::AttachmentClear::Stencil(v) => {
                         vk::ClearAttachment {
                             aspect_mask: vk::IMAGE_ASPECT_STENCIL_BIT,
                             color_attachment: 0,
-                            clear_value: vk::ClearValue::new_depth_stencil(conv::map_clear_stencil(v)),
+                            clear_value: vk::ClearValue { depth: conv::map_clear_stencil(v) },
                         }
                     }
                     com::AttachmentClear::DepthStencil(cv) => {
                         vk::ClearAttachment {
                             aspect_mask: vk::IMAGE_ASPECT_DEPTH_BIT | vk::IMAGE_ASPECT_STENCIL_BIT,
                             color_attachment: 0,
-                            clear_value: vk::ClearValue::new_depth_stencil(conv::map_clear_depth_stencil(cv)),
+                            clear_value: vk::ClearValue { depth: conv::map_clear_depth_stencil(cv) },
                         }
                     }
                 }

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -90,9 +90,9 @@ pub fn map_image_aspects(aspects: format::Aspects) -> vk::ImageAspectFlags {
 
 pub fn map_clear_color(value: command::ClearColor) -> vk::ClearColorValue {
     match value {
-        command::ClearColor::Float(v) => vk::ClearColorValue::new_float32(v),
-        command::ClearColor::Int(v)   => vk::ClearColorValue::new_int32(v),
-        command::ClearColor::Uint(v)  => vk::ClearColorValue::new_uint32(v),
+        command::ClearColor::Float(v) => vk::ClearColorValue { float32: v },
+        command::ClearColor::Int(v)   => vk::ClearColorValue { int32: v },
+        command::ClearColor::Uint(v)  => vk::ClearColorValue { uint32: v },
     }
 }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1492,8 +1492,8 @@ impl d::Device<B> for Device {
         unsafe { self.raw.0.destroy_buffer(buffer.raw, None); }
     }
 
-    fn destroy_buffer_view(&self, _view: n::BufferView) {
-        unimplemented!()
+    fn destroy_buffer_view(&self, view: n::BufferView) {
+        unsafe { self.raw.0.destroy_buffer_view(view.raw, None); }
     }
 
     fn destroy_image(&self, image: n::Image) {


### PR DESCRIPTION
Fixes `unimplemented!()` entry in VK backend, updates the clear color semantics.
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
