### PR TITLE
Set anisotropic filter when defined

### DIFF
--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -323,11 +323,19 @@ fn map_filter_type(filter: image::Filter) -> D3D12_FILTER_TYPE {
     }
 }
 
+fn map_anisotropic(anisotropic: image::Anisotropic) -> D3D12_FILTER {
+    match anisotropic {
+        image::Anisotropic::On(_) => D3D12_FILTER_ANISOTROPIC,
+        image::Anisotropic::Off => 0,
+    }
+}
+
 pub fn map_filter(
     mag_filter: image::Filter,
     min_filter: image::Filter,
     mip_filter: image::Filter,
     reduction: D3D12_FILTER_REDUCTION_TYPE,
+    anisotropic: image::Anisotropic,
 ) -> D3D12_FILTER {
     let mag = map_filter_type(mag_filter);
     let min = map_filter_type(min_filter);
@@ -336,7 +344,8 @@ pub fn map_filter(
     (min & D3D12_FILTER_TYPE_MASK) << D3D12_MIN_FILTER_SHIFT |
     (mag & D3D12_FILTER_TYPE_MASK) << D3D12_MAG_FILTER_SHIFT |
     (mip & D3D12_FILTER_TYPE_MASK) << D3D12_MIP_FILTER_SHIFT |
-    (reduction & D3D12_FILTER_REDUCTION_TYPE_MASK) << D3D12_FILTER_REDUCTION_TYPE_SHIFT
+    (reduction & D3D12_FILTER_REDUCTION_TYPE_MASK) << D3D12_FILTER_REDUCTION_TYPE_SHIFT |
+    map_anisotropic(anisotropic)
 }
 
 pub fn map_buffer_resource_state(access: buffer::Access) -> D3D12_RESOURCE_STATES {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1908,7 +1908,7 @@ impl d::Device<B> for Device {
             None => d3d12::D3D12_FILTER_REDUCTION_TYPE_STANDARD,
         };
         let desc = d3d12::D3D12_SAMPLER_DESC {
-            Filter: conv::map_filter(info.mag_filter, info.min_filter, info.mip_filter, op),
+            Filter: conv::map_filter(info.mag_filter, info.min_filter, info.mip_filter, op, info.anisotropic),
             AddressU: conv::map_wrap(info.wrap_mode.0),
             AddressV: conv::map_wrap(info.wrap_mode.1),
             AddressW: conv::map_wrap(info.wrap_mode.2),


### PR DESCRIPTION
Fixes #1947
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: DX12