### PR TITLE
[ll] Explicit binding parameter for vertex bindings

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -269,6 +269,7 @@ fn main() {
                 pso::BlendState::ALPHA,
             ));
             pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
+                binding: 0,
                 stride: std::mem::size_of::<Vertex>() as u32,
                 rate: 0,
             });

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -436,12 +436,20 @@ impl d::Device<B> for Device {
             _ => None
         };
 
+        let mut vertex_buffers = Vec::new();
+        for vb in &desc.vertex_buffers {
+            while vertex_buffers.len() <= vb.binding as usize {
+                vertex_buffers.push(None);
+            }
+            vertex_buffers[vb.binding as usize] = Some(*vb);
+        }
+
         Ok(n::GraphicsPipeline {
             program,
             primitive: conv::primitive_to_gl_primitive(desc.input_assembler.primitive),
             patch_size,
             blend_targets: desc.blender.targets.clone(),
-            vertex_buffers: desc.vertex_buffers.clone(),
+            vertex_buffers,
             attributes: desc.attributes
                 .iter()
                 .map(|&a| {

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -45,7 +45,7 @@ pub struct GraphicsPipeline {
     pub(crate) patch_size: Option<gl::types::GLint>,
     pub(crate) blend_targets: Vec<pso::ColorBlendDesc>,
     pub(crate) attributes: Vec<AttributeDesc>,
-    pub(crate) vertex_buffers: Vec<pso::VertexBufferDesc>,
+    pub(crate) vertex_buffers: Vec<Option<pso::VertexBufferDesc>>,
 }
 
 #[derive(Clone, Debug, Copy)]

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -781,8 +781,8 @@ impl hal::Device<Backend> for Device {
 
         // Vertex buffers
         let vertex_descriptor = metal::VertexDescriptor::new();
-        for (i, vertex_buffer) in pipeline_desc.vertex_buffers.iter().enumerate() {
-            let mtl_buffer_index = pipeline_layout.attribute_buffer_index as usize + i;
+        for vertex_buffer in &pipeline_desc.vertex_buffers {
+            let mtl_buffer_index = pipeline_layout.attribute_buffer_index as usize + vertex_buffer.binding as usize;
             let mtl_buffer_desc = vertex_descriptor
                 .layouts()
                 .object_at(mtl_buffer_index)

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -363,9 +363,9 @@ impl d::Device<B> for Device {
 
             {
                 let mut vertex_bindings = Vec::new();
-                for (i, vbuf) in desc.vertex_buffers.iter().enumerate() {
+                for vbuf in &desc.vertex_buffers {
                     vertex_bindings.push(vk::VertexInputBindingDescription {
-                        binding: i as u32,
+                        binding: vbuf.binding,
                         stride: vbuf.stride as u32,
                         input_rate: if vbuf.rate == 0 {
                             vk::VertexInputRate::Vertex

--- a/src/hal/src/pso/input_assembler.rs
+++ b/src/hal/src/pso/input_assembler.rs
@@ -30,6 +30,8 @@ pub struct Element<F> {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VertexBufferDesc {
+    /// Binding number of this vertex buffer descriptor.
+    pub binding: BufferIndex,
     /// Total container size, in bytes.
     /// Specifies the byte distance between two consecutive elements.
     pub stride: ElemStride,
@@ -43,7 +45,7 @@ pub struct VertexBufferDesc {
 pub struct AttributeDesc {
     /// Attribute binding location in the shader.
     pub location: Location,
-    /// Index of the associated vertex buffer descriptor.
+    /// Binding number of the associated vertex buffer descriptor.
     pub binding: BufferIndex,
     /// Attribute element description.
     pub element: Element<format::Format>,

--- a/src/render/src/pso.rs
+++ b/src/render/src/pso.rs
@@ -386,6 +386,7 @@ impl<'a, B, T, I> Component<'a, B> for VertexBuffer<T, I>
     ) {
         let binding = pipeline_desc.vertex_buffers.len() as u32;
         pipeline_desc.vertex_buffers.push(hal::pso::VertexBufferDesc {
+            binding,
             stride: mem::size_of::<T>() as u32,
             rate: I::get_rate(&init),
         });


### PR DESCRIPTION
Implements #1994
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: `dx12`, `gl`, `metal`, `vulkan`
