### PR TITLE
Implement Clone for InitError

### DIFF
--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -30,7 +30,7 @@ use gfx_device_gl::Resources as R;
 use std::error::Error;
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum InitError {
     PixelFormatUnsupportedError,
     WindowBuildError(WindowBuildError),


### PR DESCRIPTION
Fixes #1923 

Quick fix while I learn the codebase.

PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends: Vulkan