### PR TITLE
Smaller dx12 bug fixes

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -664,7 +664,7 @@ impl CommandBuffer {
                 let row_pitch_texels = row_pitch / image.bytes_per_block as u32;
                 let gap = (layer_offset - aligned_offset) as i32;
                 let buf_offset = image::Offset {
-                    x: gap % row_pitch as i32,
+                    x: (gap % row_pitch as i32) / image.bytes_per_block as i32,
                     y: (gap % slice_pitch as i32) / row_pitch as i32,
                     z: gap / slice_pitch as i32,
                 };

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -623,7 +623,7 @@ impl Device {
         // Depth-stencil formats can't be used for SRVs.
         let format = match info.format {
             dxgiformat::DXGI_FORMAT_D16_UNORM => dxgiformat::DXGI_FORMAT_R16_UNORM,
-			dxgiformat::DXGI_FORMAT_D32_FLOAT => dxgiformat::DXGI_FORMAT_R32_FLOAT,
+            dxgiformat::DXGI_FORMAT_D32_FLOAT => dxgiformat::DXGI_FORMAT_R32_FLOAT,
             format => format,
         };
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -620,8 +620,15 @@ impl Device {
     ) -> Result<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE, image::ViewError> {
         #![allow(non_snake_case)]
 
+        // Depth-stencil formats can't be used for SRVs.
+        let format = match info.format {
+            dxgiformat::DXGI_FORMAT_D16_UNORM => dxgiformat::DXGI_FORMAT_R16_UNORM,
+			dxgiformat::DXGI_FORMAT_D32_FLOAT => dxgiformat::DXGI_FORMAT_R32_FLOAT,
+            format => format,
+        };
+
         let mut desc = d3d12::D3D12_SHADER_RESOURCE_VIEW_DESC {
-            Format: info.format,
+            Format: format,
             ViewDimension: 0,
             Shader4ComponentMapping: 0x1688, // TODO: map swizzle
             u: unsafe { mem::zeroed() },

--- a/src/backend/dx12/src/format.rs
+++ b/src/backend/dx12/src/format.rs
@@ -28,7 +28,7 @@ pub fn query_properties() -> [Properties; NUM_FORMATS] {
         // TODO: check optional supports
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR ,
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // R5g6b5Unorm
@@ -796,97 +796,97 @@ pub fn query_properties() -> [Properties; NUM_FORMATS] {
         // Bc1RgbUnorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc1RgbSrgb
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc1RgbaUnorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc1RgbaSrgb
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc2Unorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc2Srgb
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc3Unorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc3Srgb
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc4Unorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc4Inorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc5Unorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc5Inorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc6hUfloat
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc6hFloat
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc7Unorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bc7Srgb
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::SAMPLED | ImageFeature::BLIT_SRC | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Etc2R8g8b8Unorm

--- a/src/hal/src/format.rs
+++ b/src/hal/src/format.rs
@@ -5,8 +5,8 @@
 //! please see [the official Vulkan documentation](https://www.khronos.org/registry/vulkan/specs/1.0/man/html/VkFormat.html)
 //!
 //! `gfx-rs` splits a `Format` into two sub-components, a `SurfaceType` and
-//! a `ChannelType`.  The `SurfaceType` specifies how the large the channels are, 
-//! for instance `R32_G32_B32_A32`.  The `ChannelType` specifies how the 
+//! a `ChannelType`.  The `SurfaceType` specifies how the large the channels are,
+//! for instance `R32_G32_B32_A32`.  The `ChannelType` specifies how the
 //! components are interpreted, for instance `Float` or `Int`.
 
 bitflags!(
@@ -258,7 +258,7 @@ surface_types! {
     R16                 {  16, COLOR, (1, 1), color: 16 },
     R16_G16             {  32, COLOR, (1, 1), color: 32 },
     R16_G16_B16         {  48, COLOR, (1, 1), color: 48 },
-    R16_G16_B16_A16     {  48, COLOR, (1, 1), color: 48, alpha: 16 },
+    R16_G16_B16_A16     {  64, COLOR, (1, 1), color: 48, alpha: 16 },
     R32                 {  32, COLOR, (1, 1), color: 32 },
     R32_G32             {  64, COLOR, (1, 1), color: 64 },
     R32_G32_B32         {  96, COLOR, (1, 1), color: 96 },


### PR DESCRIPTION
* fix SRV format for depth stencil view
* expose more format information for BC formats
* fix buffer offset for buffer to image copies (bytes vs texels)
* fix number of bytes for rgba16 formats

Fixes #1957 
