### PR TITLE
DX12 surface only supports present queue

### DIFF
--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -50,7 +50,13 @@ unsafe impl Send for Surface { }
 unsafe impl Sync for Surface { }
 
 impl hal::Surface<Backend> for Surface {
-    fn supports_queue_family(&self, _queue_family: &QueueFamily) -> bool { true }
+    fn supports_queue_family(&self, queue_family: &QueueFamily) -> bool {
+        match queue_family {
+            &QueueFamily::Present => true,
+            _ => false
+        }
+    }
+
     fn kind(&self) -> i::Kind {
         i::Kind::D2(self.width, self.height, 1, 1)
     }


### PR DESCRIPTION
Fixes #1826 
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends:
  - DX12
