### PR TITLE
[dx12] temporary image aliases for copies of different formats

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1858,7 +1858,6 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             Type: d3d12::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
             u: unsafe { mem::zeroed() },
         };
-
         let mut dst_image = d3d12::D3D12_TEXTURE_COPY_LOCATION {
             pResource: dst.resource,
             Type: d3d12::D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use winapi::um::{d3d12, d3dcommon};
 use winapi::shared::minwindef::{FALSE, UINT, TRUE};
-use winapi::shared::dxgiformat;
+use winapi::shared::{dxgiformat, winerror};
 
 use wio::com::ComPtr;
 
@@ -312,6 +312,8 @@ pub struct CommandBuffer {
     rtv_pools: Vec<ComPtr<d3d12::ID3D12DescriptorHeap>>,
     // Temporary gpu descriptor heaps (internal).
     temporary_gpu_heaps: Vec<ComPtr<d3d12::ID3D12DescriptorHeap>>,
+    // Resources that need to be alive till the end of the GPU execution.
+    retained_resources: Vec<ComPtr<d3d12::ID3D12Resource>>,
 }
 
 unsafe impl Send for CommandBuffer { }
@@ -351,6 +353,7 @@ impl CommandBuffer {
             scissor_cache: SmallVec::new(),
             rtv_pools: Vec::new(),
             temporary_gpu_heaps: Vec::new(),
+            retained_resources: Vec::new(),
         }
     }
 
@@ -373,6 +376,7 @@ impl CommandBuffer {
         self.vertex_buffer_views = [NULL_VERTEX_BUFFER_VIEW; MAX_VERTEX_BUFFERS];
         self.rtv_pools.clear();
         self.temporary_gpu_heaps.clear();
+        self.retained_resources.clear();
     }
 
     // Indicates that the pipeline slot has been overriden with an internal pipeline.
@@ -1249,6 +1253,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<com::ImageResolve>,
     {
+        assert_eq!(src.descriptor.Format, dst.descriptor.Format);
+
         {
             // Insert barrier for `COPY_DEST` to `RESOLVE_DEST` as we only expose
             // `TRANSFER_WRITE` which is used for all copy commands.
@@ -1272,7 +1278,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         src.calc_subresource(r.src_subresource.level as UINT, r.src_subresource.layers.start as UINT + layer, 0),
                         dst.resource,
                         dst.calc_subresource(r.dst_subresource.level as UINT, r.dst_subresource.layers.start as UINT + layer, 0),
-                        src.dxgi_format,
+                        src.descriptor.Format,
                     );
                 }
             }
@@ -1330,10 +1336,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 kind: src.kind,
                 flags: src.storage_flags,
                 view_kind: image::ViewKind::D2Array, // TODO
-                format: src.dxgi_format,
+                format: src.descriptor.Format,
                 range: image::SubresourceRange {
                     aspects: format::Aspects::COLOR, // TODO
-                    levels: 0..src.num_levels,
+                    levels: 0..src.descriptor.MipLevels as _,
                     layers: 0..src.kind.num_layers(),
                 },
             }
@@ -1377,7 +1383,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     // Create RTVs of the dst image for the miplevel of the current region
                     for i in 0 .. num_layers {
                         let mut desc = d3d12::D3D12_RENDER_TARGET_VIEW_DESC {
-                            Format: dst.dxgi_format,
+                            Format: dst.descriptor.Format,
                             ViewDimension: d3d12::D3D12_RTV_DIMENSION_TEXTURE2DARRAY,
                             u: unsafe { mem::zeroed() },
                         };
@@ -1395,7 +1401,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         }
                     }
 
-                    (dst.dxgi_format, filter)
+                    (dst.descriptor.Format, filter)
                 },
                 _ => unimplemented!(),
             };
@@ -1859,12 +1865,61 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             u: unsafe { mem::zeroed() },
         };
 
+        let device = self.shared.service_pipes.device.clone();
+        if src.surface_type != dst.surface_type {
+            assert_eq!(src.surface_type.desc().bits, dst.surface_type.desc().bits);
+            // D3D12 only permits changing the channel type for copies,
+            // similarly to how it allows the views to be created.
+
+            // create an aliased resource to the source
+            let mut alias = ptr::null_mut();
+            let desc = d3d12::D3D12_RESOURCE_DESC {
+                Format: dst.descriptor.Format,
+                .. src.descriptor.clone()
+            };
+            let (heap_ptr, offset) = match src.place {
+                n::Place::SwapChain => {
+                    error!("Unable to copy from a swapchain image with format conversion: {:?} -> {:?}",
+                        src.descriptor.Format, dst.descriptor.Format);
+                    return
+                }
+                n::Place::Heap { ref raw, offset } => (raw.as_raw(), offset),
+            };
+            assert_eq!(winerror::S_OK, unsafe {
+                device.CreatePlacedResource(
+                    heap_ptr,
+                    offset,
+                    &desc,
+                    d3d12::D3D12_RESOURCE_STATE_COMMON,
+                    ptr::null(),
+                    &d3d12::IID_ID3D12Resource,
+                    &mut alias,
+                )
+            });
+            src_image.pResource = alias as _;
+            self.retained_resources.push(unsafe {
+                ComPtr::from_raw(alias as _)
+            });
+
+            // signal the aliasing transition
+            let sub_barrier = d3d12::D3D12_RESOURCE_ALIASING_BARRIER {
+                pResourceBefore: src.resource,
+                pResourceAfter: src_image.pResource,
+            };
+            let mut barrier = d3d12::D3D12_RESOURCE_BARRIER {
+                Type: d3d12::D3D12_RESOURCE_BARRIER_TYPE_ALIASING,
+                Flags: d3d12::D3D12_RESOURCE_BARRIER_FLAG_NONE,
+                u: unsafe { mem::zeroed() },
+            };
+            unsafe {
+                *barrier.u.Aliasing_mut() = sub_barrier;
+                self.raw.ResourceBarrier(1, &barrier as *const _);
+            }
+        }
+
         for region in regions {
             let r = region.borrow();
             debug_assert_eq!(r.src_subresource.layers.len(), r.dst_subresource.layers.len());
-            let num_layers = r.src_subresource.layers.len() as image::Layer;
-            let src_layer_start = r.src_subresource.layers.start;
-            let dst_layer_start = r.dst_subresource.layers.start;
             let src_box = d3d12::D3D12_BOX {
                 left: r.src_offset.x as _,
                 top: r.src_offset.y as _,
@@ -1874,11 +1929,11 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 back: (r.src_offset.z + r.extent.depth as i32) as _,
             };
 
-            for layer in 0..num_layers {
+            for (src_layer, dst_layer) in r.src_subresource.layers.clone().zip(r.dst_subresource.layers.clone()) {
                 *unsafe { src_image.u.SubresourceIndex_mut() } =
-                    src.calc_subresource(r.src_subresource.level as _, (src_layer_start + layer) as _, 0);
+                    src.calc_subresource(r.src_subresource.level as _, src_layer as _, 0);
                 *unsafe { dst_image.u.SubresourceIndex_mut() } =
-                    dst.calc_subresource(r.dst_subresource.level as _, (dst_layer_start + layer) as _, 0);
+                    dst.calc_subresource(r.dst_subresource.level as _, dst_layer as _, 0);
                 unsafe {
                     self.raw.CopyTextureRegion(
                         &dst_image,
@@ -1889,6 +1944,23 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         &src_box,
                     );
                 }
+            }
+        }
+
+        if src.surface_type != dst.surface_type {
+            // signal the aliasing transition - back to the original
+            let sub_barrier = d3d12::D3D12_RESOURCE_ALIASING_BARRIER {
+                pResourceBefore: src_image.pResource,
+                pResourceAfter: src.resource,
+            };
+            let mut barrier = d3d12::D3D12_RESOURCE_BARRIER {
+                Type: d3d12::D3D12_RESOURCE_BARRIER_TYPE_ALIASING,
+                Flags: d3d12::D3D12_RESOURCE_BARRIER_FLAG_NONE,
+                u: unsafe { mem::zeroed() },
+            };
+            unsafe {
+                *barrier.u.Aliasing_mut() = sub_barrier;
+                self.raw.ResourceBarrier(1, &barrier as *const _);
             }
         }
     }
@@ -1937,7 +2009,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             let footprint = d3d12::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
                 Offset: c.footprint_offset,
                 Footprint: d3d12::D3D12_SUBRESOURCE_FOOTPRINT {
-                    Format: image.dxgi_format,
+                    Format: image.descriptor.Format,
                     Width: c.footprint.width,
                     Height: c.footprint.height,
                     Depth: c.footprint.depth,
@@ -2003,7 +2075,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             let footprint = d3d12::D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
                 Offset: c.footprint_offset,
                 Footprint: d3d12::D3D12_SUBRESOURCE_FOOTPRINT {
-                    Format: image.dxgi_format,
+                    Format: image.descriptor.Format,
                     Width: c.footprint.width,
                     Height: c.footprint.height,
                     Depth: c.footprint.depth,

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -12,7 +12,7 @@ use winapi::shared::{dxgi, dxgi1_2, dxgi1_4, dxgiformat, dxgitype, winerror};
 use wio::com::ComPtr;
 
 use hal::{self, buffer, device as d, error, format, image, mapping, memory, pass, pso, query};
-use hal::format::Aspects;
+use hal::format::{Aspects, Format};
 use hal::memory::Requirements;
 use hal::pool::CommandPoolCreateFlags;
 use hal::queue::{RawCommandQueue, QueueFamilyId};
@@ -101,9 +101,9 @@ pub struct UnboundImage {
     desc: d3d12::D3D12_RESOURCE_DESC,
     dsv_format: dxgiformat::DXGI_FORMAT,
     requirements: memory::Requirements,
+    format: Format,
     kind: image::Kind,
     usage: image::Usage,
-    aspects: Aspects,
     storage_flags: image::StorageFlags,
     //TODO: use hal::format::FormatDesc
     bytes_per_block: u8,
@@ -1921,7 +1921,6 @@ impl d::Device<B> for Device {
         let base_format = format.base_format();
         let format_desc = base_format.0.desc();
 
-        let aspects = format_desc.aspects;
         let bytes_per_block = (format_desc.bits / 8) as _;
         let block_dim = format_desc.dim;
 
@@ -1977,9 +1976,9 @@ impl d::Device<B> for Device {
                 alignment: alloc_info.Alignment,
                 type_mask: MEM_TYPE_MASK << type_mask_shift,
             },
+            format,
             kind,
             usage,
-            aspects,
             storage_flags: flags,
             bytes_per_block,
             block_dim,
@@ -2045,17 +2044,19 @@ impl d::Device<B> for Device {
         // if the format supports being rendered into, allowing us to create clear_Xv
         let can_clear_color = image.usage.intersects(Usage::TRANSFER_DST | Usage::COLOR_ATTACHMENT);
         let can_clear_depth = image.usage.intersects(Usage::TRANSFER_DST | Usage::DEPTH_STENCIL_ATTACHMENT);
+        let aspects = image.format.surface_desc().aspects;
 
         Ok(n::Image {
             resource: resource as *mut _,
+            place: n::Place::Heap { raw: memory.heap.clone(), offset },
+            surface_type: image.format.base_format().0,
             kind: image.kind,
             usage: image.usage,
             storage_flags: image.storage_flags,
-            dxgi_format: image.desc.Format,
+            descriptor: image.desc,
             bytes_per_block: image.bytes_per_block,
             block_dim: image.block_dim,
-            num_levels: image.num_levels,
-            clear_cv: if image.aspects.contains(Aspects::COLOR) && can_clear_color {
+            clear_cv: if aspects.contains(Aspects::COLOR) && can_clear_color {
                 (0 .. num_layers)
                     .map(|layer| {
                         self.view_image_as_render_target(
@@ -2072,7 +2073,7 @@ impl d::Device<B> for Device {
             } else {
                 Vec::new()
             },
-            clear_dv: if image.aspects.contains(Aspects::DEPTH) && can_clear_depth {
+            clear_dv: if aspects.contains(Aspects::DEPTH) && can_clear_depth {
                 (0 .. num_layers)
                     .map(|layer| {
                         self.view_image_as_depth_stencil(
@@ -2090,7 +2091,7 @@ impl d::Device<B> for Device {
             } else {
                 Vec::new()
             },
-            clear_sv: if image.aspects.contains(Aspects::STENCIL) && can_clear_depth {
+            clear_sv: if aspects.contains(Aspects::STENCIL) && can_clear_depth {
                 (0 .. num_layers)
                     .map(|layer| {
                         self.view_image_as_depth_stencil(
@@ -2119,7 +2120,6 @@ impl d::Device<B> for Device {
         _swizzle: format::Swizzle,
         range: image::SubresourceRange,
     ) -> Result<n::ImageView, image::ViewError> {
-        let num_levels = image.num_levels;
         let mip_levels = (range.levels.start, range.levels.end);
         let layers = (range.layers.start, range.layers.end);
 
@@ -2159,8 +2159,8 @@ impl d::Device<B> for Device {
             } else {
                 None
             },
-            dxgi_format: image.dxgi_format,
-            num_levels,
+            dxgi_format: image.descriptor.Format,
+            num_levels: image.descriptor.MipLevels as image::Level,
             mip_levels,
             layers,
         })
@@ -2890,25 +2890,38 @@ impl d::Device<B> for Device {
                 self.raw.clone().CreateRenderTargetView(resource, &rtv_desc, rtv_handle);
             }
 
-            let format_desc = config
+            let surface_type = config
                 .color_format
                 .base_format()
-                .0
+                .0;
+            let format_desc = surface_type
                 .desc();
 
             let bytes_per_block = (format_desc.bits / 8) as _;
             let block_dim = format_desc.dim;
-
             let kind = image::Kind::D2(surface.width, surface.height, 1, 1);
+
             n::Image {
                 resource,
+                place: n::Place::SwapChain,
+                surface_type,
                 kind,
                 usage: config.image_usage,
                 storage_flags: image::StorageFlags::empty(),
-                dxgi_format: format,
+                descriptor: d3d12::D3D12_RESOURCE_DESC {
+                    Dimension: d3d12::D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+                    Alignment: 0,
+                    Width: surface.width as _,
+                    Height: surface.height as _,
+                    DepthOrArraySize: 1,
+                    MipLevels: 1,
+                    Format: format,
+                    SampleDesc: desc.SampleDesc.clone(),
+                    Layout: d3d12::D3D12_TEXTURE_LAYOUT_UNKNOWN,
+                    Flags: 0,
+                },
                 bytes_per_block,
                 block_dim,
-                num_levels: 1,
                 clear_cv: vec![rtv_handle],
                 clear_dv: Vec::new(),
                 clear_sv: Vec::new(),

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -622,7 +622,14 @@ impl Device {
             }
             image::ViewKind::Cube |
             image::ViewKind::CubeArray => {
-                unimplemented!()
+                desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
+                //TODO: double-check if any *6 are needed
+                *unsafe{ desc.u.Texture2DArray_mut() } = d3d12::D3D12_TEX2D_ARRAY_RTV {
+                    MipSlice,
+                    FirstArraySlice,
+                    ArraySize,
+                    PlaneSlice: 0, //TODO
+                }
             }
         };
 
@@ -1952,7 +1959,7 @@ impl d::Device<B> for Device {
                 image::Tiling::Optimal => d3d12::D3D12_TEXTURE_LAYOUT_UNKNOWN,
                 image::Tiling::Linear => d3d12::D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
             },
-            Flags: conv::map_image_flags(usage),
+            Flags: conv::map_image_flags(usage, format_desc.aspects),
         };
 
         let alloc_info = unsafe {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -921,6 +921,7 @@ impl hal::Instance for Instance {
                 features:
                     // TODO: add more features, based on
                     // https://msdn.microsoft.com/de-de/library/windows/desktop/mt186615(v=vs.85).aspx
+                    Features::ROBUST_BUFFER_ACCESS |
                     Features::IMAGE_CUBE_ARRAY |
                     Features::GEOMETRY_SHADER |
                     Features::TESSELLATION_SHADER |


### PR DESCRIPTION
Brings our image-image copies to the level where only depth/stencil is failing (on CTS) :tada: 

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
