### PR TITLE
mtl: Image format properties

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -237,7 +237,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         map_format(format).map(|_| image::FormatProperties {
             max_extent: image::Extent { width, height, depth },
             max_levels: max_dimension.log2().ceil() as u8 + 1,
-            max_layers: 2048,
+            // 3D images enforce a single layer
+            max_layers: if dimensions == 3 { 1 } else { 2048 },
             sample_count_mask: 0x1,
             //TODO: buffers and textures have separate limits
             // Max buffer size is determined by feature set

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -228,18 +228,21 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         &self, format: format::Format, dimensions: u8, _tiling: image::Tiling,
         _usage: image::Usage, _storage_flags: image::StorageFlags,
     ) -> Option<image::FormatProperties> {
-        let desc = format.surface_desc();
         //TODO: actually query this data
+        let width = 4096;
+        let height = if dimensions >= 2 { 4096 } else { 1 };
+        let depth = if dimensions >= 3 { 4096 } else { 1 };
+        let max_dimension = 4096f32; // Max of {width, height, depth}
+        
         map_format(format).map(|_| image::FormatProperties {
-            max_extent: image::Extent {
-                width: 4096,
-                height: if dimensions >= 2 { 4096 } else { 1 },
-                depth: if dimensions >= 3 { 4096 } else { 1 },
-            },
-            max_levels: if format::Aspects::COLOR.contains(desc.aspects) { 16 } else { 1 },
+            max_extent: image::Extent { width, height, depth },
+            max_levels: max_dimension.log2().ceil() as u8 + 1,
             max_layers: 2048,
             sample_count_mask: 0x1,
-            max_resource_size: 256 << 20,
+            //TODO: buffers and textures have separate limits
+            // Max buffer size is determined by feature set
+            // Max texture size does not appear to be documented publicly
+            max_resource_size: 1 << 31,
         })
     }
 


### PR DESCRIPTION
Fixes #1948 (several CTS errors)

PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends: Metal

Some notes:

- Resource size still labeled as `TODO`: maximum texture size is unknown, so I've increased it for now. I think this is probably okay because it's still possible for image creation to fail (see [the note about this in the Vulkan specification](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageFormatProperties.html)). I've filed a bug report with Apple to ask whether the feature set tables could be expanded to include this information. The only maximum resource size listed at the moment is for buffers, which doesn't apply to textures that aren't backed by a `MTLBuffer`, see for example [this forum post discussing this limit](https://moltengl.com/forums/topic/uploading-large-texture-data/).
- It appears we were using the wrong value for `max_levels` (it's supposed to be max mipmap levels). I don't see a value for this in the feature set table either, so until this can be clarified I simply calculated the number of expected mipmap levels using the formula in the Vulkan specification ([`maxMipLevels must be equal to ⌈log2(max(width, height, depth))⌉ + 1`](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageFormatProperties.html)).
- Vulkan restricts 3D images to only support a single layer (see [valid usage for VkImageCreateInfo - `If imageType is VK_IMAGE_TYPE_3D, arrayLayers must be 1`](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageCreateInfo.html)). I've added the restriction here too, although we could add that in the portability layer instead if it's preferable. I don't know what the semantics are for 3D image layered images in Metal, but it seems we don't have that option in Vulkan for now at least.