### PR TITLE
[dx12] layer clears

### DIFF
--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -4,7 +4,7 @@
 			kind: D2(1, 1, 1, 1),
 			num_levels: 1,
 			format: Rgba8Unorm,
-			usage: (bits: 0x24), //COLOR_ATTACHMENT | SAMPLED (temporary for GL)
+			usage: (bits: 0x14), //COLOR_ATTACHMENT | SAMPLED (temporary for GL)
 		),
 		"pass": RenderPass(
 			attachments: {

--- a/reftests/scenes/compute.ron
+++ b/reftests/scenes/compute.ron
@@ -2,7 +2,7 @@
 	resources: {
 		"buffer.output": Buffer(
 			size: 4,
-			usage: (bits: 0x8), //STORAGE
+			usage: (bits: 0x20), //STORAGE
 		),
 		"desc-layout": DescriptorSetLayout(
 			bindings: [

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1027,9 +1027,12 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         range: image::SubresourceRange,
         value: com::ClearColorRaw,
     ) {
-        assert_eq!(range, image.to_subresource_range(Aspects::COLOR));
-        let rtv = image.clear_cv.unwrap();
-        self.clear_render_target_view(rtv, value, &[]);
+        assert_eq!(range.aspects, Aspects::COLOR);
+        assert_eq!(range.levels, 0 .. 1); //TODO
+        for layer in range.layers {
+            let rtv = image.clear_cv[layer as usize];
+            self.clear_render_target_view(rtv, value, &[]);
+        }
     }
 
     fn clear_depth_stencil_image_raw(
@@ -1040,14 +1043,16 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         value: com::ClearDepthStencilRaw,
     ) {
         assert!((Aspects::DEPTH | Aspects::STENCIL).contains(range.aspects));
-        assert_eq!(range, image.to_subresource_range(range.aspects));
-        if range.aspects.contains(Aspects::DEPTH) {
-            let dsv = image.clear_dv.unwrap();
-            self.clear_depth_stencil_view(dsv, Some(value.depth), None, &[]);
-        }
-        if range.aspects.contains(Aspects::STENCIL) {
-            let dsv = image.clear_sv.unwrap();
-            self.clear_depth_stencil_view(dsv, None, Some(value.stencil as _), &[]);
+        assert_eq!(range.levels, 0 .. 1); //TODO
+        for layer in range.layers {
+            if range.aspects.contains(Aspects::DEPTH) {
+                let dsv = image.clear_dv[layer as usize];
+                self.clear_depth_stencil_view(dsv, Some(value.depth), None, &[]);
+            }
+            if range.aspects.contains(Aspects::STENCIL) {
+                let dsv = image.clear_sv[layer as usize];
+                self.clear_depth_stencil_view(dsv, None, Some(value.stencil as _), &[]);
+            }
         }
     }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -494,7 +494,7 @@ impl Device {
         present_queue: ComPtr<d3d12::ID3D12CommandQueue>,
     ) -> Self {
         // Allocate descriptor heaps
-        let max_rtvs = 256; // TODO
+        let max_rtvs = 512; // TODO
         let rtv_pool = native::DescriptorCpuPool {
             heap: Self::create_descriptor_heap_impl(
                 &mut device,

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -159,11 +159,11 @@ pub struct Image {
     pub(crate) block_dim: (u8, u8),
     pub(crate) num_levels: image::Level,
     #[derivative(Debug="ignore")]
-    pub(crate) clear_cv: Option<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>,
+    pub(crate) clear_cv: Vec<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>,
     #[derivative(Debug="ignore")]
-    pub(crate) clear_dv: Option<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>,
+    pub(crate) clear_dv: Vec<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>,
     #[derivative(Debug="ignore")]
-    pub(crate) clear_sv: Option<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>,
+    pub(crate) clear_sv: Vec<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>,
 }
 unsafe impl Send for Image { }
 unsafe impl Sync for Image { }


### PR DESCRIPTION
Fixes #1943, works around #1945
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: dx12

I found out that we didn't update the raw bit flag values in reftests after one of the recent changes... Unfortunate, but this is more of a bitflags issue than ours, and I'm pushing upstream to resolve this in https://github.com/rust-lang-nursery/bitflags/issues/147
