### PR TITLE
[pre-ll] Call glDrawArraysInstanced when base=0

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -663,7 +663,15 @@ impl Device {
             Command::Draw(primitive, start, count, instances) => {
                 let gl = &self.share.context;
                 match instances {
-                    Some((num, base)) if self.share.capabilities.instance_call_supported => unsafe {
+                    Some((num, 0)) if self.share.capabilities.instance_call_supported => unsafe {
+                        gl.DrawArraysInstanced(
+                            primitive,
+                            start as gl::types::GLsizei,
+                            count as gl::types::GLsizei,
+                            num as gl::types::GLsizei,
+                        );
+                    },
+                    Some((num, base)) if self.share.capabilities.instance_base_supported => unsafe {
                         gl.DrawArraysInstancedBaseInstance(
                             primitive,
                             start as gl::types::GLsizei,


### PR DESCRIPTION
Only call `glDrawArraysInstancedBaseInstance` when base is non-zero & `instance_base_supported`. Fixes OpenGL 3.2 instance rendering (https://github.com/alexheretic/gfx-glyph/issues/26).

PR checklist:
- [x] tested examples with the following backends: gl
