### PR TITLE
dx12: Fix buffer offset for copy splitting

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -720,7 +720,8 @@ impl CommandBuffer {
                         },
                         buf_offset: image::Offset {
                             x: 0,
-                            .. buf_offset
+                            y: buf_offset.y + 1,
+                            z: buf_offset.z,
                         },
                         copy_extent: image::Extent {
                             width: r.image_extent.width - half,


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/gfx/issues/1963
Tested the example locally with dx12