### PR TITLE
Fix memory options for upload_buffer method

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -982,7 +982,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         let src = inner.device.new_buffer_with_data(
             data.as_ptr() as _,
             data.len() as _,
-            metal::MTLResourceOptions::StorageModePrivate,
+            metal::MTLResourceOptions::CPUCacheModeWriteCombined,
         );
         inner.retained_buffers.push(src.clone());
 


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
  `metal`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/1967)
<!-- Reviewable:end -->
