### PR TITLE
Blitting for dx12

### DIFF
--- a/src/backend/dx12/shaders/blit.hlsl
+++ b/src/backend/dx12/shaders/blit.hlsl
@@ -1,0 +1,38 @@
+
+Texture2DArray blit_src : register(t0);
+SamplerState blit_sampler : register(s0);
+
+cbuffer region : register(b0) {
+    float2 src_start;
+    float2 src_end;
+    float z;
+};
+
+struct VsOutput {
+    float4 position : SV_POSITION;
+    float3 src_coords : TEXCOORD;
+};
+
+// Create a screen filling triangle
+VsOutput vs_blit_2d(uint id: SV_VertexID) {
+    VsOutput output;
+    switch (id) {
+        case 0:
+            output.position = float4(-1.0, -1.0, 0.0, 0.0);
+            output.src_coords = float3(src_start, z);
+            break;
+        case 1:
+            output.position = float4(0.0, 2.0, 0.0, 0.0);
+            output.src_coords = float3(src_start.x, 2 * src_end.y - src_start.y, z);
+            break;
+        default:
+            output.position = float4(2.0, 0.0, 0.0, 0.0);
+            output.src_coords = float3(2 * src_end.x - src_start.x, src_start.y, z);
+            break;
+    }
+    return output;
+}
+
+float4 ps_blit_2d(VsOutput input) : SV_TARGET0 {
+    return blit_src.Sample(blit_sampler, input.src_coords);
+}

--- a/src/backend/dx12/shaders/blit.hlsl
+++ b/src/backend/dx12/shaders/blit.hlsl
@@ -3,36 +3,27 @@ Texture2DArray blit_src : register(t0);
 SamplerState blit_sampler : register(s0);
 
 cbuffer region : register(b0) {
-    float2 src_start;
-    float2 src_end;
+    float2 offset;
+    float2 extent;
     float z;
+    float level;
 };
 
 struct VsOutput {
-    float4 position : SV_POSITION;
-    float3 src_coords : TEXCOORD;
+    float4 pos: SV_POSITION;
+    float4 uv: TEXCOORD0;
 };
 
 // Create a screen filling triangle
 VsOutput vs_blit_2d(uint id: SV_VertexID) {
-    VsOutput output;
-    switch (id) {
-        case 0:
-            output.position = float4(-1.0, -1.0, 0.0, 0.0);
-            output.src_coords = float3(src_start, z);
-            break;
-        case 1:
-            output.position = float4(0.0, 2.0, 0.0, 0.0);
-            output.src_coords = float3(src_start.x, 2 * src_end.y - src_start.y, z);
-            break;
-        default:
-            output.position = float4(2.0, 0.0, 0.0, 0.0);
-            output.src_coords = float3(2 * src_end.x - src_start.x, src_start.y, z);
-            break;
-    }
+    float2 coord = float2((id << 1) & 2, id & 2);
+    VsOutput output = {
+        float4(float2(-1.0, 1.0) + coord * float2(2.0, -2.0), 0.0, 1.0),
+        float4(offset + coord * extent, z, level)
+    };
     return output;
 }
 
-float4 ps_blit_2d(VsOutput input) : SV_TARGET0 {
-    return blit_src.Sample(blit_sampler, input.src_coords);
+float4 ps_blit_2d(VsOutput input) : SV_TARGET {
+    return blit_src.SampleLevel(blit_sampler, input.uv.xyz, input.uv.w);
 }

--- a/src/backend/dx12/shaders/blit.hlsl
+++ b/src/backend/dx12/shaders/blit.hlsl
@@ -1,8 +1,8 @@
 
-Texture2DArray blit_src : register(t0);
-SamplerState blit_sampler : register(s0);
+Texture2DArray BlitSource : register(t0);
+SamplerState BlitSampler : register(s0);
 
-cbuffer region : register(b0) {
+cbuffer Region : register(b0) {
     float2 offset;
     float2 extent;
     float z;
@@ -25,5 +25,5 @@ VsOutput vs_blit_2d(uint id: SV_VertexID) {
 }
 
 float4 ps_blit_2d(VsOutput input) : SV_TARGET {
-    return blit_src.SampleLevel(blit_sampler, input.uv.xyz, input.uv.w);
+    return BlitSource.SampleLevel(BlitSampler, input.uv.xyz, input.uv.w);
 }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1,5 +1,5 @@
 
-use hal::{buffer, command as com, image, memory, pass, pso, query};
+use hal::{buffer, command as com, format, image, memory, pass, pso, query};
 use hal::{IndexCount, IndexType, InstanceCount, VertexCount, VertexOffset, WorkGroupCount};
 use hal::format::Aspects;
 use hal::range::RangeArg;
@@ -7,6 +7,7 @@ use hal::range::RangeArg;
 use std::{cmp, iter, mem, ptr};
 use std::borrow::Borrow;
 use std::ops::Range;
+use std::sync::Arc;
 
 use winapi::um::d3d12;
 use winapi::shared::minwindef::{FALSE, UINT};
@@ -14,7 +15,7 @@ use winapi::shared::dxgiformat;
 
 use wio::com::ComPtr;
 
-use {conv, native as n, Backend, CmdSignatures, MAX_VERTEX_BUFFERS};
+use {conv, native as n, Backend, Shared, MAX_VERTEX_BUFFERS};
 use root_constants::RootConstant;
 use smallvec::SmallVec;
 
@@ -257,7 +258,7 @@ struct Copy {
 pub struct CommandBuffer {
     raw: ComPtr<d3d12::ID3D12GraphicsCommandList>,
     allocator: ComPtr<d3d12::ID3D12CommandAllocator>,
-    signatures: CmdSignatures,
+    shared: Arc<Shared>,
 
     // Cache renderpasses for graphics operations
     pass_cache: Option<RenderPassCache>,
@@ -310,12 +311,12 @@ impl CommandBuffer {
     pub(crate) fn new(
         raw: ComPtr<d3d12::ID3D12GraphicsCommandList>,
         allocator: ComPtr<d3d12::ID3D12CommandAllocator>,
-        signatures: CmdSignatures,
+        shared: Arc<Shared>,
     ) -> Self {
         CommandBuffer {
             raw,
             allocator,
-            signatures,
+            shared,
             pass_cache: None,
             cur_subpass: !0,
             gr_pipeline: PipelineCache::new(),
@@ -1231,17 +1232,32 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn blit_image<T>(
         &mut self,
-        _src: &n::Image,
+        src: &n::Image,
         _src_layout: image::Layout,
-        _dst: &n::Image,
+        dst: &n::Image,
         _dst_layout: image::Layout,
-        _filter: image::Filter,
-        _regions: T,
+        filter: image::Filter,
+        regions: T,
     ) where
         T: IntoIterator,
         T::Item: Borrow<com::ImageBlit>
     {
-        unimplemented!()
+        // TODO: only supporting 2D images
+
+        let filter = match filter {
+            image::Filter::Nearest => d3d12::D3D12_FILTER_MIN_MAG_MIP_POINT,
+            image::Filter::Linear => d3d12::D3D12_FILTER_MIN_MAG_LINEAR_MIP_POINT,
+        };
+
+        for region in regions {
+            let r = region.borrow();
+            let blit = match r.dst_subresource.aspects {
+                format::Aspects::COLOR => self.shared.service_pipes.get_blit_2d_color(dst.dxgi_format, filter),
+                _ => unimplemented!(),
+            };
+
+            unimplemented!()
+        }
     }
 
     fn bind_index_buffer(&mut self, ibv: buffer::IndexBufferView<Backend>) {
@@ -1457,7 +1473,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.set_compute_bind_point();
         unsafe {
             self.raw.ExecuteIndirect(
-                self.signatures.dispatch.as_raw(),
+                self.shared.signatures.dispatch.as_raw(),
                 1,
                 buffer.resource,
                 offset,
@@ -1776,7 +1792,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.set_graphics_bind_point();
         unsafe {
             self.raw.ExecuteIndirect(
-                self.signatures.draw.as_raw(),
+                self.shared.signatures.draw.as_raw(),
                 draw_count,
                 buffer.resource,
                 offset,
@@ -1797,7 +1813,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.set_graphics_bind_point();
         unsafe {
             self.raw.ExecuteIndirect(
-                self.signatures.draw_indexed.as_raw(),
+                self.shared.signatures.draw_indexed.as_raw(),
                 draw_count,
                 buffer.resource,
                 offset,

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -550,8 +550,10 @@ impl CommandBuffer {
             BindPoint::InternalGraphics => {
                 // Switch to graphics bind point
                 let (pipeline, signature) = self.gr_pipeline.pipeline.expect("No graphics pipeline bound");
-                unsafe { self.raw.SetPipelineState(pipeline); }
-                unsafe { self.raw.SetGraphicsRootSignature(signature); }
+                unsafe {
+                    self.raw.SetPipelineState(pipeline);
+                    self.raw.SetGraphicsRootSignature(signature);
+                }
                 self.active_bindpoint = BindPoint::Graphics;
             },
         }
@@ -611,14 +613,14 @@ impl CommandBuffer {
 
     fn set_compute_bind_point(&mut self) {
         match self.active_bindpoint {
-            BindPoint::Graphics => {
+            BindPoint::Graphics | BindPoint::InternalGraphics => {
                 // Switch to compute bind point
                 assert!(self.comp_pipeline.pipeline.is_some(), "No compute pipeline bound");
                 let (pipeline, _) = self.comp_pipeline.pipeline.unwrap();
                 unsafe { self.raw.SetPipelineState(pipeline); }
                 self.active_bindpoint = BindPoint::Compute;
             },
-            BindPoint::Compute | BindPoint::InternalGraphics => { }, // Nothing to do
+            BindPoint::Compute => { }, // Nothing to do
         }
 
         let cmd_buffer = &mut self.raw;
@@ -1272,6 +1274,26 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     {
         // TODO: only supporting 2D images
 
+        let rtv_pool = {
+            let desc = d3d12::D3D12_DESCRIPTOR_HEAP_DESC {
+                Type: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
+                NumDescriptors: 1,
+                Flags: d3d12::D3D12_DESCRIPTOR_HEAP_FLAG_NONE,
+                NodeMask: 0,
+            };
+
+            let mut heap: *mut d3d12::ID3D12DescriptorHeap = ptr::null_mut();
+            unsafe {
+                (*self.shared.device).CreateDescriptorHeap(
+                    &desc,
+                    &d3d12::IID_ID3D12DescriptorHeap,
+                    &mut heap as *mut *mut _ as *mut *mut _,
+                );
+            };
+            unsafe { ComPtr::from_raw(heap) }
+        };
+        let rtv = unsafe { rtv_pool.GetCPUDescriptorHandleForHeapStart() };
+
         let filter = match filter {
             image::Filter::Nearest => d3d12::D3D12_FILTER_MIN_MAG_MIP_POINT,
             image::Filter::Linear => d3d12::D3D12_FILTER_MIN_MAG_LINEAR_MIP_POINT,
@@ -1279,14 +1301,88 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
         for region in regions {
             let r = region.borrow();
+
+            let first_layer = r.dst_subresource.layers.start;
+            let num_layers = r.dst_subresource.layers.end - first_layer;
+
             let blit = match r.dst_subresource.aspects {
-                format::Aspects::COLOR => self.shared.service_pipes.get_blit_2d_color(dst.dxgi_format, filter),
+                format::Aspects::COLOR => {
+                    // Create RTV of the dst image for the miplevel of the current region
+                    let mut desc = d3d12::D3D12_RENDER_TARGET_VIEW_DESC {
+                        Format: dst.dxgi_format,
+                        ViewDimension: d3d12::D3D12_RTV_DIMENSION_TEXTURE2DARRAY,
+                        u: unsafe { mem::zeroed() },
+                    };
+
+                    *unsafe{ desc.u.Texture2DArray_mut() } = d3d12::D3D12_TEX2D_ARRAY_RTV {
+                        MipSlice: r.dst_subresource.level as _,
+                        FirstArraySlice: first_layer as _,
+                        ArraySize: num_layers as _,
+                        PlaneSlice: 0, //TODO
+                    };
+
+                    unsafe {
+                        (*self.shared.device).CreateRenderTargetView(dst.resource, &desc, rtv);
+                        self.raw.OMSetRenderTargets(
+                            1,
+                            &rtv,
+                            FALSE,
+                            ptr::null(),
+                        );
+                    }
+
+                    self.shared.service_pipes.get_blit_2d_color(dst.dxgi_format, filter)
+                },
                 _ => unimplemented!(),
             };
 
             self.set_internal_graphics_pipeline();
 
-            unimplemented!()
+            // TODO: support flipping?
+            let viewport = d3d12::D3D12_VIEWPORT {
+                TopLeftX: r.dst_bounds.start.x as _,
+                TopLeftY: r.dst_bounds.start.y as _,
+                Width: (r.dst_bounds.end.x - r.dst_bounds.start.x) as _,
+                Height: (r.dst_bounds.end.y - r.dst_bounds.start.y) as _,
+                MinDepth: 0.0,
+                MaxDepth: 1.0,
+            };
+            let scissor = d3d12::D3D12_RECT {
+                left: r.dst_bounds.start.x,
+                top: r.dst_bounds.start.y,
+                right: r.dst_bounds.end.x,
+                bottom: r.dst_bounds.end.y,
+            };
+
+            // TODO: update push constants
+
+            // Instanced full screen triangle
+            //
+            // Each instance corresponds to one blitting operation on one layer
+            unsafe {
+                self.raw.SetPipelineState(blit.pipeline.as_raw());
+                self.raw.SetGraphicsRootSignature(blit.signature.as_raw());
+                self.raw.RSSetViewports(1, &viewport);
+                self.raw.RSSetScissorRects(1, &scissor);
+                self.raw.DrawInstanced(
+                    3,
+                    num_layers as _,
+                    0,
+                    first_layer as _,
+                );
+            }
+        }
+
+        // Reset viewports and scissors
+        unsafe {
+            self.raw.RSSetViewports(
+                self.viewport_cache.len() as _,
+                self.viewport_cache.as_ptr(),
+            );
+            self.raw.RSSetScissorRects(
+                self.scissor_cache.len() as _,
+                self.scissor_cache.as_ptr(),
+            );
         }
     }
 

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -48,83 +48,6 @@ fn up_align(x: u32, alignment: u32) -> u32 {
     (x + alignment - 1) & !(alignment - 1)
 }
 
-fn bind_descriptor_sets<'a, T>(
-    raw: &ComPtr<d3d12::ID3D12GraphicsCommandList>,
-    pipeline: &mut PipelineCache,
-    layout: &n::PipelineLayout,
-    first_set: usize,
-    sets: T,
-) where
-    T: IntoIterator,
-    T::Item: Borrow<n::DescriptorSet>,
-{
-    let mut sets = sets.into_iter().peekable();
-    let (srv_cbv_uav_start, sampler_start) = if let Some(set_0) = sets.peek().map(Borrow::borrow) {
-        // Bind descriptor heaps
-        unsafe {
-            // TODO: Can we bind them always or only once?
-            //       Resize while recording?
-            let mut heaps = [
-                set_0.heap_srv_cbv_uav.as_raw(),
-                set_0.heap_samplers.as_raw(),
-            ];
-            raw.SetDescriptorHeaps(2, heaps.as_mut_ptr())
-        }
-
-        (set_0.srv_cbv_uav_gpu_start().ptr, set_0.sampler_gpu_start().ptr)
-    } else {
-        return
-    };
-
-    pipeline.srv_cbv_uav_start = srv_cbv_uav_start;
-    pipeline.sampler_start = sampler_start;
-
-    let mut table_id = 0;
-    for table in &layout.tables[..first_set] {
-        if table.contains(n::SRV_CBV_UAV) {
-            table_id += 1;
-        }
-        if table.contains(n::SAMPLERS) {
-            table_id += 1;
-        }
-    }
-
-    let table_base_offset = layout
-        .root_constants
-        .iter()
-        .fold(0, |sum, c| sum + c.range.end - c.range.start);
-
-    for (set, table) in sets.zip(layout.tables[first_set..].iter()) {
-        let set = set.borrow();
-        set.first_gpu_view.map(|gpu| {
-            assert!(table.contains(n::SRV_CBV_UAV));
-
-            let root_offset = table_id + table_base_offset;
-            // Cast is safe as offset **must** be in u32 range. Unable to
-            // create heaps with more descriptors.
-            let table_offset = (gpu.ptr - srv_cbv_uav_start) as u32;
-            pipeline
-                .user_data
-                .set_srv_cbv_uav_table(root_offset as _, table_offset);
-
-            table_id += 1;
-        });
-        set.first_gpu_sampler.map(|gpu| {
-            assert!(table.contains(n::SAMPLERS));
-
-            let root_offset = table_id + table_base_offset;
-            // Cast is safe as offset **must** be in u32 range. Unable to
-            // create heaps with more descriptors.
-            let table_offset = (gpu.ptr - sampler_start) as u32;
-            pipeline
-                .user_data
-                .set_sampler_table(root_offset as _, table_offset);
-
-            table_id += 1;
-        });
-    }
-}
-
 #[derive(Clone)]
 struct AttachmentClear {
     subpass_id: Option<pass::SubpassId>,
@@ -241,6 +164,80 @@ impl PipelineCache {
             sampler_start: 0,
         }
     }
+
+    fn bind_descriptor_sets<'a, T>(
+        &mut self,
+        layout: &n::PipelineLayout,
+        first_set: usize,
+        sets: T,
+    ) -> [*mut d3d12::ID3D12DescriptorHeap; 2]
+    where
+        T: IntoIterator,
+        T::Item: Borrow<n::DescriptorSet>,
+    {
+        let mut sets = sets.into_iter().peekable();
+        let (
+            srv_cbv_uav_start, sampler_start,
+            heap_srv_cbv_uav, heap_sampler,
+        ) = if let Some(set_0) = sets.peek().map(Borrow::borrow) {
+            (
+                set_0.srv_cbv_uav_gpu_start().ptr, set_0.sampler_gpu_start().ptr,
+                set_0.heap_srv_cbv_uav.as_raw(), set_0.heap_samplers.as_raw(),
+            )
+        } else {
+            return [ptr::null_mut(); 2];
+        };
+
+        self.srv_cbv_uav_start = srv_cbv_uav_start;
+        self.sampler_start = sampler_start;
+
+        let mut table_id = 0;
+        for table in &layout.tables[..first_set] {
+            if table.contains(n::SRV_CBV_UAV) {
+                table_id += 1;
+            }
+            if table.contains(n::SAMPLERS) {
+                table_id += 1;
+            }
+        }
+
+        let table_base_offset = layout
+            .root_constants
+            .iter()
+            .fold(0, |sum, c| sum + c.range.end - c.range.start);
+
+        for (set, table) in sets.zip(layout.tables[first_set..].iter()) {
+            let set = set.borrow();
+            set.first_gpu_view.map(|gpu| {
+                assert!(table.contains(n::SRV_CBV_UAV));
+
+                let root_offset = table_id + table_base_offset;
+                // Cast is safe as offset **must** be in u32 range. Unable to
+                // create heaps with more descriptors.
+                let table_offset = (gpu.ptr - srv_cbv_uav_start) as u32;
+                self
+                    .user_data
+                    .set_srv_cbv_uav_table(root_offset as _, table_offset);
+
+                table_id += 1;
+            });
+            set.first_gpu_sampler.map(|gpu| {
+                assert!(table.contains(n::SAMPLERS));
+
+                let root_offset = table_id + table_base_offset;
+                // Cast is safe as offset **must** be in u32 range. Unable to
+                // create heaps with more descriptors.
+                let table_offset = (gpu.ptr - sampler_start) as u32;
+                self
+                    .user_data
+                    .set_sampler_table(root_offset as _, table_offset);
+
+                table_id += 1;
+            });
+        }
+
+        [heap_srv_cbv_uav, heap_sampler]
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -283,6 +280,9 @@ pub struct CommandBuffer {
     // D3D12 only has one slot for both bindpoints. Need to rebind everything if we want to switch
     // between different bind points (ie. calling draw or dispatch).
     active_bindpoint: BindPoint,
+    // Current descriptor heaps heaps (CBV/SRV/UAV and Sampler).
+    // Required for resetting due to internal descriptor heaps.
+    active_descriptor_heaps: [*mut d3d12::ID3D12DescriptorHeap; 2],
 
     // Active queries in the command buffer.
     // Queries must begin and end in the same command buffer, which allows us to track them.
@@ -339,6 +339,7 @@ impl CommandBuffer {
             primitive_topology: d3dcommon::D3D_PRIMITIVE_TOPOLOGY_UNDEFINED,
             comp_pipeline: PipelineCache::new(),
             active_bindpoint: BindPoint::Graphics,
+            active_descriptor_heaps: [ptr::null_mut(); 2],
             occlusion_query: None,
             pipeline_stats_query: None,
             vertex_buffer_views_needs_bind: [false; MAX_VERTEX_BUFFERS],
@@ -363,6 +364,7 @@ impl CommandBuffer {
         self.primitive_topology = d3dcommon::D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
         self.comp_pipeline = PipelineCache::new();
         self.active_bindpoint = BindPoint::Graphics;
+        self.active_descriptor_heaps = [ptr::null_mut(); 2];
         self.occlusion_query = None;
         self.pipeline_stats_query = None;
         self.vertex_buffer_views_needs_bind = [false; MAX_VERTEX_BUFFERS];
@@ -377,6 +379,10 @@ impl CommandBuffer {
     fn set_internal_graphics_pipeline(&mut self) {
         self.active_bindpoint = BindPoint::InternalGraphics;
         self.gr_pipeline.user_data.dirty_all();
+    }
+
+    fn bind_descriptor_heaps(&mut self) {
+        unsafe { self.raw.SetDescriptorHeaps(2, self.active_descriptor_heaps.as_mut_ptr()); }
     }
 
     fn insert_subpass_barriers(&self, insertion: BarrierPoint) {
@@ -570,6 +576,7 @@ impl CommandBuffer {
                     self.raw.SetGraphicsRootSignature(signature);
                 }
                 self.active_bindpoint = BindPoint::Graphics;
+                self.bind_descriptor_heaps();
             },
         }
 
@@ -628,12 +635,25 @@ impl CommandBuffer {
 
     fn set_compute_bind_point(&mut self) {
         match self.active_bindpoint {
-            BindPoint::Graphics | BindPoint::InternalGraphics => {
+            BindPoint::Graphics => {
                 // Switch to compute bind point
-                assert!(self.comp_pipeline.pipeline.is_some(), "No compute pipeline bound");
-                let (pipeline, _) = self.comp_pipeline.pipeline.unwrap();
+                let (pipeline, _) = self.comp_pipeline.pipeline.expect("No compute pipeline bound");
                 unsafe { self.raw.SetPipelineState(pipeline); }
                 self.active_bindpoint = BindPoint::Compute;
+            },
+            BindPoint::InternalGraphics => {
+                // Switch to compute bind point
+                let (pipeline, _) = self.comp_pipeline.pipeline.expect("No compute pipeline bound");
+                unsafe { self.raw.SetPipelineState(pipeline); }
+                self.active_bindpoint = BindPoint::Compute;
+                self.bind_descriptor_heaps();
+
+                // Rebind the graphics root signature as we come from an internal graphics.
+                // Issuing a draw call afterwards would hide the information that we internally
+                // changed the graphics root signature.
+                if let Some((_, signature)) = self.gr_pipeline.pipeline {
+                    unsafe { self.raw.SetGraphicsRootSignature(signature); }
+                }
             },
             BindPoint::Compute => { }, // Nothing to do
         }
@@ -1686,7 +1706,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<n::DescriptorSet>,
     {
-        bind_descriptor_sets(&self.raw, &mut self.gr_pipeline, layout, first_set, sets);
+        self.active_descriptor_heaps = self.gr_pipeline.bind_descriptor_sets(layout, first_set, sets);
+        self.bind_descriptor_heaps();
     }
 
     fn bind_compute_pipeline(&mut self, pipeline: &n::ComputePipeline) {
@@ -1719,7 +1740,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<n::DescriptorSet>,
     {
-        bind_descriptor_sets(&self.raw, &mut self.comp_pipeline, layout, first_set, sets);
+        self.active_descriptor_heaps = self.comp_pipeline.bind_descriptor_sets(layout, first_set, sets);
+        self.bind_descriptor_heaps();
     }
 
     fn dispatch(&mut self, count: WorkGroupCount) {

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -470,7 +470,8 @@ pub fn map_image_flags(usage: image::Usage) -> D3D12_RESOURCE_FLAGS {
     use self::image::Usage;
     let mut flags = D3D12_RESOURCE_FLAG_NONE;
 
-    if usage.contains(Usage::COLOR_ATTACHMENT) {
+    // Blit operations implemented via a graphics pipeline
+    if usage.intersects(Usage::COLOR_ATTACHMENT | Usage::TRANSFER_DST) {
         flags = flags | D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
     }
     if usage.contains(Usage::DEPTH_STENCIL_ATTACHMENT) {

--- a/src/backend/dx12/src/format.rs
+++ b/src/backend/dx12/src/format.rs
@@ -232,7 +232,7 @@ pub fn query_properties() -> [Properties; NUM_FORMATS] {
         // Rgba8Unorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::BLIT_SRC | ImageFeature::BLIT_DST | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Rgba8Inorm
@@ -274,7 +274,7 @@ pub fn query_properties() -> [Properties; NUM_FORMATS] {
         // Bgra8Unorm
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::BLIT_DST | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Bgra8Inorm
@@ -610,7 +610,7 @@ pub fn query_properties() -> [Properties; NUM_FORMATS] {
         // R32Float
         Properties {
             linear_tiling: ImageFeature::empty(),
-            optimal_tiling: ImageFeature::empty(),
+            optimal_tiling: ImageFeature::BLIT_DST | ImageFeature::SAMPLED_LINEAR,
             buffer_features: BufferFeature::empty(),
         },
         // Rg32Uint

--- a/src/backend/dx12/src/internal.rs
+++ b/src/backend/dx12/src/internal.rs
@@ -1,0 +1,220 @@
+use hal::pso;
+use spirv_cross::hlsl;
+use std::{mem, ptr};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use d3d12;
+use winapi::shared::{dxgiformat, dxgitype, winerror};
+use winapi::shared::minwindef::{FALSE, TRUE};
+use winapi::um::d3d12::*;
+use wio::com::ComPtr;
+
+use {device};
+
+#[derive(Clone)]
+pub struct Blit {
+    pipeline: ComPtr<d3d12::ID3D12PipelineState>,
+    signature: ComPtr<d3d12::ID3D12RootSignature>,
+}
+
+pub struct ServicePipes {
+    device: ComPtr<d3d12::ID3D12Device>,
+    blits_2d_color: Mutex<HashMap<(dxgiformat::DXGI_FORMAT, d3d12::D3D12_FILTER), Blit>>,
+}
+
+impl ServicePipes {
+    pub fn new(device: ComPtr<d3d12::ID3D12Device>) -> Self {
+        ServicePipes {
+            device,
+            blits_2d_color: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn get_blit_2d_color(&self, dst_format: dxgiformat::DXGI_FORMAT, filter: d3d12::D3D12_FILTER) -> Blit {
+        let mut blits = self.blits_2d_color.lock().unwrap();
+        blits
+            .entry((dst_format, filter))
+            .or_insert_with(|| self.create_blit_2d_color(dst_format, filter))
+            .clone()
+    }
+
+    fn create_blit_2d_color(&self, dst_format: dxgiformat::DXGI_FORMAT, filter: d3d12::D3D12_FILTER) -> Blit {
+        let descriptor_range = d3d12::D3D12_DESCRIPTOR_RANGE {
+            RangeType: d3d12::D3D12_DESCRIPTOR_RANGE_TYPE_SRV,
+            NumDescriptors: 1,
+            BaseShaderRegister: 0,
+            RegisterSpace: 0,
+            OffsetInDescriptorsFromTableStart: 0,
+        };
+
+        let mut root_parameters = [
+            d3d12::D3D12_ROOT_PARAMETER {
+                ParameterType: d3d12::D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE,
+                ShaderVisibility: d3d12::D3D12_SHADER_VISIBILITY_ALL,
+                .. unsafe { mem::zeroed() }
+            },
+            d3d12::D3D12_ROOT_PARAMETER {
+                ParameterType: d3d12::D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS,
+                ShaderVisibility: d3d12::D3D12_SHADER_VISIBILITY_VERTEX,
+                .. unsafe { mem::zeroed() }
+            },
+        ];
+
+        *unsafe { root_parameters[0].u.DescriptorTable_mut() } = d3d12::D3D12_ROOT_DESCRIPTOR_TABLE {
+            NumDescriptorRanges: 1,
+            pDescriptorRanges: &descriptor_range,
+        };
+
+        *unsafe { root_parameters[1].u.Constants_mut() } = d3d12::D3D12_ROOT_CONSTANTS {
+            ShaderRegister: 0,
+            RegisterSpace: 0,
+            Num32BitValues: 5,
+        };
+
+        let static_samplers = d3d12::D3D12_STATIC_SAMPLER_DESC {
+            Filter: filter,
+            AddressU: d3d12::D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
+            AddressV: d3d12::D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
+            AddressW: d3d12::D3D12_TEXTURE_ADDRESS_MODE_CLAMP,
+            MipLODBias: 0.0,
+            MaxAnisotropy: 0,
+            ComparisonFunc: d3d12::D3D12_COMPARISON_FUNC_ALWAYS,
+            BorderColor: d3d12::D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK,
+            MinLOD: 0.0,
+            MaxLOD: d3d12::D3D12_FLOAT32_MAX,
+            ShaderRegister: 0,
+            RegisterSpace: 0,
+            ShaderVisibility: d3d12::D3D12_SHADER_VISIBILITY_PIXEL,
+        };
+
+        let root_signature_desc = d3d12::D3D12_ROOT_SIGNATURE_DESC {
+            NumParameters: root_parameters.len() as _,
+            pParameters: root_parameters.as_ptr(),
+            NumStaticSamplers: 1,
+            pStaticSamplers: &static_samplers,
+            Flags: d3d12::D3D12_ROOT_SIGNATURE_FLAG_NONE,
+        };
+
+        let mut signature = ptr::null_mut();
+        let mut signature_raw = ptr::null_mut();
+        let mut error = ptr::null_mut();
+
+        // TODO: error handling
+        unsafe {
+            let _hr = d3d12::D3D12SerializeRootSignature(
+                &root_signature_desc,
+                d3d12::D3D_ROOT_SIGNATURE_VERSION_1,
+                &mut signature_raw,
+                &mut error,
+            );
+
+            if !error.is_null() {
+                // TODO
+                let error_output = (*error).GetBufferPointer();
+                let message = ::std::ffi::CStr::from_ptr(error_output as *const _ as *const _);
+                error!("D3D12SerializeRootSignature error: {:?}", message.to_str().unwrap());
+                (*error).Release();
+            }
+
+            self.device.CreateRootSignature(
+                0,
+                (*signature_raw).GetBufferPointer(),
+                (*signature_raw).GetBufferSize(),
+                &d3d12::IID_ID3D12RootSignature,
+                &mut signature as *mut *mut _ as *mut *mut _,
+            );
+            (*signature_raw).Release();
+        }
+
+        let shader_src = include_bytes!("../shaders/blit.hlsl");
+        let vs = device::compile_shader(pso::Stage::Vertex, hlsl::ShaderModel::V5_0, "vs_blit_2d", shader_src).unwrap();
+        let ps = device::compile_shader(pso::Stage::Fragment, hlsl::ShaderModel::V5_0, "ps_blit_2d", shader_src).unwrap();
+
+        let mut rtvs = [dxgiformat::DXGI_FORMAT_UNKNOWN; 8];
+        rtvs[0] = dst_format;
+
+        let dummy_target = D3D12_RENDER_TARGET_BLEND_DESC {
+            BlendEnable: FALSE,
+            LogicOpEnable: FALSE,
+            SrcBlend: D3D12_BLEND_ZERO,
+            DestBlend: D3D12_BLEND_ZERO,
+            BlendOp: D3D12_BLEND_OP_ADD,
+            SrcBlendAlpha: D3D12_BLEND_ZERO,
+            DestBlendAlpha: D3D12_BLEND_ZERO,
+            BlendOpAlpha: D3D12_BLEND_OP_ADD,
+            LogicOp: D3D12_LOGIC_OP_CLEAR,
+            RenderTargetWriteMask: 0,
+        };
+        let render_targets = [dummy_target; 8];
+
+        let pso_desc = d3d12::D3D12_GRAPHICS_PIPELINE_STATE_DESC {
+            pRootSignature: signature,
+            VS: device::shader_bytecode(vs),
+            PS: device::shader_bytecode(ps),
+            GS: device::shader_bytecode(ptr::null_mut()),
+            DS: device::shader_bytecode(ptr::null_mut()),
+            HS: device::shader_bytecode(ptr::null_mut()),
+            StreamOutput: d3d12::D3D12_STREAM_OUTPUT_DESC {
+                pSODeclaration: ptr::null(),
+                NumEntries: 0,
+                pBufferStrides: ptr::null(),
+                NumStrides: 0,
+                RasterizedStream: 0,
+            },
+            BlendState: d3d12::D3D12_BLEND_DESC {
+                AlphaToCoverageEnable: FALSE,
+                IndependentBlendEnable: FALSE,
+                RenderTarget: render_targets,
+            },
+            SampleMask: !0,
+            RasterizerState: D3D12_RASTERIZER_DESC {
+                FillMode: D3D12_FILL_MODE_SOLID,
+                CullMode: D3D12_CULL_MODE_NONE,
+                FrontCounterClockwise: TRUE,
+                DepthBias: 0,
+                DepthBiasClamp: 0.0,
+                SlopeScaledDepthBias: 0.0,
+                DepthClipEnable: FALSE,
+                MultisampleEnable: FALSE,
+                ForcedSampleCount: 0,
+                AntialiasedLineEnable: FALSE,
+                ConservativeRaster: D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF,
+            },
+            DepthStencilState: unsafe { mem::zeroed() },
+            InputLayout: d3d12::D3D12_INPUT_LAYOUT_DESC {
+                pInputElementDescs: ptr::null(),
+                NumElements: 0,
+            },
+            IBStripCutValue: d3d12::D3D12_INDEX_BUFFER_STRIP_CUT_VALUE_DISABLED,
+            PrimitiveTopologyType: D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
+            NumRenderTargets: 1,
+            RTVFormats: rtvs,
+            DSVFormat: dxgiformat::DXGI_FORMAT_UNKNOWN,
+            SampleDesc: dxgitype::DXGI_SAMPLE_DESC {
+                Count: 1,
+                Quality: 0,
+            },
+            NodeMask: 0,
+            CachedPSO: d3d12::D3D12_CACHED_PIPELINE_STATE {
+                pCachedBlob: ptr::null(),
+                CachedBlobSizeInBytes: 0,
+            },
+            Flags: d3d12::D3D12_PIPELINE_STATE_FLAG_NONE,
+        };
+
+        let mut pipeline = ptr::null_mut();
+        let hr = unsafe {
+            self.device.CreateGraphicsPipelineState(
+                &pso_desc,
+                &d3d12::IID_ID3D12PipelineState,
+                &mut pipeline as *mut *mut _ as *mut *mut _)
+        };
+        assert_eq!(hr, winerror::S_OK);
+
+        Blit {
+            pipeline: unsafe { ComPtr::from_raw(pipeline) },
+            signature: unsafe { ComPtr::from_raw(signature) },
+        }
+    }
+}

--- a/src/backend/dx12/src/internal.rs
+++ b/src/backend/dx12/src/internal.rs
@@ -14,8 +14,8 @@ use {device};
 
 #[derive(Clone)]
 pub struct Blit {
-    pipeline: ComPtr<d3d12::ID3D12PipelineState>,
-    signature: ComPtr<d3d12::ID3D12RootSignature>,
+    pub pipeline: ComPtr<d3d12::ID3D12PipelineState>,
+    pub signature: ComPtr<d3d12::ID3D12RootSignature>,
 }
 
 pub struct ServicePipes {

--- a/src/backend/dx12/src/internal.rs
+++ b/src/backend/dx12/src/internal.rs
@@ -27,9 +27,11 @@ pub struct BlitData {
     pub level: f32,
 }
 
+type BlitMap = HashMap<(dxgiformat::DXGI_FORMAT, d3d12::D3D12_FILTER), Blit>;
+
 pub(crate) struct ServicePipes {
     pub(crate) device: ComPtr<d3d12::ID3D12Device>,
-    blits_2d_color: Mutex<HashMap<(dxgiformat::DXGI_FORMAT, d3d12::D3D12_FILTER), Blit>>,
+    blits_2d_color: Mutex<BlitMap>,
 }
 
 impl ServicePipes {

--- a/src/backend/dx12/src/internal.rs
+++ b/src/backend/dx12/src/internal.rs
@@ -18,6 +18,15 @@ pub struct Blit {
     pub signature: ComPtr<d3d12::ID3D12RootSignature>,
 }
 
+// Information to pass to the shader
+#[repr(C)]
+pub struct BlitData {
+    pub src_offset: [f32; 2],
+    pub src_extent: [f32; 2],
+    pub layer: f32,
+    pub level: f32,
+}
+
 pub struct ServicePipes {
     device: ComPtr<d3d12::ID3D12Device>,
     blits_2d_color: Mutex<HashMap<(dxgiformat::DXGI_FORMAT, d3d12::D3D12_FILTER), Blit>>,
@@ -69,7 +78,7 @@ impl ServicePipes {
         *unsafe { root_parameters[1].u.Constants_mut() } = d3d12::D3D12_ROOT_CONSTANTS {
             ShaderRegister: 0,
             RegisterSpace: 0,
-            Num32BitValues: 5,
+            Num32BitValues: (mem::size_of::<BlitData>() / 4) as _,
         };
 
         let static_samplers = d3d12::D3D12_STATIC_SAMPLER_DESC {
@@ -144,7 +153,7 @@ impl ServicePipes {
             DestBlendAlpha: D3D12_BLEND_ZERO,
             BlendOpAlpha: D3D12_BLEND_OP_ADD,
             LogicOp: D3D12_LOGIC_OP_CLEAR,
-            RenderTargetWriteMask: 0,
+            RenderTargetWriteMask: D3D12_COLOR_WRITE_ENABLE_ALL as _,
         };
         let render_targets = [dummy_target; 8];
 

--- a/src/backend/dx12/src/internal.rs
+++ b/src/backend/dx12/src/internal.rs
@@ -27,8 +27,8 @@ pub struct BlitData {
     pub level: f32,
 }
 
-pub struct ServicePipes {
-    device: ComPtr<d3d12::ID3D12Device>,
+pub(crate) struct ServicePipes {
+    pub(crate) device: ComPtr<d3d12::ID3D12Device>,
     blits_2d_color: Mutex<HashMap<(dxgiformat::DXGI_FORMAT, d3d12::D3D12_FILTER), Blit>>,
 }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -464,7 +464,6 @@ struct CmdSignatures {
 struct Shared {
     pub signatures: CmdSignatures,
     pub service_pipes: internal::ServicePipes,
-    pub device: *mut d3d12::ID3D12Device,
 }
 
 pub struct Device {
@@ -605,7 +604,6 @@ impl Device {
         let shared = Shared {
             signatures,
             service_pipes,
-            device: device.as_raw(),
         };
 
         Device {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -462,8 +462,9 @@ struct CmdSignatures {
 
 // Shared objects between command buffers, owned by the device.
 struct Shared {
-    signatures: CmdSignatures,
-    service_pipes: internal::ServicePipes
+    pub signatures: CmdSignatures,
+    pub service_pipes: internal::ServicePipes,
+    pub device: *mut d3d12::ID3D12Device,
 }
 
 pub struct Device {
@@ -601,6 +602,11 @@ impl Device {
             dispatch: dispatch_signature,
         };
         let service_pipes = internal::ServicePipes::new(device.clone());
+        let shared = Shared {
+            signatures,
+            service_pipes,
+            device: device.as_raw(),
+        };
 
         Device {
             raw: device,
@@ -615,7 +621,7 @@ impl Device {
             heap_srv_cbv_uav: Mutex::new(heap_srv_cbv_uav),
             heap_sampler: Mutex::new(heap_sampler),
             events: Mutex::new(Vec::new()),
-            shared: Arc::new(Shared { signatures, service_pipes }),
+            shared: Arc::new(shared),
             present_queue,
             queues: Vec::new(),
             open: physical_device.is_open.clone(),

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -17,6 +17,7 @@ mod conv;
 mod device;
 mod format;
 mod free_list;
+mod internal;
 mod native;
 mod pool;
 mod root_constants;
@@ -459,6 +460,12 @@ struct CmdSignatures {
     dispatch: ComPtr<d3d12::ID3D12CommandSignature>,
 }
 
+// Shared objects between command buffers, owned by the device.
+struct Shared {
+    signatures: CmdSignatures,
+    service_pipes: internal::ServicePipes
+}
+
 pub struct Device {
     raw: ComPtr<d3d12::ID3D12Device>,
     private_caps: Capabilities,
@@ -474,7 +481,7 @@ pub struct Device {
     heap_srv_cbv_uav: Mutex<native::DescriptorHeap>,
     heap_sampler: Mutex<native::DescriptorHeap>,
     events: Mutex<Vec<winnt::HANDLE>>,
-    signatures: CmdSignatures,
+    shared: Arc<Shared>,
     // Present queue exposed by the `Present` queue family.
     // Required for swapchain creation. Only a single queue supports presentation.
     present_queue: ComPtr<d3d12::ID3D12CommandQueue>,
@@ -588,6 +595,13 @@ impl Device {
             device::CommandSignature::Dispatch,
         );
 
+        let signatures = CmdSignatures {
+            draw: draw_signature,
+            draw_indexed: draw_indexed_signature,
+            dispatch: dispatch_signature,
+        };
+        let service_pipes = internal::ServicePipes::new(device.clone());
+
         Device {
             raw: device,
             private_caps: physical_device.private_caps,
@@ -601,11 +615,7 @@ impl Device {
             heap_srv_cbv_uav: Mutex::new(heap_srv_cbv_uav),
             heap_sampler: Mutex::new(heap_sampler),
             events: Mutex::new(Vec::new()),
-            signatures: CmdSignatures {
-                draw: draw_signature,
-                draw_indexed: draw_indexed_signature,
-                dispatch: dispatch_signature,
-            },
+            shared: Arc::new(Shared { signatures, service_pipes }),
             present_queue,
             queues: Vec::new(),
             open: physical_device.is_open.clone(),

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -1,18 +1,19 @@
 use wio::com::ComPtr;
 use std::ptr;
+use std::sync::Arc;
 
 use winapi::um::d3d12;
 use winapi::shared::winerror::SUCCEEDED;
 
 use hal::{pool, command};
 use command::{CommandBuffer};
-use {Backend, CmdSignatures};
+use {Backend, Shared};
 
 pub struct RawCommandPool {
     pub(crate) inner: ComPtr<d3d12::ID3D12CommandAllocator>,
     pub(crate) device: ComPtr<d3d12::ID3D12Device>,
     pub(crate) list_type: d3d12::D3D12_COMMAND_LIST_TYPE,
-    pub(crate) signatures: CmdSignatures,
+    pub(crate) shared: Arc<Shared>,
 }
 
 impl RawCommandPool {
@@ -63,7 +64,7 @@ impl pool::RawCommandPool<Backend> for RawCommandPool {
             .map(|_| CommandBuffer::new(
                 self.create_command_list(),
                 self.inner.clone(),
-                self.signatures.clone(),
+                self.shared.clone(),
             ))
             .collect()
     }


### PR DESCRIPTION
Revives work of #2001

PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
