### PR TITLE
Implement `set_line_width`

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -12,7 +12,6 @@ use {CommandList, DeferredContext, ShaderModel};
 use native;
 use wio::com::ComPtr;
 
-
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct MappingGate {
     pointer: *mut c_void,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1037,6 +1037,10 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
+    fn set_line_width(&mut self, width: f32) {
+        validate_line_width(width);
+    }
+
     fn bind_graphics_pipeline(&mut self, pipeline: &GraphicsPipeline) {
         unimplemented!()
     }
@@ -1288,4 +1292,11 @@ impl hal::Backend for Backend {
     type Fence = Fence;
     type Semaphore = Semaphore;
     type QueryPool = QueryPool;
+}
+
+fn validate_line_width(width: f32) {
+    // Note from the Vulkan spec:
+    // > If the wide lines feature is not enabled, lineWidth must be 1.0
+    // Simply assert and no-op because DX11 never exposes `Features::LINE_WIDTH` 
+    assert_eq!(width, 1.0);
 }

--- a/src/backend/dx11/src/state.rs
+++ b/src/backend/dx11/src/state.rs
@@ -3,6 +3,7 @@ use winapi::*;
 use core::{pso, state};
 use data::map_function;
 use wio::com::ComPtr;
+use { validate_line_width };
 
 pub fn make_rasterizer(device: &mut ComPtr<ID3D11Device>, rast: &state::Rasterizer, use_scissor: bool)
                        -> *const ID3D11RasterizerState {
@@ -12,7 +13,10 @@ pub fn make_rasterizer(device: &mut ComPtr<ID3D11Device>, rast: &state::Rasteriz
                 error!("Point rasterization is not supported");
                 D3D11_FILL_WIREFRAME
             },
-            state::RasterMethod::Line(_) => D3D11_FILL_WIREFRAME,
+            state::RasterMethod::Line(width) => {
+                validate_line_width(width);
+                D3D11_FILL_WIREFRAME
+            },
             state::RasterMethod::Fill => D3D11_FILL_SOLID,
         },
         CullMode: match rast.cull_face {

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -16,7 +16,7 @@ use winapi::shared::{dxgiformat, winerror};
 
 use wio::com::ComPtr;
 
-use {conv, device, internal, native as n, Backend, Device, Shared, MAX_VERTEX_BUFFERS};
+use {conv, device, internal, native as n, Backend, Device, Shared, MAX_VERTEX_BUFFERS, validate_line_width};
 use device::ViewInfo;
 use root_constants::RootConstant;
 use smallvec::SmallVec;
@@ -1682,6 +1682,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             Ok(cmd_list1) => unsafe { cmd_list1.OMSetDepthBounds(bounds.start, bounds.end) },
             Err(_) => warn!("Depth bounds test is not supported"),
         }
+    }
+    
+    fn set_line_width(&mut self, width: f32) {
+        validate_line_width(width);
     }
 
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -1,3 +1,5 @@
+use { validate_line_width };
+
 use std::mem;
 use spirv_cross::spirv;
 
@@ -10,7 +12,6 @@ use winapi::um::d3dcommon::*;
 use hal::format::{Format, ImageFeature, SurfaceType};
 use hal::{buffer, image, pso, Primitive};
 use hal::pso::DescriptorSetLayoutBinding;
-
 
 pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
     use hal::format::Format::*;
@@ -156,7 +157,10 @@ pub fn map_rasterizer(rasterizer: &pso::Rasterizer) -> D3D12_RASTERIZER_DESC {
                 error!("Point rasterization is not supported");
                 D3D12_FILL_MODE_WIREFRAME
             },
-            Line(_) => D3D12_FILL_MODE_WIREFRAME,
+            Line(width) => {
+                validate_line_width(width);
+                D3D12_FILL_MODE_WIREFRAME
+            },
             Fill => D3D12_FILL_MODE_SOLID,
         },
         CullMode: match rasterizer.cull_face {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1155,3 +1155,10 @@ impl hal::Backend for Backend {
     type Semaphore = native::Semaphore;
     type QueryPool = native::QueryPool;
 }
+
+fn validate_line_width(width: f32) {
+    // Note from the Vulkan spec:
+    // > If the wide lines feature is not enabled, lineWidth must be 1.0
+    // Simply assert and no-op because DX12 never exposes `Features::LINE_WIDTH` 
+    assert_eq!(width, 1.0);
+}

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -511,21 +511,21 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-
     fn set_stencil_reference(&mut self, _: pso::StencilValue, _: pso::StencilValue) {
         unimplemented!()
     }
-
 
     fn set_blend_constants(&mut self, _: pso::ColorValue) {
         unimplemented!()
     }
 
-
     fn set_depth_bounds(&mut self, _: Range<f32>) {
         unimplemented!()
     }
 
+    fn set_line_width(&mut self, _: f32) {
+        unimplemented!();
+    }
 
     fn begin_render_pass<T>(
         &mut self,

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -793,6 +793,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         warn!("Depth bounds test is not supported");
     }
 
+    fn set_line_width(&mut self, _width: f32) {
+        unimplemented!();
+    }
+
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {
         let n::GraphicsPipeline {
             primitive,

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1,4 +1,4 @@
-use {AutoreleasePool, Backend, Shared};
+use {AutoreleasePool, Backend, Shared, validate_line_width};
 use {native, window};
 use internal::{BlitVertex, Channel};
 
@@ -1677,6 +1677,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn set_depth_bounds(&mut self, _: Range<f32>) {
         warn!("Depth bounds test is not supported");
+    }
+
+    fn set_line_width(&mut self, width: f32) {
+        validate_line_width(width);
     }
 
     fn begin_render_pass<T>(

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1,4 +1,4 @@
-use {AutoreleasePool, Backend, PrivateCapabilities, QueueFamily, Shared, Surface, Swapchain};
+use {AutoreleasePool, Backend, PrivateCapabilities, QueueFamily, Shared, Surface, Swapchain, validate_line_width};
 use {conversions as conv, command, native as n, soft};
 use internal::Channel;
 
@@ -840,6 +840,10 @@ impl hal::Device<Backend> for Device {
         }
 
         pipeline.set_vertex_descriptor(Some(&vertex_descriptor));
+
+        if let pso::PolygonMode::Line(width) = pipeline_desc.rasterizer.polygon_mode {
+            validate_line_width(width);
+        }
 
         device.new_render_pipeline_state(&pipeline)
             .map(|raw|

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -213,3 +213,10 @@ impl AutoreleasePool {
         self.pool = NSAutoreleasePool::new(cocoa::base::nil);
     }
 }
+
+fn validate_line_width(width: f32) {
+    // Note from the Vulkan spec:
+    // > If the wide lines feature is not enabled, lineWidth must be 1.0
+    // Simply assert and no-op because Metal never exposes `Features::LINE_WIDTH` 
+    assert_eq!(width, 1.0);
+}

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1"
 log = "0.4"
 lazy_static = "1"
 shared_library = "0.1"
-ash = "0.24.0"
+ash = "0.24.1"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.13", optional = true }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -578,6 +578,12 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
+    fn set_line_width(&mut self, width: f32) {
+        unsafe {
+            self.device.0.cmd_set_line_width(self.raw, width);
+        }
+    }
+
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {
         unsafe {
             self.device.0.cmd_bind_pipeline(

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -253,6 +253,11 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
+    pub fn set_line_width(&mut self, width: f32) {
+        self.raw.set_line_width(width);
+    }
+
+    /// Identical to the `RawCommandBuffer` method of the same name.
     pub fn push_graphics_constants(&mut self, layout: &B::PipelineLayout, stages: pso::ShaderStageFlags, offset: u32, constants: &[u32]) {
         self.raw.push_graphics_constants(layout, stages, offset, constants)
     }

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -261,6 +261,9 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     /// Set the depth bounds test values dynamically.
     fn set_depth_bounds(&mut self, bounds: Range<f32>);
 
+    /// Set the line width dynamically.
+    fn set_line_width(&mut self, width: f32);
+
     /// Begins recording commands for a render pass on the given framebuffer.
     /// `render_area` is the section of the framebuffer to render,
     /// `clear_values` is an iterator of `ClearValueRaw`'s to use to use for

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -49,6 +49,7 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
     pub fn draw_indexed(&mut self, indices: Range<IndexCount>, base_vertex: VertexOffset, instances: Range<InstanceCount>) {
         self.0.draw_indexed(indices, base_vertex, instances)
     }
+
     ///
     pub fn draw_indirect(&mut self, buffer: &B::Buffer, offset: buffer::Offset, draw_count: u32, stride: u32) {
         self.0.draw_indirect(buffer, offset, draw_count, stride)
@@ -124,7 +125,11 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
         self.0.push_graphics_constants(layout, stages, offset, constants);
     }
 
-    // TODO: set_line_width
+    ///
+    pub fn set_line_width(&mut self, width: f32) {
+        self.0.set_line_width(width);
+    }
+
     // TODO: set_depth_bias
     // TODO: set_stencil_compare_mask
     // TODO: set_stencil_write_mask


### PR DESCRIPTION
Just implementing stubs for `set_line_width` to help with portability crashes. No-ops on DX12 and Metal because it doesn't seem we have any way to expose it there (at least at first glance), so we simply don't expose `wideLines` as a feature and force `1.0` as the line width.

(I haven't actually tried to build the Vulkan and DX12 backends yet, so CI may fail here – I'll fix later if it does)

PR checklist:
- [X] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
