### PR TITLE
Remove directory structure explanation

### DIFF
--- a/info/contrib.md
+++ b/info/contrib.md
@@ -10,19 +10,6 @@ There is also a [Waffle board](https://waffle.io/gfx-rs/gfx-rs), which you can u
 
 Finally, feel free to hop on [#rust-gamedev](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev).
 
-### Directory Structure 
-
-* _src/backend_ : The different backends GFX supports.
-* _src/core_ : core structures and the interface that backends must provide
-* _src/corell_ : contains low-level graphics implementation (no resource management overhead).
-* _src/macros_ : Macros used internally by GFX.
-* _src/support_ : Support code that is used by GFX examples. This package contains all of the
-  non-essential functionality for running the GFX examples. Feel free to use this code in your own
-  project.
-* _info_ : Information and documentation.
-* _src/render_ : The main gfx package. This is where all user code that uses gfx::* lives.
-* _src/window_ : Different backends to create windows and initialize their graphics
-
 ### Code
 
 gfx-rs adheres to [Rust Coding Guidelines](http://aturon.github.io/).


### PR DESCRIPTION
This should be all that is necessary to finally update the license, this explanation is also not very useful as it is outdated and most of those directories have READMEs anyway.