### PR TITLE
Further dx12 fixes

### DIFF
--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -23,7 +23,7 @@ derivative = "1"
 gfx-hal = { path = "../../hal", version = "0.1" }
 log = "0.4"
 smallvec = "0.6"
-spirv_cross = "0.7.3"
+spirv_cross = "0.7.4"
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.12", optional = true }
 wio = "0.2"

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -159,7 +159,7 @@ pub fn map_rasterizer(rasterizer: &pso::Rasterizer) -> D3D12_RASTERIZER_DESC {
         DepthBias: rasterizer.depth_bias.map_or(0, |bias| bias.const_factor as INT),
         DepthBiasClamp: rasterizer.depth_bias.map_or(0.0, |bias| bias.clamp),
         SlopeScaledDepthBias: rasterizer.depth_bias.map_or(0.0, |bias| bias.slope_factor),
-        DepthClipEnable: rasterizer.depth_clamping as _,
+        DepthClipEnable: !rasterizer.depth_clamping as _,
         MultisampleEnable: FALSE, // TODO: currently not supported
         ForcedSampleCount: 0, // TODO: currently not supported
         AntialiasedLineEnable: FALSE, // TODO: currently not supported

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1406,7 +1406,7 @@ impl d::Device<B> for Device {
             RasterizerState: conv::map_rasterizer(&desc.rasterizer),
             DepthStencilState: desc.depth_stencil.as_ref().map_or(unsafe { mem::zeroed() }, conv::map_depth_stencil),
             InputLayout: d3d12::D3D12_INPUT_LAYOUT_DESC {
-                pInputElementDescs: input_element_descs.as_ptr(),
+                pInputElementDescs: if input_element_descs.is_empty() { ptr::null() } else { input_element_descs.as_ptr() },
                 NumElements: input_element_descs.len() as u32,
             },
             IBStripCutValue: d3d12::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_DISABLED, // TODO

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -895,6 +895,7 @@ impl hal::Instance for Instance {
                     Features::IMAGE_CUBE_ARRAY |
                     Features::GEOMETRY_SHADER |
                     Features::TESSELLATION_SHADER |
+                    Features::NON_FILL_POLYGON_MODE |
                     //logic_op: false, // Optional on feature level 11_0
                     Features::MULTI_DRAW_INDIRECT |
                     Features::FORMAT_BC |


### PR DESCRIPTION
* bump spirv_cross for specialization constant fixes (fixes a few Vulkan samples)
* fix depth clipping (inverse of vulkan's depth clamping)
* silence debug layer warning: `pInputElementDesc` might be non-zero for empty vec's triggering a warning
* expose wireframe polygon fill mode (fixes pipeline example)