### PR TITLE
Immutable samplers

### DIFF
--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -49,14 +49,17 @@ fn main() {
     let shader = device.create_shader_module(include_bytes!("shader/collatz.spv")).unwrap();
 
     let (pipeline_layout, pipeline, set_layout, mut desc_pool) = {
-        let set_layout = device.create_descriptor_set_layout(&[
+        let set_layout = device.create_descriptor_set_layout(
+            &[
                 pso::DescriptorSetLayoutBinding {
                     binding: 0,
                     ty: pso::DescriptorType::StorageBuffer,
                     count: 1,
                     stage_flags: pso::ShaderStageFlags::COMPUTE,
+                    immutable_samplers: false,
                 }
             ],
+            &[],
         );
 
         let pipeline_layout = device.create_pipeline_layout(Some(&set_layout), &[]);

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -141,20 +141,24 @@ fn main() {
     let (mut swap_chain, backbuffer) = device.create_swapchain(&mut surface, swap_config);
 
     // Setup renderpass and pipeline
-    let set_layout = device.create_descriptor_set_layout(&[
+    let set_layout = device.create_descriptor_set_layout(
+        &[
             pso::DescriptorSetLayoutBinding {
                 binding: 0,
                 ty: pso::DescriptorType::SampledImage,
                 count: 1,
                 stage_flags: ShaderStageFlags::FRAGMENT,
+                immutable_samplers: false,
             },
             pso::DescriptorSetLayoutBinding {
                 binding: 1,
                 ty: pso::DescriptorType::Sampler,
                 count: 1,
                 stage_flags: ShaderStageFlags::FRAGMENT,
+                immutable_samplers: false,
             },
         ],
+        &[],
     );
 
     let pipeline_layout = device.create_pipeline_layout(

--- a/reftests/scenes/compute.ron
+++ b/reftests/scenes/compute.ron
@@ -11,6 +11,7 @@
 					ty: StorageBuffer,
 					count: 1,
 					stage_flags: (bits: 0x20), //COMPUTE
+					immutable_samplers: false,
 				),
 			],
 		),

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -610,13 +610,14 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_descriptor_set_layout<I>(
-        &self,
-        bindings: I,
-    )-> DescriptorSetLayout
+    fn create_descriptor_set_layout<I, J>(
+        &self, _bindings: I, _immutable_samplers: J
+    ) -> DescriptorSetLayout
     where
         I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetLayoutBinding>
+        I::Item: Borrow<pso::DescriptorSetLayoutBinding>,
+        J: IntoIterator,
+        J::Item: Borrow<Sampler>,
     {
         unimplemented!()
     }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2335,16 +2335,17 @@ impl d::Device<B> for Device {
         }
     }
 
-    fn create_descriptor_set_layout<I>(
-        &self,
-        bindings: I,
-    )-> n::DescriptorSetLayout
+    fn create_descriptor_set_layout<I, J>(
+        &self, bindings: I, _immutable_samplers: J
+    ) -> n::DescriptorSetLayout
     where
         I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetLayoutBinding>
+        I::Item: Borrow<pso::DescriptorSetLayoutBinding>,
+        J: IntoIterator,
+        J::Item: Borrow<n::Sampler>,
     {
         n::DescriptorSetLayout {
-            bindings: bindings.into_iter().map(|bind| bind.borrow().clone()).collect()
+            bindings: bindings.into_iter().map(|b| b.borrow().clone()).collect()
         }
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -224,10 +224,12 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_descriptor_set_layout<I>(&self, _: I) -> ()
+    fn create_descriptor_set_layout<I, J>(&self, _: I, _: J) -> ()
     where
         I: IntoIterator,
         I::Item: Borrow<pso::DescriptorSetLayoutBinding>,
+        J: IntoIterator,
+        J::Item: Borrow<()>
     {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -973,10 +973,12 @@ impl d::Device<B> for Device {
         n::DescriptorPool { }
     }
 
-    fn create_descriptor_set_layout<I>(&self, _: I) -> n::DescriptorSetLayout
+    fn create_descriptor_set_layout<I, J>(&self, _: I, _: J) -> n::DescriptorSetLayout
     where
         I: IntoIterator,
         I::Item: Borrow<pso::DescriptorSetLayoutBinding>,
+        J: IntoIterator,
+        J::Item: Borrow<n::FatSampler>,
     {
         n::DescriptorSetLayout
     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1939,27 +1939,20 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                     }));
                                 }
                                 Combined(ref combos) => {
-                                    for (i, combo) in combos.iter().cloned().enumerate() {
+                                    for (i, (ref tex, ref sampler)) in combos.iter().cloned().enumerate() {
                                         let id_tx = res.texture_id as usize + i;
                                         let id_sm = res.sampler_id as usize + i;
-                                        let (texture, sampler) = match combo {
-                                            Some((ref t, _, ref s)) => (Some(t.clone()), Some(s.clone())),
-                                            None => (None, None)
-                                        };
-                                        resources.add_textures(
-                                            id_tx,
-                                            &[combo.as_ref().map(|&(ref texture, layout, _)| (texture.clone(), layout))],
-                                        );
+                                        resources.add_textures(id_tx, &[tex.clone()]);
                                         resources.add_samplers(id_sm, &[sampler.clone()]);
                                         commands.push(soft::RenderCommand::BindTexture {
                                             stage: pso::Stage::Vertex,
                                             index: id_tx,
-                                            texture,
+                                            texture: tex.as_ref().map(|(t, _)| t.clone()),
                                         });
                                         commands.push(soft::RenderCommand::BindSampler {
                                             stage: pso::Stage::Vertex,
                                             index: id_sm,
-                                            sampler,
+                                            sampler: sampler.clone(),
                                         });
                                     }
                                 }
@@ -2013,27 +2006,20 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                     }));
                                 }
                                 Combined(ref combos) => {
-                                    for (i, combo) in combos.iter().cloned().enumerate() {
+                                    for (i, (ref tex, ref sampler)) in combos.iter().cloned().enumerate() {
                                         let id_tx = res.texture_id as usize + i;
                                         let id_sm = res.sampler_id as usize + i;
-                                        let (texture, sampler) = match combo {
-                                            Some((ref t, _, ref s)) => (Some(t.clone()), Some(s.clone())),
-                                            None => (None, None)
-                                        };
-                                        resources.add_textures(
-                                            id_tx,
-                                            &[combo.as_ref().map(|&(ref texture, layout, _)| (texture.clone(), layout))],
-                                        );
+                                        resources.add_textures(id_tx, &[tex.clone()]);
                                         resources.add_samplers(id_sm, &[sampler.clone()]);
                                         commands.push(soft::RenderCommand::BindTexture {
                                             stage: pso::Stage::Fragment,
                                             index: id_tx,
-                                            texture,
+                                            texture: tex.as_ref().map(|(t, _)| t.clone()),
                                         });
                                         commands.push(soft::RenderCommand::BindSampler {
                                             stage: pso::Stage::Fragment,
                                             index: id_sm,
-                                            sampler,
+                                            sampler: sampler.clone(),
                                         });
                                     }
                                 }
@@ -2155,25 +2141,18 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                     }));
                                 }
                                 Combined(ref combos) => {
-                                    for (i, combo) in combos.iter().cloned().enumerate() {
+                                    for (i, (ref tex, ref sampler)) in combos.iter().cloned().enumerate() {
                                         let id_tx = res.texture_id as usize + i;
                                         let id_sm = res.sampler_id as usize + i;
-                                        let (texture, sampler) = match combo {
-                                            Some((ref t, _, ref s)) => (Some(t.clone()), Some(s.clone())),
-                                            None => (None, None)
-                                        };
-                                        resources.add_textures(
-                                            id_tx,
-                                            &[combo.as_ref().map(|&(ref texture, layout, _)| (texture.clone(), layout))],
-                                        );
+                                        resources.add_textures(id_tx, &[tex.clone()]);
                                         resources.add_samplers(id_sm, &[sampler.clone()]);
                                         commands.push(soft::ComputeCommand::BindTexture {
                                             index: id_tx,
-                                            texture,
+                                            texture: tex.as_ref().map(|(t, _)| t.clone()),
                                         });
                                         commands.push(soft::ComputeCommand::BindSampler {
                                             index: id_sm,
-                                            sampler,
+                                            sampler: sampler.clone(),
                                         });
                                     }
                                 }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -368,10 +368,14 @@ pub trait Device<B: Backend>: Any + Send + Sync {
     fn destroy_descriptor_pool(&self, pool: B::DescriptorPool);
 
     /// Create a descriptor set layout.
-    fn create_descriptor_set_layout<I>(&self, bindings: I) -> B::DescriptorSetLayout
+    fn create_descriptor_set_layout<I, J>(
+        &self, bindings: I, immutable_samplers: J
+    ) -> B::DescriptorSetLayout
     where
         I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetLayoutBinding>;
+        I::Item: Borrow<pso::DescriptorSetLayoutBinding>,
+        J: IntoIterator,
+        J::Item: Borrow<B::Sampler>;
 
     ///
     fn destroy_descriptor_set_layout(&self, layout: B::DescriptorSetLayout);

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -74,7 +74,8 @@ pub struct DescriptorSetLayoutBinding {
     pub count: DescriptorArrayIndex,
     /// Valid shader stages.
     pub stage_flags: ShaderStageFlags,
-    // TODO: immutable samplers?
+    /// Use the associated list of immutable samplers.
+    pub immutable_samplers: bool,
 }
 
 /// Set of descriptors of a specific type.

--- a/src/render/src/device.rs
+++ b/src/render/src/device.rs
@@ -299,7 +299,7 @@ impl<B: Backend> Device<B> {
         &mut self,
         bindings: &[hal::pso::DescriptorSetLayoutBinding],
     ) -> handle::raw::DescriptorSetLayout<B> {
-        let layout = self.raw.create_descriptor_set_layout(bindings);
+        let layout = self.raw.create_descriptor_set_layout(bindings, &[]);
         DescriptorSetLayout::new(layout, (), self.garbage.clone()).into()
     }
 

--- a/src/render/src/macros/descriptors.rs
+++ b/src/render/src/macros/descriptors.rs
@@ -48,6 +48,7 @@ macro_rules! gfx_descriptors {
                             count: <$bind as pso::BindDesc>::COUNT as _,
                             // TODO: specify stage
                             stage_flags: hal::pso::ShaderStageFlags::all(),
+                            immutable_samplers: false,
                         });
                     })*
                     bindings

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -538,8 +538,10 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                             .unwrap();
                         resources.shaders.insert(name.clone(), module);
                     }
-                    raw::Resource::DescriptorSetLayout { ref bindings } => {
-                        let layout = device.create_descriptor_set_layout(bindings);
+                    raw::Resource::DescriptorSetLayout { ref bindings, ref immutable_samplers } => {
+                        assert!(immutable_samplers.is_empty()); //TODO! requires changing the order,
+                        // since samples are expect to be all read by this point
+                        let layout = device.create_descriptor_set_layout(bindings, &[]);
                         let binding_indices = bindings.iter().map(|dsb| dsb.binding).collect();
                         resources.desc_set_layouts.insert(name.clone(), (binding_indices, layout));
                     }

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -77,6 +77,8 @@ pub enum Resource {
     Shader(String),
     DescriptorSetLayout {
         bindings: Vec<hal::pso::DescriptorSetLayoutBinding>,
+        #[serde(default)]
+        immutable_samplers: Vec<String>,
     },
     DescriptorPool {
         capacity: usize,


### PR DESCRIPTION
Fixes #1723
- [x] hal/empty/render/warden
- [x] metal
- [ ] d3d12
- [x] vulkan

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
