### PR TITLE
[ll] First slot for vertex buffer binding

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -553,7 +553,7 @@ fn main() {
             cmd_buffer.set_viewports(0, &[viewport.clone()]);
             cmd_buffer.set_scissors(0, &[viewport.rect]);
             cmd_buffer.bind_graphics_pipeline(&pipeline.as_ref().unwrap());
-            cmd_buffer.bind_vertex_buffers(pso::VertexBufferSet(vec![(&vertex_buffer, 0)]));
+            cmd_buffer.bind_vertex_buffers(0, pso::VertexBufferSet(vec![(&vertex_buffer, 0)]));
             cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, Some(&desc_set)); //TODO
 
             {

--- a/src/backend/dx11/src/command.rs
+++ b/src/backend/dx11/src/command.rs
@@ -169,13 +169,13 @@ impl<P: 'static + Parser> command::Buffer<Resources> for RawCommandBuffer<P> {
         self.parser.parse(Command::BindProgram(pso.program));
     }
 
-    fn bind_vertex_buffers(&mut self, vbs: pso::VertexBufferSet<Resources>) {
+    fn bind_vertex_buffers(&mut self, first_binding: u32, vbs: pso::VertexBufferSet<Resources>) {
         //Note: assumes `bind_pipeline_state` is called prior
         let mut buffers = [native::Buffer(ptr::null_mut()); MAX_VERTEX_ATTRIBUTES];
         let mut strides = [0; MAX_VERTEX_ATTRIBUTES];
         let mut offsets = [0; MAX_VERTEX_ATTRIBUTES];
-        for i in 0 .. MAX_VERTEX_ATTRIBUTES {
-            match (vbs.0[i], self.cache.attrib_strides[i]) {
+        for i in first_binding as usize .. MAX_VERTEX_ATTRIBUTES {
+            match (vbs.0[i - first_binding as usize], self.cache.attrib_strides[i]) {
                 (None, Some(stride)) => {
                     error!("No vertex input provided for slot {} with stride {}", i, stride)
                 },

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -494,7 +494,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn bind_vertex_buffers(&mut self, _: pso::VertexBufferSet<Backend>) {
+    fn bind_vertex_buffers(&mut self, _: u32, _: pso::VertexBufferSet<Backend>) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -696,7 +696,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         self.push_cmd(Command::BindIndexBuffer(ibv.buffer.raw));
     }
 
-    fn bind_vertex_buffers(&mut self, vbs: hal::pso::VertexBufferSet<Backend>) {
+    fn bind_vertex_buffers(&mut self, _first_binding: u32, vbs: hal::pso::VertexBufferSet<Backend>) {
         if vbs.0.len() == 0 {
             return
         }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1114,18 +1114,18 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         });
     }
 
-    fn bind_vertex_buffers(&mut self, buffer_set: pso::VertexBufferSet<Backend>) {
+    fn bind_vertex_buffers(&mut self, first_binding: u32, buffer_set: pso::VertexBufferSet<Backend>) {
+        let attribute_buffer_index = self.state.attribute_buffer_index + first_binding as usize;
         {
             let buffers = &mut self.state.resources_vs.buffers;
-            while buffers.len() < self.state.attribute_buffer_index + buffer_set.0.len()    {
+            while buffers.len() < attribute_buffer_index + buffer_set.0.len()    {
                 buffers.push(None)
             }
-            for (ref mut out, &(ref buffer, offset)) in buffers[self.state.attribute_buffer_index..].iter_mut().zip(buffer_set.0.iter()) {
+            for (ref mut out, &(ref buffer, offset)) in buffers[attribute_buffer_index..].iter_mut().zip(buffer_set.0.iter()) {
                 **out = Some((buffer.raw.clone(), offset));
             }
         }
 
-        let attribute_buffer_index = self.state.attribute_buffer_index;
         let commands = buffer_set.0.iter().enumerate().map(|(i, &(buffer, offset))| {
             soft::RenderCommand::BindBuffer {
                 stage: pso::Stage::Vertex,

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -476,7 +476,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn bind_vertex_buffers(&mut self, vbs: pso::VertexBufferSet<Backend>) {
+    fn bind_vertex_buffers(&mut self, first_binding: u32, vbs: pso::VertexBufferSet<Backend>) {
         let buffers: SmallVec<[vk::Buffer; 16]> =
             vbs.0.iter().map(|&(ref buffer, _)| buffer.raw).collect();
         let offsets: SmallVec<[vk::DeviceSize; 16]> =
@@ -485,7 +485,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         unsafe {
             self.device.0.cmd_bind_vertex_buffers(
                 self.raw,
-                0,
+                first_binding,
                 &buffers,
                 &offsets,
             );

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -185,8 +185,8 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
-    pub fn bind_vertex_buffers(&mut self, vbs: pso::VertexBufferSet<B>) {
-        self.raw.bind_vertex_buffers(vbs)
+    pub fn bind_vertex_buffers(&mut self, first_binding: u32, vbs: pso::VertexBufferSet<B>) {
+        self.raw.bind_vertex_buffers(first_binding, vbs)
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -238,7 +238,10 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
 
     /// Bind the vertex buffer set, making it the "current" one that draw commands
     /// will operate on.
-    fn bind_vertex_buffers(&mut self, pso::VertexBufferSet<B>);
+    ///
+    /// Each buffer passed corresponds to the vertex input binding with the same index,
+    /// starting from an offset index `first_binding`.
+    fn bind_vertex_buffers(&mut self, first_binding: u32, pso::VertexBufferSet<B>);
 
     /// Set the viewport parameters for the rasterizer.
     /// 

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -64,8 +64,8 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
     }
 
     ///
-    pub fn bind_vertex_buffers(&mut self, vbs: pso::VertexBufferSet<B>) {
-        self.0.bind_vertex_buffers(vbs);
+    pub fn bind_vertex_buffers(&mut self, first_binding: u32, vbs: pso::VertexBufferSet<B>) {
+        self.0.bind_vertex_buffers(first_binding, vbs);
     }
 
     ///

--- a/src/render/src/macros/pipeline.rs
+++ b/src/render/src/macros/pipeline.rs
@@ -136,7 +136,7 @@ macro_rules! gfx_graphics_pipeline {
                     $(
                         vbs.extend(<$cmp as pso::Component<'a, B>>::vertex_buffer(&self.$cmp_name));
                     )*
-                    cmd_buffer.bind_vertex_buffers(cpso::VertexBufferSet(vbs));
+                    cmd_buffer.bind_vertex_buffers(0, cpso::VertexBufferSet(vbs));
                     let mut descs = Vec::new();
                     $(
                         descs.extend(<$cmp as pso::Component<'a, B>>::descriptor_set(&self.$cmp_name));

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -774,7 +774,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                                         })
                                         .collect::<Vec<_>>();
                                     let set = pso::VertexBufferSet(buffers_raw);
-                                    encoder.bind_vertex_buffers(set);
+                                    encoder.bind_vertex_buffers(0, set);
                                 }
                                 Dc::BindPipeline(ref name) => {
                                     let pso = resources.graphics_pipelines


### PR DESCRIPTION
Implements #1684

I want to start contributing to this project and this issue seemed like a good introduction. I apologize if I'm not doing something according to procedures.

Tested on Windows 10 with `dx12` and `vulkan` backends, Ubuntu 18.04 with `vulkan`, and macOS 10.13 with `metal`.

One thing I noticed while adding this that seemed a little bit awkward is that `GraphicsPipelineDesc::vertex_buffers` doesn't provide any way to skip around binding indices. The roughly equivalent part of Vulkan, `VkVertexInputBindingDescription`, allows you to specify the binding `index` explicitly along with the `stride` and `rate` instead of just making it implicit. Food for thought.

PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends: `dx12`, `vulkan`, `metal`
