### PR TITLE
[pre-ll] Update winit -> 0.15, glutin -> 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ name = "gfx_app"
 [dependencies]
 log = "0.4"
 env_logger = "0.5"
-glutin = "0.15"
-winit = "0.13"
+glutin = "0.16"
+winit = "0.15"
 gfx_core = { path = "src/core", version = "0.8" }
 gfx = { path = "src/render", version = "0.17" }
 gfx_macros = { path = "src/macros", version = "0.2" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.16" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.23" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.24" }
 gfx_window_glfw = { path = "src/window/glfw", version = "0.17", optional = true }
 gfx_window_sdl = { path = "src/window/sdl", version = "0.9", optional = true }
 
@@ -57,7 +57,7 @@ optional = true
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.7" }
-gfx_window_dxgi = { path = "src/window/dxgi", version = "0.14" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.15" }
 
 [[example]]
 name = "blend"

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.14.0"
+version = "0.15.0"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,6 +29,6 @@ name = "gfx_window_dxgi"
 [dependencies]
 log = "0.4"
 winapi = { version = "0.3" , features = ["d3d11", "dxgi"] }
-winit = "0.13"
+winit = "0.15"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.7" }

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.23.0"
+version = "0.24.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,7 +28,7 @@ documentation = "https://docs.rs/gfx_window_glutin"
 name = "gfx_window_glutin"
 
 [dependencies]
-glutin = "0.15"
+glutin = "0.16"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.16" }
 

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -30,7 +30,7 @@ name = "gfx_window_metal"
 log = "0.4"
 cocoa = "0.9"
 objc = "0.2"
-winit = "0.13"
+winit = "0.15"
 metal-rs = "0.4"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.3" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/gfx_window_vulkan"
 name = "gfx_window_vulkan"
 
 [dependencies]
-winit = "0.13"
+winit = "0.15"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.2" }


### PR DESCRIPTION
Bump affected `gfx_window_glutin`, `gfx_window_dxgi`  versions for release

PR checklist:
- [x] tested examples with the following backends: gl
