### PR TITLE
[pre-ll] Update glutin and winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ name = "gfx_app"
 [dependencies]
 log = "0.4"
 env_logger = "0.5"
-glutin = "0.13"
-winit = "0.11"
+glutin = "0.14"
+winit = "0.12"
 gfx_core = { path = "src/core", version = "0.8" }
 gfx = { path = "src/render", version = "0.17" }
 gfx_macros = { path = "src/macros", version = "0.2" }

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -29,6 +29,6 @@ name = "gfx_window_dxgi"
 [dependencies]
 log = "0.4"
 winapi = { version = "0.3" , features = ["d3d11", "dxgi"] }
-winit = "0.11"
+winit = "0.12"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.7" }

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -28,7 +28,7 @@ documentation = "https://docs.rs/gfx_window_glutin"
 name = "gfx_window_glutin"
 
 [dependencies]
-glutin = "0.13"
+glutin = "0.14"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.16" }
 

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -111,8 +111,7 @@ fn get_window_dimensions(window: &glutin::GlWindow) -> texture::Dimensions {
     #[cfg(not(target_os = "emscripten"))]
     let (width, height) = {
         let (w, h) = window.get_inner_size().unwrap();
-        let factor = window.hidpi_factor();
-        ((w as f32 * factor) as _, (h as f32 * factor) as _)
+        (w as _, h as _)
     };
     let aa = window
         .get_pixel_format().multisampling

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -30,7 +30,7 @@ name = "gfx_window_metal"
 log = "0.4"
 cocoa = "0.9"
 objc = "0.2"
-winit = "0.11"
+winit = "0.12"
 metal-rs = "0.4"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.3" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/gfx_window_vulkan"
 name = "gfx_window_vulkan"
 
 [dependencies]
-winit = "0.11"
+winit = "0.12"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.2" }


### PR DESCRIPTION
Fixes [multiple issues with X11 and macOS](https://github.com/tomaka/winit/blob/master/CHANGELOG.md#version-0120-2018-04-06). Most importantly for me is the HiDPI fix for macOS, which affects dependents such as: https://github.com/Gekkio/imgui-rs/issues/98

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: OpenGL

`make` is N/A because this is for `pre-ll`