### PR TITLE
[ll] Depth bounds test

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1328,6 +1328,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         unsafe { self.raw.OMSetStencilRef(front as _); }
     }
 
+    fn set_depth_bounds(&mut self, min: f32, max: f32) {
+        warn!("Depth bounds test is not supported");
+    }
+
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {
         unsafe {
             match self.gr_pipeline.pipeline {

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1329,7 +1329,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn set_depth_bounds(&mut self, min: f32, max: f32) {
-        warn!("Depth bounds test is not supported");
+        match self.raw.cast::<d3d12::ID3D12GraphicsCommandList1>() {
+            Ok(cmd_list1) => unsafe { cmd_list1.OMSetDepthBounds(min, max) },
+            Err(_) => warn!("Depth bounds test is not supported"),
+        }
     }
 
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {
@@ -1369,6 +1372,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
         if let Some(color) = pipeline.baked_states.blend_color {
             self.set_blend_constants(color);
+        }
+        if let Some(ref bounds) = pipeline.baked_states.depth_bounds {
+            self.set_depth_bounds(bounds.start, bounds.end);
         }
     }
 

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1328,9 +1328,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         unsafe { self.raw.OMSetStencilRef(front as _); }
     }
 
-    fn set_depth_bounds(&mut self, min: f32, max: f32) {
+    fn set_depth_bounds(&mut self, bounds: Range<f32>) {
         match self.raw.cast::<d3d12::ID3D12GraphicsCommandList1>() {
-            Ok(cmd_list1) => unsafe { cmd_list1.OMSetDepthBounds(min, max) },
+            Ok(cmd_list1) => unsafe { cmd_list1.OMSetDepthBounds(bounds.start, bounds.end) },
             Err(_) => warn!("Depth bounds test is not supported"),
         }
     }
@@ -1374,7 +1374,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             self.set_blend_constants(color);
         }
         if let Some(ref bounds) = pipeline.baked_states.depth_bounds {
-            self.set_depth_bounds(bounds.start, bounds.end);
+            self.set_depth_bounds(bounds.clone());
         }
     }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -752,6 +752,20 @@ impl hal::Instance for Instance {
                     mem::size_of::<d3d12::D3D12_FEATURE_DATA_ARCHITECTURE>() as _)
             });
 
+            let depth_bounds_test_supported = {
+                let mut features2: d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS2 = unsafe { mem::zeroed() };
+                let hr = unsafe {
+                    device.CheckFeatureSupport(d3d12::D3D12_FEATURE_D3D12_OPTIONS2,
+                        &mut features2 as *mut _ as *mut _,
+                        mem::size_of::<d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS2>() as _)
+                };
+                if hr == winerror::S_OK  {
+                    features2.DepthBoundsTestSupported != 0
+                } else {
+                    false
+                }
+            };
+
             let heterogeneous_resource_heaps = features.ResourceHeapTier != d3d12::D3D12_RESOURCE_HEAP_TIER_1;
 
             let uma = features_architecture.UMA == TRUE;
@@ -899,7 +913,8 @@ impl hal::Instance for Instance {
                     //logic_op: false, // Optional on feature level 11_0
                     Features::MULTI_DRAW_INDIRECT |
                     Features::FORMAT_BC |
-                    Features::INSTANCE_RATE,
+                    Features::INSTANCE_RATE |
+                    if depth_bounds_test_supported { Features::DEPTH_BOUNDS } else { Features::empty() },
                 limits: Limits { // TODO
                     max_texture_size: 0,
                     max_patch_size: 0,

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -525,7 +525,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
 
-    fn set_depth_bounds(&mut self, min: f32, max: f32) {
+    fn set_depth_bounds(&mut self, _: Range<f32>) {
         unimplemented!()
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -525,6 +525,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
 
+    fn set_depth_bounds(&mut self, min: f32, max: f32) {
+        unimplemented!()
+    }
+
+
     fn begin_render_pass_raw<T>(
         &mut self,
         _: &(),

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -793,7 +793,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         }
     }
 
-    fn set_depth_bounds(&mut self, min: f32, max: f32) {
+    fn set_depth_bounds(&mut self, _: Range<f32>) {
         warn!("Depth bounds test is not supported");
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -793,6 +793,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         }
     }
 
+    fn set_depth_bounds(&mut self, min: f32, max: f32) {
+        warn!("Depth bounds test is not supported");
+    }
+
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {
         let n::GraphicsPipeline {
             primitive,

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1453,7 +1453,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.sink().pre_render_commands(iter::once(com));
     }
 
-    fn set_depth_bounds(&mut self, min: f32, max: f32) {
+    fn set_depth_bounds(&mut self, _: Range<f32>) {
         warn!("Depth bounds test is not supported");
     }
 

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1453,6 +1453,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.sink().pre_render_commands(iter::once(com));
     }
 
+    fn set_depth_bounds(&mut self, min: f32, max: f32) {
+        warn!("Depth bounds test is not supported");
+    }
+
     fn begin_render_pass_raw<T>(
         &mut self,
         render_pass: &native::RenderPass,

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1"
 log = "0.4"
 lazy_static = "1"
 shared_library = "0.1"
-ash = "0.23.0"
+ash = "0.24.0"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.12", optional = true }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -559,9 +559,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn set_depth_bounds(&mut self, min: f32, max: f32) {
+    fn set_depth_bounds(&mut self, bounds: Range<f32>) {
         unsafe {
-            self.device.0.cmd_set_depth_bounds(self.raw, min, max);
+            self.device.0.cmd_set_depth_bounds(self.raw, bounds.start, bounds.end);
         }
     }
 

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -559,6 +559,12 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
+    fn set_depth_bounds(&mut self, min: f32, max: f32) {
+        unsafe {
+            self.device.0.cmd_set_depth_bounds(self.raw, min, max);
+        }
+    }
+
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {
         unsafe {
             self.device.0.cmd_bind_pipeline(

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -519,6 +519,13 @@ impl d::Device<B> for Device {
                 ),
                 pso::StencilTest::Off => unsafe { mem::zeroed() },
             };
+            let (min_depth_bounds, max_depth_bounds) = match desc.baked_states.depth_bounds {
+                Some(ref range) => (range.start, range.end),
+                None => {
+                    dynamic_states.push(vk::DynamicState::DepthBounds);
+                    (0.0, 1.0)
+                }
+            };
 
             info_depth_stencil_states.push(vk::PipelineDepthStencilStateCreateInfo {
                 s_type: vk::StructureType::PipelineDepthStencilStateCreateInfo,
@@ -531,8 +538,8 @@ impl d::Device<B> for Device {
                 stencil_test_enable,
                 front,
                 back,
-                min_depth_bounds: 0.0,
-                max_depth_bounds: 1.0,
+                min_depth_bounds,
+                max_depth_bounds,
             });
 
             // Build blend states for color attachments

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -236,8 +236,8 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
-    pub fn set_depth_bounds(&mut self, min: f32, max: f32) {
-        self.raw.set_depth_bounds(min, max)
+    pub fn set_depth_bounds(&mut self, bounds: Range<f32>) {
+        self.raw.set_depth_bounds(bounds)
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -236,6 +236,11 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
+    pub fn set_depth_bounds(&mut self, min: f32, max: f32) {
+        self.raw.set_depth_bounds(min, max)
+    }
+
+    /// Identical to the `RawCommandBuffer` method of the same name.
     pub fn push_graphics_constants(&mut self, layout: &B::PipelineLayout, stages: pso::ShaderStageFlags, offset: u32, constants: &[u32]) {
         self.raw.push_graphics_constants(layout, stages, offset, constants)
     }

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -292,6 +292,9 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     /// Set the blend constant values dynamically.
     fn set_blend_constants(&mut self, pso::ColorValue);
 
+    /// Set the depth bounds test values dynamically.
+    fn set_depth_bounds(&mut self, min: f32, max: f32);
+
     /// Just does some type conversions and calls `begin_render_pass_raw`.
     fn begin_render_pass<T>(
         &mut self,

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -293,7 +293,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     fn set_blend_constants(&mut self, pso::ColorValue);
 
     /// Set the depth bounds test values dynamically.
-    fn set_depth_bounds(&mut self, min: f32, max: f32);
+    fn set_depth_bounds(&mut self, bounds: Range<f32>);
 
     /// Just does some type conversions and calls `begin_render_pass_raw`.
     fn begin_render_pass<T>(

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -115,8 +115,8 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
     }
 
     ///
-    pub fn set_depth_bounds(&mut self, min: f32, max: f32) {
-        self.0.set_depth_bounds(min, max)
+    pub fn set_depth_bounds(&mut self, bounds: Range<f32>) {
+        self.0.set_depth_bounds(bounds)
     }
 
     ///

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -115,12 +115,16 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
     }
 
     ///
+    pub fn set_depth_bounds(&mut self, min: f32, max: f32) {
+        self.0.set_depth_bounds(min, max)
+    }
+
+    ///
     pub fn push_graphics_constants(&mut self, layout: &B::PipelineLayout, stages: pso::ShaderStageFlags, offset: u32, constants: &[u32]) {
         self.0.push_graphics_constants(layout, stages, offset, constants);
     }
 
     // TODO: set_line_width
-    // TODO: set_depth_bounds
     // TODO: set_depth_bias
     // TODO: set_stencil_compare_mask
     // TODO: set_stencil_write_mask

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -81,6 +81,8 @@ pub struct BakedStates {
     pub scissor: Option<Rect>,
     /// Static blend constant color.
     pub blend_color: Option<ColorValue>,
+    /// Static depth bounds.
+    pub depth_bounds: Option<Range<f32>>,
     //pub stencil_read: Option<Stencil>,
     //pub stencil_write: Option<Stencil>,
     //pub stencil_ref: Option<Stencil>,


### PR DESCRIPTION
Stubs and DirectX 12 amd Vulkan implementations of #1737

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: `dx12`, `vulkan`
