### PR TITLE
Implement `set_depth_bias`

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1047,6 +1047,10 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         validate_line_width(width);
     }
 
+    fn set_depth_bias(&mut self, _depth_bias: pso::DepthBias) {
+        unimplemented!()
+    }
+
     fn bind_graphics_pipeline(&mut self, pipeline: &GraphicsPipeline) {
         unimplemented!()
     }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1688,6 +1688,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         validate_line_width(width);
     }
 
+    fn set_depth_bias(&mut self, _depth_bias: pso::DepthBias) {
+        unimplemented!()
+    }
+
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {
         unsafe {
             match self.gr_pipeline.pipeline {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -528,7 +528,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
     fn set_line_width(&mut self, _: f32) {
-        unimplemented!();
+        unimplemented!()
+    }
+
+    fn set_depth_bias(&mut self, _: pso::DepthBias) {
+        unimplemented!()
     }
 
     fn begin_render_pass<T>(

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -794,7 +794,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     }
 
     fn set_line_width(&mut self, _width: f32) {
-        unimplemented!();
+        unimplemented!()
+    }
+
+    fn set_depth_bias(&mut self, _depth_bias: pso::DepthBias) {
+        unimplemented!()
     }
 
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -947,12 +947,14 @@ impl hal::Device<Backend> for Device {
         if let pso::PolygonMode::Line(width) = pipeline_desc.rasterizer.polygon_mode {
             validate_line_width(width);
         }
+
         let rasterizer_state = Some(n::RasterizerState {
             depth_clip: if pipeline_desc.rasterizer.depth_clamping {
                 metal::MTLDepthClipMode::Clamp
             } else {
                 metal::MTLDepthClipMode::Clip
             },
+            depth_bias: pipeline_desc.rasterizer.depth_bias.unwrap_or_default(),
         });
 
         device.new_render_pipeline_state(&pipeline)

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -54,6 +54,16 @@ pub struct PipelineLayout {
 pub struct RasterizerState {
     //TODO: more states
     pub depth_clip: metal::MTLDepthClipMode,
+    pub depth_bias: pso::DepthBias,
+}
+
+impl Default for RasterizerState {
+    fn default() -> Self {
+        RasterizerState {
+            depth_clip: metal::MTLDepthClipMode::Clip,
+            depth_bias: Default::default(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -19,6 +19,7 @@ pub enum RenderCommand {
     SetViewport(metal::MTLViewport),
     SetScissor(metal::MTLScissorRect),
     SetBlendColor(hal::pso::ColorValue),
+    SetDepthBias(hal::pso::DepthBias),
     BindBuffer {
         stage: hal::pso::Stage,
         index: usize,

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1"
 log = "0.4"
 lazy_static = "1"
 shared_library = "0.1"
-ash = "0.24.2"
+ash = "0.24.3"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.13", optional = true }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -584,6 +584,17 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
+    fn set_depth_bias(&mut self, depth_bias: pso::DepthBias) {
+        unsafe {
+            self.device.0.cmd_set_depth_bias(
+                self.raw,
+                depth_bias.const_factor,
+                depth_bias.clamp,
+                depth_bias.slope_factor,
+            );
+        }
+    }
+
     fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {
         unsafe {
             self.device.0.cmd_bind_pipeline(

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -422,7 +422,7 @@ impl d::Device<B> for Device {
                     vk::VK_FALSE
                 },
                 rasterizer_discard_enable: if desc.shaders.fragment.is_none() { vk::VK_TRUE } else { vk::VK_FALSE },
-                polygon_mode: polygon_mode,
+                polygon_mode,
                 cull_mode: desc.rasterizer.cull_face.map(conv::map_cull_face).unwrap_or(vk::CULL_MODE_NONE),
                 front_face: conv::map_front_face(desc.rasterizer.front_face),
                 depth_bias_enable: if desc.rasterizer.depth_bias.is_some() { vk::VK_TRUE } else { vk::VK_FALSE },

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -243,6 +243,11 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
+    pub fn set_depth_bias(&mut self, depth_bias: pso::DepthBias) {
+        self.raw.set_depth_bias(depth_bias);
+    }
+
+    /// Identical to the `RawCommandBuffer` method of the same name.
     pub fn push_graphics_constants(&mut self, layout: &B::PipelineLayout, stages: pso::ShaderStageFlags, offset: u32, constants: &[u32]) {
         self.raw.push_graphics_constants(layout, stages, offset, constants)
     }

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -264,6 +264,9 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     /// Set the line width dynamically.
     fn set_line_width(&mut self, width: f32);
 
+    /// Set the depth bias dynamically.
+    fn set_depth_bias(&mut self, depth_bias: pso::DepthBias);
+
     /// Begins recording commands for a render pass on the given framebuffer.
     /// `render_area` is the section of the framebuffer to render,
     /// `clear_values` is an iterator of `ClearValueRaw`'s to use to use for

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -130,7 +130,11 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
         self.0.set_line_width(width);
     }
 
-    // TODO: set_depth_bias
+    ///
+    pub fn set_depth_bias(&mut self, depth_bias: pso::DepthBias) {
+        self.0.set_depth_bias(depth_bias);
+    }
+
     // TODO: set_stencil_compare_mask
     // TODO: set_stencil_write_mask
     // TODO: pipeline barrier (postponed)

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -204,7 +204,7 @@ pub enum FrontFace {
 ///
 /// For details of the algorithm and equations, see
 /// [the Vulkan spec](https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#primsrast-depthbias).
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DepthBias {
     /// A constant depth value added to each fragment.


### PR DESCRIPTION
Fixes some CTS Metal issues with dynamic depth bias, or possibly areas where static depth bias is applied (through rasterizer info)

~~Depends on MaikKlein/ash#65~~

PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends: Metal
