### PR TITLE
Out-of-pass image clears

### DIFF
--- a/reftests/local.ron
+++ b/reftests/local.ron
@@ -25,6 +25,11 @@
 			jobs: ["copy-image-buf"],
 			expect: Buffer("buffer.output", [52, 53, 54, 55]),
 		),
+		"clear-image": (
+			features: (bits: 0),
+			jobs: ["clear-image"],
+			expect: ImageRow("image.output", 0, [128, 128, 128, 128]),
+		),
 		"blit-image": (
 			features: (bits: 0),
 			jobs: ["blit-image"],

--- a/reftests/scenes/transfer.ron
+++ b/reftests/scenes/transfer.ron
@@ -140,6 +140,20 @@
 				],
 			),
 		),
+		"clear-image": Transfer(
+			ClearImage(
+				image: "image.output",
+				color: Float((0.5, 0.5, 0.5, 0.5)),
+				depth_stencil: (0.0, 0),
+				ranges: [
+					(
+						aspects: (bits: 0x1), //COLOR
+						levels: (start: 0, end: 1),
+						layers: (start: 0, end: 1),
+					),
+				],
+			),
+		),
 		"blit-image": Transfer(
 			BlitImage(
 				src: "image.input",

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -434,23 +434,17 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn clear_color_image_raw(
+    fn clear_image<T>(
         &mut self,
         _: &(),
         _: image::Layout,
-        _: image::SubresourceRange,
         _: command::ClearColorRaw,
-    ) {
-        unimplemented!()
-    }
-
-    fn clear_depth_stencil_image_raw(
-        &mut self,
-        _: &(),
-        _: image::Layout,
-        _: image::SubresourceRange,
         _: command::ClearDepthStencilRaw,
-    ) {
+        _: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<image::SubresourceRange>,
+    {
         unimplemented!()
     }
 
@@ -533,7 +527,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
 
-    fn begin_render_pass_raw<T>(
+    fn begin_render_pass<T>(
         &mut self,
         _: &(),
         _: &(),

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -542,7 +542,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn begin_render_pass_raw<T>(
+    fn begin_render_pass<T>(
         &mut self,
         render_pass: &n::RenderPass,
         framebuffer: &n::FrameBuffer,
@@ -609,13 +609,17 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         // TODO
     }
 
-    fn clear_color_image_raw(
+    fn clear_image<T>(
         &mut self,
         image: &n::Image,
         _: image::Layout,
-        _range: image::SubresourceRange,
-        value: command::ClearColorRaw,
-    ) {
+        color: command::ClearColorRaw,
+        _depth_stencil: command::ClearDepthStencilRaw,
+        _subresource_ranges: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<image::SubresourceRange>,
+    {
         // TODO: clearing strategies
         //  1.  < GL 3.0 / GL ES 3.0: glClear
         //  2.  < GL 4.4: glClearBuffer
@@ -635,20 +639,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         match image.channel {
             ChannelType::Unorm | ChannelType::Inorm | ChannelType::Ufloat |
             ChannelType::Float | ChannelType::Srgb | ChannelType::Uscaled |
-            ChannelType::Iscaled => self.push_cmd(Command::ClearBufferColorF(0, unsafe { value.float32 })),
-            ChannelType::Uint => self.push_cmd(Command::ClearBufferColorU(0, unsafe { value.uint32 })),
-            ChannelType::Int => self.push_cmd(Command::ClearBufferColorI(0, unsafe { value.int32 })),
+            ChannelType::Iscaled => self.push_cmd(Command::ClearBufferColorF(0, unsafe { color.float32 })),
+            ChannelType::Uint => self.push_cmd(Command::ClearBufferColorU(0, unsafe { color.uint32 })),
+            ChannelType::Int => self.push_cmd(Command::ClearBufferColorI(0, unsafe { color.int32 })),
         }
-    }
-
-    fn clear_depth_stencil_image_raw(
-        &mut self,
-        _image: &n::Image,
-        _: image::Layout,
-        _range: image::SubresourceRange,
-        _value: command::ClearDepthStencilRaw,
-    ) {
-        unimplemented!()
     }
 
     fn clear_attachments<T, U>(&mut self, _: T, _: U)

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -22,7 +22,7 @@ name = "gfx_backend_metal"
 gfx-hal = { path = "../../hal", version = "0.1" }
 log = "0.4"
 winit = { version = "0.13", optional = true }
-metal-rs = "0.9.2"
+metal-rs = "0.9.3"
 foreign-types = "0.3"
 objc = "0.2"
 block = "0.1"

--- a/src/backend/metal/shaders/commands.metal
+++ b/src/backend/metal/shaders/commands.metal
@@ -1,6 +1,44 @@
 #include <metal_stdlib>
 using namespace metal;
 
+// -------------- Image Clears -------------- //
+
+typedef struct {
+    float4 coords [[attribute(0)]];
+} ClearAttributes;
+
+typedef struct {
+    float4 position [[position]];
+    uint layer [[render_target_array_index]];
+} ClearVertexData;
+
+vertex ClearVertexData vs_clear(ClearAttributes in [[stage_in]]) {
+    float4 pos = { 0.0, 0.0, 0.0f, 1.0f };
+    pos.xy = in.coords.xy * 2.0 - 1.0;
+    return ClearVertexData { pos, uint(in.coords.z) };
+}
+
+fragment float4 ps_blit_float(
+    ClearVertexData in [[stage_in]],
+    constant float4 &value [[ buffer(0) ]]
+) {
+  return value;
+}
+
+fragment int4 ps_blit_int(
+    ClearVertexData in [[stage_in]],
+    constant int4 &value [[ buffer(0) ]]
+) {
+  return value;
+}
+
+fragment uint4 ps_blit_uint(
+    ClearVertexData in [[stage_in]],
+    constant uint4 &value [[ buffer(0) ]]
+) {
+  return value;
+}
+
 // -------------- Image Blits -------------- //
 
 typedef struct {

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1234,7 +1234,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
         let clear_color = unsafe {
             match image.shader_channel {
-                Channel::Float =>metal::MTLClearColor::new(
+                Channel::Float => metal::MTLClearColor::new(
                     color.float32[0] as _,
                     color.float32[1] as _,
                     color.float32[2] as _,
@@ -1271,7 +1271,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             for level in sub.levels.start .. end_level {
                 for layer in sub.layers.start .. end_layer {
                     let descriptor = metal::RenderPassDescriptor::new().to_owned();
-                    // descriptor.set_render_target_array_length(sub.layers.end as _); //TODO: fast patg
+                    // descriptor.set_render_target_array_length(sub.layers.end as _); //TODO: fast path
                     if sub.aspects.contains(Aspects::COLOR) {
                         let attachment = descriptor
                             .color_attachments()

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1257,9 +1257,19 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
         for subresource_range in subresource_ranges {
             let sub = subresource_range.borrow();
+            let end_level = if sub.levels.end == !0 {
+                image.raw.mipmap_level_count() as _
+            } else {
+                sub.levels.end
+            };
+            let end_layer = if sub.layers.end == !0 {
+                image.raw.array_length() as _
+            } else {
+                sub.layers.end
+            };
 
-            for level in sub.levels.clone() {
-                for layer in sub.layers.clone() {
+            for level in sub.levels.start .. end_level {
+                for layer in sub.layers.start .. end_layer {
                     let descriptor = metal::RenderPassDescriptor::new().to_owned();
                     // descriptor.set_render_target_array_length(sub.layers.end as _); //TODO: fast patg
                     if sub.aspects.contains(Aspects::COLOR) {
@@ -1269,7 +1279,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             .unwrap();
                         attachment.set_texture(Some(&image.raw));
                         attachment.set_level(level as _);
-                        attachment.set_depth_plane(layer as _);
+                        attachment.set_slice(layer as _);
+                        //attachment.set_depth_plane();
                         attachment.set_load_action(metal::MTLLoadAction::Clear);
                         attachment.set_clear_color(clear_color.clone());
                     }
@@ -1280,7 +1291,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             .unwrap();
                         attachment.set_texture(Some(&image.raw));
                         attachment.set_level(level as _);
-                        attachment.set_depth_plane(layer as _);
+                        attachment.set_slice(layer as _);
+                        //attachment.set_depth_plane();
                         attachment.set_load_action(metal::MTLLoadAction::Clear);
                         attachment.set_clear_depth(depth_stencil.depth as _);
                     }
@@ -1290,7 +1302,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             .unwrap();
                         attachment.set_texture(Some(&image.raw));
                         attachment.set_level(level as _);
-                        attachment.set_depth_plane(layer as _);
+                        attachment.set_slice(layer as _);
+                        //attachment.set_depth_plane(_);
                         attachment.set_load_action(metal::MTLLoadAction::Clear);
                         attachment.set_clear_stencil(depth_stencil.stencil);
                     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1,6 +1,6 @@
 use {AutoreleasePool, Backend};
 use {native, window};
-use internal::{BlitVertex, ServicePipes};
+use internal::{BlitVertex, Channel, ServicePipes};
 
 use std::borrow::{self, Borrow};
 use std::cell::RefCell;
@@ -494,10 +494,37 @@ impl CommandSink {
         }
     }
 
+    fn quick_render_pass<I>(
+        &mut self,
+        descriptor: metal::RenderPassDescriptor,
+        commands: I,
+    ) where
+        I: IntoIterator<Item = soft::RenderCommand>,
+    {
+        match *self {
+            CommandSink::Immediate { ref cmd_buffer, ref mut encoder_state, .. } => {
+                match *encoder_state {
+                    EncoderState::None => (),
+                    _ => panic!("Must be outside of encoding"),
+                };
+                let _ap = AutoreleasePool::new();
+                let encoder = cmd_buffer.new_render_command_encoder(&descriptor);
+                for command in commands {
+                    exec_render(encoder, &command);
+                }
+                encoder.end_encoding();
+            }
+            CommandSink::Deferred { ref mut passes, ref mut is_encoding } => {
+                assert!(!*is_encoding);
+                passes.push(soft::Pass::Render(descriptor, commands.into_iter().collect()));
+            }
+        }
+    }
+
     fn begin_render_pass(
         &mut self,
-        init_commands: Vec<soft::RenderCommand>,
         descriptor: metal::RenderPassDescriptor,
+        init_commands: Vec<soft::RenderCommand>,
     ) {
         self.stop_encoding();
 
@@ -1191,24 +1218,88 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             .blit_commands(iter::once(command));
     }
 
-    fn clear_color_image_raw(
+    fn clear_image<T>(
         &mut self,
-        _image: &native::Image,
+        image: &native::Image,
         _layout: Layout,
-        _range: SubresourceRange,
-        _value: com::ClearColorRaw,
-    ) {
-        unimplemented!()
-    }
+        color: com::ClearColorRaw,
+        depth_stencil: com::ClearDepthStencilRaw,
+        subresource_ranges: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<SubresourceRange>,
+    {
+        let mut inner = self.inner.borrow_mut();
+        inner.sink().stop_encoding();
 
-    fn clear_depth_stencil_image_raw(
-        &mut self,
-        _image: &native::Image,
-        _layout: Layout,
-        _range: SubresourceRange,
-        _value: com::ClearDepthStencilRaw,
-    ) {
-        unimplemented!()
+        let clear_color = unsafe {
+            match image.shader_channel {
+                Channel::Float =>metal::MTLClearColor::new(
+                    color.float32[0] as _,
+                    color.float32[1] as _,
+                    color.float32[2] as _,
+                    color.float32[3] as _,
+                ),
+                Channel::Int => metal::MTLClearColor::new(
+                    color.int32[0] as _,
+                    color.int32[1] as _,
+                    color.int32[2] as _,
+                    color.int32[3] as _,
+                ),
+                Channel::Uint => metal::MTLClearColor::new(
+                    color.uint32[0] as _,
+                    color.uint32[1] as _,
+                    color.uint32[2] as _,
+                    color.uint32[3] as _,
+                ),
+            }
+        };
+
+        for subresource_range in subresource_ranges {
+            let sub = subresource_range.borrow();
+
+            for level in sub.levels.clone() {
+                for layer in sub.layers.clone() {
+                    let descriptor = metal::RenderPassDescriptor::new().to_owned();
+                    // descriptor.set_render_target_array_length(sub.layers.end as _); //TODO: fast patg
+                    if sub.aspects.contains(Aspects::COLOR) {
+                        let attachment = descriptor
+                            .color_attachments()
+                            .object_at(0)
+                            .unwrap();
+                        attachment.set_texture(Some(&image.raw));
+                        attachment.set_level(level as _);
+                        attachment.set_depth_plane(layer as _);
+                        attachment.set_load_action(metal::MTLLoadAction::Clear);
+                        attachment.set_clear_color(clear_color.clone());
+                    }
+
+                    if sub.aspects.intersects(Aspects::DEPTH | Aspects::STENCIL) {
+                        let attachment = descriptor
+                            .depth_attachment()
+                            .unwrap();
+                        attachment.set_texture(Some(&image.raw));
+                        attachment.set_level(level as _);
+                        attachment.set_depth_plane(layer as _);
+                        attachment.set_load_action(metal::MTLLoadAction::Clear);
+                        attachment.set_clear_depth(depth_stencil.depth as _);
+                    }
+                    if sub.aspects.contains(Aspects::STENCIL) {
+                        let attachment = descriptor
+                            .stencil_attachment()
+                            .unwrap();
+                        attachment.set_texture(Some(&image.raw));
+                        attachment.set_level(level as _);
+                        attachment.set_depth_plane(layer as _);
+                        attachment.set_load_action(metal::MTLLoadAction::Clear);
+                        attachment.set_clear_stencil(depth_stencil.stencil);
+                    }
+
+                    inner.sink().quick_render_pass(descriptor, None);
+                    // no actual pass body - everything is in the attachment clear operations
+                }
+            }
+        }
     }
 
     fn clear_attachments<T, U>(
@@ -1385,10 +1476,12 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             // Note: we don't bother to restore any render states here, since we are currently
             // outside of a render pass, and the state will be reset automatically once
             // we enter the next pass.
+            inner.sink().stop_encoding();
+
             let mut pipes = self.shared.service_pipes
                 .lock()
                 .unwrap();
-            let key = (dst.mtl_type, dst.mtl_format, dst.blit_channel);
+            let key = (dst.mtl_type, dst.mtl_format, dst.shader_channel);
             let pso = pipes
                 .get_blit_image(key, &self.shared.device)
                 .to_owned();
@@ -1463,14 +1556,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 let commands = prelude
                     .iter()
                     .chain(&extra)
-                    .cloned()
-                    .collect();
+                    .cloned();
 
-                inner.sink().begin_render_pass(commands, descriptor);
-                // no actual pass body - everything is in the init commands
+                inner.sink().quick_render_pass(descriptor, commands);
             }
-
-            inner.sink().stop_encoding();
         }
     }
 
@@ -1574,7 +1663,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         warn!("Depth bounds test is not supported");
     }
 
-    fn begin_render_pass_raw<T>(
+    fn begin_render_pass<T>(
         &mut self,
         render_pass: &native::RenderPass,
         frame_buffer: &native::FrameBuffer,
@@ -1613,7 +1702,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.inner
             .borrow_mut()
             .sink()
-            .begin_render_pass(init_commands, descriptor);
+            .begin_render_pass(descriptor, init_commands);
     }
 
     fn next_subpass(&mut self, _contents: com::SubpassContents) {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1444,18 +1444,20 @@ impl hal::Device<Backend> for Device {
         let descriptor = metal::TextureDescriptor::new();
 
         let mtl_type = match kind {
-            image::Kind::D1(_, 1) => {
+            image::Kind::D1(_, 1) if mip_levels == 1=> {
                 assert!(!is_cube);
                 MTLTextureType::D1
             }
-            image::Kind::D1(_, layers) => {
+            image::Kind::D1(_, layers) if mip_levels == 1 => {
                 assert!(!is_cube);
                 descriptor.set_array_length(layers as u64);
                 MTLTextureType::D1Array
             }
+            image::Kind::D1(_, 1) |
             image::Kind::D2(_, _, 1, 1) => {
                 MTLTextureType::D2
             }
+            image::Kind::D1(_, layers) |
             image::Kind::D2(_, _, layers, 1) => {
                 if is_cube && layers > 6 {
                     assert_eq!(layers % 6, 0);
@@ -1490,7 +1492,6 @@ impl hal::Device<Backend> for Device {
         descriptor.set_width(extent.width as u64);
         descriptor.set_height(extent.height as u64);
         descriptor.set_depth(extent.depth as u64);
-
         descriptor.set_mipmap_level_count(mip_levels as u64);
         descriptor.set_pixel_format(mtl_format);
         descriptor.set_usage(map_texture_usage(usage));

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1,7 +1,7 @@
 use {AutoreleasePool, Backend, PrivateCapabilities, QueueFamily, Surface, Swapchain};
 use {native as n, command, soft};
 use conversions::*;
-use internal::BlitChannel;
+use internal::Channel;
 
 use std::borrow::Borrow;
 use std::collections::HashMap;
@@ -1572,16 +1572,16 @@ impl hal::Device<Backend> for Device {
             raw,
             extent: image.extent,
             format_desc: base.0.desc(),
-            blit_channel: match base.1 {
+            shader_channel: match base.1 {
                 format::ChannelType::Unorm |
                 format::ChannelType::Inorm |
                 format::ChannelType::Ufloat |
                 format::ChannelType::Float |
                 format::ChannelType::Uscaled |
                 format::ChannelType::Iscaled |
-                format::ChannelType::Srgb => BlitChannel::Float,
-                format::ChannelType::Uint => BlitChannel::Uint,
-                format::ChannelType::Int => BlitChannel::Int,
+                format::ChannelType::Srgb => Channel::Float,
+                format::ChannelType::Uint => Channel::Uint,
+                format::ChannelType::Int => Channel::Int,
             },
             mtl_format: match self.private_caps.map_format(image.format) {
                 Some(format) => format,

--- a/src/backend/metal/src/internal.rs
+++ b/src/backend/metal/src/internal.rs
@@ -7,25 +7,44 @@ use std::path::Path;
 
 
 #[derive(Debug)]
+pub struct _ClearVertex {
+    pub pos: [f32; 4],
+}
+
+#[derive(Debug)]
 pub struct BlitVertex {
     pub uv: [f32; 4],
     pub pos: [f32; 4],
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub enum BlitChannel {
+pub enum Channel {
     Float,
     Int,
     Uint,
 }
 
-pub type BlitKey = (metal::MTLTextureType, metal::MTLPixelFormat, BlitChannel);
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct ClearMask {
+    color: Option<Channel>,
+    depth: bool,
+    stencil: bool,
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct ClearKey {
+    color: Option<(metal::MTLPixelFormat, Channel)>,
+    depth: Option<metal::MTLPixelFormat>,
+    stencil: Option<metal::MTLPixelFormat>,
+}
+pub type BlitKey = (metal::MTLTextureType, metal::MTLPixelFormat, Channel);
 
 //#[derive(Clone)]
 pub struct ServicePipes {
     library: metal::Library,
     sampler_nearest: metal::SamplerState,
     sampler_linear: metal::SamplerState,
+    _clears: HashMap<ClearKey, metal::RenderPipelineState>,
     blits: HashMap<BlitKey, metal::RenderPipelineState>,
     copy_buffer: metal::ComputePipelineState,
     fill_buffer: metal::ComputePipelineState,
@@ -50,6 +69,7 @@ impl ServicePipes {
         let fill_buffer = Self::create_fill_buffer(&library, device);
 
         ServicePipes {
+            _clears: HashMap::new(),
             blits: HashMap::new(),
             sampler_nearest,
             sampler_linear,
@@ -64,6 +84,76 @@ impl ServicePipes {
             Filter::Nearest => self.sampler_nearest.clone(),
             Filter::Linear => self.sampler_linear.clone(),
         }
+    }
+
+    pub fn _get_clear_image(
+        &mut self,
+        key: ClearKey,
+        device: &metal::DeviceRef,
+    ) -> &metal::RenderPipelineStateRef {
+        let lib = &self.library;
+        self._clears
+            .entry(key)
+            .or_insert_with(|| Self::_create_clear_image(key, lib, device))
+    }
+
+    fn _create_clear_image(
+        key: ClearKey, library: &metal::LibraryRef, device: &metal::DeviceRef,
+    ) -> metal::RenderPipelineState {
+        let pipeline = metal::RenderPipelineDescriptor::new();
+        pipeline.set_input_primitive_topology(metal::MTLPrimitiveTopologyClass::Triangle);
+
+        let vs_clear = library.get_function("vs_clear", None).unwrap();
+        pipeline.set_vertex_function(Some(&vs_clear));
+
+        if let Some((format, channel)) = key.color {
+            let s_channel = match channel {
+                Channel::Float => "float",
+                Channel::Int => "int",
+                Channel::Uint => "uint",
+            };
+            let ps_name = format!("ps_clear_{}", s_channel);
+            let ps_blit = library.get_function(&ps_name, None).unwrap();
+            pipeline.set_fragment_function(Some(&ps_blit));
+
+            pipeline
+                .color_attachments()
+                .object_at(0)
+                .unwrap()
+                .set_pixel_format(format);
+        }
+
+        /*
+        if let Some(format) = key.depth {
+            pipeline
+                .depth_attachment()
+                .set_pixel_format(format);
+        }
+        if let Some(format) = key.stencil {
+            pipeline
+                .stentil_attachment()
+                .set_pixel_format(format);
+        }*/
+
+        // Vertex buffers
+        let vertex_descriptor = metal::VertexDescriptor::new();
+        let mtl_buffer_desc = vertex_descriptor
+            .layouts()
+            .object_at(0)
+            .unwrap();
+        mtl_buffer_desc.set_stride(mem::size_of::<_ClearVertex>() as _);
+        for i in 0 .. 1 {
+            let mtl_attribute_desc = vertex_descriptor
+                .attributes()
+                .object_at(i)
+                .expect("too many vertex attributes");
+            mtl_attribute_desc.set_buffer_index(0);
+            mtl_attribute_desc.set_offset((i * mem::size_of::<[f32; 4]>()) as _);
+            mtl_attribute_desc.set_format(metal::MTLVertexFormat::Float4);
+        }
+        pipeline.set_vertex_descriptor(Some(&vertex_descriptor));
+
+        device.new_render_pipeline_state(&pipeline).unwrap()
     }
 
     pub fn get_blit_image(
@@ -96,9 +186,9 @@ impl ServicePipes {
             Tt::CubeArray => unimplemented!()
         };
         let s_channel = match key.2 {
-            BlitChannel::Float => "float",
-            BlitChannel::Int => "int",
-            BlitChannel::Uint => "uint",
+            Channel::Float => "float",
+            Channel::Int => "int",
+            Channel::Uint => "uint",
         };
         let ps_name = format!("ps_blit_{}_{}", s_type, s_channel);
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1,5 +1,5 @@
 use {Backend};
-use internal::BlitChannel;
+use internal::Channel;
 
 use std::cell::Cell;
 use std::collections::{Bound, BTreeMap, HashMap};
@@ -84,7 +84,7 @@ pub struct Image {
     pub(crate) raw: metal::Texture,
     pub(crate) extent: hal::image::Extent,
     pub(crate) format_desc: hal::format::FormatDesc,
-    pub(crate) blit_channel: BlitChannel,
+    pub(crate) shader_channel: Channel,
     pub(crate) mtl_format: metal::MTLPixelFormat,
     pub(crate) mtl_type: metal::MTLTextureType,
 }

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -1,5 +1,5 @@
 use {Backend, QueueFamily};
-use internal::BlitChannel;
+use internal::Channel;
 use native;
 use device::{Device, PhysicalDevice};
 
@@ -161,7 +161,7 @@ impl Device {
                         depth: 1,
                     },
                     format_desc: config.color_format.surface_desc(),
-                    blit_channel: BlitChannel::Float,
+                    shader_channel: Channel::Float,
                     mtl_format,
                     mtl_type: metal::MTLTextureType::D2,
                 }

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -183,12 +183,12 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
         layout: image::Layout,
         color: ClearColor,
         depth_stencil: ClearDepthStencil,
-        ranges: T,
+        subresource_ranges: T,
     ) where
         T: IntoIterator,
         T::Item: Borrow<image::SubresourceRange>,
     {
-        self.raw.clear_image(image, layout, color.into(), depth_stencil.into(), ranges)
+        self.raw.clear_image(image, layout, color.into(), depth_stencil.into(), subresource_ranges)
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -10,7 +10,6 @@ use query::{PipelineStatistic, Query, QueryControl, QueryId};
 use range::RangeArg;
 use super::{
     AttachmentClear, BufferCopy, BufferImageCopy,
-    ClearColor, ClearDepthStencil, ClearValue,
     ImageBlit, ImageCopy, ImageResolve, SubpassContents,
 };
 
@@ -48,6 +47,7 @@ pub union ClearValueRaw {
     pub depth_stencil: ClearDepthStencilRaw,
     _align: [u32; 4],
 }
+
 
 bitflags! {
     /// Option flags for various command buffer settings.
@@ -147,56 +147,17 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
         data: &[u8],
     );
 
-    /// Clears an image to the given color.
-    /// Just calls `clear_color_raw` with some minor type conversion.
-    fn clear_color_image(
+    /// Clears an image to the given color/depth/stencil.
+    fn clear_image<T>(
         &mut self,
         image: &B::Image,
         layout: Layout,
-        range: SubresourceRange,
-        cv: ClearColor,
-    ) {
-        self.clear_color_image_raw(
-            image,
-            layout,
-            range,
-            cv.into(),
-        )
-    }
-
-    /// Clears an image to the given color.
-    fn clear_color_image_raw(
-        &mut self,
-        &B::Image,
-        Layout,
-        SubresourceRange,
-        ClearColorRaw,
-    );
-
-    /// Clear a depth-stencil image to the given value.
-    /// Just calls `clear_depth_stencil_image_raw` with some minor type conversion.
-    fn clear_depth_stencil_image(
-        &mut self,
-        image: &B::Image,
-        layout: Layout,
-        range: SubresourceRange,
-        cv: ClearDepthStencil,
-    ) {
-        let cv = ClearDepthStencilRaw {
-            depth: cv.0,
-            stencil: cv.1,
-        };
-        self.clear_depth_stencil_image_raw(image, layout, range, cv)
-    }
-
-    /// Clear a depth-stencil image to the given value.
-    fn clear_depth_stencil_image_raw(
-        &mut self,
-        &B::Image,
-        Layout,
-        SubresourceRange,
-        ClearDepthStencilRaw,
-    );
+        color: ClearColorRaw,
+        depth_stencil: ClearDepthStencilRaw,
+        ranges: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<SubresourceRange>;
 
     /// Takes an iterator of attachments and an iterator of rect's,
     /// and clears the given rect's for *each* attachment.
@@ -246,7 +207,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     fn bind_vertex_buffers(&mut self, first_binding: u32, pso::VertexBufferSet<B>);
 
     /// Set the viewport parameters for the rasterizer.
-    /// 
+    ///
     /// Each viewport passed corrosponds to the viewport with the same index,
     /// starting from an offset index `first_viewport`.
     ///
@@ -300,50 +261,14 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     /// Set the depth bounds test values dynamically.
     fn set_depth_bounds(&mut self, bounds: Range<f32>);
 
-    /// Just does some type conversions and calls `begin_render_pass_raw`.
-    fn begin_render_pass<T>(
-        &mut self,
-        render_pass: &B::RenderPass,
-        framebuffer: &B::Framebuffer,
-        render_area: pso::Rect,
-        clear_values: T,
-        first_subpass: SubpassContents,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<ClearValue>
-    {
-        let clear_values = clear_values
-            .into_iter()
-            .map(|cv| {
-                match *cv.borrow() {
-                    ClearValue::Color(ClearColor::Float(cv)) =>
-                        ClearValueRaw { color: ClearColorRaw { float32: cv }},
-                    ClearValue::Color(ClearColor::Int(cv)) =>
-                        ClearValueRaw { color: ClearColorRaw { int32: cv }},
-                    ClearValue::Color(ClearColor::Uint(cv)) =>
-                        ClearValueRaw { color: ClearColorRaw { uint32: cv }},
-                    ClearValue::DepthStencil(ClearDepthStencil(depth, stencil)) =>
-                        ClearValueRaw { depth_stencil: ClearDepthStencilRaw { depth, stencil }},
-                }
-            });
-
-        self.begin_render_pass_raw(
-            render_pass,
-            framebuffer,
-            render_area,
-            clear_values,
-            first_subpass,
-        )
-    }
-
     /// Begins recording commands for a render pass on the given framebuffer.
     /// `render_area` is the section of the framebuffer to render,
-    /// `clear_values` is an iterator of `ClearValue`'s to use to use for
+    /// `clear_values` is an iterator of `ClearValueRaw`'s to use to use for
     /// `clear_*` commands, one for each attachment of the render pass.
     /// `first_subpass` specifies, for the first subpass, whether the
     /// rendering commands are provided inline or whether the render
     /// pass is composed of subpasses.
-    fn begin_render_pass_raw<T>(
+    fn begin_render_pass<T>(
         &mut self,
         render_pass: &B::RenderPass,
         framebuffer: &B::Framebuffer,

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -154,7 +154,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
         layout: Layout,
         color: ClearColorRaw,
         depth_stencil: ClearDepthStencilRaw,
-        ranges: T,
+        subresource_ranges: T,
     ) where
         T: IntoIterator,
         T::Item: Borrow<SubresourceRange>;

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -6,7 +6,7 @@ use {buffer, pso};
 use {Backend, IndexCount, InstanceCount, VertexCount, VertexOffset};
 use queue::{Supports, Graphics};
 use super::{
-    AttachmentClear, ClearValue, CommandBuffer, RawCommandBuffer,
+    AttachmentClear, ClearValue, ClearValueRaw, CommandBuffer, RawCommandBuffer,
     Shot, Level, Primary, Secondary, Submittable, Submit
 };
 
@@ -152,13 +152,22 @@ impl<'a, B: Backend, L: Level> RenderPassInlineEncoder<'a, B, L> {
         T: IntoIterator,
         T::Item: Borrow<ClearValue>,
     {
+        let clear_values = clear_values
+            .into_iter()
+            .map(|cv| ClearValueRaw::from(*cv.borrow()));
+
         cmd_buffer.raw.begin_render_pass(
             render_pass,
             frame_buffer,
             render_area,
             clear_values,
-            SubpassContents::Inline);
-        RenderPassInlineEncoder(Some(RenderSubpassCommon(cmd_buffer.raw)), PhantomData)
+            SubpassContents::Inline,
+        );
+
+        RenderPassInlineEncoder(
+            Some(RenderSubpassCommon(cmd_buffer.raw)),
+            PhantomData,
+        )
     }
 
     /// Start the next subpass.
@@ -220,14 +229,21 @@ impl<'a, B: Backend> RenderPassSecondaryEncoder<'a, B> {
         T: IntoIterator,
         T::Item: Borrow<ClearValue>,
     {
+        let clear_values = clear_values
+            .into_iter()
+            .map(|cv| ClearValueRaw::from(*cv.borrow()));
+
         cmd_buffer.raw.begin_render_pass(
             render_pass,
             frame_buffer,
             render_area,
             clear_values,
-            SubpassContents::SecondaryBuffers
+            SubpassContents::SecondaryBuffers,
         );
-        RenderPassSecondaryEncoder(Some(cmd_buffer.raw))
+
+        RenderPassSecondaryEncoder(
+            Some(cmd_buffer.raw),
+        )
     }
 
     /// Executes the given commands as a secondary command buffer.

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -633,10 +633,11 @@ impl<'a, B: Backend, C> Encoder<'a, B, C>
     }
 
     /// Clears `image` to `value`.
-    pub fn clear_color_raw(
+    pub fn clear_image_raw(
         &mut self,
         image: &handle::raw::Image<B>,
-        value: ClearColor,
+        color: ClearColor,
+        depth_stencil: ClearDepthStencil,
     ) {
         let layout = self.require_clear_state(image);
         //TODO
@@ -646,35 +647,19 @@ impl<'a, B: Backend, C> Encoder<'a, B, C>
             layers: 0 .. 1,
         };
         self.handles.add(image.clone());
-        self.buffer.clear_color_image(image.resource(), layout, range, value);
+        self.buffer.clear_image(image.resource(), layout, color, depth_stencil, Some(range));
     }
 
     /// Clears `image` to `value`.
-    pub fn clear_color<F>(
+    pub fn clear_image<F>(
         &mut self,
         image: &handle::Image<B, F>,
-        value: ClearColor,
+        color: ClearColor,
+        depth_stencil: ClearDepthStencil,
     ) where
         F: format::AsFormat,
     {
-        self.clear_color_raw(image.as_ref(), value);
-    }
-
-    /// Clears `image`'s depth/stencil with `value`
-    pub fn clear_depth_stencil_raw(
-        &mut self,
-        image: &handle::raw::Image<B>,
-        value: ClearDepthStencil,
-    ) {
-        let layout = self.require_clear_state(image);
-        //TODO
-        let range = i::SubresourceRange {
-            aspects: Aspects::DEPTH | Aspects::STENCIL,
-            levels: 0 .. 1,
-            layers: 0 .. 1,
-        };
-        self.handles.add(image.clone());
-        self.buffer.clear_depth_stencil_image(image.resource(), layout, range, value);
+        self.clear_image_raw(image.as_ref(), color, depth_stencil);
     }
 
     pub fn draw<D>(

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -827,6 +827,31 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                             ],
                         );
                     }
+                    Tc::ClearImage { ref image, color, depth_stencil, ref ranges } => {
+                        let img = resources.images
+                            .get(image)
+                            .expect(&format!("Missing clear image: {}", image));
+                        command_buf.pipeline_barrier(
+                            pso::PipelineStage::TOP_OF_PIPE .. pso::PipelineStage::TRANSFER,
+                            memory::Dependencies::empty(),
+                            vec![
+                                img.barrier_to(i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal),
+                            ],
+                        );
+                        command_buf.clear_image(
+                            &img.handle, i::Layout::TransferDstOptimal,
+                            color,
+                            depth_stencil,
+                            ranges,
+                        );
+                        command_buf.pipeline_barrier(
+                            pso::PipelineStage::TRANSFER .. pso::PipelineStage::BOTTOM_OF_PIPE,
+                            memory::Dependencies::empty(),
+                            vec![
+                                img.barrier_from(i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal),
+                            ],
+                        );
+                    }
                     Tc::BlitImage { ref src, ref dst, filter, ref regions } => {
                         let st = resources.images
                             .get(src)

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -138,6 +138,12 @@ pub enum TransferCommand {
         dst: String,
         regions: Vec<hal::command::BufferImageCopy>,
     },
+    ClearImage {
+        image: String,
+        color: hal::command::ClearColor,
+        depth_stencil: hal::command::ClearDepthStencil,
+        ranges: Vec<hal::image::SubresourceRange>,
+    },
     BlitImage {
         src: String,
         dst: String,


### PR DESCRIPTION
Fixes #2007
Depends on https://github.com/gfx-rs/metal-rs/pull/49
With this PR as well as the upcoming portability changes, we can go through the whole `api.image_clearing` section (on Metal) without crashes. 143 passes and 216 failures at the moment, out of 1027 tests in total.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
