### PR TITLE
Use autorelease pools internally in Metal backend

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -59,9 +59,6 @@ const COLOR_RANGE: i::SubresourceRange = i::SubresourceRange {
 fn main() {
     env_logger::init();
 
-    #[cfg(feature = "metal")]
-    let mut autorelease_pool = unsafe { back::AutoreleasePool::new() };
-
     let mut events_loop = winit::EventsLoop::new();
 
     let wb = winit::WindowBuilder::new()
@@ -580,11 +577,6 @@ fn main() {
 
         // present frame
         swap_chain.present(&mut queue, &[]);
-
-        #[cfg(feature = "metal")]
-        unsafe {
-            autorelease_pool.reset();
-        }
     }
 
     // cleanup!

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -52,9 +52,6 @@ gfx_graphics_pipeline! {
 fn main() {
     env_logger::init();
 
-    #[cfg(feature = "metal")]
-    let mut autorelease_pool = unsafe { back::AutoreleasePool::new() };
-
     let mut events_loop = winit::EventsLoop::new();
     let window = winit::WindowBuilder::new()
         .with_dimensions(1024, 768)
@@ -273,11 +270,6 @@ fn main() {
 
         submits.push(encoder.finish());
         context.present(submits.drain(..).collect::<Vec<_>>());
-
-        #[cfg(feature = "metal")]
-        unsafe {
-            autorelease_pool.reset();
-        }
     }
 
     println!("cleanup!");

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -404,6 +404,7 @@ impl CommandBufferInner {
 
         match self.sink {
             CommandSink::Immediate { ref cmd_buffer, ref mut encoder_state } => {
+                let _ap = AutoreleasePool::new();
                 let encoder = cmd_buffer.new_render_command_encoder(&descriptor);
                 for command in commands {
                     exec_render(encoder, &command);
@@ -696,6 +697,7 @@ fn exec_compute(encoder: &metal::ComputeCommandEncoderRef, command: &soft::Compu
 }
 
 fn record_commands(command_buf: &metal::CommandBufferRef, passes: &[soft::Pass]) {
+    let _ap = AutoreleasePool::new(); // for encoder creation
     for pass in passes {
         match *pass {
             soft::Pass::Render(ref desc, ref list) => {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -158,9 +158,11 @@ impl Drop for AutoreleasePool {
 }
 
 impl AutoreleasePool {
-    pub unsafe fn new() -> Self {
+    pub fn new() -> Self {
         AutoreleasePool {
-            pool: NSAutoreleasePool::new(cocoa::base::nil),
+            pool: unsafe {
+                NSAutoreleasePool::new(cocoa::base::nil)
+            },
         }
     }
 


### PR DESCRIPTION
Fixes #1941
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
