### PR TITLE
[ll] layer range for clear_attachments

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -16,7 +16,7 @@ use winapi::shared::dxgiformat;
 
 use wio::com::ComPtr;
 
-use {conv, internal, native as n, Backend, Device, Shared, MAX_VERTEX_BUFFERS};
+use {conv, device, internal, native as n, Backend, Device, Shared, MAX_VERTEX_BUFFERS};
 use device::ViewInfo;
 use root_constants::RootConstant;
 use smallvec::SmallVec;
@@ -1204,15 +1204,25 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<com::AttachmentClear>,
         U: IntoIterator,
-        U::Item: Borrow<pso::Rect>,
+        U::Item: Borrow<pso::ClearRect>,
     {
-        assert!(self.pass_cache.is_some(), "`clear_attachments` can only be called inside a renderpass");
-        let rects: SmallVec<[d3d12::D3D12_RECT; 16]> = rects.into_iter().map(|rect| get_rect(rect.borrow())).collect();
+        assert!(
+            self.pass_cache.is_some(),
+            "`clear_attachments` can only be called inside a renderpass"
+        );
+
+        let clear_rects: SmallVec<[pso::ClearRect; 16]> = rects
+            .into_iter()
+            .map(|rect| rect.borrow().clone())
+            .collect();
+
+        let mut device = self.shared.service_pipes.device.clone();
+
         for clear in clears {
             let clear = clear.borrow();
             match *clear {
                 com::AttachmentClear::Color(index, cv) => {
-                    let rtv = {
+                    let attachment = {
                         let pass_cache = self.pass_cache.as_ref().unwrap();
                         let rtv_id = pass_cache
                             .render_pass
@@ -1220,18 +1230,50 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             .color_attachments[index]
                             .0;
 
-                        pass_cache
-                            .framebuffer
-                            .attachments[rtv_id]
-                            .handle_rtv
-                            .unwrap()
+                        pass_cache.framebuffer.attachments[rtv_id]
                     };
 
-                    self.clear_render_target_view(
-                        rtv,
-                        cv.into(),
-                        &rects,
-                    );
+                    let mut rtv_pool = n::DescriptorCpuPool {
+                        heap: Device::create_descriptor_heap_impl(
+                            &mut device.clone(),
+                            d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
+                            false,
+                            clear_rects.len()
+                        ),
+                        offset: 0,
+                        size: 0,
+                        max_size: clear_rects.len() as _
+                    };
+
+                    self.rtv_pools.push(rtv_pool.heap.raw.clone());
+
+                    for clear_rect in &clear_rects {
+                        let rect = [get_rect(&clear_rect.rect)];
+
+                        let view_info = device::ViewInfo {
+                            resource: attachment.resource,
+                            kind: attachment.kind,
+                            flags: image::StorageFlags::empty(),
+                            view_kind: image::ViewKind::D2Array,
+                            format: attachment.dxgi_format,
+                            range: image::SubresourceRange {
+                                aspects: Aspects::COLOR,
+                                levels: 0 .. 1,
+                                layers: clear_rect.layers.clone()
+                            }
+                        };
+                        let rtv = Device::view_image_as_render_target_impl(
+                            &mut device,
+                            &mut rtv_pool,
+                            view_info
+                        ).unwrap();
+
+                        self.clear_render_target_view(
+                            rtv,
+                            cv.into(),
+                            &rect,
+                        );
+                    }
                 }
                 _ => unimplemented!(),
             }

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -215,6 +215,7 @@ pub struct ImageView {
     pub(crate) num_levels: image::Level,
     pub(crate) mip_levels: (image::Level, image::Level),
     pub(crate) layers: (image::Layer, image::Layer),
+    pub(crate) kind: image::Kind,
 }
 unsafe impl Send for ImageView { }
 unsafe impl Sync for ImageView { }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -453,7 +453,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<command::AttachmentClear>,
         U: IntoIterator,
-        U::Item: Borrow<pso::Rect>,
+        U::Item: Borrow<pso::ClearRect>,
     {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -650,7 +650,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<command::AttachmentClear>,
         U: IntoIterator,
-        U::Item: Borrow<pso::Rect>,
+        U::Item: Borrow<pso::ClearRect>,
     {
         unimplemented!()
     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1333,7 +1333,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<com::AttachmentClear>,
         U: IntoIterator,
-        U::Item: Borrow<pso::Rect>,
+        U::Item: Borrow<pso::ClearRect>,
     {
         unimplemented!()
     }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -354,7 +354,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<com::AttachmentClear>,
         U: IntoIterator,
-        U::Item: Borrow<pso::Rect>,
+        U::Item: Borrow<pso::ClearRect>,
     {
         let clears: SmallVec<[vk::ClearAttachment; 16]> = clears
             .into_iter()
@@ -396,11 +396,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         let rects: SmallVec<[vk::ClearRect; 16]> = rects
             .into_iter()
             .map(|rect| {
-                vk::ClearRect {
-                    base_array_layer: 0,
-                    layer_count: vk::VK_REMAINING_ARRAY_LAYERS,
-                    rect: conv::map_rect(rect.borrow()),
-                }
+                conv::map_clear_rect(rect.borrow())
             })
             .collect();
 

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -492,6 +492,14 @@ pub fn map_rect(rect: &pso::Rect) -> vk::Rect2D {
     }
 }
 
+pub fn map_clear_rect(rect: &pso::ClearRect) -> vk::ClearRect {
+    vk::ClearRect {
+        base_array_layer: rect.layers.start as _,
+        layer_count: (rect.layers.end - rect.layers.start) as _,
+        rect: map_rect(&rect.rect),
+    }
+}
+
 pub fn map_viewport(vp: &pso::Viewport) -> vk::Viewport {
     vk::Viewport {
         x: vp.rect.x as _,

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -166,7 +166,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
         T: IntoIterator,
         T::Item: Borrow<AttachmentClear>,
         U: IntoIterator,
-        U::Item: Borrow<pso::Rect>;
+        U::Item: Borrow<pso::ClearRect>;
 
     /// "Resolves" a multisampled image, converting it into a non-multisampled
     /// image. Takes an iterator of regions to apply the resolution to.

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -35,7 +35,7 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
         T: IntoIterator,
         T::Item: Borrow<AttachmentClear>,
         U: IntoIterator,
-        U::Item: Borrow<pso::Rect>,
+        U::Item: Borrow<pso::ClearRect>,
     {
         self.0.clear_attachments(clears, rects)
     }

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -22,6 +22,16 @@ pub struct Rect {
     pub h: u16,
 }
 
+/// A simple struct describing a rect with integer coordinates.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ClearRect {
+    /// 2D region.
+    pub rect: Rect,
+    /// Layer range.
+    pub layers: Range<image::Layer>,
+}
+
 /// A viewport, generally equating to a window on a display.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
Replaces the `Rect` in `clear_attachments` with `ClearRect` to allow for clearing layers in an attachment. Only implemented for vulkan & dx12 for now.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan, dx12
