### PR TITLE
Add destroy_swapchain method and update example

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -610,10 +610,11 @@ fn main() {
     for framebuffer in framebuffers {
         device.destroy_framebuffer(framebuffer);
     }
-    for (image, rtv) in frame_images {
+    for (_, rtv) in frame_images {
         device.destroy_image_view(rtv);
-        device.destroy_image(image);
     }
+
+    device.destroy_swapchain(swap_chain);
 }
 
 #[cfg(not(any(feature = "vulkan", feature = "dx12", feature = "metal", feature = "gl")))]

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2618,6 +2618,10 @@ impl d::Device<B> for Device {
         (swapchain, hal::Backbuffer::Images(images))
     }
 
+    fn destroy_swapchain(&self, _swapchain: w::Swapchain) {
+        // automatic
+    }
+
     fn wait_idle(&self) -> Result<(), error::HostExecutionError> {
         for queue in &self.queues {
             queue.wait_idle()?;

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -356,6 +356,10 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
+    fn destroy_swapchain(&self, _: Swapchain) {
+        unimplemented!()
+    }
+
     fn wait_idle(&self) -> Result<(), error::HostExecutionError> {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1088,6 +1088,10 @@ impl d::Device<B> for Device {
         self.create_swapchain_impl(surface, config)
     }
 
+    fn destroy_swapchain(&self, _swapchain: Swapchain) {
+        unimplemented!()
+    }
+
     fn wait_idle(&self) -> Result<(), error::HostExecutionError> {
         unsafe { self.share.context.Finish(); }
         Ok(())

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1461,6 +1461,9 @@ impl hal::Device<Backend> for Device {
         self.build_swapchain(surface, config)
     }
 
+    fn destroy_swapchain(&self, _swapchain: Swapchain) {
+    }
+
     fn wait_idle(&self) -> Result<(), error::HostExecutionError> {
         unimplemented!()
     }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1460,6 +1460,10 @@ impl d::Device<B> for Device {
         (swapchain, Backbuffer::Images(images))
     }
 
+    fn destroy_swapchain(&self, swapchain: w::Swapchain) {
+        unsafe { swapchain.functor.destroy_swapchain_khr(swapchain.raw, None); }
+    }
+
     fn destroy_query_pool(&self, pool: n::QueryPool) {
         unsafe { self.raw.0.destroy_query_pool(pool.0, None); }
     }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -581,6 +581,11 @@ pub trait Device<B: Backend>: Any + Send + Sync {
         config: SwapchainConfig,
     ) -> (B::Swapchain, Backbuffer<B>);
 
+    /// 
+    fn destroy_swapchain(
+        &self,
+        swapchain: B::Swapchain);
+
     /// Wait for all queues associated with this device to idle.
     ///
     /// Host access to all queues needs to be **externally** sycnhronized!


### PR DESCRIPTION
This fixes the Vulkan object tracker error in the _hal/quad_ example:

```
ERROR 2018-04-06T18:20:46Z: gfx_backend_vulkan: [ObjectTracker] OBJ ERROR : For device 0x2a20eda1c50, SwapchainKHR object 0x3 has not been destroyed. The spec valid usage text states 'All child objects created on device must have been destroyed prior to destroying device' (https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#VUID-vkDestroyDevice-device-00378)
```

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends:
  - DX12
  - GL
  - Vulkan
