### PR TITLE
Remove unnamed parameters in traits

### DIFF
--- a/src/backend/dx11/src/command.rs
+++ b/src/backend/dx11/src/command.rs
@@ -120,9 +120,9 @@ impl command::CommandBuffer<Backend> for RawCommandBuffer<CommandList> {
 }
 pub trait Parser: Sized + Send {
     fn reset(&mut self);
-    fn parse(&mut self, Command);
-    fn update_buffer(&mut self, Buffer, &[u8], usize);
-    fn update_texture(&mut self, Texture, tex::Kind, Option<tex::CubeFace>, &[u8], tex::RawImageInfo);
+    fn parse(&mut self, cmd: Command);
+    fn update_buffer(&mut self, buf: Buffer, data: &[u8], offset: usize);
+    fn update_texture(&mut self, tex: Texture, kind: tex::Kind, face: Option<tex::CubeFace>, data: &[u8], image: tex::RawImageInfo);
 }
 
 impl<P: Parser> From<P> for RawCommandBuffer<P> {

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -70,10 +70,10 @@ pub trait PhysicalDevice<B: Backend>: Any + Send + Sync {
     /// let gpu = physical_device.open(vec![(&family, vec![1.0; 1])]);
     /// # }
     /// ```
-    fn open(&self, Vec<(&B::QueueFamily, Vec<QueuePriority>)>) -> Result<Gpu<B>, DeviceCreationError>;
+    fn open(&self, families: Vec<(&B::QueueFamily, Vec<QueuePriority>)>) -> Result<Gpu<B>, DeviceCreationError>;
 
     /// Fetch details for a particular image format.
-    fn format_properties(&self, Option<format::Format>) -> format::Properties;
+    fn format_properties(&self, fmt: Option<format::Format>) -> format::Properties;
 
     /// Fetch details for the memory regions provided by the device.
     fn memory_properties(&self) -> MemoryProperties;

--- a/src/hal/src/queue/capability.rs
+++ b/src/hal/src/queue/capability.rs
@@ -19,7 +19,7 @@ pub enum GraphicsOrCompute {}
 pub trait Capability {
     /// Return true if this type level capability is supported by
     /// a run-time queue type.
-    fn supported_by(QueueType) -> bool;
+    fn supported_by(qt: QueueType) -> bool;
 }
 impl Capability for General {
     fn supported_by(qt: QueueType) -> bool {

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -50,7 +50,7 @@ pub trait RawCommandQueue<B: Backend>: Any + Send + Sync {
     /// Unsafe because it's not checked that the queue can process the submitted command buffers.
     /// Trying to submit compute commands to a graphics queue will result in undefined behavior.
     /// Each queue implements safe wrappers according to their supported functionalities!
-    unsafe fn submit_raw<IC>(&mut self, RawSubmission<B, IC>, Option<&B::Fence>)
+    unsafe fn submit_raw<IC>(&mut self, submission: RawSubmission<B, IC>, fence: Option<&B::Fence>)
     where
         Self: Sized,
         IC: IntoIterator,

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -120,7 +120,7 @@ pub trait Surface<B: Backend>: Any + Send + Sync {
     /// ```no_run
     ///
     /// ```
-    fn supports_queue_family(&self, &B::QueueFamily) -> bool;
+    fn supports_queue_family(&self, family: &B::QueueFamily) -> bool;
 
     /// Query surface capabilities and formats for this physical device.
     ///
@@ -129,7 +129,7 @@ pub trait Surface<B: Backend>: Any + Send + Sync {
     /// Returns a tuple of surface capabilities and formats.
     /// If formats is `None` than the surface has no preferred format and the
     /// application may use any desired format.
-    fn capabilities_and_formats(&self, &B::PhysicalDevice) -> (SurfaceCapabilities, Option<Vec<Format>>);
+    fn capabilities_and_formats(&self, physical_device: &B::PhysicalDevice) -> (SurfaceCapabilities, Option<Vec<Format>>);
 }
 
 /// Handle to a backbuffer of the swapchain.


### PR DESCRIPTION
Fixes #1829 

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
