### PR TITLE
metal: Add debug capture scopes

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -13,6 +13,7 @@ workspace = "../../.."
 
 [features]
 default = ["winit"]
+metal_default_capture_scope=[]
 
 [lib]
 name = "gfx_backend_metal"


### PR DESCRIPTION
Because of the way Swapchains are implemented, Xcode's frame capture
gets confused on where the frame starts and ends (which is the default
capture scope).

This commit creates a capture scope that tries to mimic the usual
behaviour. Enabled only when debug_assertations is on.

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:


I was just noodling around and this annoyed me a bit. The commit may not quite be ready for merge, perhaps those classes/methods should be exposed in metal-rs first?


