### PR TITLE
[dx12] Add mapping between depth format and typeless format

### DIFF
--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -99,6 +99,20 @@ pub fn map_format_dsv(surface: SurfaceType) -> Option<DXGI_FORMAT> {
     })
 }
 
+pub fn map_format_typeless(format: Format, usage: image::Usage) -> Option<DXGI_FORMAT> { 
+    use hal::format::Format::*; 
+ 
+    if usage.contains(image::Usage::SAMPLED) && usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT) { 
+        return Some(match format { 
+            D16Unorm => DXGI_FORMAT_R16_TYPELESS,
+            D32Float => DXGI_FORMAT_R32_TYPELESS, 
+            _ => return map_format(format), 
+        }) 
+    } 
+ 
+    map_format(format) 
+} 
+
 pub fn map_topology_type(primitive: Primitive) -> D3D12_PRIMITIVE_TOPOLOGY_TYPE {
     use hal::Primitive::*;
     match primitive {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1692,7 +1692,7 @@ impl d::Device<B> for Device {
                 kind.num_layers() as _
             },
             MipLevels: mip_levels as _,
-            Format: match conv::map_format(format) {
+            Format: match conv::map_format_typeless(format, usage) {
                 Some(format) => format,
                 None => return Err(image::CreationError::Format(format)),
             },


### PR DESCRIPTION
This builds upon #c9b825 which automatically switches between D32-R32 depending on whether you're creating a depth or shader attachment. I'm not sure if this PR is actually needed, but I think the proper thing to do is create the image as `TYPELESS` format, and then the views are responsible for the types, so it just does this conversion in the background if you've asked for a depth format and also said you're going to be sampling from it.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
