### PR TITLE
[mtl] dependencies, dpi, more formats

### DIFF
--- a/examples/hal/Cargo.toml
+++ b/examples/hal/Cargo.toml
@@ -24,7 +24,7 @@ path = "compute/main.rs"
 env_logger = "0.5"
 image = "0.18"
 log = "0.4"
-winit = "0.11"
+winit = "0.12"
 gfx-hal = { path = "../../src/hal", version = "0.1" }
 
 [dependencies.gfx-backend-gl]

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -305,7 +305,7 @@ fn main() {
         pipeline
     };
 
-    println!("Pipeline: {:?}", pipeline);
+    //println!("Pipeline: {:?}", pipeline);
 
     // Descriptors
     let mut desc_pool = device.create_descriptor_pool(

--- a/examples/render/quad_render/Cargo.toml
+++ b/examples/render/quad_render/Cargo.toml
@@ -15,10 +15,10 @@ metal = ["gfx-backend-metal"]
 
 [dependencies]
 env_logger = "0.5"
-glutin = { version = "0.13", optional = true }
+glutin = { version = "0.14", optional = true }
 image = "0.18"
 log = "0.4"
-winit = "0.11"
+winit = "0.12"
 gfx-hal = { path = "../../../src/hal", version = "0.1" }
 gfx-render = { path = "../../../src/render", version = "0.1" }
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -25,5 +25,5 @@ log = "0.4"
 smallvec = "0.6"
 spirv_cross = "0.7.3"
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
-winit = { version = "0.11", optional = true }
+winit = { version = "0.12", optional = true }
 wio = "0.2"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -23,5 +23,5 @@ log = "0.4"
 gfx_gl = "0.5"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
-glutin = { version = "0.13", optional = true }
+glutin = { version = "0.14", optional = true }
 spirv_cross = "0.7"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -21,13 +21,13 @@ name = "gfx_backend_metal"
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.1" }
 log = "0.4"
-winit = { version = "0.11", optional = true }
-metal-rs = "0.6.5"
+winit = { version = "0.12", optional = true }
+metal-rs = "0.8"
 foreign-types = "0.3"
 objc = "0.2"
 block = "0.1"
-cocoa = "0.13"
-core-foundation = "0.4.6"
-core-graphics = "0.12"
-io-surface = "0.8"
+cocoa = "0.14"
+core-foundation = "0.5"
+core-graphics = "0.13"
+io-surface = "0.9"
 spirv_cross = "0.7"

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -3,29 +3,34 @@ use hal::format::Format;
 use hal::pso::Comparison;
 use metal::*;
 
-// The boolean indicates whether this is a depth format
-pub fn map_format(format: Format) -> Option<(MTLPixelFormat, bool)> {
+pub fn map_format(format: Format) -> Option<MTLPixelFormat> {
     Some(match format {
-        Format::Rgba8Unorm => (MTLPixelFormat::RGBA8Unorm, false),
-        Format::Rgba8Srgb => (MTLPixelFormat::RGBA8Unorm_sRGB, false),
-        Format::Bgra8Unorm => (MTLPixelFormat::BGRA8Unorm, false),
-        Format::Bgra8Srgb => (MTLPixelFormat::BGRA8Unorm_sRGB, false),
-        Format::Rgba32Float => (MTLPixelFormat::RGBA32Float, false),
-        Format::D32Float => (MTLPixelFormat::Depth32Float, true),
-        Format::D24UnormS8Uint => (MTLPixelFormat::Depth24Unorm_Stencil8, true),
-        Format::D32FloatS8Uint => (MTLPixelFormat::Depth32Float_Stencil8, true),
+        Format::R8Unorm        => MTLPixelFormat::R8Unorm,
+        Format::R8Inorm        => MTLPixelFormat::R8Snorm,
+        Format::R8Srgb         => MTLPixelFormat::R8Unorm_sRGB,
+        Format::R8Uint         => MTLPixelFormat::R8Uint,
+        Format::R8Int          => MTLPixelFormat::R8Sint,
+        Format::Rg8Unorm       => MTLPixelFormat::RG8Unorm,
+        Format::Rg8Inorm       => MTLPixelFormat::RG8Snorm,
+        Format::Rg8Srgb        => MTLPixelFormat::RG8Unorm_sRGB,
+        Format::Rg8Uint        => MTLPixelFormat::RG8Uint,
+        Format::Rg8Int         => MTLPixelFormat::RG8Sint,
+        Format::Rgba8Unorm     => MTLPixelFormat::RGBA8Unorm,
+        Format::Rgba8Inorm     => MTLPixelFormat::RGBA8Snorm,
+        Format::Rgba8Srgb      => MTLPixelFormat::RGBA8Unorm_sRGB,
+        Format::Rgba8Uint      => MTLPixelFormat::RGBA8Uint,
+        Format::Rgba8Int       => MTLPixelFormat::RGBA8Sint,
+        Format::Bgra8Unorm     => MTLPixelFormat::BGRA8Unorm,
+        Format::Bgra8Srgb      => MTLPixelFormat::BGRA8Unorm_sRGB,
+        Format::Rgba32Float    => MTLPixelFormat::RGBA32Float,
+        Format::D32Float       => MTLPixelFormat::Depth32Float,
+        Format::D24UnormS8Uint => MTLPixelFormat::Depth24Unorm_Stencil8,
+        Format::D32FloatS8Uint => MTLPixelFormat::Depth32Float_Stencil8,
+        //Format::Bgra4Unorm =>
+        //Format::R5g6b5Unorm =>
+        //Format::A1r5g5b5Unorm =>
         _ => return None,
     })
-}
-
-pub fn get_format_bytes_per_pixel(format: MTLPixelFormat) -> usize {
-    // TODO: more formats
-    match format {
-        MTLPixelFormat::RGBA8Unorm => 4,
-        MTLPixelFormat::RGBA8Unorm_sRGB => 4,
-        MTLPixelFormat::BGRA8Unorm => 4,
-        _ => unimplemented!(),
-    }
 }
 
 pub fn map_load_operation(operation: pass::AttachmentLoadOp) -> MTLLoadAction {

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -1,5 +1,5 @@
 use {Backend, QueueFamily};
-use {native, conversions};
+use native;
 use device::{Device, PhysicalDevice};
 
 use std::sync::{Arc, Mutex};
@@ -108,6 +108,7 @@ impl Device {
         let render_layer_borrow = surface.0.render_layer.lock().unwrap();
         let render_layer = *render_layer_borrow;
         let nsview = surface.0.nsview;
+        let pixel_size = config.color_format.base_format().0.desc().bits as i32 / 8;
 
         unsafe {
             // Update render layer size
@@ -123,7 +124,6 @@ impl Device {
             info!("view points size {:?} scale factor {:?}", view_points_size, scale_factor);
             let pixel_width = (view_points_size.size.width * scale_factor) as u64;
             let pixel_height = (view_points_size.size.height * scale_factor) as u64;
-            let pixel_size = conversions::get_format_bytes_per_pixel(mtl_format) as i32;
 
             info!("allocating {} IOSurface backbuffers of size {}x{} with pixel format 0x{:x}", config.image_count, pixel_width, pixel_height, cv_format);
             // Create swap chain surfaces

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -11,9 +11,9 @@ use hal::window::Extent2D;
 use metal::{self, MTLPixelFormat, MTLTextureUsage};
 use objc::runtime::{Object};
 use core_foundation::base::TCFType;
-use core_foundation::string::{CFString, CFStringRef};
+use core_foundation::string::CFString;
 use core_foundation::dictionary::CFDictionary;
-use core_foundation::number::{CFNumber, CFNumberRef};
+use core_foundation::number::CFNumber;
 use core_graphics::base::CGFloat;
 use core_graphics::geometry::CGRect;
 use cocoa::foundation::{NSRect};
@@ -119,14 +119,16 @@ impl Device {
             }
             let scale_factor: CGFloat = msg_send![view_window, backingScaleFactor];
             msg_send![render_layer, setContentsScale: scale_factor];
-            let pixel_width = view_points_size.size.width as u64;
-            let pixel_height = view_points_size.size.height as u64;
+
+            info!("view points size {:?} scale factor {:?}", view_points_size, scale_factor);
+            let pixel_width = (view_points_size.size.width * scale_factor) as u64;
+            let pixel_height = (view_points_size.size.height * scale_factor) as u64;
             let pixel_size = conversions::get_format_bytes_per_pixel(mtl_format) as i32;
 
             info!("allocating {} IOSurface backbuffers of size {}x{} with pixel format 0x{:x}", config.image_count, pixel_width, pixel_height, cv_format);
             // Create swap chain surfaces
             let io_surfaces: Vec<_> = (0..config.image_count).map(|_| {
-                io_surface::new(&CFDictionary::from_CFType_pairs::<CFStringRef, CFNumberRef, CFString, CFNumber>(&[
+                io_surface::new(&CFDictionary::from_CFType_pairs::<CFString, CFNumber>(&[
                     (TCFType::wrap_under_get_rule(io_surface::kIOSurfaceWidth), CFNumber::from(pixel_width as i32)),
                     (TCFType::wrap_under_get_rule(io_surface::kIOSurfaceHeight), CFNumber::from(pixel_height as i32)),
                     (TCFType::wrap_under_get_rule(io_surface::kIOSurfaceBytesPerRow), CFNumber::from(pixel_width as i32 * pixel_size)),

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -25,7 +25,7 @@ shared_library = "0.1"
 ash = "0.23.0"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
-winit = { version = "0.11", optional = true }
+winit = { version = "0.12", optional = true }
 glsl-to-spirv = { version = "0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Improves the CTS support.
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Metal

~~A follow-up is planned to use https://github.com/gfx-rs/metal-rs/pull/37 , but it doesn't have to go here.~~