### PR TITLE
Improve static/dynamic stencil support

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -403,11 +403,7 @@ impl hal::Device<Backend> for Device {
         let (topology, input_layout) = self.create_input_layout(vs.clone(), &desc.vertex_buffers, &desc.attributes, &desc.input_assembler)?;
         let rasterizer_state = self.create_rasterizer_state(&desc.rasterizer)?;
         let blend_state = self.create_blend_state(&desc.blender)?;
-        let depth_stencil_state = if let Some(desc) = desc.depth_stencil {
-            Some(self.create_depth_stencil_state(&desc)?)
-        } else {
-            None
-        };
+        let depth_stencil_state = Some(self.create_depth_stencil_state(&desc.depth_stencil)?);
 
         let vs = self.create_vertex_shader(vs)?;
         let ps = if let Some(blob) = ps {

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -692,7 +692,7 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
-    fn set_stencil_reference(&mut self, front: pso::StencilValue, back: pso::StencilValue) {
+    fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue) {
         unimplemented!()
     }
 

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1668,16 +1668,17 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         unsafe { self.raw.OMSetBlendFactor(&color); }
     }
 
-    fn set_stencil_reference(&mut self, front: pso::StencilValue, back: pso::StencilValue) {
-        if front != back {
-            error!(
-                "Unable to set different stencil ref values for front ({}) and back ({})",
-                front,
-                back,
+    fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue) {
+        assert!(!faces.is_empty());
+
+        if !faces.is_all() {
+            warn!(
+                "Stencil ref values set for both faces but only one was requested ({})",
+                faces.bits(),
             );
         }
 
-        unsafe { self.raw.OMSetStencilRef(front as _); }
+        unsafe { self.raw.OMSetStencilRef(value as _); }
     }
 
     fn set_depth_bounds(&mut self, bounds: Range<f32>) {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -517,7 +517,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn set_stencil_reference(&mut self, _: pso::StencilValue, _: pso::StencilValue) {
+    fn set_stencil_reference(&mut self, _: pso::Face, _: pso::StencilValue) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -775,7 +775,25 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         }
     }
 
-    fn set_stencil_reference(&mut self, front: pso::StencilValue, back: pso::StencilValue) {
+    fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue) {
+        assert!(!faces.is_empty());
+
+        let mut front = 0;
+        let mut back = 0;
+
+        if let Some((last_front, last_back)) = self.cache.stencil_ref {
+            front = last_front;
+            back = last_back;
+        }
+
+        if faces.contains(pso::Face::FRONT) {
+            front = value;
+        }
+
+        if faces.contains(pso::Face::BACK) {
+            back = value;
+        }
+
         // Only cache the stencil references values until
         // we assembled all the pieces to set the stencil state
         // from the pipeline.

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -2,7 +2,7 @@ use PrivateCapabilities;
 
 use hal::{pass, image, pso, IndexType};
 use hal::format::Format;
-use hal::pso::Comparison;
+use hal::pso::{Comparison, StencilOp};
 use metal::*;
 
 impl PrivateCapabilities {
@@ -347,5 +347,18 @@ pub fn map_offset(offset: image::Offset) -> MTLOrigin {
         x: offset.x as _,
         y: offset.y as _,
         z: offset.z as _,
+    }
+}
+
+pub fn map_stencil_op(op: StencilOp) -> MTLStencilOperation {
+    match op {
+        StencilOp::Keep => MTLStencilOperation::Keep,
+        StencilOp::Zero => MTLStencilOperation::Zero,
+        StencilOp::Replace => MTLStencilOperation::Replace,
+        StencilOp::IncrementClamp => MTLStencilOperation::IncrementClamp,
+        StencilOp::IncrementWrap => MTLStencilOperation::IncrementWrap,
+        StencilOp::DecrementClamp => MTLStencilOperation::DecrementClamp,
+        StencilOp::DecrementWrap => MTLStencilOperation::DecrementWrap,
+        StencilOp::Invert => MTLStencilOperation::Invert,
     }
 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -904,8 +904,25 @@ impl hal::Device<Backend> for Device {
             }
 
             match depth_stencil.stencil {
-                pso::StencilTest::On { .. } => {
-                    unimplemented!()
+                pso::StencilTest::On { ref front, ref back } => {
+                    let front_desc = metal::StencilDescriptor::new();
+                    front_desc.set_stencil_compare_function(conv::map_compare_function(front.fun));
+                    front_desc.set_read_mask(front.mask_read);
+                    front_desc.set_write_mask(front.mask_write);
+                    front_desc.set_stencil_failure_operation(conv::map_stencil_op(front.op_fail));
+                    front_desc.set_depth_failure_operation(conv::map_stencil_op(front.op_depth_fail));
+                    front_desc.set_depth_stencil_pass_operation(conv::map_stencil_op(front.op_pass));
+
+                    let back_desc = metal::StencilDescriptor::new();
+                    back_desc.set_stencil_compare_function(conv::map_compare_function(back.fun));
+                    back_desc.set_read_mask(back.mask_read);
+                    back_desc.set_write_mask(back.mask_write);
+                    back_desc.set_stencil_failure_operation(conv::map_stencil_op(back.op_fail));
+                    back_desc.set_depth_failure_operation(conv::map_stencil_op(back.op_depth_fail));
+                    back_desc.set_depth_stencil_pass_operation(conv::map_stencil_op(back.op_pass));
+
+                    desc.set_front_face_stencil(Some(&front_desc));
+                    desc.set_back_face_stencil(Some(&back_desc));
                 }
                 pso::StencilTest::Off => {}
             }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -3,6 +3,7 @@ use {
     Shared, Surface, Swapchain, validate_line_width
 };
 use {conversions as conv, command, native as n};
+use native;
 
 use std::borrow::Borrow;
 use std::collections::hash_map::{Entry, HashMap};
@@ -892,7 +893,8 @@ impl hal::Device<Backend> for Device {
             }
         }
 
-        let depth_stencil_state = pipeline_desc.depth_stencil.map(|depth_stencil| {
+        let depth_stencil = pipeline_desc.depth_stencil;
+        let depth_stencil_state = {
             let desc = metal::DepthStencilDescriptor::new();
 
             match depth_stencil.depth {
@@ -907,28 +909,40 @@ impl hal::Device<Backend> for Device {
                 pso::StencilTest::On { ref front, ref back } => {
                     let front_desc = metal::StencilDescriptor::new();
                     front_desc.set_stencil_compare_function(conv::map_compare_function(front.fun));
-                    front_desc.set_read_mask(front.mask_read);
-                    front_desc.set_write_mask(front.mask_write);
+                    if let pso::State::Static(mr) = front.mask_read {
+                        front_desc.set_read_mask(mr);
+                    }
+                    if let pso::State::Static(mw) = front.mask_write {
+                        front_desc.set_write_mask(mw);
+                    }
                     front_desc.set_stencil_failure_operation(conv::map_stencil_op(front.op_fail));
                     front_desc.set_depth_failure_operation(conv::map_stencil_op(front.op_depth_fail));
                     front_desc.set_depth_stencil_pass_operation(conv::map_stencil_op(front.op_pass));
 
+                    desc.set_front_face_stencil(Some(&front_desc));
+
                     let back_desc = metal::StencilDescriptor::new();
-                    back_desc.set_stencil_compare_function(conv::map_compare_function(back.fun));
-                    back_desc.set_read_mask(back.mask_read);
-                    back_desc.set_write_mask(back.mask_write);
+                    back_desc.set_stencil_compare_function(conv::map_compare_function(back.fun));                    
+                    if let pso::State::Static(mr) = back.mask_read {
+                        back_desc.set_read_mask(mr);
+                    }
+                    if let pso::State::Static(mw) = back.mask_write {
+                        back_desc.set_write_mask(mw);
+                    }
                     back_desc.set_stencil_failure_operation(conv::map_stencil_op(back.op_fail));
                     back_desc.set_depth_failure_operation(conv::map_stencil_op(back.op_depth_fail));
                     back_desc.set_depth_stencil_pass_operation(conv::map_stencil_op(back.op_pass));
 
-                    desc.set_front_face_stencil(Some(&front_desc));
                     desc.set_back_face_stencil(Some(&back_desc));
                 }
                 pso::StencilTest::Off => {}
             }
 
-            device.new_depth_stencil_state(&desc)
-        });
+            native::DepthStencilState {
+                depth_stencil_desc: Some(device.new_depth_stencil_state(&desc)),
+                ..Default::default()
+            }
+        };
 
         // Vertex buffers
         let vertex_descriptor = metal::VertexDescriptor::new();

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -78,6 +78,23 @@ impl Default for RasterizerState {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct DepthStencilState {
+    pub depth_stencil_desc: Option<metal::DepthStencilState>,
+    pub stencil_front_reference: pso::State<pso::StencilValue>,
+    pub stencil_back_reference: pso::State<pso::StencilValue>,
+}
+
+impl Default for DepthStencilState {
+    fn default() -> Self {
+        DepthStencilState {
+            depth_stencil_desc: None,
+            stencil_front_reference: pso::State::Static(0),
+            stencil_back_reference: pso::State::Static(0),
+        }
+    }
+}
+
 pub type VertexBufferMap = HashMap<(pso::BufferIndex, pso::ElemOffset), pso::VertexBufferDesc>;
 
 #[derive(Debug)]
@@ -90,7 +107,7 @@ pub struct GraphicsPipeline {
     pub(crate) primitive_type: metal::MTLPrimitiveType,
     pub(crate) attribute_buffer_index: u32,
     pub(crate) rasterizer_state: Option<RasterizerState>,
-    pub(crate) depth_stencil_state: Option<metal::DepthStencilState>,
+    pub(crate) depth_stencil_state: DepthStencilState,
     pub(crate) baked_states: pso::BakedStates,
     /// The mapping of additional vertex buffer bindings over the original ones.
     /// This is needed because Vulkan allows attribute offsets to exceed the strides,

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -1,11 +1,10 @@
-use command::IndexBuffer;
-use native::RasterizerState;
+use command::{IndexBuffer};
+use native::{RasterizerState};
 
 use hal;
 use metal;
 
 use std::ops::Range;
-
 
 pub fn push_data(constants: &[u32]) -> Vec<u8> {
     constants
@@ -20,6 +19,8 @@ pub enum RenderCommand {
     SetScissor(metal::MTLScissorRect),
     SetBlendColor(hal::pso::ColorValue),
     SetDepthBias(hal::pso::DepthBias),
+    SetDepthStencilDesc(metal::DepthStencilState),
+    SetStencilReferenceValues(hal::pso::StencilValue, hal::pso::StencilValue),
     BindBuffer {
         stage: hal::pso::Stage,
         index: usize,
@@ -44,7 +45,6 @@ pub enum RenderCommand {
     BindPipeline(
         metal::RenderPipelineState,
         Option<RasterizerState>,
-        Option<metal::DepthStencilState>,
     ),
     Draw {
         primitive_type: metal::MTLPrimitiveType,

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -539,30 +539,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn set_stencil_reference(
-        &mut self, front: pso::StencilValue, back: pso::StencilValue
-    ) {
+    fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue) {
         unsafe {
-            if front == back {
-                // set front _and_ back
-                self.device.0.cmd_set_stencil_reference(
-                    self.raw,
-                    vk::STENCIL_FRONT_AND_BACK,
-                    front as u32,
-                );
-            } else {
-                // set both individually
-                self.device.0.cmd_set_stencil_reference(
-                    self.raw,
-                    vk::STENCIL_FACE_FRONT_BIT,
-                    front as u32,
-                );
-                self.device.0.cmd_set_stencil_reference(
-                    self.raw,
-                    vk::STENCIL_FACE_BACK_BIT,
-                    back as u32,
-                );
-            }
+            // Vulkan and HAL share same faces bit flags
+            self.device.0.cmd_set_stencil_reference(self.raw, mem::transmute(faces), value);
         }
     }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -506,7 +506,7 @@ impl d::Device<B> for Device {
             };
             info_multisample_states.push(multisampling_state);
 
-            let depth_stencil = desc.depth_stencil.unwrap_or_default();
+            let depth_stencil = desc.depth_stencil;
             let (depth_test_enable, depth_write_enable, depth_compare_op) = match depth_stencil.depth {
                 pso::DepthTest::On { fun, write } => (vk::VK_TRUE, write as _, conv::map_comparison(fun)),
                 pso::DepthTest::Off => (vk::VK_FALSE, vk::VK_FALSE, vk::CompareOp::Never),

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -223,8 +223,8 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
-    pub fn set_stencil_reference(&mut self, front: pso::StencilValue, back: pso::StencilValue) {
-        self.raw.set_stencil_reference(front, back)
+    pub fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue) {
+        self.raw.set_stencil_reference(faces, value);
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -253,7 +253,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     /// Sets the stencil reference value for comparison operations and store operations.
     /// Will be used on the LHS of stencil compare ops and as store value when the
     /// store op is Reference.
-    fn set_stencil_reference(&mut self, front: pso::StencilValue, back: pso::StencilValue);
+    fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue);
 
     /// Set the blend constant values dynamically.
     fn set_blend_constants(&mut self, pso::ColorValue);

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -106,8 +106,8 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
     }
 
     ///
-    pub fn set_stencil_reference(&mut self, front: pso::StencilValue, back: pso::StencilValue) {
-        self.0.set_stencil_reference(front, back)
+    pub fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue) {
+        self.0.set_stencil_reference(faces, value);
     }
 
     ///

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -3,7 +3,7 @@
 use {image, pass, Backend, Primitive};
 use super::{BasePipeline, EntryPoint, PipelineCreationFlags};
 use super::input_assembler::{AttributeDesc, InputAssemblerDesc, VertexBufferDesc};
-use super::output_merger::{ColorBlendDesc, DepthStencilDesc};
+use super::output_merger::{ColorBlendDesc, DepthStencilDesc, Face};
 
 use std::ops::Range;
 
@@ -48,7 +48,6 @@ pub type ColorValue = [f32; 4];
 pub type DepthValue = f32;
 /// A single value from a stencil buffer.
 pub type StencilValue = u32;
-
 
 /// A complete set of shaders to build a graphics pipeline.
 ///
@@ -116,7 +115,7 @@ pub struct GraphicsPipelineDesc<'a, B: Backend> {
     /// Description of how blend operations should be performed.
     pub blender: BlendDesc,
     /// Depth stencil (DSV)
-    pub depth_stencil: Option<DepthStencilDesc>,
+    pub depth_stencil: DepthStencilDesc,
     /// Multisampling.
     pub multisampling: Option<Multisampling>,
     /// Static pipeline states.
@@ -148,7 +147,7 @@ impl<'a, B: Backend> GraphicsPipelineDesc<'a, B> {
             attributes: Vec::new(),
             input_assembler: InputAssemblerDesc::new(primitive),
             blender: BlendDesc::default(),
-            depth_stencil: None,
+            depth_stencil: DepthStencilDesc::default(),
             multisampling: None,
             baked_states: BakedStates::default(),
             layout,
@@ -170,19 +169,6 @@ pub enum PolygonMode {
     Line(f32),
     /// Rasterize as a face.
     Fill,
-}
-
-/// Which faces of the polygon, if any, to cull. Face culling
-/// is often used to reduce the amount of geometry that has to get
-/// drawn, so the renderer, for instance, doesn't have to worry about
-/// drawing the insides of closed objects.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum CullFace {
-    /// Cull front faces
-    Front,
-    /// Cull back faces.
-    Back,
 }
 
 /// The front face winding order of a set of vertices. This is
@@ -222,7 +208,7 @@ pub struct Rasterizer {
     /// How to rasterize this primitive.
     pub polygon_mode: PolygonMode,
     /// Which face should be culled.
-    pub cull_face: Option<CullFace>,
+    pub cull_face: Option<Face>,
     /// Which vertex winding is considered to be the front face for culling.
     pub front_face: FrontFace,
     /// Whether or not to enable depth clamping; when enabled, instead of

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -229,3 +229,13 @@ pub enum Constant {
     F32(f32),
     F64(f64),
 }
+
+/// Pipeline state which may be static or dynamic.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum State<T> {
+    /// Static state that cannot be altered.
+    Static(T),
+    /// Dynamic state set through a command buffer.
+    Dynamic,
+}

--- a/src/hal/src/pso/output_merger.rs
+++ b/src/hal/src/pso/output_merger.rs
@@ -3,6 +3,7 @@
 //! the input shader results, depth/stencil information, etc.
 
 use super::graphics::StencilValue;
+use super::State;
 
 /// A pixel-wise comparison function.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -237,7 +238,7 @@ pub enum StencilOp {
     Keep,
     /// Set the value in the stencil buffer to zero.
     Zero,
-    /// Set the stencil buffer value to `value` from `StencilSide`
+    /// Set the stencil buffer value to `reference` from `StencilFace`.
     Replace,
     /// Increment the stencil buffer value, clamping to its maximum value.
     IncrementClamp,
@@ -259,15 +260,17 @@ pub struct StencilFace {
     pub fun: Comparison,
     /// A mask that is ANDd with both the stencil buffer value and the reference value when they
     /// are read before doing the stencil test.
-    pub mask_read: StencilValue,
+    pub mask_read: State<StencilValue>,
     /// A mask that is ANDd with the stencil value before writing to the stencil buffer.
-    pub mask_write: StencilValue,
+    pub mask_write: State<StencilValue>,
     /// What operation to do if the stencil test fails.
     pub op_fail: StencilOp,
     /// What operation to do if the stencil test passes but the depth test fails.
     pub op_depth_fail: StencilOp,
     /// What operation to do if both the depth and stencil test pass.
     pub op_pass: StencilOp,
+    /// The reference value used for stencil tests.
+    pub reference: State<StencilValue>,
 }
 
 /// Defines a stencil test. Stencil testing is an operation
@@ -303,3 +306,14 @@ pub struct DepthStencilDesc {
     /// Stencil test/write.
     pub stencil: StencilTest,
 }
+
+bitflags!(
+    /// Face.
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct Face: u32 {
+        /// Front face.
+        const FRONT = 0x1;
+        /// Back face.
+        const BACK = 0x2;
+    }
+);

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -103,7 +103,7 @@ pub enum Resource {
         input_assembler: hal::pso::InputAssemblerDesc,
         blender: hal::pso::BlendDesc,
         #[serde(default)]
-        depth_stencil: Option<hal::pso::DepthStencilDesc>,
+        depth_stencil: hal::pso::DepthStencilDesc,
         layout: String,
         subpass: SubpassRef,
     },


### PR DESCRIPTION
Fixes #2067.

- Map static stencil values for Metal
- Implement dynamic stencil reference values for Metal
- Modify signature of `set_stencil_reference` to match Vulkan (debatable, although otherwise we don't have a way to set single faces..)
- Add a new `State` type (open to better name ideas) to try out the idea of static/dynamic fields instead of moving them all into `baked_states`

I haven't had a chance to run any test cases for this yet, so I'm hoping the state setup/binds at least make sense logically.

I also haven't added dynamic read/write masks yet, though maybe I can do that in a followup PR instead.

PR checklist:
- [X] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds (having an issue with it after rebasing, not sure if it's related to my change?.. Will look into it more)
- [X] tested examples with the following backends: Metal, Vulkan, DX12 (crash at #2097), GL 