### PR TITLE
[mtl] Only invalidate/flush on memory map/unmap for coherent types, fix size alignment

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -939,6 +939,7 @@ impl hal::Instance for Instance {
                     framebuffer_color_samples_count: 0b101,
                     framebuffer_depth_samples_count: 0b101,
                     framebuffer_stencil_samples_count: 0b101,
+                    non_coherent_atom_size: 1, //TODO: confirm
                 },
                 private_caps: Capabilities {
                     heterogeneous_resource_heaps,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -621,7 +621,9 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment as _,
             framebuffer_color_samples_count: limits.framebuffer_color_sample_counts.flags() as _,
             framebuffer_depth_samples_count: limits.framebuffer_depth_sample_counts.flags() as _,
-            framebuffer_stencil_samples_count: limits.framebuffer_stencil_sample_counts.flags() as _,        }
+            framebuffer_stencil_samples_count: limits.framebuffer_stencil_sample_counts.flags() as _,
+            non_coherent_atom_size: limits.non_coherent_atom_size as _,
+        }
     }
 }
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -253,6 +253,8 @@ pub struct Limits {
     pub framebuffer_depth_samples_count: image::NumSamples,
     /// Number of samples supported for stencil attachments of framebuffers.
     pub framebuffer_stencil_samples_count: image::NumSamples,
+    /// Size and alignment in bytes that bounds concurrent access to host-mapped device memory.
+    pub non_coherent_atom_size: usize,
 }
 
 /// Describes the type of geometric primitives,

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -160,7 +160,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
         let upload_type: hal::MemoryTypeId = memory_types
             .iter()
             .position(|mt| {
-                mt.properties.contains(memory::Properties::CPU_VISIBLE)
+                mt.properties.contains(memory::Properties::CPU_VISIBLE | memory::Properties::COHERENT)
                 //&&!mt.properties.contains(memory::Properties::CPU_CACHED)
             })
             .unwrap()
@@ -168,7 +168,8 @@ impl<B: hal::Backend> Scene<B, hal::General> {
         let download_type = memory_types
             .iter()
             .position(|mt| {
-                mt.properties.contains(memory::Properties::CPU_VISIBLE | memory::Properties::CPU_CACHED)
+                mt.properties.contains(memory::Properties::CPU_VISIBLE | memory::Properties::COHERENT)
+                //&&!mt.properties.contains(memory::Properties::CPU_CACHED)
             })
             .unwrap()
             .into();


### PR DESCRIPTION
Fixes #2014

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
