### PR TITLE
[WIP] Support setting scissors/viewports from starting index

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -551,8 +551,8 @@ fn main() {
         let submit = {
             let mut cmd_buffer = command_pool.acquire_command_buffer(false);
 
-            cmd_buffer.set_viewports(&[viewport.clone()]);
-            cmd_buffer.set_scissors(&[viewport.rect]);
+            cmd_buffer.set_viewports(0, &[viewport.clone()]);
+            cmd_buffer.set_scissors(0, &[viewport.rect]);
             cmd_buffer.bind_graphics_pipeline(&pipeline.as_ref().unwrap());
             cmd_buffer.bind_vertex_buffers(pso::VertexBufferSet(vec![(&vertex_buffer, 0)]));
             cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, Some(&desc_set)); //TODO

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -498,7 +498,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn set_viewports<T>(&mut self, _: T)
+    fn set_viewports<T>(&mut self, _: u32, _: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Viewport>,
@@ -506,7 +506,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn set_scissors<T>(&mut self, _: T)
+    fn set_scissors<T>(&mut self, _: u32, _: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Rect>,

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -387,7 +387,7 @@ impl CommandQueue {
                     gl.DispatchComputeIndirect(offset as _);
                 }
             }
-            com::Command::SetViewports { viewport_ptr, depth_range_ptr } => {
+            com::Command::SetViewports { first_viewport, viewport_ptr, depth_range_ptr } => {
                 let gl = &self.share.context;
                 let viewports = Self::get::<[f32; 4]>(data_buf, viewport_ptr);
                 let depth_ranges = Self::get::<[f64; 2]>(data_buf, depth_range_ptr);
@@ -404,11 +404,11 @@ impl CommandQueue {
                 } else if num_viewports > 1 {
                     // Support for these functions is coupled with the support
                     // of multiple viewports.
-                    unsafe { gl.ViewportArrayv(0, num_viewports as i32, viewports.as_ptr() as *const _) };
-                    unsafe { gl.DepthRangeArrayv(0, num_viewports as i32, depth_ranges.as_ptr() as *const _) };
+                    unsafe { gl.ViewportArrayv(first_viewport, num_viewports as i32, viewports.as_ptr() as *const _) };
+                    unsafe { gl.DepthRangeArrayv(first_viewport, num_viewports as i32, depth_ranges.as_ptr() as *const _) };
                 }
             }
-            com::Command::SetScissors(data_ptr) => {
+            com::Command::SetScissors(first_scissor, data_ptr) => {
                 let gl = &self.share.context;
                 let scissors = Self::get::<[i32; 4]>(data_buf, data_ptr);
                 let num_scissors = scissors.len();
@@ -420,7 +420,7 @@ impl CommandQueue {
                 } else {
                     // Support for this function is coupled with the support
                     // of multiple viewports.
-                    unsafe { gl.ScissorArrayv(0, num_scissors as i32, scissors.as_ptr() as *const _) };
+                    unsafe { gl.ScissorArrayv(first_scissor, num_scissors as i32, scissors.as_ptr() as *const _) };
                 }
             }
             com::Command::SetBlendColor(color) => {

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1075,30 +1075,39 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         inner.sink.pre_render_commands(commands);
     }
 
-    fn set_viewports<T>(&mut self, vps: T)
+    fn set_viewports<T>(&mut self, first_viewport: u32, vps: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Viewport>,
     {
+        // macOS_GPUFamily1_v3 supports >1 viewport, todo
+        if first_viewport != 0 {
+            panic!("First viewport != 0; Metal supports only one viewport");
+        }
         let mut vps = vps.into_iter();
         let vp_borrowable = vps.next().expect("No viewport provided, Metal supports exactly one");
         let vp = vp_borrowable.borrow();
         if vps.next().is_some() {
-            panic!("Metal supports only one viewport");
+            // TODO should we panic here or set buffer in an erronous state?
+            panic!("More than one viewport set; Metal supports only one viewport");
         }
         self.inner().set_viewport(vp);
     }
 
-    fn set_scissors<T>(&mut self, rects: T)
+    fn set_scissors<T>(&mut self, first_scissor: u32, rects: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Rect>,
     {
+        // macOS_GPUFamily1_v3 supports >1 scissor/viewport, todo
+        if first_scissor != 0 {
+            panic!("First scissor != 0; Metal supports only one viewport");
+        }
         let mut rects = rects.into_iter();
         let rect_borrowable = rects.next().expect("No scissor provided, Metal supports exactly one");
         let rect = rect_borrowable.borrow();
         if rects.next().is_some() {
-            panic!("Metal supports only one scissor");
+            panic!("More than one scissor set; Metal supports only one viewport");
         }
         self.inner().set_scissor(rect);
     }

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1"
 log = "0.4"
 lazy_static = "1"
 shared_library = "0.1"
-ash = "0.22.2"
+ash = "0.23.0"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.11", optional = true }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -481,7 +481,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn set_viewports<T>(&mut self, viewports: T)
+    fn set_viewports<T>(&mut self, first_viewport: u32, viewports: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Viewport>,
@@ -494,11 +494,11 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             .collect();
 
         unsafe {
-            self.device.0.cmd_set_viewport(self.raw, 0, &viewports);
+            self.device.0.cmd_set_viewport(self.raw, first_viewport, &viewports);
         }
     }
 
-    fn set_scissors<T>(&mut self, scissors: T)
+    fn set_scissors<T>(&mut self, first_scissor: u32, scissors: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Rect>,
@@ -511,7 +511,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             .collect();
 
         unsafe {
-            self.device.0.cmd_set_scissor(self.raw, &scissors);
+            self.device.0.cmd_set_scissor(self.raw, first_scissor, &scissors);
         }
     }
 

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -208,21 +208,21 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
-    pub fn set_viewports<T>(&mut self, viewports: T)
+    pub fn set_viewports<T>(&mut self, first_viewport: u32, viewports: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Viewport>,
     {
-        self.raw.set_viewports(viewports)
+        self.raw.set_viewports(first_viewport, viewports)
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
-    pub fn set_scissors<T>(&mut self, scissors: T)
+    pub fn set_scissors<T>(&mut self, first_scissor: u32, scissors: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Rect>,
     {
-        self.raw.set_scissors(scissors)
+        self.raw.set_scissors(first_scissor, scissors)
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -219,45 +219,45 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     fn bind_vertex_buffers(&mut self, pso::VertexBufferSet<B>);
 
     /// Set the viewport parameters for the rasterizer.
-    ///
-    /// Every other viewport, which is not specified in this call,
-    /// will be disabled.
-    ///
-    /// Ensure that the number of set viewports at draw time is equal
-    /// (or higher) to the number specified in the bound pipeline.
+    /// 
+    /// Each viewport passed corrosponds to the viewport with the same index,
+    /// starting from an offset index `first_viewport`.
     ///
     /// # Errors
     ///
     /// This function does not return an error. Invalid usage of this function
-    /// will result in an error on `finish`.
+    /// will result in undefined behavior.
     ///
     /// - Command buffer must be in recording state.
-    /// - Number of viewports must be between 1 and `max_viewports`.
+    /// - Number of viewports must be between 1 and `max_viewports - first_viewport`.
+    /// - The first viewport must be less than `max_viewports`.
     /// - Only queues with graphics capability support this function.
-    fn set_viewports<T>(&mut self, viewports: T)
+    /// - The bound pipeline must not have baked viewport state.
+    /// - All viewports used by the pipeline must be specified before the first
+    ///   draw call.
+    fn set_viewports<T>(&mut self, first_viewport: u32, viewports: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Viewport>;
 
     /// Set the scissor rectangles for the rasterizer.
     ///
-    /// Every other scissor, which is not specified in this call,
-    /// will be disabled.
-    ///
-    /// Each scissor corresponds to the viewport with the same index.
-    ///
-    /// Ensure that the number of set scissors at draw time is equal (or higher)
-    /// to the number of viewports specified in the bound pipeline.
+    /// Each scissor corresponds to the viewport with the same index, starting
+    /// from an offset index `first_scissor`.
     ///
     /// # Errors
     ///
     /// This function does not return an error. Invalid usage of this function
-    /// will result in an error on `finish`.
+    /// will result in undefined behavior.
     ///
     /// - Command buffer must be in recording state.
-    /// - Number of scissors must be between 1 and `max_viewports`.
+    /// - Number of scissors must be between 1 and `max_viewports - first_scissor`.
+    /// - The first scissor must be less than `max_viewports`.
     /// - Only queues with graphics capability support this function.
-    fn set_scissors<T>(&mut self, rects: T)
+    /// - The bound pipeline must not have baked scissor state.
+    /// - All scissors used by the pipeline must be specified before the first draw
+    ///   call.
+    fn set_scissors<T>(&mut self, first_scissor: u32, rects: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Rect>;

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -87,21 +87,21 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
     }
 
     ///
-    pub fn set_viewports<T>(&mut self, viewports: T)
+    pub fn set_viewports<T>(&mut self, first_viewport: u32, viewports: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Viewport>,
     {
-        self.0.set_viewports(viewports)
+        self.0.set_viewports(first_viewport, viewports)
     }
 
     ///
-    pub fn set_scissors<T>(&mut self, scissors: T)
+    pub fn set_scissors<T>(&mut self, first_scissor: u32, scissors: T)
     where
         T: IntoIterator,
         T::Item: Borrow<pso::Rect>,
     {
-        self.0.set_scissors(scissors)
+        self.0.set_scissors(first_scissor, scissors)
     }
 
     ///

--- a/src/render/src/macros/pipeline.rs
+++ b/src/render/src/macros/pipeline.rs
@@ -127,8 +127,8 @@ macro_rules! gfx_graphics_pipeline {
                     );
 
                     let cmd_buffer = encoder.mut_buffer();
-                    cmd_buffer.set_viewports(self.viewports);
-                    cmd_buffer.set_scissors(self.scissors);
+                    cmd_buffer.set_viewports(0, self.viewports);
+                    cmd_buffer.set_scissors(0, self.scissors);
                     cmd_buffer.bind_graphics_pipeline(meta.pipeline.resource());
                     let mut vbs = Vec::new();
                     $(

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -732,8 +732,8 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                         h: extent.height as _,
                     };
                     let mut encoder = command_buf.begin_render_pass_inline(&rp.handle, fb, rect, clear_values);
-                    encoder.set_scissors(Some(rect));
-                    encoder.set_viewports(Some(pso::Viewport {
+                    encoder.set_scissors(0, Some(rect));
+                    encoder.set_viewports(0, Some(pso::Viewport {
                         rect,
                         depth: 0.0 .. 1.0,
                     }));
@@ -796,10 +796,10 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                                     encoder.draw_indexed(indices.clone(), base_vertex, instances.clone());
                                 }
                                 Dc::SetViewports(ref viewports) => {
-                                    encoder.set_viewports(viewports);
+                                    encoder.set_viewports(0, viewports);
                                 }
                                 Dc::SetScissors(ref scissors) => {
-                                    encoder.set_scissors(scissors);
+                                    encoder.set_scissors(0, scissors);
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes #1824
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan, dx12, gl, metal

The state cache impl for dx12 inside the command buffer is not the cleanest, and we don't have the most recent Metal interfaces for multiple viewports, so metal support remains as-is.

Todo: ~~warden support~~, ~~waiting on upstream ash support for cmd_set_scissors~~.