### PR TITLE
[mtl] fixed borrowing and pooling of command buffers

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -22,7 +22,7 @@ name = "gfx_backend_metal"
 gfx-hal = { path = "../../hal", version = "0.1" }
 log = "0.4"
 winit = { version = "0.13", optional = true }
-metal-rs = "0.9.1"
+metal-rs = "0.9.2"
 foreign-types = "0.3"
 objc = "0.2"
 block = "0.1"


### PR DESCRIPTION
Enforces the queue pool counts.

Fixes the borrowed command buffer release strategy: instead of releasing the counts at the commission time, we are now automatically adding a competition handler to release the counter. The cases where we wait for GPU instantly are specifically handled in order to avoid hanging on the queue pool mutex.
Note: previously we could hang on trying to acquire a borrowed command buffer, since the code thinks they are instantly freed but the metal runtime only gets more available when they are done, so this was a rather dangerous mistake on our part.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal
