### PR TITLE
Metal mipmapping, private depth/stencil storage, and other goodies

### DIFF
--- a/src/backend/metal/shaders/blit.metal
+++ b/src/backend/metal/shaders/blit.metal
@@ -1,46 +1,6 @@
 #include <metal_stdlib>
 using namespace metal;
 
-// -------------- Image Clears -------------- //
-
-typedef struct {
-    float4 coords [[attribute(0)]];
-} ClearAttributes;
-
-typedef struct {
-    float4 position [[position]];
-    uint layer [[render_target_array_index]];
-} ClearVertexData;
-
-vertex ClearVertexData vs_clear(ClearAttributes in [[stage_in]]) {
-    float4 pos = { 0.0, 0.0, 0.0f, 1.0f };
-    pos.xy = in.coords.xy * 2.0 - 1.0;
-    return ClearVertexData { pos, uint(in.coords.z) };
-}
-
-fragment float4 ps_blit_float(
-    ClearVertexData in [[stage_in]],
-    constant float4 &value [[ buffer(0) ]]
-) {
-  return value;
-}
-
-fragment int4 ps_blit_int(
-    ClearVertexData in [[stage_in]],
-    constant int4 &value [[ buffer(0) ]]
-) {
-  return value;
-}
-
-fragment uint4 ps_blit_uint(
-    ClearVertexData in [[stage_in]],
-    constant uint4 &value [[ buffer(0) ]]
-) {
-  return value;
-}
-
-// -------------- Image Blits -------------- //
-
 typedef struct {
     float4 src_coords [[attribute(0)]];
     float4 dst_coords [[attribute(1)]];
@@ -51,6 +11,7 @@ typedef struct {
     float4 uv;
     uint layer [[render_target_array_index]];
 } BlitVertexData;
+
 
 vertex BlitVertexData vs_blit(BlitAttributes in [[stage_in]]) {
     float4 pos = { 0.0, 0.0, 0.0f, 1.0f };
@@ -66,6 +27,7 @@ fragment float4 ps_blit_1d_float(
   return tex1D.sample(sampler2D, in.uv.x);
 }
 
+
 fragment float4 ps_blit_1d_array_float(
     BlitVertexData in [[stage_in]],
     texture1d_array<float> tex1DArray [[ texture(0) ]],
@@ -73,6 +35,7 @@ fragment float4 ps_blit_1d_array_float(
 ) {
   return tex1DArray.sample(sampler2D, in.uv.x, uint(in.uv.z));
 }
+
 
 fragment float4 ps_blit_2d_float(
     BlitVertexData in [[stage_in]],
@@ -98,6 +61,7 @@ fragment int4 ps_blit_2d_int(
   return tex2D.sample(sampler2D, in.uv.xy, level(in.uv.w));
 }
 
+
 fragment float4 ps_blit_2d_array_float(
     BlitVertexData in [[stage_in]],
     texture2d_array<float> tex2DArray [[ texture(0) ]],
@@ -122,38 +86,11 @@ fragment int4 ps_blit_2d_array_int(
   return tex2DArray.sample(sampler2D, in.uv.xy, uint(in.uv.z), level(in.uv.w));
 }
 
+
 fragment float4 ps_blit_3d_float(
     BlitVertexData in [[stage_in]],
     texture3d<float> tex3D [[ texture(0) ]],
     sampler sampler2D [[ sampler(0) ]]
 ) {
   return tex3D.sample(sampler2D, in.uv.xyz, level(in.uv.w));
-}
-
-// -------------- Buffer Fill/Copy -------------- //
-
-typedef struct {
-    uint value;
-    uint length;
-} FillBufferValue;
-
-kernel void cs_fill_buffer(
-    device uint *buffer [[ buffer(0) ]],
-    constant FillBufferValue &fill [[ buffer(1) ]],
-    uint index [[ thread_position_in_grid ]]
-) {
-    if (index < fill.length) {
-        buffer[index] = fill.value;
-    }
-}
-
-kernel void cs_copy_buffer(
-    device uchar *dest [[ buffer(0) ]],
-    device uchar *source [[ buffer(1) ]],
-    constant uint &size [[ buffer(2) ]],
-    uint index [[ thread_position_in_grid ]]
-) {
-    if (index < size) {
-        dest[index] = source[index];
-    }
 }

--- a/src/backend/metal/shaders/clear.metal
+++ b/src/backend/metal/shaders/clear.metal
@@ -1,0 +1,39 @@
+#include <metal_stdlib>
+using namespace metal;
+
+typedef struct {
+    float4 coords [[attribute(0)]];
+} ClearAttributes;
+
+typedef struct {
+    float4 position [[position]];
+    uint layer [[render_target_array_index]];
+} ClearVertexData;
+
+vertex ClearVertexData vs_clear(ClearAttributes in [[stage_in]]) {
+    float4 pos = { 0.0, 0.0, 0.0f, 1.0f };
+    pos.xy = in.coords.xy * 2.0 - 1.0;
+    return ClearVertexData { pos, uint(in.coords.z) };
+}
+
+
+fragment float4 ps_clear_float(
+    ClearVertexData in [[stage_in]],
+    constant float4 &value [[ buffer(0) ]]
+) {
+  return value;
+}
+
+fragment int4 ps_clear_int(
+    ClearVertexData in [[stage_in]],
+    constant int4 &value [[ buffer(0) ]]
+) {
+  return value;
+}
+
+fragment uint4 ps_clear_uint(
+    ClearVertexData in [[stage_in]],
+    constant uint4 &value [[ buffer(0) ]]
+) {
+  return value;
+}

--- a/src/backend/metal/shaders/commands.metal
+++ b/src/backend/metal/shaders/commands.metal
@@ -105,6 +105,23 @@ fragment float4 ps_blit_2d_array_float(
 ) {
   return tex2DArray.sample(sampler2D, in.uv.xy, uint(in.uv.z), level(in.uv.w));
 }
+
+fragment uint4 ps_blit_2d_array_uint(
+    BlitVertexData in [[stage_in]],
+    texture2d_array<uint> tex2DArray [[ texture(0) ]],
+    sampler sampler2D [[ sampler(0) ]]
+) {
+  return tex2DArray.sample(sampler2D, in.uv.xy, uint(in.uv.z), level(in.uv.w));
+}
+
+fragment int4 ps_blit_2d_array_int(
+    BlitVertexData in [[stage_in]],
+    texture2d_array<int> tex2DArray [[ texture(0) ]],
+    sampler sampler2D [[ sampler(0) ]]
+) {
+  return tex2DArray.sample(sampler2D, in.uv.xy, uint(in.uv.z), level(in.uv.w));
+}
+
 fragment float4 ps_blit_3d_float(
     BlitVertexData in [[stage_in]],
     texture3d<float> tex3D [[ texture(0) ]],

--- a/src/backend/metal/shaders/fill.metal
+++ b/src/backend/metal/shaders/fill.metal
@@ -1,0 +1,28 @@
+#include <metal_stdlib>
+using namespace metal;
+
+typedef struct {
+    uint value;
+    uint length;
+} FillBufferValue;
+
+kernel void cs_fill_buffer(
+    device uint *buffer [[ buffer(0) ]],
+    constant FillBufferValue &fill [[ buffer(1) ]],
+    uint index [[ thread_position_in_grid ]]
+) {
+    if (index < fill.length) {
+        buffer[index] = fill.value;
+    }
+}
+
+kernel void cs_copy_buffer(
+    device uchar *dest [[ buffer(0) ]],
+    device uchar *source [[ buffer(1) ]],
+    constant uint &size [[ buffer(2) ]],
+    uint index [[ thread_position_in_grid ]]
+) {
+    if (index < size) {
+        dest[index] = source[index];
+    }
+}

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1519,8 +1519,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     error!("Aspects {:?} are not supported yet, ignoring blit_image", r.src_subresource.aspects);
                     continue
                 }
-                let se = &src.extent;
-                let de = &dst.extent;
+                let se = src.extent.at_level(r.src_subresource.level);
+                let de = dst.extent.at_level(r.dst_subresource.level);
                 //TODO: support 3D textures
                 if se.depth != 1 || de.depth != 1 {
                     warn!("3D image blits are not supported properly yet: {:?} -> {:?}", se, de);

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1712,10 +1712,9 @@ impl hal::Device<Backend> for Device {
                     continue
                 }
                 let (storage, cache_mode) = MemoryTypes::describe(i);
-                let options = conv::resource_options_from_storage_and_cache(storage, cache_mode);
-                image.texture_desc.set_resource_options(options);
                 image.texture_desc.set_storage_mode(storage);
                 image.texture_desc.set_cpu_cache_mode(cache_mode);
+
                 let requirements = self.shared.device
                     .lock()
                     .unwrap()
@@ -1793,14 +1792,13 @@ impl hal::Device<Backend> for Device {
                 let stride = (row_size + STRIDE_MASK) & !STRIDE_MASK;
 
                 let (storage_mode, cache_mode) = MemoryTypes::describe(memory_type.0);
-                let options = conv::resource_options_from_storage_and_cache(storage_mode, cache_mode);
                 image.texture_desc.set_storage_mode(storage_mode);
                 image.texture_desc.set_cpu_cache_mode(cache_mode);
-                image.texture_desc.set_resource_options(options);
 
                 cpu_buffer.new_texture_from_contents(&image.texture_desc, offset, stride)
             }
             n::MemoryHeap::Private => {
+                image.texture_desc.set_storage_mode(MTLStorageMode::Private);
                 self.shared.device
                     .lock()
                     .unwrap()


### PR DESCRIPTION
Fixes:
  - all of the "generate_mipmaps" section of CTS, adding about 1K passes to our collection ;) No failures/crashes there
  - all of the "texture.shadow" tests of the CTS, adding 300 passes ;)

Note: I'm slightly confused about the interaction of `set_resource_options` versus `set_storage_mode` and `set_cpu_cache_mode`. So far it looks like those affect the same bits, so I'm not issuing redundant commands any more.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds - NOPE. Unfortunately, we can't run Warden atm for the COHERENT heaps are disabled...
- [ ] tested examples with the following backends:
