### PR TITLE
Metal mega-queue, coherent memory, and other goodies

### DIFF
--- a/src/backend/metal/shaders/blit.metal
+++ b/src/backend/metal/shaders/blit.metal
@@ -12,6 +12,10 @@ typedef struct {
     uint layer [[render_target_array_index]];
 } BlitVertexData;
 
+typedef struct {
+  float depth [[depth(any)]];
+} BlitDepthFragment;
+
 
 vertex BlitVertexData vs_blit(BlitAttributes in [[stage_in]]) {
     float4 pos = { 0.0, 0.0, 0.0f, 1.0f };
@@ -59,6 +63,15 @@ fragment int4 ps_blit_2d_int(
     sampler sampler2D [[ sampler(0) ]]
 ) {
   return tex2D.sample(sampler2D, in.uv.xy, level(in.uv.w));
+}
+
+fragment BlitDepthFragment ps_blit_2d_depth(
+    BlitVertexData in [[stage_in]],
+    depth2d<float> tex2D [[ texture(0) ]],
+    sampler sampler2D [[ sampler(0) ]]
+) {
+  float depth = tex2D.sample(sampler2D, in.uv.xy, level(in.uv.w));
+  return BlitDepthFragment { depth };
 }
 
 

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -32,6 +32,8 @@ pub struct QueueInner {
     reserve: Range<usize>,
 }
 
+#[must_use]
+#[derive(Debug)]
 pub struct Token {
     active: bool,
 }
@@ -281,6 +283,7 @@ impl StageResources {
     }
 }
 
+#[derive(Debug)]
 enum CommandSink {
     Immediate {
         cmd_buffer: metal::CommandBuffer,
@@ -568,6 +571,7 @@ impl CommandBufferInner {
 }
 
 
+#[derive(Debug)]
 enum EncoderState {
     None,
     Blit(metal::BlitCommandEncoder),
@@ -1164,6 +1168,7 @@ impl CommandBuffer {
 
 impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn begin(&mut self, flags: com::CommandBufferFlags, _info: com::CommandBufferInheritanceInfo<Backend>) {
+        self.reset(false);
         //TODO: Implement secondary command buffers
         let sink = if flags.contains(com::CommandBufferFlags::ONE_TIME_SUBMIT) {
             let (cmd_buffer, token) = self.shared.queue.lock().unwrap().spawn();

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -74,7 +74,7 @@ impl QueueInner {
         debug!("waiting for idle");
         let _pool = AutoreleasePool::new();
         // note: we deliberately don't hold the Mutex lock while waiting,
-        // since the completition handlers need to access it.
+        // since the completion handlers need to access it.
         let (cmd_buf, token) = queue.lock().unwrap().spawn();
         cmd_buf.commit();
         cmd_buf.wait_until_completed();
@@ -1053,7 +1053,11 @@ impl CommandBuffer {
             width: vp.rect.w as _,
             height: vp.rect.h as _,
             znear: vp.depth.start as _,
-            zfar: vp.depth.end as _,
+            zfar: if self.shared.disabilities.broken_viewport_near_depth {
+                (vp.depth.end - vp.depth.start) as _
+            } else {
+                vp.depth.end as _
+            },
         };
         self.state.viewport = Some(viewport);
         soft::RenderCommand::SetViewport(viewport)

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1,4 +1,7 @@
-use {AutoreleasePool, Backend, PrivateCapabilities, QueueFamily, Shared, Surface, Swapchain, validate_line_width};
+use {
+    AutoreleasePool, Backend, PrivateCapabilities, QueueFamily,
+    Shared, Surface, Swapchain, validate_line_width
+};
 use {conversions as conv, command, native as n};
 use internal::Channel;
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -49,8 +49,6 @@ const PUSH_CONSTANTS_DESC_BINDING: u32 = 0;
 // greater than or equal to the size of one pixel, in bytes, multiplied by the pixel width of one row.
 const STRIDE_MASK: u64 = 0xFF;
 
-const ALLOW_SHARED: bool = true; //TODO: figure out how to make it work
-
 /// Emit error during shader module parsing.
 fn gen_parse_error(err: SpirvErrorCode) -> ShaderError {
     let msg = match err {
@@ -1503,7 +1501,7 @@ impl hal::Device<Backend> for Device {
         memory::Requirements {
             size: (max_size + SIZE_MASK) & !SIZE_MASK,
             alignment: max_alignment,
-            type_mask: if ALLOW_SHARED && (!supports_texel_view || self.private_caps.shared_textures) && buffer.size == 16384 {
+            type_mask: if !supports_texel_view || self.private_caps.shared_textures {
                 MemoryTypes::all().bits()
             } else {
                 (MemoryTypes::all() ^ MemoryTypes::SHARED).bits()
@@ -1728,7 +1726,7 @@ impl hal::Device<Backend> for Device {
             memory::Requirements {
                 size: (image.mip_sizes[0] + mask) & !mask,
                 alignment: self.private_caps.buffer_alignment,
-                type_mask: if ALLOW_SHARED && self.private_caps.shared_textures {
+                type_mask: if self.private_caps.shared_textures {
                     MemoryTypes::all().bits()
                 } else {
                     (MemoryTypes::all() ^ MemoryTypes::SHARED).bits()

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -57,23 +57,29 @@ impl hal::QueueFamily for QueueFamily {
     fn id(&self) -> QueueFamilyId { QueueFamilyId(0) }
 }
 
-pub struct Shared {
-    pub(crate) device: Mutex<metal::Device>,
-    pub(crate) queue: Mutex<command::QueueInner>,
-    pub(crate) service_pipes: Mutex<internal::ServicePipes>,
-    pub(crate) push_constants_buffer_id: u32,
+struct Shared {
+    device: Mutex<metal::Device>,
+    queue: Mutex<command::QueueInner>,
+    service_pipes: Mutex<internal::ServicePipes>,
+    push_constants_buffer_id: u32,
+    disabilities: PrivateDisabilities,
 }
 
 unsafe impl Send for Shared {}
 unsafe impl Sync for Shared {}
 
 impl Shared {
-    pub(crate) fn new(device: metal::Device) -> Self {
+    fn new(device: metal::Device) -> Self {
+        let feature_macos_10_14: metal::MTLFeatureSet = unsafe { mem::transmute(10004u64) };
         Shared {
             queue: Mutex::new(command::QueueInner::new(&device, MAX_ACTIVE_COMMAND_BUFFERS)),
             service_pipes: Mutex::new(internal::ServicePipes::new(&device)),
-            device: Mutex::new(device),
             push_constants_buffer_id: 30,
+            disabilities: PrivateDisabilities {
+                broken_viewport_near_depth: device.name().starts_with("Intel") &&
+                    !device.supports_feature_set(feature_macos_10_14),
+            },
+            device: Mutex::new(device),
         }
     }
 }
@@ -182,7 +188,7 @@ impl hal::Backend for Backend {
     type QueryPool = ();
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct PrivateCapabilities {
     resource_heaps: bool,
     argument_buffers: bool,
@@ -196,6 +202,11 @@ struct PrivateCapabilities {
     max_samplers_per_stage: usize,
     buffer_alignment: u64,
     max_buffer_size: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PrivateDisabilities {
+    broken_viewport_near_depth: bool,
 }
 
 pub struct AutoreleasePool {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -274,7 +274,7 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
                             ..
                         } => {
                             let handle_range = (*offset)..offset + encoder.encoded_length();
-                            range_allocator.free_range(handle_range);
+                            let _ = range_allocator.free_range(handle_range);
                         },
                     }
                 }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -4,7 +4,7 @@ use internal::Channel;
 use std::collections::{HashMap};
 use std::ops::Range;
 use std::os::raw::{c_void, c_long};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 
 use hal::{self, image, pass, pso};
 
@@ -382,7 +382,12 @@ unsafe impl Send for UnboundImage {}
 unsafe impl Sync for UnboundImage {}
 
 #[derive(Debug)]
-pub struct Fence(pub Arc<Mutex<bool>>);
+pub struct FenceInner {
+    pub(crate) mutex: Mutex<bool>,
+    pub(crate) condvar: Condvar,
+}
+
+pub type Fence = Arc<FenceInner>;
 
 extern "C" {
     #[allow(dead_code)]

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -128,6 +128,7 @@ pub enum ComputeCommand {
     },
 }
 
+#[derive(Debug)]
 pub enum Pass {
     Render(metal::RenderPassDescriptor, Vec<RenderCommand>),
     Blit(Vec<BlitCommand>),


### PR DESCRIPTION
Fixes #2069
Fixes #2094
Fixes #2092 

This PR accumulated quite a few seemingly unrelated changes, but all rather tasty ones:
  - one mega-queue instead of a queue pool
  - condvars for fences
  - enabled coherent memory
  - inverted depth range workaround
  - depth blits

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
