### PR TITLE
[dx11] add graphics pipeline creation & shader module creation

### DIFF
--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -1,10 +1,20 @@
 use hal::format::{Format};
-use hal::pso::{Rect, Viewport};
+use hal::pso::{
+    BlendDesc, BlendOp, BlendState, ColorBlendDesc, Comparison, CullFace, DepthStencilDesc,
+    DepthTest, Factor, PolygonMode, Rasterizer, Rect, StencilFace, StencilOp, StencilTest,
+    Viewport, Stage
+};
+use hal::Primitive;
+
+use spirv_cross::spirv;
+
+use winapi::shared::dxgiformat::*;
+use winapi::shared::minwindef::{FALSE, INT, TRUE};
 
 use winapi::um::d3dcommon::*;
-use winapi::shared::dxgiformat::*;
+use winapi::um::d3d11::*;
 
-use winapi::um::d3d11::{D3D11_RECT, D3D11_VIEWPORT};
+use std::mem;
 
 // TODO: stolen from d3d12 backend, maybe share function somehow?
 pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
@@ -100,5 +110,212 @@ pub fn map_rect(rect: &Rect) -> D3D11_RECT {
         top: rect.y as _,
         right: rect.w as _,
         bottom: rect.h as _,
+    }
+}
+
+pub fn map_topology(primitive: Primitive) -> D3D11_PRIMITIVE_TOPOLOGY {
+    match primitive {
+        Primitive::PointList              => D3D_PRIMITIVE_TOPOLOGY_POINTLIST,
+        Primitive::LineList               => D3D_PRIMITIVE_TOPOLOGY_LINELIST,
+        Primitive::LineListAdjacency      => D3D_PRIMITIVE_TOPOLOGY_LINELIST_ADJ,
+        Primitive::LineStrip              => D3D_PRIMITIVE_TOPOLOGY_LINESTRIP,
+        Primitive::LineStripAdjacency     => D3D_PRIMITIVE_TOPOLOGY_LINESTRIP_ADJ,
+        Primitive::TriangleList           => D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST,
+        Primitive::TriangleListAdjacency  => D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST,
+        Primitive::TriangleStrip          => D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
+        Primitive::TriangleStripAdjacency => D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
+        Primitive::PatchList(num) => { assert!(num != 0);
+            D3D_PRIMITIVE_TOPOLOGY_1_CONTROL_POINT_PATCHLIST + (num as u32) - 1
+        },
+    }
+}
+
+fn map_fill_mode(mode: PolygonMode) -> D3D11_FILL_MODE {
+    match mode {
+        PolygonMode::Fill => D3D11_FILL_SOLID,
+        PolygonMode::Line(_) => D3D11_FILL_WIREFRAME,
+        // TODO: return error
+        _ => unimplemented!()
+    }
+}
+
+fn map_cull_mode(mode: Option<CullFace>) -> D3D11_CULL_MODE {
+    match mode {
+        Some(CullFace::Front) => D3D11_CULL_FRONT,
+        Some(CullFace::Back) => D3D11_CULL_BACK,
+        None => D3D11_CULL_NONE,
+    }
+}
+
+pub(crate) fn map_rasterizer_desc(desc: &Rasterizer) -> D3D11_RASTERIZER_DESC {
+    D3D11_RASTERIZER_DESC {
+        FillMode: map_fill_mode(desc.polygon_mode),
+        CullMode: map_cull_mode(desc.cull_face),
+        FrontCounterClockwise: match desc.front_face {
+            Clockwise => FALSE,
+            CounterClockwise => TRUE,
+        },
+        DepthBias: desc.depth_bias.map_or(0, |bias| bias.const_factor as INT),
+        DepthBiasClamp: desc.depth_bias.map_or(0.0, |bias| bias.clamp),
+        SlopeScaledDepthBias: desc.depth_bias.map_or(0.0, |bias| bias.slope_factor),
+        DepthClipEnable: !desc.depth_clamping as _,
+        // TODO:
+        ScissorEnable: TRUE,
+        // TODO: msaa
+        MultisampleEnable: FALSE,
+        // TODO: line aa?
+        AntialiasedLineEnable: FALSE,
+        // TODO: conservative raster in >=11.x
+    }
+}
+
+fn map_blend_factor(factor: Factor) -> D3D11_BLEND {
+    match factor {
+        Factor::Zero => D3D11_BLEND_ZERO,
+        Factor::One => D3D11_BLEND_ONE,
+        Factor::SrcColor => D3D11_BLEND_SRC_COLOR,
+        Factor::OneMinusSrcColor => D3D11_BLEND_INV_SRC_COLOR,
+        Factor::DstColor => D3D11_BLEND_DEST_COLOR,
+        Factor::OneMinusDstColor => D3D11_BLEND_INV_DEST_COLOR,
+        Factor::SrcAlpha => D3D11_BLEND_SRC_ALPHA,
+        Factor::OneMinusSrcAlpha => D3D11_BLEND_INV_SRC_ALPHA,
+        Factor::DstAlpha => D3D11_BLEND_DEST_ALPHA,
+        Factor::OneMinusDstAlpha => D3D11_BLEND_INV_DEST_ALPHA,
+        Factor::ConstColor | Factor::ConstAlpha => D3D11_BLEND_BLEND_FACTOR,
+        Factor::OneMinusConstColor | Factor::OneMinusConstAlpha => D3D11_BLEND_INV_BLEND_FACTOR,
+        Factor::SrcAlphaSaturate => D3D11_BLEND_SRC_ALPHA_SAT,
+        Factor::Src1Color => D3D11_BLEND_SRC1_COLOR,
+        Factor::OneMinusSrc1Color => D3D11_BLEND_INV_SRC1_COLOR,
+        Factor::Src1Alpha => D3D11_BLEND_SRC1_ALPHA,
+        Factor::OneMinusSrc1Alpha => D3D11_BLEND_INV_SRC1_ALPHA,
+    }
+}
+
+fn map_blend_op(operation: BlendOp) -> (D3D11_BLEND_OP, D3D11_BLEND, D3D11_BLEND) {
+    match operation {
+        BlendOp::Add    { src, dst } => (D3D11_BLEND_OP_ADD,          map_blend_factor(src), map_blend_factor(dst)),
+        BlendOp::Sub    { src, dst } => (D3D11_BLEND_OP_SUBTRACT,     map_blend_factor(src), map_blend_factor(dst)),
+        BlendOp::RevSub { src, dst } => (D3D11_BLEND_OP_REV_SUBTRACT, map_blend_factor(src), map_blend_factor(dst)),
+        BlendOp::Min => (D3D11_BLEND_OP_MIN, D3D11_BLEND_ZERO, D3D11_BLEND_ZERO),
+        BlendOp::Max => (D3D11_BLEND_OP_MAX, D3D11_BLEND_ZERO, D3D11_BLEND_ZERO),
+    }
+}
+
+fn map_blend_targets(render_target_blends: &[ColorBlendDesc]) -> [D3D11_RENDER_TARGET_BLEND_DESC; 8] {
+    let mut targets: [D3D11_RENDER_TARGET_BLEND_DESC; 8] = [unsafe { mem::zeroed() }; 8];
+
+    for (mut target, &ColorBlendDesc(mask, blend)) in
+        targets.iter_mut().zip(render_target_blends.iter())
+    {
+        target.RenderTargetWriteMask = mask.bits() as _;
+        if let BlendState::On { color, alpha } = blend {
+            let (color_op, color_src, color_dst) = map_blend_op(color);
+            let (alpha_op, alpha_src, alpha_dst) = map_blend_op(alpha);
+            target.BlendEnable = TRUE;
+            target.BlendOp = color_op;
+            target.SrcBlend = color_src;
+            target.DestBlend = color_dst;
+            target.BlendOpAlpha = alpha_op;
+            target.SrcBlendAlpha = alpha_src;
+            target.DestBlendAlpha = alpha_dst;
+        }
+    }
+
+    targets
+}
+
+pub(crate) fn map_blend_desc(desc: &BlendDesc) -> D3D11_BLEND_DESC {
+    D3D11_BLEND_DESC {
+        // TODO: msaa
+        AlphaToCoverageEnable: FALSE,
+        IndependentBlendEnable: TRUE,
+        RenderTarget: map_blend_targets(&desc.targets)
+    }
+}
+
+fn map_comparison(func: Comparison) -> D3D11_COMPARISON_FUNC {
+    match func {
+        Comparison::Never => D3D11_COMPARISON_NEVER,
+        Comparison::Less => D3D11_COMPARISON_LESS,
+        Comparison::LessEqual => D3D11_COMPARISON_LESS_EQUAL,
+        Comparison::Equal => D3D11_COMPARISON_EQUAL,
+        Comparison::GreaterEqual => D3D11_COMPARISON_GREATER_EQUAL,
+        Comparison::Greater => D3D11_COMPARISON_GREATER,
+        Comparison::NotEqual => D3D11_COMPARISON_NOT_EQUAL,
+        Comparison::Always => D3D11_COMPARISON_ALWAYS,
+    }
+}
+
+fn map_stencil_op(op: StencilOp) -> D3D11_STENCIL_OP {
+    match op {
+        StencilOp::Keep => D3D11_STENCIL_OP_KEEP,
+        StencilOp::Zero => D3D11_STENCIL_OP_ZERO,
+        StencilOp::Replace => D3D11_STENCIL_OP_REPLACE,
+        StencilOp::IncrementClamp => D3D11_STENCIL_OP_INCR_SAT,
+        StencilOp::IncrementWrap => D3D11_STENCIL_OP_INCR,
+        StencilOp::DecrementClamp => D3D11_STENCIL_OP_DECR_SAT,
+        StencilOp::DecrementWrap => D3D11_STENCIL_OP_DECR,
+        StencilOp::Invert => D3D11_STENCIL_OP_INVERT,
+    }
+}
+
+fn map_stencil_side(side: &StencilFace) -> D3D11_DEPTH_STENCILOP_DESC {
+    D3D11_DEPTH_STENCILOP_DESC {
+        StencilFailOp: map_stencil_op(side.op_fail),
+        StencilDepthFailOp: map_stencil_op(side.op_depth_fail),
+        StencilPassOp: map_stencil_op(side.op_pass),
+        StencilFunc: map_comparison(side.fun),
+    }
+}
+
+pub(crate) fn map_depth_stencil_desc(desc: &DepthStencilDesc) -> D3D11_DEPTH_STENCIL_DESC {
+    let (depth_on, depth_write, depth_func) = match desc.depth {
+        DepthTest::On { fun, write } => (TRUE, write, map_comparison(fun)),
+        DepthTest::Off => unsafe { mem::zeroed() },
+    };
+
+    let (stencil_on, front, back, read_mask, write_mask) = match desc.stencil {
+        StencilTest::On { ref front, ref back } => {
+            // TODO: cascade to create_pipeline
+            if front.mask_read != back.mask_read || front.mask_write != back.mask_write {
+                // error!("Different masks on stencil front ({:?}) and back ({:?}) are not supported", front, back);
+            }
+            (TRUE, map_stencil_side(front), map_stencil_side(back), front.mask_read, front.mask_write)
+        },
+        StencilTest::Off => unsafe { mem::zeroed() },
+    };
+
+    D3D11_DEPTH_STENCIL_DESC {
+        DepthEnable: depth_on,
+        DepthWriteMask: if depth_write {D3D11_DEPTH_WRITE_MASK_ALL} else {D3D11_DEPTH_WRITE_MASK_ZERO},
+        DepthFunc: depth_func,
+        StencilEnable: stencil_on,
+        StencilReadMask: read_mask as _,
+        StencilWriteMask: write_mask as _,
+        FrontFace: front,
+        BackFace: back,
+    }
+}
+
+pub(crate) fn map_execution_model(model: spirv::ExecutionModel) -> Stage {
+    match model {
+        spirv::ExecutionModel::Vertex => Stage::Vertex,
+        spirv::ExecutionModel::Fragment => Stage::Fragment,
+        spirv::ExecutionModel::Geometry => Stage::Geometry,
+        spirv::ExecutionModel::GlCompute => Stage::Compute,
+        spirv::ExecutionModel::TessellationControl => Stage::Hull,
+        spirv::ExecutionModel::TessellationEvaluation => Stage::Domain,
+        spirv::ExecutionModel::Kernel => panic!("Kernel is not a valid execution model."),
+    }
+}
+
+pub(crate) fn map_stage(stage: Stage) -> spirv::ExecutionModel {
+    match stage {
+        Stage::Vertex => spirv::ExecutionModel::Vertex,
+        Stage::Fragment => spirv::ExecutionModel::Fragment,
+        Stage::Geometry => spirv::ExecutionModel::Geometry,
+        Stage::Compute => spirv::ExecutionModel::GlCompute,
+        Stage::Hull => spirv::ExecutionModel::TessellationControl,
+        Stage::Domain => spirv::ExecutionModel::TessellationEvaluation,
     }
 }

--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -297,7 +297,7 @@ pub(crate) fn map_depth_stencil_desc(desc: &DepthStencilDesc) -> D3D11_DEPTH_STE
     }
 }
 
-pub(crate) fn map_execution_model(model: spirv::ExecutionModel) -> Stage {
+pub fn map_execution_model(model: spirv::ExecutionModel) -> Stage {
     match model {
         spirv::ExecutionModel::Vertex => Stage::Vertex,
         spirv::ExecutionModel::Fragment => Stage::Fragment,
@@ -309,7 +309,7 @@ pub(crate) fn map_execution_model(model: spirv::ExecutionModel) -> Stage {
     }
 }
 
-pub(crate) fn map_stage(stage: Stage) -> spirv::ExecutionModel {
+pub fn map_stage(stage: Stage) -> spirv::ExecutionModel {
     match stage {
         Stage::Vertex => spirv::ExecutionModel::Vertex,
         Stage::Fragment => spirv::ExecutionModel::Fragment,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -372,10 +372,10 @@ impl Device {
             )
         };
 
-        if !winerror::SUCCEEDED(hr) {
-            Err(pso::CreationError::Other)
-        } else {
+        if winerror::SUCCEEDED(hr) {
             Ok(unsafe { ComPtr::from_raw(rasterizer) })
+        } else {
+            Err(pso::CreationError::Other)
         }
     }
 
@@ -390,10 +390,10 @@ impl Device {
             )
         };
 
-        if !winerror::SUCCEEDED(hr) {
-            Err(pso::CreationError::Other)
-        } else {
+        if winerror::SUCCEEDED(hr) {
             Ok(unsafe { ComPtr::from_raw(blend) })
+        } else {
+            Err(pso::CreationError::Other)
         }
     }
 
@@ -408,10 +408,10 @@ impl Device {
             )
         };
 
-        if !winerror::SUCCEEDED(hr) {
-            Err(pso::CreationError::Other)
-        } else {
+        if winerror::SUCCEEDED(hr) {
             Ok(unsafe { ComPtr::from_raw(depth) })
+        } else {
+            Err(pso::CreationError::Other)
         }
     }
 
@@ -467,12 +467,12 @@ impl Device {
             )
         };
 
-        if !winerror::SUCCEEDED(hr) {
-            Err(pso::CreationError::Other)
-        } else {
+        if winerror::SUCCEEDED(hr) {
             let topology = conv::map_topology(input_assembler.primitive);
 
             Ok((topology, unsafe { ComPtr::from_raw(layout) }))
+        } else {
+            Err(pso::CreationError::Other)
         }
     }
 
@@ -489,9 +489,9 @@ impl Device {
         };
 
         if !winerror::SUCCEEDED(hr) {
-            Err(pso::CreationError::Other)
-        } else {
             Ok(unsafe { ComPtr::from_raw(vs) })
+        } else {
+            Err(pso::CreationError::Other)
         }
     }
 
@@ -507,10 +507,10 @@ impl Device {
             )
         };
 
-        if !winerror::SUCCEEDED(hr) {
-            Err(pso::CreationError::Other)
-        } else {
+        if winerror::SUCCEEDED(hr) {
             Ok(unsafe { ComPtr::from_raw(ps) })
+        } else {
+            Err(pso::CreationError::Other)
         }
     }
 
@@ -662,7 +662,10 @@ impl hal::Device<Backend> for Device {
         I: IntoIterator,
         I::Item: Borrow<ImageView>
     {
-        unimplemented!()
+        Ok(Framebuffer {
+            attachments: attachments.into_iter().map(|att| att.borrow().clone()).collect(),
+            layers: extent.depth as _,
+        })
     }
 
     fn create_shader_module(&self, raw_data: &[u8]) -> Result<ShaderModule, device::ShaderError> {
@@ -750,16 +753,16 @@ impl hal::Device<Backend> for Device {
             )
         };
 
-        if !winerror::SUCCEEDED(hr) {
-            // TODO: any better error?
-            Err(device::BindError::WrongMemory)
-        } else {
+        if winerror::SUCCEEDED(hr) {
             let buffer: ComPtr<d3d11::ID3D11Buffer> = unsafe { ComPtr::from_raw(buffer) };
             memory.buffer.replace(Some(buffer.clone()));
             Ok(Buffer {
                 buffer: buffer,
                 size: unbound_buffer.size
             })
+        } else {
+            // TODO: any better error?
+            Err(device::BindError::WrongMemory)
         }
     }
 
@@ -811,7 +814,36 @@ impl hal::Device<Backend> for Device {
         _swizzle: format::Swizzle,
         range: image::SubresourceRange,
     ) -> Result<ImageView, image::ViewError> {
-        unimplemented!()
+        // TODO: move out into separate functions
+        // TODO: mip level
+        // TODO: handle case where range layers >= 1
+        assert_eq!(range.layers, 0..1);
+        // TODO: SRV, UAV, DSV?
+
+        // TODO: check for rtv/srv/etc format support
+        let format = conv::map_format(format).unwrap();
+
+        let mut desc: d3d11::D3D11_RENDER_TARGET_VIEW_DESC = unsafe { mem::zeroed() };
+        desc.Format = format;
+        desc.ViewDimension = d3d11::D3D11_RTV_DIMENSION_TEXTURE2D;
+
+        let mut rtv = ptr::null_mut();
+        let hr = unsafe {
+            self.device.CreateRenderTargetView(
+                image.resource,
+                &desc,
+                &mut rtv as *mut *mut _ as *mut *mut _
+            )
+        };
+
+        if winerror::SUCCEEDED(hr) {
+            Ok(ImageView {
+                rtv: unsafe { ComPtr::from_raw(rtv) }
+            })
+        } else {
+            // TODO: better errors
+            Err(image::ViewError::Unsupported)
+        }
     }
 
     fn create_sampler(&self, info: image::SamplerInfo) -> Sampler {
@@ -827,11 +859,13 @@ impl hal::Device<Backend> for Device {
         I: IntoIterator,
         I::Item: Borrow<pso::DescriptorRangeDesc>
     {
-        unimplemented!()
+        // TODO: descriptor pool
+
+        DescriptorPool
     }
 
     fn create_descriptor_set_layout<I, J>(
-        &self, _bindings: I, _immutable_samplers: J
+        &self, bindings: I, _immutable_samplers: J
     ) -> DescriptorSetLayout
     where
         I: IntoIterator,
@@ -841,7 +875,9 @@ impl hal::Device<Backend> for Device {
     {
         // TODO: descriptorsetlayout
 
-        DescriptorSetLayout
+        DescriptorSetLayout {
+            bindings: bindings.into_iter().map(|b| b.borrow().clone()).collect()
+        }
     }
 
     fn write_descriptor_sets<'a, I, J>(&self, write_iter: I)
@@ -1323,7 +1359,17 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<command::ClearValueRaw>,
     {
-        unimplemented!()
+        // TODO: very temp
+        let color_views = framebuffer.attachments.iter().map(|a| a.rtv.as_raw()).collect::<Vec<_>>();
+        unsafe {
+            self.context.OMSetRenderTargets(
+                color_views.len() as _,
+                color_views.as_ptr(),
+                ptr::null_mut(),
+            );
+        }
+        // TODO: begin render pass
+        //unimplemented!()
     }
 
     fn next_subpass(&mut self, _contents: command::SubpassContents) {
@@ -1331,7 +1377,8 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn end_render_pass(&mut self) {
-        unimplemented!()
+        // TODO: end render pass
+        //unimplemented!()
     }
 
     fn pipeline_barrier<'a, T>(&mut self, _stages: Range<pso::PipelineStage>, _dependencies: memory::Dependencies, barriers: T)
@@ -1390,7 +1437,22 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn bind_vertex_buffers(&mut self, first_binding: u32, vbs: pso::VertexBufferSet<Backend>) {
-        unimplemented!()
+        let (buffers, offsets): (Vec<*mut d3d11::ID3D11Buffer>, Vec<u32>) = vbs.0.iter()
+            .map(|(buf, offset)| (buf.buffer.as_raw(), *offset as u32))
+            .unzip();
+
+        // TODO: strides
+        let strides = [16u32; 16];
+
+        unsafe {
+            self.context.IASetVertexBuffers(
+                first_binding,
+                buffers.len() as _,
+                buffers.as_ptr(),
+                strides.as_ptr(),
+                offsets.as_ptr(),
+            );
+        }
     }
 
     fn set_viewports<T>(&mut self, first_viewport: u32, viewports: T)
@@ -1440,7 +1502,24 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn bind_graphics_pipeline(&mut self, pipeline: &GraphicsPipeline) {
-        unimplemented!()
+        unsafe {
+            self.context.IASetPrimitiveTopology(pipeline.topology);
+            self.context.IASetInputLayout(pipeline.input_layout.as_raw());
+
+            self.context.VSSetShader(pipeline.vs.as_raw(), ptr::null_mut(), 0);
+            if let Some(ref ps) = pipeline.ps {
+                self.context.PSSetShader(ps.as_raw(), ptr::null_mut(), 0);
+            }
+
+            self.context.RSSetState(pipeline.rasterizer_state.as_raw());
+
+            // TODO: blend constants
+            self.context.OMSetBlendState(pipeline.blend_state.as_raw(), &[1f32; 4], !0);
+            if let Some(ref state) = pipeline.depth_stencil_state {
+                // TODO stencil
+                self.context.OMSetDepthStencilState(state.as_raw(), 0);
+            }
+        }
     }
 
     fn bind_graphics_descriptor_sets<'a, T>(&mut self, layout: &PipelineLayout, first_set: usize, sets: T)
@@ -1516,11 +1595,26 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn draw(&mut self, vertices: Range<VertexCount>, instances: Range<InstanceCount>) {
-        unimplemented!()
+        unsafe {
+            self.context.DrawInstanced(
+                vertices.end - vertices.start,
+                instances.end - instances.start,
+                vertices.start,
+                instances.start,
+            );
+        }
     }
 
     fn draw_indexed(&mut self, indices: Range<IndexCount>, base_vertex: VertexOffset, instances: Range<InstanceCount>) {
-        unimplemented!()
+        unsafe {
+            self.context.DrawIndexedInstanced(
+                indices.end - indices.start,
+                instances.end - instances.start,
+                indices.start,
+                base_vertex,
+                instances.start,
+            );
+        }
     }
 
     fn draw_indirect(&mut self, buffer: &Buffer, offset: buffer::Offset, draw_count: DrawCount, stride: u32) {
@@ -1623,7 +1717,10 @@ unsafe impl Sync for ShaderModule { }
 #[derive(Debug)]
 pub struct RenderPass;
 #[derive(Debug)]
-pub struct Framebuffer;
+pub struct Framebuffer {
+    attachments: Vec<ImageView>,
+    layers: image::Layer,
+}
 
 #[derive(Debug)]
 pub struct UnboundBuffer {
@@ -1668,8 +1765,16 @@ pub struct Image {
 unsafe impl Send for Image { }
 unsafe impl Sync for Image { }
 
-#[derive(Debug)]
-pub struct ImageView;
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
+pub struct ImageView {
+    #[derivative(Debug="ignore")]
+    rtv: ComPtr<d3d11::ID3D11RenderTargetView>
+}
+
+unsafe impl Send for ImageView { }
+unsafe impl Sync for ImageView { }
+
 #[derive(Debug)]
 pub struct Sampler;
 
@@ -1706,15 +1811,20 @@ unsafe impl Sync for GraphicsPipeline { }
 
 #[derive(Debug)]
 pub struct PipelineLayout;
+
 #[derive(Debug)]
-pub struct DescriptorSetLayout;
+pub struct DescriptorSetLayout {
+    bindings: Vec<pso::DescriptorSetLayoutBinding>,
+}
 
 // TODO: descriptor pool
 #[derive(Debug)]
 pub struct DescriptorPool;
 impl hal::DescriptorPool<Backend> for DescriptorPool {
     fn allocate_set(&mut self, layout: &DescriptorSetLayout) -> Result<DescriptorSet, pso::AllocationError> {
-        unimplemented!()
+        // TODO: descriptor set
+
+        Ok(DescriptorSet)
     }
 
     fn reset(&mut self) {

--- a/src/backend/dx11/src/shader.rs
+++ b/src/backend/dx11/src/shader.rs
@@ -1,0 +1,266 @@
+use std::{ffi, mem, ptr, slice};
+
+use spirv_cross::{hlsl, spirv, ErrorCode as SpirvErrorCode};
+
+use winapi::um::{d3dcommon, d3dcompiler};
+use winapi::shared::{winerror};
+use wio::com::ComPtr;
+
+use hal::{device, pso};
+
+use {conv, Backend, PipelineLayout};
+
+
+/// Emit error during shader module creation. Used if we don't expect an error
+/// but might panic due to an exception in SPIRV-Cross.
+fn gen_unexpected_error(err: SpirvErrorCode) -> device::ShaderError {
+    let msg = match err {
+        SpirvErrorCode::CompilationError(msg) => msg,
+        SpirvErrorCode::Unhandled => "Unexpected error".into(),
+    };
+    device::ShaderError::CompilationFailed(msg)
+}
+
+/// Emit error during shader module creation. Used if we execute an query command.
+fn gen_query_error(err: SpirvErrorCode) -> device::ShaderError {
+    let msg = match err {
+        SpirvErrorCode::CompilationError(msg) => msg,
+        SpirvErrorCode::Unhandled => "Unknown query error".into(),
+    };
+    device::ShaderError::CompilationFailed(msg)
+}
+
+pub(crate) fn compile_spirv_entrypoint(
+    raw_data: &[u8],
+    stage: pso::Stage,
+    source: &pso::EntryPoint<Backend>,
+    layout: &PipelineLayout,
+) -> Result<Option<ComPtr<d3dcommon::ID3DBlob>>, device::ShaderError> {
+
+    let mut ast = parse_spirv(raw_data)?;
+    let spec_constants = ast
+        .get_specialization_constants()
+        .map_err(gen_query_error)?;
+
+    for spec_constant in spec_constants {
+        if let Some(constant) = source
+            .specialization
+            .iter()
+            .find(|c| c.id == spec_constant.constant_id)
+        {
+            // Override specialization constant values
+            unsafe {
+                let value = match constant.value {
+                    pso::Constant::Bool(v) => v as u64,
+                    pso::Constant::U32(v) => v as u64,
+                    pso::Constant::U64(v) => v,
+                    pso::Constant::I32(v) => *(&v as *const _ as *const u64),
+                    pso::Constant::I64(v) => *(&v as *const _ as *const u64),
+                    pso::Constant::F32(v) => *(&v as *const _ as *const u64),
+                    pso::Constant::F64(v) => *(&v as *const _ as *const u64),
+                };
+                ast.set_scalar_constant(spec_constant.id, value).map_err(gen_query_error)?;
+            }
+        }
+    }
+
+    patch_spirv_resources(&mut ast, Some(layout))?;
+    let shader_model = hlsl::ShaderModel::V5_0;
+    let shader_code = translate_spirv(&mut ast, shader_model, layout, stage)?;
+
+    let real_name = ast
+        .get_cleansed_entry_point_name(source.entry, conv::map_stage(stage))
+        .map_err(gen_query_error)?;
+
+    // TODO: opt: don't query *all* entry points.
+    let entry_points = ast.get_entry_points().map_err(gen_query_error)?;
+    entry_points
+        .iter()
+        .find(|entry_point| entry_point.name == real_name)
+        .ok_or(device::ShaderError::MissingEntryPoint(source.entry.into()))
+        .and_then(|entry_point| {
+            let stage = conv::map_execution_model(entry_point.execution_model);
+            let shader = compile_hlsl_shader(
+                stage,
+                shader_model,
+                &entry_point.name,
+                shader_code.as_bytes(),
+            )?;
+            Ok(Some(unsafe { ComPtr::from_raw(shader) }))
+        })
+}
+
+pub(crate) fn compile_hlsl_shader(
+    stage: pso::Stage,
+    shader_model: hlsl::ShaderModel,
+    entry: &str,
+    code: &[u8],
+) -> Result<*mut d3dcommon::ID3DBlob, device::ShaderError> {
+    let stage_to_str = |stage, shader_model| {
+        let stage = match stage {
+            pso::Stage::Vertex => "vs",
+            pso::Stage::Fragment => "ps",
+            pso::Stage::Compute => "cs",
+            _ => unimplemented!(),
+        };
+
+        let model = match shader_model {
+            hlsl::ShaderModel::V5_0 => "5_0",
+            // TODO: >= 11.3
+            hlsl::ShaderModel::V5_1 => "5_1",
+            // TODO: >= 12?, no mention of 11 on msdn
+            hlsl::ShaderModel::V6_0 => "6_0",
+            _ => unimplemented!(),
+        };
+
+        format!("{}_{}\0", stage, model)
+    };
+
+    let mut blob = ptr::null_mut();
+    let mut error = ptr::null_mut();
+    let entry = ffi::CString::new(entry).unwrap();
+    let hr = unsafe {
+        d3dcompiler::D3DCompile(
+            code.as_ptr() as *const _,
+            code.len(),
+            ptr::null(),
+            ptr::null(),
+            ptr::null_mut(),
+            entry.as_ptr() as *const _,
+            stage_to_str(stage, shader_model).as_ptr() as *const i8,
+            1,
+            0,
+            &mut blob as *mut *mut _,
+            &mut error as *mut *mut _
+        )
+    };
+
+    if !winerror::SUCCEEDED(hr) {
+        let error = unsafe { ComPtr::<d3dcommon::ID3DBlob>::from_raw(error) };
+        let message = unsafe {
+            let pointer = error.GetBufferPointer();
+            let size = error.GetBufferSize();
+            let slice = slice::from_raw_parts(pointer as *const u8, size as usize);
+            String::from_utf8_lossy(slice).into_owned()
+        };
+        Err(device::ShaderError::CompilationFailed(message))
+    } else {
+        Ok(blob)
+    }
+}
+
+
+fn parse_spirv(raw_data: &[u8]) -> Result<spirv::Ast<hlsl::Target>, device::ShaderError> {
+    // spec requires "codeSize must be a multiple of 4"
+    assert_eq!(raw_data.len() & 3, 0);
+
+    let module = spirv::Module::from_words(unsafe {
+        slice::from_raw_parts(
+            raw_data.as_ptr() as *const u32,
+            raw_data.len() / mem::size_of::<u32>(),
+        )
+    });
+
+    spirv::Ast::parse(&module)
+        .map_err(|err| {
+            let msg =  match err {
+                SpirvErrorCode::CompilationError(msg) => msg,
+                SpirvErrorCode::Unhandled => "Unknown parsing error".into(),
+            };
+            device::ShaderError::CompilationFailed(msg)
+        })
+}
+
+fn patch_spirv_resources(
+    ast: &mut spirv::Ast<hlsl::Target>,
+    layout: Option<&PipelineLayout>,
+) -> Result<(), device::ShaderError> {
+    // Patch descriptor sets due to the splitting of descriptor heaps into
+    // SrvCbvUav and sampler heap. Each set will have a new location to match
+    // the layout of the root signatures.
+
+    // TODO:
+    let space_offset = 1;
+
+    let shader_resources = ast.get_shader_resources().map_err(gen_query_error)?;
+    for image in &shader_resources.separate_images {
+        let set = ast.get_decoration(image.id, spirv::Decoration::DescriptorSet).map_err(gen_query_error)?;
+        ast.set_decoration(image.id, spirv::Decoration::DescriptorSet, space_offset + set)
+           .map_err(gen_unexpected_error)?;
+    }
+
+    for uniform_buffer in &shader_resources.uniform_buffers {
+        let set = ast.get_decoration(uniform_buffer.id, spirv::Decoration::DescriptorSet).map_err(gen_query_error)?;
+        ast.set_decoration(uniform_buffer.id, spirv::Decoration::DescriptorSet, space_offset + set)
+           .map_err(gen_unexpected_error)?;
+    }
+
+    for storage_buffer in &shader_resources.storage_buffers {
+        let set = ast.get_decoration(storage_buffer.id, spirv::Decoration::DescriptorSet).map_err(gen_query_error)?;
+        ast.set_decoration(storage_buffer.id, spirv::Decoration::DescriptorSet, space_offset + set)
+           .map_err(gen_unexpected_error)?;
+    }
+
+    for image in &shader_resources.storage_images {
+        let set = ast.get_decoration(image.id, spirv::Decoration::DescriptorSet).map_err(gen_query_error)?;
+        ast.set_decoration(image.id, spirv::Decoration::DescriptorSet, space_offset + set)
+           .map_err(gen_unexpected_error)?;
+    }
+
+    for sampler in &shader_resources.separate_samplers {
+        let set = ast.get_decoration(sampler.id, spirv::Decoration::DescriptorSet).map_err(gen_query_error)?;
+        ast.set_decoration(sampler.id, spirv::Decoration::DescriptorSet, space_offset + set)
+           .map_err(gen_unexpected_error)?;
+    }
+
+    for image in &shader_resources.sampled_images {
+        let set = ast.get_decoration(image.id, spirv::Decoration::DescriptorSet).map_err(gen_query_error)?;
+        ast.set_decoration(image.id, spirv::Decoration::DescriptorSet, space_offset + set)
+           .map_err(gen_unexpected_error)?;
+    }
+
+    // tODO: other resources
+
+    Ok(())
+}
+
+fn translate_spirv(
+    ast: &mut spirv::Ast<hlsl::Target>,
+    shader_model: hlsl::ShaderModel,
+    layout: &PipelineLayout,
+    stage: pso::Stage,
+) -> Result<String, device::ShaderError> {
+    let mut compile_options = hlsl::CompilerOptions::default();
+    compile_options.shader_model = shader_model;
+    compile_options.vertex.invert_y = true;
+
+    //let stage_flag = stage.into();
+    
+    // TODO:
+    /*let root_constant_layout = layout
+        .root_constants
+        .iter()
+        .filter_map(|constant| if constant.stages.contains(stage_flag) {
+            Some(hlsl::RootConstant {
+                start: constant.range.start * 4,
+                end: constant.range.end * 4,
+                binding: constant.range.start,
+                space: 0,
+            })
+        } else {
+            None
+        })
+        .collect();*/
+    ast.set_compiler_options(&compile_options)
+        .map_err(gen_unexpected_error)?;
+    //ast.set_root_constant_layout(root_constant_layout)
+    //    .map_err(gen_unexpected_error)?;
+    ast.compile()
+        .map_err(|err| {
+            let msg = match err {
+                SpirvErrorCode::CompilationError(msg) => msg,
+                SpirvErrorCode::Unhandled => "Unknown compile error".into(),
+            };
+            device::ShaderError::CompilationFailed(msg)
+        })
+}


### PR DESCRIPTION
Adds basic pipeline creation and some plumbing for creating/converting from hal to dx11 state. The shader stuff is mostly from the dx12 backend without the root signature stuff, need to investigate how much patching needs to be done on the output (SM 5.0 vs 5.1)

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
