### PR TITLE
mtl: Add temporary workaround for validation issue

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -706,7 +706,14 @@ impl hal::Device<Backend> for Device {
                 pipeline.set_fragment_function(Some(&fs_function));
                 Some(lib)
             }
-            None => None,
+            None => {
+                // TODO: This is a workaround for what appears to be a Metal validation bug
+                // A pixel format is required even though no attachments are provided
+                if pass_descriptor.main_pass.attachments.len() == 0 {
+                    pipeline.set_depth_attachment_pixel_format(metal::MTLPixelFormat::Depth32Float);
+                }
+                None
+            },
         };
 
         // Other shaders


### PR DESCRIPTION
Temporary workaround so we can prevent some crashes in portability.

PR checklist:
- [X] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
