### PR TITLE
Add inheritance info to begin command buffer

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -799,8 +799,8 @@ impl CommandBuffer {
 }
 
 impl com::RawCommandBuffer<Backend> for CommandBuffer {
-    fn begin(&mut self, _flags: com::CommandBufferFlags) {
-        // TODO: Implement flags somehow.
+    fn begin(&mut self, _flags: com::CommandBufferFlags, _info: com::CommandBufferInheritanceInfo<Backend>) {
+        // TODO: Implement flags and secondary command buffers (bundles).
         self.reset();
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -399,7 +399,7 @@ impl pool::RawCommandPool<Backend> for RawCommandPool {
 #[derive(Clone)]
 pub struct RawCommandBuffer;
 impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
-    fn begin(&mut self, _: command::CommandBufferFlags) {
+    fn begin(&mut self, _: command::CommandBufferFlags, _: command::CommandBufferInheritanceInfo<Backend>) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -472,7 +472,11 @@ impl RawCommandBuffer {
 }
 
 impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
-    fn begin(&mut self, _flags: hal::command::CommandBufferFlags) { // TODO: Implement flags!
+    fn begin(
+        &mut self,
+        _flags: hal::command::CommandBufferFlags,
+        _inheritance_info: hal::command::CommandBufferInheritanceInfo<Backend>
+    ) { // TODO: Implement flags!
         if self.individual_reset {
             // Implicit buffer reset when individual reset is set.
             self.reset(false);

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -894,7 +894,8 @@ impl CommandBuffer {
 }
 
 impl com::RawCommandBuffer<Backend> for CommandBuffer {
-    fn begin(&mut self, flags: com::CommandBufferFlags) {
+    fn begin(&mut self, flags: com::CommandBufferFlags, _info: com::CommandBufferInheritanceInfo<Backend>) {
+        //TODO: Implement secondary command buffers
         let inner = unsafe { &mut *self.inner.get() };
         inner.reset_resources();
 

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -393,6 +393,11 @@ pub fn map_pipeline_statistics(
     unsafe { mem::transmute(statistics) }
 }
 
+pub fn map_query_control_flags(flags: query::QueryControl) -> vk::QueryControlFlags {
+    // Safe due to equivalence of HAL values and Vulkan values
+    unsafe { mem::transmute(flags) }
+}
+
 pub fn map_image_features(features: vk::FormatFeatureFlags) -> format::ImageFeature {
     // Safe due to equivalence of HAL values and Vulkan values
     unsafe { mem::transmute(features) }

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -24,7 +24,7 @@ mod render_pass;
 mod transfer;
 
 pub use self::graphics::*;
-pub use self::raw::{ClearValueRaw, ClearColorRaw, ClearDepthStencilRaw, RawCommandBuffer, CommandBufferFlags, Level as RawLevel};
+pub use self::raw::{ClearValueRaw, ClearColorRaw, ClearDepthStencilRaw, RawCommandBuffer, CommandBufferFlags, Level as RawLevel, CommandBufferInheritanceInfo};
 pub use self::render_pass::*;
 pub use self::transfer::*;
 

--- a/src/hal/src/query.rs
+++ b/src/hal/src/query.rs
@@ -22,7 +22,7 @@ pub struct Query<'a, B: Backend> {
 bitflags!(
     /// Query control flags.
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct QueryControl: u8 {
+    pub struct QueryControl: u32 {
         /// Occlusion queries **must** return the exact sampler number.
         ///
         /// Requires `precise_occlusion_query` device feature.


### PR DESCRIPTION
Add `CommandBufferInheritanceInfo` which is nonnull for secondary command buffers. It is necessary for portability to continue the CTS.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan, OpenGL
