### PR TITLE
[dx12] filter out unknown formats

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -323,9 +323,10 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn image_format_properties(
-        &self, _format: f::Format, dimensions: u8, tiling: image::Tiling,
+        &self, format: f::Format, dimensions: u8, tiling: image::Tiling,
         usage: image::Usage, storage_flags: image::StorageFlags,
     ) -> Option<image::FormatProperties> {
+        conv::map_format(format)?; //filter out unknown formats
         let is_optimal = tiling == image::Tiling::Optimal;
         Some(image::FormatProperties {
             max_extent: match dimensions {


### PR DESCRIPTION
This is a small but important piece we need for dx12 blitting (after #2028). CTS results for "dEQP-VK.api.copy_and_blit.core.blit_image" are:

- Passed: 110
- Failed: 0 (!)
- Not supported: 44964

Formally speaking, we pass this test :) :tada: 

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
