### PR TITLE
dx12: Increase descriptor heap limits temporarily

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -494,7 +494,7 @@ impl Device {
         present_queue: ComPtr<d3d12::ID3D12CommandQueue>,
     ) -> Self {
         // Allocate descriptor heaps
-        let max_rtvs = 512; // TODO
+        let max_rtvs = 2048; // TODO
         let rtv_pool = native::DescriptorCpuPool {
             heap: Self::create_descriptor_heap_impl(
                 &mut device,
@@ -507,7 +507,7 @@ impl Device {
             max_size: max_rtvs as _,
         };
 
-        let max_dsvs = 64; // TODO
+        let max_dsvs = 128; // TODO
         let dsv_pool = native::DescriptorCpuPool {
             heap: Self::create_descriptor_heap_impl(
                 &mut device,


### PR DESCRIPTION
See https://github.com/gfx-rs/gfx/issues/1945#issuecomment-384558682

PR checklist:
- [X] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: dx12

As a side note I noticed `make reftests` is failing on dx12 for me (on master).