### PR TITLE
[vk] disable dual-source blending on Intel/Windows

### DIFF
--- a/src/backend/vulkan/src/info.rs
+++ b/src/backend/vulkan/src/info.rs
@@ -1,0 +1,4 @@
+pub mod intel {
+    pub const VENDOR: u32 = 0x8086;
+    pub const DEVICE_KABY_LAKE_MASK: u32 = 0x5900;
+}


### PR DESCRIPTION
Fixes #1930
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
