### PR TITLE
Provide unsafe methods to convert raw command pool and queue into typed

### DIFF
--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -149,7 +149,7 @@ fn main() {
         device.release_mapping_reader(reader);
     }
 
-    device.destroy_command_pool(command_pool.downgrade());
+    device.destroy_command_pool(command_pool.into_raw());
     device.destroy_descriptor_pool(desc_pool);
     device.destroy_descriptor_set_layout(set_layout);
     device.destroy_shader_module(shader);

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -580,7 +580,7 @@ fn main() {
     }
 
     // cleanup!
-    device.destroy_command_pool(command_pool.downgrade());
+    device.destroy_command_pool(command_pool.into_raw());
     device.destroy_descriptor_pool(desc_pool);
     device.destroy_descriptor_set_layout(set_layout);
 

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -106,6 +106,16 @@ impl<'a, B: Backend, C, S: Shot, L: Level> CommandBuffer<'a, B, C, S, L> {
         }
     }
 
+    /// Get a reference to the raw command buffer
+    pub fn as_raw(&self) -> &B::CommandBuffer {
+        &*self.raw
+    }
+
+    /// Get a mutable reference to the raw command buffer
+    pub fn as_raw_mut(&mut self) -> &mut B::CommandBuffer {
+        self.raw
+    }
+
     /// Finish recording commands to the command buffers.
     ///
     /// The command buffer will be consumed and can't be modified further.

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -155,7 +155,9 @@ pub trait Device<B: Backend>: Any + Send + Sync {
         max_buffers: usize,
     ) -> CommandPool<B, C> {
         let raw = self.create_command_pool(group.family(), flags);
-        CommandPool::new(raw, max_buffers)
+        let mut pool = unsafe { CommandPool::new(raw) };
+        pool.reserve(max_buffers);
+        pool
     }
 
     /// Destroys a command pool.

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -8,7 +8,6 @@ use queue::capability::{Capability, Graphics, Compute};
 use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::marker::PhantomData;
 
 /// General information about a queue family, available upon adapter discovery.
 ///
@@ -60,7 +59,7 @@ impl<B: Backend, C: Capability> QueueGroup<B, C> {
             family: id,
             queues: raw.queues
                 .into_iter()
-                .map(|q| CommandQueue(q, PhantomData))
+                .map(|q| unsafe { CommandQueue::new(q) })
                 .collect(),
         }
     }

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -927,7 +927,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
         self.queue_group.queues[0].submit(submission, Some(&copy_fence));
         self.device.wait_for_fence(&copy_fence, !0);
         self.device.destroy_fence(copy_fence);
-        self.device.destroy_command_pool(command_pool.downgrade());
+        self.device.destroy_command_pool(command_pool.into_raw());
 
         let mapping = self
             .device
@@ -1035,7 +1035,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
         self.queue_group.queues[0].submit(submission, Some(&copy_fence));
         self.device.wait_for_fence(&copy_fence, !0);
         self.device.destroy_fence(copy_fence);
-        self.device.destroy_command_pool(command_pool.downgrade());
+        self.device.destroy_command_pool(command_pool.into_raw());
 
         let mapping = self
             .device
@@ -1061,6 +1061,6 @@ impl<B: hal::Backend, C> Drop for Scene<B, C> {
         }
         //TODO: free those properly
         let _ = &self.queue_group;
-        self.device.destroy_command_pool(self.command_pool.take().unwrap().downgrade());
+        self.device.destroy_command_pool(self.command_pool.take().unwrap().into_raw());
     }
 }


### PR DESCRIPTION
This allows middle-level crates to use raw command pools and queues while providing typed for higher-level code.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/1970)
<!-- Reviewable:end -->
