### PR TITLE
Metal revised memory types

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -20,6 +20,7 @@ name = "gfx_backend_metal"
 
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.1" }
+bitflags = "1.0"
 log = "0.4"
 winit = { version = "0.13", optional = true }
 metal-rs = "0.10.1"

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1103,7 +1103,7 @@ impl CommandBuffer {
         while data.len() < offset + constants.len() {
             data.push(0);
         }
-        data[offset ..].copy_from_slice(constants);
+        data[offset .. offset + constants.len()].copy_from_slice(constants);
     }
 }
 

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -1,6 +1,6 @@
 use PrivateCapabilities;
 
-use hal::{pass, image, memory, pso, IndexType};
+use hal::{pass, image, pso, IndexType};
 use hal::format::Format;
 use hal::pso::Comparison;
 use metal::*;
@@ -247,45 +247,6 @@ pub fn map_vertex_format(format: Format) -> Option<MTLVertexFormat> {
         f::Rgba32Float => Float4,
         _ => return None,
     })
-}
-
-pub fn map_memory_properties_to_options(properties: memory::Properties) -> MTLResourceOptions {
-    let mut options = MTLResourceOptions::empty();
-    if properties.contains(memory::Properties::CPU_VISIBLE) {
-        if properties.contains(memory::Properties::COHERENT) {
-            options |= MTLResourceOptions::StorageModeShared;
-        } else {
-            options |= MTLResourceOptions::StorageModeManaged;
-        }
-    } else if properties.contains(memory::Properties::DEVICE_LOCAL) {
-        options |= MTLResourceOptions::StorageModePrivate;
-    } else {
-        panic!("invalid heap properties");
-    }
-    if !properties.contains(memory::Properties::CPU_CACHED) {
-        options |= MTLResourceOptions::CPUCacheModeWriteCombined;
-    }
-    options
-}
-
-pub fn map_memory_properties_to_storage_and_cache(properties: memory::Properties) -> (MTLStorageMode, MTLCPUCacheMode) {
-    let storage = if properties.contains(memory::Properties::CPU_VISIBLE) {
-        if properties.contains(memory::Properties::COHERENT) {
-            MTLStorageMode::Shared
-        } else {
-            MTLStorageMode::Managed
-        }
-    } else if properties.contains(memory::Properties::DEVICE_LOCAL) {
-        MTLStorageMode::Private
-    } else {
-        panic!("invalid heap properties");
-    };
-    let cpu = if properties.contains(memory::Properties::CPU_CACHED) {
-        MTLCPUCacheMode::DefaultCache
-    } else {
-        MTLCPUCacheMode::WriteCombined
-    };
-    (storage, cpu)
 }
 
 pub fn resource_options_from_storage_and_cache(storage: MTLStorageMode, cache: MTLCPUCacheMode) -> MTLResourceOptions {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -180,6 +180,7 @@ impl hal::Backend for Backend {
 struct PrivateCapabilities {
     resource_heaps: bool,
     argument_buffers: bool,
+    shared_textures: bool,
     format_depth24_stencil8: bool,
     format_depth32_stencil8: bool,
     format_min_srgb_channels: u8,
@@ -188,6 +189,7 @@ struct PrivateCapabilities {
     max_textures_per_stage: usize,
     max_samplers_per_stage: usize,
     buffer_alignment: u64,
+    max_buffer_size: u64,
 }
 
 pub struct AutoreleasePool {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate gfx_hal as hal;
+#[macro_use] extern crate bitflags;
 extern crate cocoa;
 extern crate foreign_types;
 #[macro_use] extern crate objc;

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -53,6 +53,7 @@ impl hal::QueueFamily for QueueFamily {
 
 pub struct Shared {
     pub(crate) device: Mutex<metal::Device>,
+    pub(crate) aux_queue: Mutex<metal::CommandQueue>,
     pub(crate) queue_pool: Mutex<command::QueuePool>,
     pub(crate) service_pipes: Mutex<internal::ServicePipes>,
     pub(crate) push_constants_buffer_id: u32,
@@ -65,6 +66,7 @@ impl Shared {
     pub(crate) fn new(device: metal::Device) -> Self {
         Shared {
             queue_pool: Mutex::new(command::QueuePool::default()),
+            aux_queue: Mutex::new(device.new_command_queue()),
             service_pipes: Mutex::new(internal::ServicePipes::new(&device)),
             device: Mutex::new(device),
             push_constants_buffer_id: 30,

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -298,6 +298,7 @@ pub(crate) enum MemoryHeap {
 #[derive(Debug)]
 pub struct UnboundBuffer {
     pub(crate) size: u64,
+    pub(crate) usage: hal::buffer::Usage,
 }
 unsafe impl Send for UnboundBuffer {}
 unsafe impl Sync for UnboundBuffer {}

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1,9 +1,7 @@
 use {Backend};
 use internal::Channel;
 
-use std::cell::Cell;
 use std::collections::{HashMap};
-use std::marker::PhantomData;
 use std::ops::Range;
 use std::os::raw::{c_void, c_long};
 use std::sync::{Arc, Mutex};
@@ -88,7 +86,6 @@ unsafe impl Sync for ComputePipeline {}
 #[derive(Debug)]
 pub struct Image {
     pub(crate) raw: metal::Texture,
-    pub(crate) allocations: Option<Arc<Mutex<MemoryAllocations>>>,
     pub(crate) extent: image::Extent,
     pub(crate) num_layers: Option<image::Layer>,
     pub(crate) format_desc: hal::format::FormatDesc,
@@ -144,8 +141,7 @@ unsafe impl Sync for Semaphore {}
 #[derive(Debug)]
 pub struct Buffer {
     pub(crate) raw: metal::Buffer,
-    pub(crate) allocations: Option<Arc<Mutex<MemoryAllocations>>>,
-    pub(crate) offset: u64,
+    pub(crate) range: Range<u64>,
     pub(crate) res_options: metal::MTLResourceOptions,
 }
 
@@ -274,23 +270,13 @@ pub enum DescriptorSetBinding {
 pub struct Memory {
     pub(crate) heap: MemoryHeap,
     pub(crate) size: u64,
-    pub(crate) allocations: Arc<Mutex<MemoryAllocations>>,
-    pub(crate) mapping: Mutex<Option<Range<u64>>>,
-    pub(crate) cpu_buffer: Option<metal::Buffer>,
-    pub(crate) initialized: Cell<bool>,
 }
 
 impl Memory {
-    pub(crate) fn new(
-        heap: MemoryHeap, size: u64, cpu_buffer: Option<metal::Buffer>
-    ) -> Self {
+    pub(crate) fn new(heap: MemoryHeap, size: u64) -> Self {
         Memory {
             heap,
             size,
-            allocations: Arc::new(Mutex::new(MemoryAllocations::new())),
-            mapping: Mutex::new(None),
-            cpu_buffer,
-            initialized: Cell::new(false),
         }
     }
 
@@ -302,50 +288,10 @@ impl Memory {
 unsafe impl Send for Memory {}
 unsafe impl Sync for Memory {}
 
-#[derive(Clone, Debug)]
-pub enum Resource {
-    Buffer(metal::Buffer),
-    Texture {
-        raw: metal::Texture,
-        format_desc: hal::format::FormatDesc,
-        extent: image::Extent,
-        subresource: image::SubresourceLayers,
-    },
-}
-
-#[derive(Debug)]
-pub struct MemoryAllocations {
-    resources: HashMap<Range<u64>, Resource>,
-}
-
-impl MemoryAllocations {
-    fn new() -> Self {
-        MemoryAllocations {
-            resources: HashMap::new(),
-        }
-    }
-
-    // Don't ask why there is a phantom data at the end of the iterated tuple...
-    /// Get all unique buffers that intersects specified range
-    pub fn find<'a>(&'a self, range: &'a Range<u64>) -> impl Iterator<Item=(Range<u64>, Resource, PhantomData<&'a Resource>)> {
-        self.resources
-            .iter()
-            .filter(move |&(ref r, _)| r.start < range.end && r.end > range.start)
-            .map(|(r, res)| (r.clone(), res.clone(), PhantomData))
-    }
-
-    pub fn insert(&mut self, range: Range<u64>, resource: Resource) {
-        self.resources.insert(range, resource);
-    }
-
-    pub fn remove(&mut self, range: Range<u64>) {
-        self.resources.remove(&range);
-    }
-}
-
 #[derive(Debug)]
 pub(crate) enum MemoryHeap {
-    Emulated(hal::MemoryTypeId),
+    Private,
+    Public(hal::MemoryTypeId, metal::Buffer),
     Native(metal::Heap),
 }
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -299,7 +299,6 @@ pub(crate) enum MemoryHeap {
 pub struct UnboundBuffer {
     pub(crate) size: u64,
 }
-
 unsafe impl Send for UnboundBuffer {}
 unsafe impl Sync for UnboundBuffer {}
 
@@ -307,10 +306,10 @@ unsafe impl Sync for UnboundBuffer {}
 pub struct UnboundImage {
     pub(crate) texture_desc: metal::TextureDescriptor,
     pub(crate) format: hal::format::Format,
-    pub(crate) tiling: image::Tiling,
     pub(crate) extent: image::Extent,
     pub(crate) num_layers: Option<image::Layer>,
     pub(crate) mip_sizes: Vec<u64>,
+    pub(crate) host_visible: bool,
 }
 unsafe impl Send for UnboundImage {}
 unsafe impl Sync for UnboundImage {}

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -156,7 +156,6 @@ impl Device {
                 ];
                 native::Image {
                     raw: mapped_texture,
-                    allocations: None,
                     extent: image::Extent {
                         width: pixel_width as _,
                         height: pixel_height as _,


### PR DESCRIPTION
Fixes #2069
~~Includes #2070 (please only review the last 2 commits)~~

The PR effectively removes all the complicated memory allocation tracking from the Metal backend, instead relying on mapping the available storage types (with CPU caching policy) more accurately to what can be represented in Vulkan API.

With this in, we slice through the whole `memory` section without crashes. The only issue I failed to fix/workaround is filed as #2077

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
