### PR TITLE
Initial multisampling support

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -167,6 +167,7 @@ fn main() {
     let render_pass = {
         let attachment = pass::Attachment {
             format: Some(surface_format),
+            samples: 1,
             ops: pass::AttachmentOps::new(pass::AttachmentLoadOp::Clear, pass::AttachmentStoreOp::Store),
             stencil_ops: pass::AttachmentOps::DONT_CARE,
             layouts: i::Layout::Undefined .. i::Layout::Present,
@@ -176,6 +177,7 @@ fn main() {
             colors: &[(0, i::Layout::ColorAttachmentOptimal)],
             depth_stencil: None,
             inputs: &[],
+            resolves: &[],
             preserves: &[],
         };
 

--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -10,6 +10,7 @@
 			attachments: {
 				"c": (
 					format: Some(Rgba8Unorm),
+					samples: 1,
 					ops: (load: Clear, store: Store),
 					layouts: (start: General, end: General),
 				),

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -449,7 +449,7 @@ impl CommandBuffer {
                     (resolve_dst.layers.0 + l) as _,
                 );
 
-                // TODO: take widht and height of render area into account.
+                // TODO: take width and height of render area into account.
                 unsafe {
                     self.raw.ResolveSubresource(
                         resolve_dst.resource,

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1563,7 +1563,7 @@ impl d::Device<B> for Device {
         &self,
         _renderpass: &n::RenderPass,
         attachments: I,
-        _extent: image::Extent,
+        extent: image::Extent,
     ) -> Result<n::Framebuffer, d::FramebufferError>
     where
         I: IntoIterator,
@@ -1571,6 +1571,7 @@ impl d::Device<B> for Device {
     {
         Ok(n::Framebuffer {
             attachments: attachments.into_iter().map(|att| *att.borrow()).collect(),
+            layers: extent.depth as _,
         })
     }
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1006,8 +1006,8 @@ impl d::Device<B> for Device {
             for (i, &(id, _layout)) in sub.colors.iter().enumerate() {
                 let dst_state = att_infos[id].target_state;
                 let state = match sub.resolves.get(i) {
-                    Some(_) => SubState::New(dst_state),
-                    None => SubState::Resolve(dst_state),
+                    Some(_) => SubState::Resolve(dst_state),
+                    None => SubState::New(dst_state),
                 };
                 let old = mem::replace(&mut att_infos[id].sub_states[sid], state);
                 debug_assert_eq!(SubState::Undefined, old);

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1911,6 +1911,10 @@ impl d::Device<B> for Device {
         _swizzle: format::Swizzle,
         range: image::SubresourceRange,
     ) -> Result<n::ImageView, image::ViewError> {
+        let num_levels = image.num_levels;
+        let mip_levels = (range.levels.start, range.levels.end);
+        let layers = (range.layers.start, range.layers.end);
+
         let info = ViewInfo {
             resource: image.resource,
             kind: image.kind,
@@ -1948,6 +1952,9 @@ impl d::Device<B> for Device {
                 None
             },
             dxgi_format: image.dxgi_format,
+            num_levels,
+            mip_levels,
+            layers,
         })
     }
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1421,7 +1421,10 @@ impl d::Device<B> for Device {
         };
 
         let sample_desc = dxgitype::DXGI_SAMPLE_DESC {
-            Count: desc.multisampling.as_ref().map_or(1, |ms| ms.rasterization_samples as _),
+            Count: match desc.multisampling {
+                Some(ref ms) => ms.rasterization_samples as _,
+                None => 1,
+            },
             Quality: 0,
         };
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -852,7 +852,7 @@ impl d::Device<B> for Device {
         let desc = d3d12::D3D12_HEAP_DESC {
             SizeInBytes: size,
             Properties: properties,
-            Alignment: 0, //Warning: has to be 4K for MSAA targets
+            Alignment: d3d12::D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT as _, // TODO: not always..?
             Flags: match mem_group {
                 0 => d3d12::D3D12_HEAP_FLAG_ALLOW_ALL_BUFFERS_AND_TEXTURES,
                 1 => d3d12::D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS,
@@ -969,6 +969,8 @@ impl d::Device<B> for Device {
         #[derive(Copy, Clone, Debug, PartialEq)]
         pub enum SubState {
             New(d3d12::D3D12_RESOURCE_STATES),
+            // Color attachment which will be resolved at the end of the subpass
+            Resolve(d3d12::D3D12_RESOURCE_STATES),
             Preserve,
             Undefined,
         }
@@ -1001,8 +1003,12 @@ impl d::Device<B> for Device {
         // Fill out subpass known layouts
         for (sid, sub) in subpasses.iter().enumerate() {
             let sub = sub.borrow();
-            for &(id, _layout) in sub.colors {
-                let state = SubState::New(att_infos[id].target_state);
+            for (i, &(id, _layout)) in sub.colors.iter().enumerate() {
+                let dst_state = att_infos[id].target_state;
+                let state = match sub.resolves.get(i) {
+                    Some(_) => SubState::New(dst_state),
+                    None => SubState::Resolve(dst_state),
+                };
                 let old = mem::replace(&mut att_infos[id].sub_states[sid], state);
                 debug_assert_eq!(SubState::Undefined, old);
             }
@@ -1013,6 +1019,11 @@ impl d::Device<B> for Device {
             }
             for &(id, _layout) in sub.inputs {
                 let state = SubState::New(d3d12::D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+                let old = mem::replace(&mut att_infos[id].sub_states[sid], state);
+                debug_assert_eq!(SubState::Undefined, old);
+            }
+            for &(id, _layout) in sub.resolves {
+                let state = SubState::New(d3d12::D3D12_RESOURCE_STATE_RESOLVE_DEST);
                 let old = mem::replace(&mut att_infos[id].sub_states[sid], state);
                 debug_assert_eq!(SubState::Undefined, old);
             }
@@ -1050,41 +1061,68 @@ impl d::Device<B> for Device {
                 }
             }
 
+            // Subpass barriers
             let mut pre_barriers = Vec::new();
+            let mut post_barriers = Vec::new();
             for (att_id, ai) in att_infos.iter_mut().enumerate() {
-                let state_dst = match ai.sub_states[sid] {
+                // Barrier from previous subpass to current or following subpasses.
+                match ai.sub_states[sid] {
                     SubState::Preserve => {
                         ai.barrier_start_index = rp.subpasses.len() + 1;
-                        continue;
                     },
-                    SubState::New(state) if state != ai.last_state => state,
-                    _ => continue,
+                    SubState::New(state) if state != ai.last_state => {
+                        let barrier = n::BarrierDesc::new(att_id, ai.last_state .. state);
+                        match rp.subpasses.get_mut(ai.barrier_start_index) {
+                            Some(past_subpass) => {
+                                let split = barrier.split();
+                                past_subpass.pre_barriers.push(split.start);
+                                pre_barriers.push(split.end);
+                            },
+                            None => pre_barriers.push(barrier),
+                        }
+                        ai.last_state = state;
+                        ai.barrier_start_index = rp.subpasses.len() + 1;
+                    },
+                    SubState::Resolve(state) => {
+                        // 1. Standard pre barrier to update state from previous pass into desired substate.
+                        if state != ai.last_state {
+                            let barrier = n::BarrierDesc::new(att_id, ai.last_state .. state);
+                            match rp.subpasses.get_mut(ai.barrier_start_index) {
+                                Some(past_subpass) => {
+                                    let split = barrier.split();
+                                    past_subpass.pre_barriers.push(split.start);
+                                    pre_barriers.push(split.end);
+                                },
+                                None => pre_barriers.push(barrier),
+                            }
+                        }
+
+                        // 2. Post Barrier at the end of the subpass into RESOLVE_SOURCE.
+                        let resolve_state = d3d12::D3D12_RESOURCE_STATE_RESOLVE_SOURCE;
+                        let barrier = n::BarrierDesc::new(att_id, state .. resolve_state);
+                        post_barriers.push(barrier);
+
+                        ai.last_state = resolve_state;
+                        ai.barrier_start_index = rp.subpasses.len() + 1;
+                    },
+                    _ => { }
                 };
-                let barrier = n::BarrierDesc::new(att_id, ai.last_state .. state_dst);
-                match rp.subpasses.get_mut(ai.barrier_start_index) {
-                    Some(past_subpass) => {
-                        let split = barrier.split();
-                        past_subpass.pre_barriers.push(split.start);
-                        pre_barriers.push(split.end);
-                    },
-                    None => pre_barriers.push(barrier),
-                }
-                ai.last_state = state_dst;
-                ai.barrier_start_index = rp.subpasses.len() + 1;
             }
 
             rp.subpasses.push(n::SubpassDesc {
                 color_attachments: subpasses[sid].borrow().colors.iter().cloned().collect(),
                 depth_stencil_attachment: subpasses[sid].borrow().depth_stencil.cloned(),
                 input_attachments: subpasses[sid].borrow().inputs.iter().cloned().collect(),
+                resolve_attachments: subpasses[sid].borrow().resolves.iter().cloned().collect(),
                 pre_barriers,
+                post_barriers,
             });
         }
         // if this fails, our graph has cycles
         assert_eq!(rp.subpasses.len(), subpasses.len());
         assert!(deps_left.into_iter().all(|count| count == !0));
 
-        // take care of the post-pass transitions
+        // take care of the post-pass transitions at the end of the renderpass.
         for (att_id, (ai, att)) in att_infos.iter().zip(attachments.iter()).enumerate() {
             let state_dst = conv::map_image_resource_state(image::Access::empty(), att.layouts.end);
             if state_dst == ai.last_state {
@@ -1382,6 +1420,11 @@ impl d::Device<B> for Device {
             (rtvs, num_rtvs)
         };
 
+        let sample_desc = dxgitype::DXGI_SAMPLE_DESC {
+            Count: desc.multisampling.as_ref().map_or(1, |ms| ms.rasterization_samples as _),
+            Quality: 0,
+        };
+
         // Setup pipeline description
         let pso_desc = d3d12::D3D12_GRAPHICS_PIPELINE_STATE_DESC {
             pRootSignature: desc.layout.raw,
@@ -1398,7 +1441,10 @@ impl d::Device<B> for Device {
                 RasterizedStream: 0,
             },
             BlendState: d3d12::D3D12_BLEND_DESC {
-                AlphaToCoverageEnable: if desc.blender.alpha_coverage { TRUE } else { FALSE },
+                AlphaToCoverageEnable: desc
+                    .multisampling
+                    .as_ref()
+                    .map_or(FALSE, |ms| if ms.alpha_coverage { TRUE } else { FALSE }),
                 IndependentBlendEnable: TRUE,
                 RenderTarget: conv::map_render_targets(&desc.blender.targets),
             },
@@ -1422,10 +1468,7 @@ impl d::Device<B> for Device {
                         .and_then(|f| conv::map_format_dsv(f.base_format().0))
                 )
                 .unwrap_or(dxgiformat::DXGI_FORMAT_UNKNOWN),
-            SampleDesc: dxgitype::DXGI_SAMPLE_DESC {
-                Count: 1, // TODO
-                Quality: 0, // TODO
-            },
+            SampleDesc: sample_desc,
             NodeMask: 0,
             CachedPSO: d3d12::D3D12_CACHED_PIPELINE_STATE {
                 pCachedBlob: ptr::null(),
@@ -1904,6 +1947,7 @@ impl d::Device<B> for Device {
             } else {
                 None
             },
+            dxgi_format: image.dxgi_format,
         })
     }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -919,9 +919,9 @@ impl hal::Instance for Instance {
                     min_texel_buffer_offset_alignment: 1, // TODO
                     min_uniform_buffer_offset_alignment: 256, // Required alignment for CBVs
                     min_storage_buffer_offset_alignment: 1, // TODO
-                    framebuffer_color_samples_count: 0b111,
-                    framebuffer_depth_samples_count: 0b111,
-                    framebuffer_stencil_samples_count: 0b111,
+                    framebuffer_color_samples_count: 0b101,
+                    framebuffer_depth_samples_count: 0b101,
+                    framebuffer_stencil_samples_count: 0b101,
                 },
                 private_caps: Capabilities {
                     heterogeneous_resource_heaps,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -919,6 +919,8 @@ impl hal::Instance for Instance {
                     min_texel_buffer_offset_alignment: 1, // TODO
                     min_uniform_buffer_offset_alignment: 256, // Required alignment for CBVs
                     min_storage_buffer_offset_alignment: 1, // TODO
+                    // TODO: query supported sample count for all framebuffer formats and increase the limit
+                    //       if possible.
                     framebuffer_color_samples_count: 0b101,
                     framebuffer_depth_samples_count: 0b101,
                     framebuffer_stencil_samples_count: 0b101,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -919,6 +919,9 @@ impl hal::Instance for Instance {
                     min_texel_buffer_offset_alignment: 1, // TODO
                     min_uniform_buffer_offset_alignment: 256, // Required alignment for CBVs
                     min_storage_buffer_offset_alignment: 1, // TODO
+                    framebuffer_color_samples_count: 0b111,
+                    framebuffer_depth_samples_count: 0b111,
+                    framebuffer_stencil_samples_count: 0b111,
                 },
                 private_caps: Capabilities {
                     heterogeneous_resource_heaps,

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -134,6 +134,8 @@ unsafe impl Sync for PipelineLayout { }
 #[derive(Debug, Clone)]
 pub struct Framebuffer {
     pub(crate) attachments: Vec<ImageView>,
+    // Number of layers in the render area. Required for subpass resolves.
+    pub(crate) layers: image::Layer,
 }
 
 #[derive(Debug)]
@@ -207,6 +209,12 @@ pub struct ImageView {
 }
 unsafe impl Send for ImageView { }
 unsafe impl Sync for ImageView { }
+
+impl ImageView {
+    pub fn calc_subresource(&self, mip_level: UINT, layer: UINT) -> UINT {
+        mip_level + (layer * self.num_levels as UINT)
+    }
+}
 
 #[derive(Derivative)]
 #[derivative(Debug)]

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -201,6 +201,9 @@ pub struct ImageView {
     pub(crate) handle_uav: Option<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>,
     // Required for attachment resolves.
     pub(crate) dxgi_format: DXGI_FORMAT,
+    pub(crate) num_levels: image::Level,
+    pub(crate) mip_levels: (image::Level, image::Level),
+    pub(crate) layers: (image::Layer, image::Layer),
 }
 unsafe impl Send for ImageView { }
 unsafe impl Sync for ImageView { }

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -58,7 +58,9 @@ pub struct SubpassDesc {
     pub(crate) color_attachments: Vec<pass::AttachmentRef>,
     pub(crate) depth_stencil_attachment: Option<pass::AttachmentRef>,
     pub(crate) input_attachments: Vec<pass::AttachmentRef>,
+    pub(crate) resolve_attachments: Vec<pass::AttachmentRef>,
     pub(crate) pre_barriers: Vec<BarrierDesc>,
+    pub(crate) post_barriers: Vec<BarrierDesc>,
 }
 
 impl SubpassDesc {
@@ -68,6 +70,7 @@ impl SubpassDesc {
         self.color_attachments.iter()
             .chain(self.depth_stencil_attachment.iter())
             .chain(self.input_attachments.iter())
+            .chain(self.resolve_attachments.iter())
             .any(|&(id, _)| id == at_id)
     }
 }
@@ -196,6 +199,8 @@ pub struct ImageView {
     pub(crate) handle_dsv: Option<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>,
     #[derivative(Debug="ignore")]
     pub(crate) handle_uav: Option<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>,
+    // Required for attachment resolves.
+    pub(crate) dxgi_format: DXGI_FORMAT,
 }
 unsafe impl Send for ImageView { }
 unsafe impl Sync for ImageView { }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -227,7 +227,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         let height = if dimensions >= 2 { 4096 } else { 1 };
         let depth = if dimensions >= 3 { 4096 } else { 1 };
         let max_dimension = 4096f32; // Max of {width, height, depth}
-        
+
         map_format(format).map(|_| image::FormatProperties {
             max_extent: image::Extent { width, height, depth },
             max_levels: max_dimension.log2().ceil() as u8 + 1,
@@ -266,6 +266,10 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
             max_compute_group_count: [16; 3], // TODO
             max_compute_group_size: [64; 3], // TODO
+
+            framebuffer_color_samples_count: 0b101, // TODO
+            framebuffer_depth_samples_count: 0b101, // TODO
+            framebuffer_stencil_samples_count: 0b101, // TODO
         }
     }
 }
@@ -514,7 +518,7 @@ impl hal::Device<Backend> for Device {
                 Some(f) => f.is_depth(),
                 None => continue,
             };
-            
+
             let mtl_attachment: &metal::RenderPassAttachmentDescriptorRef = if is_depth {
                 pass
                     .depth_attachment()

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -472,37 +472,38 @@ impl d::Device<B> for Device {
                 },
             });
 
-            // Multisampling
-            //
-            // Default multi sampling state, required even if we only have a single sample attachment.
-            let mut multisampling_state = vk::PipelineMultisampleStateCreateInfo {
-                s_type: vk::StructureType::PipelineMultisampleStateCreateInfo,
-                p_next: ptr::null(),
-                flags: vk::PipelineMultisampleStateCreateFlags::empty(),
-                rasterization_samples: vk::SAMPLE_COUNT_1_BIT,
-                sample_shading_enable: vk::VK_FALSE,
-                min_sample_shading: 0.0,
-                p_sample_mask: ptr::null(),
-                alpha_to_coverage_enable: vk::VK_FALSE,
-                alpha_to_one_enable: vk::VK_FALSE,
+            let multisampling_state = match desc.multisampling {
+                Some(ref ms) => {
+                    let sample_mask = [
+                        (ms.sample_mask & 0xFFFFFFFF) as u32,
+                        ((ms.sample_mask >> 32) & 0xFFFFFFFF) as u32,
+                    ];
+                    sample_masks.push(sample_mask);
+
+                    vk::PipelineMultisampleStateCreateInfo {
+                        s_type: vk::StructureType::PipelineMultisampleStateCreateInfo,
+                        p_next: ptr::null(),
+                        flags: vk::PipelineMultisampleStateCreateFlags::empty(),
+                        rasterization_samples: vk::SampleCountFlags::from_flags_truncate(ms.rasterization_samples as _),
+                        sample_shading_enable: ms.sample_shading.is_some() as _,
+                        min_sample_shading: ms.sample_shading.unwrap_or(0.0),
+                        p_sample_mask: sample_masks.last().unwrap().as_ptr(),
+                        alpha_to_coverage_enable: ms.alpha_coverage as _,
+                        alpha_to_one_enable: ms.alpha_to_one as _,
+                    }
+                },
+                None => vk::PipelineMultisampleStateCreateInfo {
+                    s_type: vk::StructureType::PipelineMultisampleStateCreateInfo,
+                    p_next: ptr::null(),
+                    flags: vk::PipelineMultisampleStateCreateFlags::empty(),
+                    rasterization_samples: vk::SAMPLE_COUNT_1_BIT,
+                    sample_shading_enable: vk::VK_FALSE,
+                    min_sample_shading: 0.0,
+                    p_sample_mask: ptr::null(),
+                    alpha_to_coverage_enable: vk::VK_FALSE,
+                    alpha_to_one_enable: vk::VK_FALSE,
+                },
             };
-
-            if let Some(ref multisample) = desc.multisampling {
-                let sample_mask = [
-                    (multisample.sample_mask & 0xFFFFFFFF) as u32,
-                    ((multisample.sample_mask >> 32) & 0xFFFFFFFF) as u32,
-                ];
-                sample_masks.push(sample_mask);
-
-                multisampling_state.rasterization_samples =
-                    vk::SampleCountFlags::from_flags_truncate(multisample.rasterization_samples as _);
-                multisampling_state.sample_shading_enable = multisample.sample_shading.is_some() as _;
-                multisampling_state.min_sample_shading = multisample.sample_shading.unwrap_or(0.0);
-                multisampling_state.p_sample_mask = sample_masks.last().unwrap().as_ptr();
-                multisampling_state.alpha_to_coverage_enable = multisample.alpha_coverage as _;
-                multisampling_state.alpha_to_one_enable = multisample.alpha_to_one as _;
-            };
-
             info_multisample_states.push(multisampling_state);
 
             let depth_stencil = desc.depth_stencil.unwrap_or_default();

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -619,7 +619,9 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             min_texel_buffer_offset_alignment: limits.min_texel_buffer_offset_alignment as _,
             min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment as _,
             min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment as _,
-        }
+            framebuffer_color_samples_count: limits.framebuffer_color_sample_counts.flags() as _,
+            framebuffer_depth_samples_count: limits.framebuffer_depth_sample_counts.flags() as _,
+            framebuffer_stencil_samples_count: limits.framebuffer_stencil_sample_counts.flags() as _,        }
     }
 }
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -252,7 +252,8 @@ pub struct Limits {
     /// Number of samples supported for depth attachments of framebuffers.
     pub framebuffer_depth_samples_count: image::NumSamples,
     /// Number of samples supported for stencil attachments of framebuffers.
-    pub framebuffer_stencil_samples_count: image::NumSamples,}
+    pub framebuffer_stencil_samples_count: image::NumSamples,
+}
 
 /// Describes the type of geometric primitives,
 /// created from vertex data.

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -247,7 +247,12 @@ pub struct Limits {
     pub min_uniform_buffer_offset_alignment: buffer::Offset,
     /// The alignment of the start of buffer used as a storage buffer, in bytes, non-zero.
     pub min_storage_buffer_offset_alignment: buffer::Offset,
-}
+    /// Number of samples supported for color attachments of framebuffers (floating/fixed point).
+    pub framebuffer_color_samples_count: image::NumSamples,
+    /// Number of samples supported for depth attachments of framebuffers.
+    pub framebuffer_depth_samples_count: image::NumSamples,
+    /// Number of samples supported for stencil attachments of framebuffers.
+    pub framebuffer_stencil_samples_count: image::NumSamples,}
 
 /// Describes the type of geometric primitives,
 /// created from vertex data.

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -125,8 +125,14 @@ pub struct SubpassDesc<'a> {
     pub colors: &'a [AttachmentRef],
     /// Which attachments will be used as depth/stencil buffers.
     pub depth_stencil: Option<&'a AttachmentRef>,
-    /// Which attachments will be used by this subpass.
+    /// Which attachments will be used as input attachments.
     pub inputs: &'a [AttachmentRef],
+    /// Which attachments will be used as resolve destinations.
+    ///
+    /// The number of resolve attachments may be zero or equal to the number of color attachments.
+    /// At the end of a subpass the color attachment will be resolved to the corresponding
+    /// resolve attachment. The resolve attachment must not be multisampled.
+    pub resolves: &'a [AttachmentRef],
     /// Attachments that are not used by the subpass but must be preserved to be
     /// passed on to subsequent passes.
     pub preserves: &'a [AttachmentId],

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -76,6 +76,8 @@ pub struct Attachment {
     /// creating dummy renderpasses, which are used as placeholder for compatible
     /// renderpasses.
     pub format: Option<Format>,
+    /// Number of samples.
+    pub samples: image::NumSamples,
     /// Load and store operations of the attachment
     pub ops: AttachmentOps,
     /// Load and store operations of the stencil aspect, if any

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -273,7 +273,7 @@ pub enum LogicOp {
 pub type SampleMask = u64;
 
 ///
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Multisampling {
     ///
     pub rasterization_samples: image::NumSamples,

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -269,7 +269,6 @@ pub enum LogicOp {
 }
 
 ///
-// TODO: Max 64 samples supported atm
 pub type SampleMask = u64;
 
 ///

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -1,6 +1,6 @@
 //! Graphics pipeline descriptor.
 
-use {pass, Backend, Primitive};
+use {image, pass, Backend, Primitive};
 use super::{BasePipeline, EntryPoint, PipelineCreationFlags};
 use super::input_assembler::{AttributeDesc, InputAssemblerDesc, VertexBufferDesc};
 use super::output_merger::{ColorBlendDesc, DepthStencilDesc};
@@ -105,6 +105,8 @@ pub struct GraphicsPipelineDesc<'a, B: Backend> {
     pub blender: BlendDesc,
     /// Depth stencil (DSV)
     pub depth_stencil: Option<DepthStencilDesc>,
+    /// Multisampling.
+    pub multisampling: Option<Multisampling>,
     /// Static pipeline states.
     pub baked_states: BakedStates,
     /// Pipeline layout.
@@ -135,6 +137,7 @@ impl<'a, B: Backend> GraphicsPipelineDesc<'a, B> {
             input_assembler: InputAssemblerDesc::new(primitive),
             blender: BlendDesc::default(),
             depth_stencil: None,
+            multisampling: None,
             baked_states: BakedStates::default(),
             layout,
             subpass,
@@ -218,7 +221,6 @@ pub struct Rasterizer {
     pub depth_bias: Option<DepthBias>,
     /// Controls how triangles will be rasterized depending on their overlap with pixels.
     pub conservative: bool,
-    //TODO: multisampling
 }
 
 impl Rasterizer {
@@ -237,10 +239,6 @@ impl Rasterizer {
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BlendDesc {
-    /// Toggles alpha-to-coverage multisampling, which can produce nicer edges
-    /// when many partially-transparent polygons are overlapping.
-    /// See [here]( https://msdn.microsoft.com/en-us/library/windows/desktop/bb205072(v=vs.85).aspx#Alpha_To_Coverage) for a full description.
-    pub alpha_coverage: bool,
     /// The logic operation to apply to the blending equation, if any.
     pub logic_op: Option<LogicOp>,
     /// Which color targets to apply the blending operation to.
@@ -268,4 +266,25 @@ pub enum LogicOp {
     Invert,
     Nand,
     Set,
+}
+
+///
+// TODO: Max 64 samples supported atm
+pub type SampleMask = u64;
+
+///
+#[derive(Debug)]
+pub struct Multisampling {
+    ///
+    pub rasterization_samples: image::NumSamples,
+    ///
+    pub sample_shading: Option<f32>,
+    ///
+    pub sample_mask: SampleMask,
+    /// Toggles alpha-to-coverage multisampling, which can produce nicer edges
+    /// when many partially-transparent polygons are overlapping.
+    /// See [here]( https://msdn.microsoft.com/en-us/library/windows/desktop/bb205072(v=vs.85).aspx#Alpha_To_Coverage) for a full description.
+    pub alpha_coverage: bool,
+    ///
+    pub alpha_to_one: bool,
 }

--- a/src/render/src/macros/pipeline.rs
+++ b/src/render/src/macros/pipeline.rs
@@ -54,6 +54,7 @@ macro_rules! gfx_graphics_pipeline {
                                 let attach_id = attachments.len();
                                 attachments.push(cpass::Attachment {
                                     format: Some(attach.format),
+                                    samples: 1,
                                     ops: attach.ops,
                                     stencil_ops: attach.stencil_ops,
                                     layouts: attach.required_layout .. attach.required_layout,
@@ -66,6 +67,7 @@ macro_rules! gfx_graphics_pipeline {
                             depth_stencil: None, //TODO
                             inputs: &[],
                             preserves: &[],
+                            resolves: &[],
                         };
 
                         device.create_render_pass_raw(&attachments[..], &[subpass], &[])

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -456,7 +456,11 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                                         attachments.keys().position(|s| s == sp).unwrap()
                                     })
                                     .collect::<Vec<_>>();
-                                (colors, ds, inputs, preserves)
+                                let resolves = sp.resolves
+                                    .iter()
+                                    .map(&att_ref)
+                                    .collect::<Vec<_>>();
+                                (colors, ds, inputs, preserves, resolves)
                             })
                             .collect::<Vec<_>>();
                         let raw_subs = temp
@@ -466,6 +470,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                                 depth_stencil: t.1.as_ref(),
                                 inputs: &t.2,
                                 preserves: &t.3,
+                                resolves: &t.4,
                             })
                             .collect::<Vec<_>>();
                         let raw_deps = dependencies
@@ -643,6 +648,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                             blender: blender.clone(),
                             depth_stencil: depth_stencil.clone(),
                             baked_states: pso::BakedStates::default(), //TODO
+                            multisampling: None, // TODO
                             layout: &resources.pipeline_layouts[layout],
                             subpass: hal::pass::Subpass {
                                 main_pass: &resources.render_passes[&subpass.parent].handle,

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -15,6 +15,8 @@ pub struct Subpass {
     pub inputs: Vec<AttachmentRef>,
     #[serde(default)]
     pub preserves: Vec<String>,
+    #[serde(default)]
+    pub resolves: Vec<AttachmentRef>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
* hal: Add resolve attachments, limits and multisampling desc to pso
* dx12: Handle sampling settings for images and pipeline states
* dx12: Add resolve operations for renderpasses
* dx12: Update resource barriers between subpasses

TODO:
- [x] dx12: Subpass transitions are not 100% correct yet
- [x] dx12: Select correct subresource on resolve
- [x] Implement for vulkan
- [x] Fix build errors on other backends (gl and metal)

Fixes https://github.com/gfx-rs/gfx/issues/1542
PR checklist:
- [x] reftests working on dx12
- [x] `multisampling` example on backends: dx12