### PR TITLE
[mtl] Improved blitting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,10 @@ test:
 	cd src/render && cargo test --features "$(FEATURES_RENDER) $(FEATURES_EXTRA)"
 
 reftests:
-	cd src/warden && cargo test --features "gl"
 	cd src/warden && cargo run --features "$(FEATURES_HAL) $(FEATURES_HAL2)" -- local #TODO: gl
 
 reftests-ci:
+	cd src/warden && cargo test --features "gl"
 	cd src/warden && cargo run --features "gl" -- ci #TODO: "gl-headless"
 
 travis-sdl2:

--- a/src/backend/metal/shaders/commands.metal
+++ b/src/backend/metal/shaders/commands.metal
@@ -20,7 +20,7 @@ vertex BlitVertexData vs_blit(BlitAttributes in [[stage_in]]) {
     return BlitVertexData { pos, in.src_coords, uint(in.dst_coords.z) };
 }
 
-fragment float4 ps_blit_1d(
+fragment float4 ps_blit_1d_float(
     BlitVertexData in [[stage_in]],
     texture1d<float> tex1D [[ texture(0) ]],
     sampler sampler2D [[ sampler(0) ]]
@@ -28,7 +28,7 @@ fragment float4 ps_blit_1d(
   return tex1D.sample(sampler2D, in.uv.x);
 }
 
-fragment float4 ps_blit_1d_array(
+fragment float4 ps_blit_1d_array_float(
     BlitVertexData in [[stage_in]],
     texture1d_array<float> tex1DArray [[ texture(0) ]],
     sampler sampler2D [[ sampler(0) ]]
@@ -36,7 +36,7 @@ fragment float4 ps_blit_1d_array(
   return tex1DArray.sample(sampler2D, in.uv.x, uint(in.uv.z));
 }
 
-fragment float4 ps_blit_2d(
+fragment float4 ps_blit_2d_float(
     BlitVertexData in [[stage_in]],
     texture2d<float> tex2D [[ texture(0) ]],
     sampler sampler2D [[ sampler(0) ]]
@@ -44,15 +44,30 @@ fragment float4 ps_blit_2d(
   return tex2D.sample(sampler2D, in.uv.xy, level(in.uv.w));
 }
 
-fragment float4 ps_blit_2d_array(
+fragment uint4 ps_blit_2d_uint(
+    BlitVertexData in [[stage_in]],
+    texture2d<uint> tex2D [[ texture(0) ]],
+    sampler sampler2D [[ sampler(0) ]]
+) {
+  return tex2D.sample(sampler2D, in.uv.xy, level(in.uv.w));
+}
+
+fragment int4 ps_blit_2d_int(
+    BlitVertexData in [[stage_in]],
+    texture2d<int> tex2D [[ texture(0) ]],
+    sampler sampler2D [[ sampler(0) ]]
+) {
+  return tex2D.sample(sampler2D, in.uv.xy, level(in.uv.w));
+}
+
+fragment float4 ps_blit_2d_array_float(
     BlitVertexData in [[stage_in]],
     texture2d_array<float> tex2DArray [[ texture(0) ]],
     sampler sampler2D [[ sampler(0) ]]
 ) {
   return tex2DArray.sample(sampler2D, in.uv.xy, uint(in.uv.z), level(in.uv.w));
 }
-
-fragment float4 ps_blit_3d(
+fragment float4 ps_blit_3d_float(
     BlitVertexData in [[stage_in]],
     texture3d<float> tex3D [[ texture(0) ]],
     sampler sampler2D [[ sampler(0) ]]

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1356,8 +1356,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             let mut pipes = self.shared.service_pipes
                 .lock()
                 .unwrap();
+            let key = (dst.mtl_type, dst.mtl_format, dst.blit_channel);
             let pso = pipes
-                .get_blit_image(dst.mtl_type, dst.mtl_format, &self.shared.device)
+                .get_blit_image(key, &self.shared.device)
                 .to_owned();
             let sampler = pipes.get_sampler(filter);
             let ext = &dst.extent;

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -24,6 +24,7 @@ use {conversions as conv, soft};
 
 use smallvec::SmallVec;
 
+
 pub(crate) struct QueueInner {
     queue: metal::CommandQueue,
     reserve: Range<usize>,

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -1,114 +1,118 @@
+use PrivateCapabilities;
+
 use hal::{pass, image, memory, pso, IndexType};
 use hal::format::Format;
 use hal::pso::Comparison;
 use metal::*;
 
-pub fn map_format(format: Format) -> Option<MTLPixelFormat> {
-    use metal::MTLPixelFormat::*;
-    use hal::format::Format as f;
-    Some(match format {
-        //f::B5g6r5Unorm       => B5G6R5Unorm, // !macOS
-        //f::B5g5r5a1Unorm     => BGR5A1Unorm, // !macOS
-        f::R8Unorm           => R8Unorm,
-        f::R8Inorm           => R8Snorm,
-        //f::R8Srgb            => R8Unorm_sRGB, // !macOS
-        f::R8Uint            => R8Uint,
-        f::R8Int             => R8Sint,
-        f::Rg8Unorm          => RG8Unorm,
-        f::Rg8Inorm          => RG8Snorm,
-        //f::Rg8Srgb           => RG8Unorm_sRGB, // !macOS
-        f::Rg8Uint           => RG8Uint,
-        f::Rg8Int            => RG8Sint,
-        f::Rgba8Unorm        => RGBA8Unorm,
-        f::Rgba8Inorm        => RGBA8Snorm,
-        f::Rgba8Srgb         => RGBA8Unorm_sRGB,
-        f::Rgba8Uint         => RGBA8Uint,
-        f::Rgba8Int          => RGBA8Sint,
-        f::Bgra8Unorm        => BGRA8Unorm,
-        f::Bgra8Srgb         => BGRA8Unorm_sRGB,
-        f::R16Unorm          => R16Unorm,
-        f::R16Inorm          => R16Snorm,
-        f::R16Uint           => R16Uint,
-        f::R16Int            => R16Sint,
-        f::R16Float          => R16Float,
-        f::Rg16Unorm         => RG16Unorm,
-        f::Rg16Inorm         => RG16Snorm,
-        f::Rg16Uint          => RG16Uint,
-        f::Rg16Int           => RG16Sint,
-        f::Rg16Float         => RG16Float,
-        f::Rgba16Unorm       => RGBA16Unorm,
-        f::Rgba16Inorm       => RGBA16Snorm,
-        f::Rgba16Uint        => RGBA16Uint,
-        f::Rgba16Int         => RGBA16Sint,
-        f::Rgba16Float       => RGBA16Float,
-        f::R32Uint           => R32Uint,
-        f::R32Int            => R32Sint,
-        f::R32Float          => R32Float,
-        f::Rg32Uint          => RG32Uint,
-        f::Rg32Int           => RG32Sint,
-        f::Rg32Float         => RG32Float,
-        f::Rgba32Uint        => RGBA32Uint,
-        f::Rgba32Int         => RGBA32Sint,
-        f::Rgba32Float       => RGBA32Float,
-        f::D16Unorm          => Depth16Unorm,
-        f::D32Float          => Depth32Float,
-        //f::D24UnormS8Uint    => Depth24Unorm_Stencil8, // !macOS
-        f::D32FloatS8Uint    => Depth32Float_Stencil8,
-        //f::Bc1RgbUnorm       => BC1_RGBA,
-        //f::Bc1RgbSrgb        => BC1_RGBA_sRGB,
-        //f::Bc2Unorm          => BC2_RGBA,
-        //f::Bc2Srgb           => BC2_RGBA_sRGB,
-        //f::Bc3Unorm          => BC3_RGBA,
-        //f::Bc3Srgb           => BC3_RGBA_sRGB,
-        //f::Bc4Unorm          => BC4_RUnorm,
-        //f::Bc4Inorm          => BC4_RSnorm,
-        //f::Bc5Unorm          => BC5_RGUnorm,
-        //f::Bc5Inorm          => BC5_RGSnorm,
-        //f::Bc6hUfloat        => BC6H_RGBUfloat,
-        //f::Bc6hFloat         => BC6H_RGBFloat,
-        //f::Bc7Unorm          => BC7_RGBAUnorm,
-        //f::Bc7Srgb           => BC7_RGBAUnorm_sRGB,
-        //f::EacR11Unorm       => EAC_R11Unorm, // !macOS
-        //f::EacR11Inorm       => EAC_R11Snorm, // !macOS
-        //f::EacR11g11Unorm    => EAC_RG11Unorm, // !macOS
-        //f::EacR11g11Inorm    => EAC_RG11Snorm, // !macOS
-        //f::Etc2R8g8b8Unorm   => ETC2_RGB8, // !macOS
-        //f::Etc2R8g8b8Srgb    => ETC2_RGB8_sRGB, // !macOS
-        //f::Etc2R8g8b8a1Unorm => ETC2_RGB8A1, // !macOS
-        //f::Etc2R8g8b8a1Srgb  => ETC2_RGBA1_sRGB, // !macOS
-        //f::Astc4x4Unorm      => ASTC_4x4_LDR, // !macOS
-        //f::Astc4x4Srgb       => ASTC_4x4_sRGB, // !macOS
-        //f::Astc5x4Unorm      => ASTC_5x4_LDR, // !macOS
-        //f::Astc5x4Srgb       => ASTC_5x4_sRGB, // !macOS
-        //f::Astc5x5Unorm      => ASTC_5x5_LDR, // !macOS
-        //f::Astc5x5Srgb       => ASTC_5x5_sRGB, // !macOS
-        //f::Astc6x5Unorm      => ASTC_6x5_LDR, // !macOS
-        //f::Astc6x5Srgb       => ASTC_6x5_sRGB, // !macOS
-        //f::Astc6x6Unorm      => ASTC_6x6_LDR, // !macOS
-        //f::Astc6x6Srgb       => ASTC_6x6_sRGB, // !macOS
-        //f::Astc8x5Unorm      => ASTC_8x5_LDR, // !macOS
-        //f::Astc8x5Srgb       => ASTC_8x5_sRGB, // !macOS
-        //f::Astc8x6Unorm      => ASTC_8x6_LDR, // !macOS
-        //f::Astc8x6Srgb       => ASTC_8x6_sRGB, // !macOS
-        //f::Astc8x8Unorm      => ASTC_8x8_LDR, // !macOS
-        //f::Astc8x8Srgb       => ASTC_8x8_sRGB, // !macOS
-        //f::Astc10x5Unorm     => ASTC_10x5_LDR, // !macOS
-        //f::Astc10x5Srgb      => ASTC_10x5_sRGB, // !macOS
-        //f::Astc10x6Unorm     => ASTC_10x6_LDR, // !macOS
-        //f::Astc10x6Srgb      => ASTC_10x6_sRGB, // !macOS
-        //f::Astc10x8Unorm     => ASTC_10x8_LDR, // !macOS
-        //f::Astc10x8Srgb      => ASTC_10x8_sRGB, // !macOS
-        //f::Astc10x10Unorm    => ASTC_10x10_LDR, // !macOS
-        //f::Astc10x10Srgb     => ASTC_10x10_sRGB, // !macOS
-        //f::Astc12x10Unorm    => ASTC_12x10_LDR, // !macOS
-        //f::Astc12x10Srgb     => ASTC_12x10_sRGB, // !macOS
-        //f::Astc12x12Unorm    => ASTC_12x12_LDR, // !macOS
-        //f::Astc12x12Srgb     => ASTC_12x12_sRGB, // !macOS
-        //f::Bgra4Unorm =>
-        //f::R5g6b5Unorm =>
-        //f::A1r5g5b5Unorm =>
-        _ => return None,
-    })
+impl PrivateCapabilities {
+    pub fn map_format(&self, format: Format) -> Option<MTLPixelFormat> {
+        use metal::MTLPixelFormat::*;
+        use hal::format::Format as f;
+        Some(match format {
+            f::B5g6r5Unorm   if self.format_b5 => B5G6R5Unorm,
+            f::B5g5r5a1Unorm if self.format_b5 => BGR5A1Unorm,
+            f::R8Srgb  if self.format_min_srgb_channels <= 1 => R8Unorm_sRGB,
+            f::Rg8Srgb if self.format_min_srgb_channels <= 2 => RG8Unorm_sRGB,
+            f::D24UnormS8Uint if self.format_depth24_stencil8 => Depth24Unorm_Stencil8,
+            f::D32FloatS8Uint if self.format_depth32_stencil8 => Depth32Float_Stencil8,
+            f::R8Unorm           => R8Unorm,
+            f::R8Inorm           => R8Snorm,
+            f::R8Uint            => R8Uint,
+            f::R8Int             => R8Sint,
+            f::Rg8Unorm          => RG8Unorm,
+            f::Rg8Inorm          => RG8Snorm,
+            f::Rg8Uint           => RG8Uint,
+            f::Rg8Int            => RG8Sint,
+            f::Rgba8Unorm        => RGBA8Unorm,
+            f::Rgba8Inorm        => RGBA8Snorm,
+            f::Rgba8Srgb         => RGBA8Unorm_sRGB,
+            f::Rgba8Uint         => RGBA8Uint,
+            f::Rgba8Int          => RGBA8Sint,
+            f::Bgra8Unorm        => BGRA8Unorm,
+            f::Bgra8Srgb         => BGRA8Unorm_sRGB,
+            f::R16Unorm          => R16Unorm,
+            f::R16Inorm          => R16Snorm,
+            f::R16Uint           => R16Uint,
+            f::R16Int            => R16Sint,
+            f::R16Float          => R16Float,
+            f::Rg16Unorm         => RG16Unorm,
+            f::Rg16Inorm         => RG16Snorm,
+            f::Rg16Uint          => RG16Uint,
+            f::Rg16Int           => RG16Sint,
+            f::Rg16Float         => RG16Float,
+            f::Rgba16Unorm       => RGBA16Unorm,
+            f::Rgba16Inorm       => RGBA16Snorm,
+            f::Rgba16Uint        => RGBA16Uint,
+            f::Rgba16Int         => RGBA16Sint,
+            f::Rgba16Float       => RGBA16Float,
+            f::R32Uint           => R32Uint,
+            f::R32Int            => R32Sint,
+            f::R32Float          => R32Float,
+            f::Rg32Uint          => RG32Uint,
+            f::Rg32Int           => RG32Sint,
+            f::Rg32Float         => RG32Float,
+            f::Rgba32Uint        => RGBA32Uint,
+            f::Rgba32Int         => RGBA32Sint,
+            f::Rgba32Float       => RGBA32Float,
+            f::D16Unorm          => Depth16Unorm,
+            f::D32Float          => Depth32Float,
+            //f::Bc1RgbUnorm       => BC1_RGBA,
+            //f::Bc1RgbSrgb        => BC1_RGBA_sRGB,
+            //f::Bc2Unorm          => BC2_RGBA,
+            //f::Bc2Srgb           => BC2_RGBA_sRGB,
+            //f::Bc3Unorm          => BC3_RGBA,
+            //f::Bc3Srgb           => BC3_RGBA_sRGB,
+            //f::Bc4Unorm          => BC4_RUnorm,
+            //f::Bc4Inorm          => BC4_RSnorm,
+            //f::Bc5Unorm          => BC5_RGUnorm,
+            //f::Bc5Inorm          => BC5_RGSnorm,
+            //f::Bc6hUfloat        => BC6H_RGBUfloat,
+            //f::Bc6hFloat         => BC6H_RGBFloat,
+            //f::Bc7Unorm          => BC7_RGBAUnorm,
+            //f::Bc7Srgb           => BC7_RGBAUnorm_sRGB,
+            //f::EacR11Unorm       => EAC_R11Unorm, // !macOS
+            //f::EacR11Inorm       => EAC_R11Snorm, // !macOS
+            //f::EacR11g11Unorm    => EAC_RG11Unorm, // !macOS
+            //f::EacR11g11Inorm    => EAC_RG11Snorm, // !macOS
+            //f::Etc2R8g8b8Unorm   => ETC2_RGB8, // !macOS
+            //f::Etc2R8g8b8Srgb    => ETC2_RGB8_sRGB, // !macOS
+            //f::Etc2R8g8b8a1Unorm => ETC2_RGB8A1, // !macOS
+            //f::Etc2R8g8b8a1Srgb  => ETC2_RGBA1_sRGB, // !macOS
+            //f::Astc4x4Unorm      => ASTC_4x4_LDR, // !macOS
+            //f::Astc4x4Srgb       => ASTC_4x4_sRGB, // !macOS
+            //f::Astc5x4Unorm      => ASTC_5x4_LDR, // !macOS
+            //f::Astc5x4Srgb       => ASTC_5x4_sRGB, // !macOS
+            //f::Astc5x5Unorm      => ASTC_5x5_LDR, // !macOS
+            //f::Astc5x5Srgb       => ASTC_5x5_sRGB, // !macOS
+            //f::Astc6x5Unorm      => ASTC_6x5_LDR, // !macOS
+            //f::Astc6x5Srgb       => ASTC_6x5_sRGB, // !macOS
+            //f::Astc6x6Unorm      => ASTC_6x6_LDR, // !macOS
+            //f::Astc6x6Srgb       => ASTC_6x6_sRGB, // !macOS
+            //f::Astc8x5Unorm      => ASTC_8x5_LDR, // !macOS
+            //f::Astc8x5Srgb       => ASTC_8x5_sRGB, // !macOS
+            //f::Astc8x6Unorm      => ASTC_8x6_LDR, // !macOS
+            //f::Astc8x6Srgb       => ASTC_8x6_sRGB, // !macOS
+            //f::Astc8x8Unorm      => ASTC_8x8_LDR, // !macOS
+            //f::Astc8x8Srgb       => ASTC_8x8_sRGB, // !macOS
+            //f::Astc10x5Unorm     => ASTC_10x5_LDR, // !macOS
+            //f::Astc10x5Srgb      => ASTC_10x5_sRGB, // !macOS
+            //f::Astc10x6Unorm     => ASTC_10x6_LDR, // !macOS
+            //f::Astc10x6Srgb      => ASTC_10x6_sRGB, // !macOS
+            //f::Astc10x8Unorm     => ASTC_10x8_LDR, // !macOS
+            //f::Astc10x8Srgb      => ASTC_10x8_sRGB, // !macOS
+            //f::Astc10x10Unorm    => ASTC_10x10_LDR, // !macOS
+            //f::Astc10x10Srgb     => ASTC_10x10_sRGB, // !macOS
+            //f::Astc12x10Unorm    => ASTC_12x10_LDR, // !macOS
+            //f::Astc12x10Srgb     => ASTC_12x10_sRGB, // !macOS
+            //f::Astc12x12Unorm    => ASTC_12x12_LDR, // !macOS
+            //f::Astc12x12Srgb     => ASTC_12x12_sRGB, // !macOS
+            //f::Bgra4Unorm =>
+            //f::R5g6b5Unorm =>
+            //f::A1r5g5b5Unorm =>
+            _ => return None,
+        })
+    }
 }
 
 pub fn map_load_operation(operation: pass::AttachmentLoadOp) -> MTLLoadAction {

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -52,7 +52,7 @@ pub fn map_format(format: Format) -> Option<MTLPixelFormat> {
         f::Rgba32Float       => RGBA32Float,
         f::D16Unorm          => Depth16Unorm,
         f::D32Float          => Depth32Float,
-        f::D24UnormS8Uint    => Depth24Unorm_Stencil8,
+        //f::D24UnormS8Uint    => Depth24Unorm_Stencil8, // !macOS
         f::D32FloatS8Uint    => Depth32Float_Stencil8,
         //f::Bc1RgbUnorm       => BC1_RGBA,
         //f::Bc1RgbSrgb        => BC1_RGBA_sRGB,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1,6 +1,7 @@
 use {AutoreleasePool, Backend, QueueFamily, Surface, Swapchain};
 use {native as n, command, soft};
 use conversions::*;
+use internal::BlitChannel;
 
 use std::borrow::Borrow;
 use std::collections::HashMap;
@@ -1564,10 +1565,23 @@ impl hal::Device<Backend> for Device {
             }
         };
 
+        let base = image.format.base_format();
+
         Ok(n::Image {
             raw,
             extent: image.extent,
-            format_desc: image.format.surface_desc(),
+            format_desc: base.0.desc(),
+            blit_channel: match base.1 {
+                format::ChannelType::Unorm |
+                format::ChannelType::Inorm |
+                format::ChannelType::Ufloat |
+                format::ChannelType::Float |
+                format::ChannelType::Uscaled |
+                format::ChannelType::Iscaled |
+                format::ChannelType::Srgb => BlitChannel::Float,
+                format::ChannelType::Uint => BlitChannel::Uint,
+                format::ChannelType::Int => BlitChannel::Int,
+            },
             mtl_format: match map_format(image.format) {
                 Some(format) => format,
                 None => {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -149,6 +149,19 @@ impl hal::Backend for Backend {
     type QueryPool = ();
 }
 
+#[derive(Clone, Copy)]
+struct PrivateCapabilities {
+    resource_heaps: bool,
+    argument_buffers: bool,
+    format_depth24_stencil8: bool,
+    format_depth32_stencil8: bool,
+    format_min_srgb_channels: u8,
+    format_b5: bool,
+    max_buffers_per_stage: usize,
+    max_textures_per_stage: usize,
+    max_samplers_per_stage: usize,
+}
+
 pub struct AutoreleasePool {
     pool: cocoa::base::id,
 }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1,4 +1,5 @@
 use {Backend};
+use internal::BlitChannel;
 
 use std::cell::Cell;
 use std::collections::{Bound, BTreeMap, HashMap};
@@ -83,6 +84,7 @@ pub struct Image {
     pub(crate) raw: metal::Texture,
     pub(crate) extent: hal::image::Extent,
     pub(crate) format_desc: hal::format::FormatDesc,
+    pub(crate) blit_channel: BlitChannel,
     pub(crate) mtl_format: metal::MTLPixelFormat,
     pub(crate) mtl_type: metal::MTLTextureType,
 }

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -1,4 +1,5 @@
 use {Backend, QueueFamily};
+use internal::BlitChannel;
 use native;
 use device::{Device, PhysicalDevice};
 
@@ -159,6 +160,7 @@ impl Device {
                         depth: 1,
                     },
                     format_desc: config.color_format.surface_desc(),
+                    blit_channel: BlitChannel::Float,
                     mtl_format,
                     mtl_type: metal::MTLTextureType::D2,
                 }

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -46,8 +46,18 @@ pub struct Offset {
 }
 
 impl Offset {
-    /// Zero offset shortcut
+    /// Zero offset shortcut.
     pub const ZERO: Self = Offset { x: 0, y: 0, z: 0 };
+
+    /// Convert the offset into 2-sided bounds given the extent.
+    pub fn into_bounds(self, extent: &Extent) -> Range<Offset> {
+        let end = Offset {
+            x: self.x + extent.width as i32,
+            y: self.y + extent.height as i32,
+            z: self.z + extent.depth as i32,
+        };
+        self .. end
+    }
 }
 
 /// Image tiling modes.


### PR DESCRIPTION
Fixes #2006
(note: also disables d32s8 for now)

Brings the following goodies:
  - actually working blits. I was missing the Y-flip in rendering, which I encoded into the viewport now.
  - proper fast-path for copy_image. I screwed the src/dst arguments...
  - basic integer support for blit shaders (to be extended)
  - retained textures
  - non-equal formats support for copy_image (not verified by CTS yet)

Overall with this change, I was able to get through "api.copy_and_blit.core.blit_image.all_formats.color" section with the following stats:
  - 3538 successes
  - 29 failures (!)
  - 15 crashes

The failures/crashes don't appear systematic, may be caused by #1984

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
