### PR TITLE
Remove UnsafeCell from Metal

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -493,7 +493,8 @@ impl hal::Device<Backend> for Device {
     fn destroy_command_pool(&self, pool: command::CommandPool) {
         if let Some(vec) = pool.managed {
             for cmd_buf in vec {
-                unsafe { &mut *cmd_buf.get() }
+                cmd_buf
+                    .borrow_mut()
                     .reset(&self.command_shared);
             }
         }


### PR DESCRIPTION
~~Only the last commit matters. Eventually to be rebased on #2004.~~

Greatly reduces the amount of unsafety we have in the backend, at the cost of a bit of extra verbosity.

The idea previously was that since the API isn't valid for accessing the same command buffer concurrently, we don't need to check for that at run-time. I believe it's a wishful thinking, and a footgun for possible unexpected issues.
Unless proven otherwise (by benchmarks), we should stick to safe Rust and be kept in warm and safety by the combination of type (where possible) and run-time checks.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
