### PR TITLE
dx12: Block compressed format support for buffer-image copies

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -38,8 +38,11 @@ fn get_rect(rect: &pso::Rect) -> d3d12::D3D12_RECT {
 }
 
 fn div(a: u32, b: u32) -> u32 {
-    assert_eq!(a % b, 0);
-    a / b
+    (a + b - 1) / b
+}
+
+fn up_align(x: u32, alignment: u32) -> u32 {
+    (x + alignment - 1) & !(alignment - 1)
 }
 
 fn bind_descriptor_sets<'a, T>(
@@ -686,6 +689,11 @@ impl CommandBuffer {
         } else {
             r.buffer_height
         };
+        let image_extent_aligned = image::Extent {
+            width: up_align(r.image_extent.width, image.block_dim.0 as _),
+            height: up_align(r.image_extent.height, image.block_dim.1 as _),
+            depth: r.image_extent.depth,
+        };
         let row_pitch = div(buffer_width, image.block_dim.0 as _) * image.bytes_per_block as u32;
         let slice_pitch = div(buffer_height, image.block_dim.1 as _) * row_pitch;
         let is_pitch_aligned = row_pitch % d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT == 0;
@@ -700,27 +708,26 @@ impl CommandBuffer {
                 // trivial case: everything is aligned, ready for copying
                 copies.push(Copy {
                     footprint_offset: aligned_offset,
-                    footprint: r.image_extent,
+                    footprint: image_extent_aligned,
                     row_pitch,
                     img_subresource,
                     img_offset: r.image_offset,
                     buf_offset: image::Offset::ZERO,
-                    copy_extent: r.image_extent,
+                    copy_extent: image_extent_aligned,
                 });
             } else if is_pitch_aligned {
                 // buffer offset is not aligned
-                assert_eq!(image.block_dim, (1, 1)); // TODO
-                let row_pitch_texels = row_pitch / image.bytes_per_block as u32;
+                let row_pitch_texels = row_pitch / image.bytes_per_block as u32 * image.block_dim.0 as u32;
                 let gap = (layer_offset - aligned_offset) as i32;
                 let buf_offset = image::Offset {
-                    x: (gap % row_pitch as i32) / image.bytes_per_block as i32,
-                    y: (gap % slice_pitch as i32) / row_pitch as i32,
+                    x: (gap % row_pitch as i32) / image.bytes_per_block as i32 * image.block_dim.0 as i32,
+                    y: (gap % slice_pitch as i32) / row_pitch as i32 * image.block_dim.1 as i32,
                     z: gap / slice_pitch as i32,
                 };
                 let footprint = image::Extent {
-                    width: buf_offset.x as u32 + r.image_extent.width,
-                    height: buf_offset.y as u32 + r.image_extent.height,
-                    depth: buf_offset.z as u32 + r.image_extent.depth,
+                    width: buf_offset.x as u32 + image_extent_aligned.width,
+                    height: buf_offset.y as u32 + image_extent_aligned.height,
+                    depth: buf_offset.z as u32 + image_extent_aligned.depth,
                 };
                 if r.image_extent.width + buf_offset.x as u32 <= row_pitch_texels {
                     // we can map it to the aligned one and adjust the offsets accordingly
@@ -731,7 +738,7 @@ impl CommandBuffer {
                         img_subresource,
                         img_offset: r.image_offset,
                         buf_offset,
-                        copy_extent: r.image_extent,
+                        copy_extent: image_extent_aligned
                     });
                 } else {
                     // split the copy region into 2 that suffice the previous condition
@@ -757,8 +764,8 @@ impl CommandBuffer {
                     copies.push(Copy {
                         footprint_offset: aligned_offset,
                         footprint: image::Extent {
-                            width: r.image_extent.width - half,
-                            height: footprint.height + 1,
+                            width: image_extent_aligned.width - half,
+                            height: footprint.height + image.block_dim.1 as u32,
                             depth: footprint.depth,
                         },
                         row_pitch,
@@ -769,29 +776,28 @@ impl CommandBuffer {
                         },
                         buf_offset: image::Offset {
                             x: 0,
-                            y: buf_offset.y + 1,
+                            y: buf_offset.y + image.block_dim.1 as i32,
                             z: buf_offset.z,
                         },
                         copy_extent: image::Extent {
-                            width: r.image_extent.width - half,
-                            .. r.image_extent
+                            width: image_extent_aligned.width - half,
+                            .. image_extent_aligned
                         },
                     });
                 }
             } else {
                 // worst case: row by row copy
-                assert_eq!(image.block_dim, (1, 1)); // TODO
                 for z in 0 .. r.image_extent.depth {
-                    for y in 0 .. r.image_extent.height {
+                    for y in 0 .. image_extent_aligned.height / image.block_dim.1 as u32 {
                         // an image row starts non-aligned
                         let row_offset = layer_offset +
                             z as u64 * slice_pitch as u64 +
                             y as u64 * row_pitch as u64;
                         let aligned_offset = row_offset & !(d3d12::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as u64 - 1);
                         let next_aligned_offset = aligned_offset + d3d12::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as u64;
-                        let cut_row_texels = (next_aligned_offset - row_offset) / image.bytes_per_block as u64;
-                        let cut_width = cmp::min(r.image_extent.width, cut_row_texels as image::Size);
-                        let gap_texels = (row_offset - aligned_offset) as image::Size / image.bytes_per_block as image::Size;
+                        let cut_row_texels = (next_aligned_offset - row_offset) / image.bytes_per_block as u64 * image.block_dim.0 as u64;
+                        let cut_width = cmp::min(image_extent_aligned.width, cut_row_texels as image::Size);
+                        let gap_texels = (row_offset - aligned_offset) as image::Size / image.bytes_per_block as image::Size * image.block_dim.0 as image::Size;
                         // this is a conservative row pitch that should be compatible with both copies
                         let max_unaligned_pitch = (r.image_extent.width + gap_texels) * image.bytes_per_block as u32;
                         let row_pitch = (max_unaligned_pitch | (d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1)) + 1;
@@ -800,14 +806,14 @@ impl CommandBuffer {
                             footprint_offset: aligned_offset,
                             footprint: image::Extent {
                                 width: cut_width + gap_texels,
-                                height: 1,
+                                height: image.block_dim.1 as _,
                                 depth: 1,
                             },
                             row_pitch,
                             img_subresource,
                             img_offset: image::Offset {
                                 x: r.image_offset.x,
-                                y: r.image_offset.y + y as i32,
+                                y: r.image_offset.y + image.block_dim.1 as i32 * y as i32,
                                 z: r.image_offset.z + z as i32,
                             },
                             buf_offset: image::Offset {
@@ -817,35 +823,35 @@ impl CommandBuffer {
                             },
                             copy_extent: image::Extent {
                                 width: cut_width,
-                                height: 1,
+                                height: image.block_dim.1 as _,
                                 depth: 1,
                             },
                         });
 
                         // and if it crosses a pitch alignment - we copy the rest separately
-                        if cut_width == r.image_extent.width {
+                        if cut_width >= image_extent_aligned.width {
                             continue;
                         }
-                        let leftover = r.image_extent.width - cut_width;
+                        let leftover = image_extent_aligned.width - cut_width;
 
                         copies.push(Copy {
                             footprint_offset: next_aligned_offset,
                             footprint: image::Extent {
                                 width: leftover,
-                                height: 1,
+                                height: image.block_dim.1 as _,
                                 depth: 1,
                             },
                             row_pitch,
                             img_subresource,
                             img_offset: image::Offset {
                                 x: r.image_offset.x + cut_width as i32,
-                                y: r.image_offset.y + y as i32,
+                                y: r.image_offset.y + y as i32 * image.block_dim.1 as i32,
                                 z: r.image_offset.z + z as i32,
                             },
                             buf_offset: image::Offset::ZERO,
                             copy_extent: image::Extent {
                                 width: leftover,
-                                height: 1,
+                                height: image.block_dim.1 as _,
                                 depth: 1,
                             },
                         });


### PR DESCRIPTION
Tested against a few of the vulkan samples, hit every path at least once iirc.
