### PR TITLE
Metal image views

### DIFF
--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -313,6 +313,19 @@ pub fn map_texture_usage(usage: image::Usage) -> MTLTextureUsage {
     texture_usage
 }
 
+pub fn map_texture_type(view_kind: image::ViewKind) -> MTLTextureType {
+    use hal::image::ViewKind as Vk;
+    match view_kind {
+        Vk::D1 => MTLTextureType::D1,
+        Vk::D1Array => MTLTextureType::D1Array,
+        Vk::D2 => MTLTextureType::D2,
+        Vk::D2Array => MTLTextureType::D2Array,
+        Vk::D3 => MTLTextureType::D3,
+        Vk::Cube => MTLTextureType::Cube,
+        Vk::CubeArray => MTLTextureType::CubeArray,
+    }
+}
+
 pub fn map_index_type(index_type: IndexType) -> MTLIndexType {
     match index_type {
         IndexType::U16 => MTLIndexType::UInt16,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1050,8 +1050,10 @@ impl hal::Device<Backend> for Device {
 
         // temporary command buffer to copy the contents from
         // the given buffers into the allocated CPU-visible buffers
-        let mut pool = self.command_shared.queue_pool.lock().unwrap();
-        let (queue_id, cmd_buffer) = pool.make_command_buffer(&self.device);
+        let (queue_id, cmd_buffer) = self.command_shared.queue_pool
+            .lock()
+            .unwrap()
+            .make_command_buffer(&self.device);
         let encoder = cmd_buffer.new_blit_command_encoder();
         let mut num_copies = 0;
 
@@ -1090,7 +1092,10 @@ impl hal::Device<Backend> for Device {
         }
 
         encoder.end_encoding();
-        pool.release_command_buffer(queue_id);
+        self.command_shared.queue_pool
+            .lock()
+            .unwrap()
+            .release_command_buffer(queue_id);
         if num_copies != 0 {
             debug!("\twaiting...");
             cmd_buffer.commit();

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1633,13 +1633,11 @@ impl hal::Device<Backend> for Device {
     fn create_image_view(
         &self,
         image: &n::Image,
-        _kind: image::ViewKind,
+        kind: image::ViewKind,
         format: format::Format,
-        _swizzle: format::Swizzle,
-        _range: image::SubresourceRange,
+        swizzle: format::Swizzle,
+        range: image::SubresourceRange,
     ) -> Result<n::ImageView, image::ViewError> {
-        // TODO: subresource range
-
         let mtl_format = match self.private_caps.map_format(format) {
             Some(f) => f,
             None => {
@@ -1648,7 +1646,25 @@ impl hal::Device<Backend> for Device {
             },
         };
 
-        Ok(n::ImageView(image.raw.new_texture_view(mtl_format)))
+        if swizzle != format::Swizzle::NO {
+            error!("swizzling not supported");
+            return Err(image::ViewError::Unsupported);
+        }
+
+        let view = image.raw.new_texture_view_from_slice(
+            mtl_format,
+            map_texture_type(kind),
+            NSRange {
+                location: range.levels.start as _,
+                length: (range.levels.end - range.levels.start) as _,
+            },
+            NSRange {
+                location: range.layers.start as _,
+                length: (range.layers.end - range.layers.start) as _,
+            },
+        );
+
+        Ok(n::ImageView(view))
     }
 
     fn destroy_image_view(&self, _view: n::ImageView) {


### PR DESCRIPTION
Fixes #2019
(finally had a good reason to learn "git bisect", at last)

The image views should be robust now. Unfortunately, related CTS tests fail because one of the buffers used in their compute somehow ends up with offset of 5 being bound, which is not supported by Metal. Need to investigate more (later).

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds (yay!)
- [ ] tested examples with the following backends:
