### PR TITLE
Metal attachment clears

### DIFF
--- a/reftests/scenes/vertex-offset.ron
+++ b/reftests/scenes/vertex-offset.ron
@@ -81,7 +81,7 @@
                     binding: 0,
                     element: Element(
                         offset: 32,
-                        format: Rgba32Float,
+                        format: Rgba32Uint,
                     ),
                 ),
             ],
@@ -128,7 +128,7 @@
                     binding: 0,
                     element: Element(
                         offset: 8,
-                        format: Rgba32Float,
+                        format: Rgba32Uint,
                     ),
                 ),
             ],

--- a/src/backend/metal/shaders/blit.metal
+++ b/src/backend/metal/shaders/blit.metal
@@ -18,9 +18,9 @@ typedef struct {
 
 
 vertex BlitVertexData vs_blit(BlitAttributes in [[stage_in]]) {
-    float4 pos = { 0.0, 0.0, 0.0f, 1.0f };
+    float4 pos = { 0.0, 0.0, in.dst_coords.z, 1.0f };
     pos.xy = in.dst_coords.xy * 2.0 - 1.0;
-    return BlitVertexData { pos, in.src_coords, uint(in.dst_coords.z) };
+    return BlitVertexData { pos, in.src_coords, uint(in.dst_coords.w) };
 }
 
 fragment float4 ps_blit_1d_float(

--- a/src/backend/metal/shaders/clear.metal
+++ b/src/backend/metal/shaders/clear.metal
@@ -1,6 +1,11 @@
 #include <metal_stdlib>
 using namespace metal;
 
+//TODO: simplified code path for Metal 2.0?
+//> Starting in Metal 2.0, the [[color(n)]] and [[raster_order_group(index)]] indices can
+//> also be a function constant. The function constant specified as indices for color and
+//> raster order group attributes must be a scalar integer type.
+
 typedef struct {
     float4 coords [[attribute(0)]];
 } ClearAttributes;
@@ -11,29 +16,63 @@ typedef struct {
 } ClearVertexData;
 
 vertex ClearVertexData vs_clear(ClearAttributes in [[stage_in]]) {
-    float4 pos = { 0.0, 0.0, 0.0f, 1.0f };
+    float4 pos = { 0.0, 0.0, in.coords.z, 1.0f };
     pos.xy = in.coords.xy * 2.0 - 1.0;
-    return ClearVertexData { pos, uint(in.coords.z) };
+    return ClearVertexData { pos, uint(in.coords.w) };
 }
 
 
-fragment float4 ps_clear_float(
+fragment float4 ps_clear0_float(
     ClearVertexData in [[stage_in]],
     constant float4 &value [[ buffer(0) ]]
 ) {
   return value;
 }
 
-fragment int4 ps_clear_int(
+fragment int4 ps_clear0_int(
     ClearVertexData in [[stage_in]],
     constant int4 &value [[ buffer(0) ]]
 ) {
   return value;
 }
 
-fragment uint4 ps_clear_uint(
+fragment uint4 ps_clear0_uint(
     ClearVertexData in [[stage_in]],
     constant uint4 &value [[ buffer(0) ]]
 ) {
   return value;
+}
+
+
+typedef struct {
+    float4 color [[color(1)]];
+} Clear1FloatFragment;
+
+fragment Clear1FloatFragment ps_clear1_float(
+    ClearVertexData in [[stage_in]],
+    constant float4 &value [[ buffer(0) ]]
+) {
+  return Clear1FloatFragment { value };
+}
+
+typedef struct {
+    int4 color [[color(1)]];
+} Clear1IntFragment;
+
+fragment Clear1IntFragment ps_clear1_int(
+    ClearVertexData in [[stage_in]],
+    constant int4 &value [[ buffer(0) ]]
+) {
+  return Clear1IntFragment { value };
+}
+
+typedef struct {
+    uint4 color [[color(1)]];
+} Clear1UintFragment;
+
+fragment Clear1UintFragment ps_clear1_uint(
+    ClearVertexData in [[stage_in]],
+    constant uint4 &value [[ buffer(0) ]]
+) {
+  return Clear1UintFragment { value };
 }

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -166,7 +166,7 @@ impl hal::Backend for Backend {
 
     type ShaderModule = native::ShaderModule;
     type RenderPass = native::RenderPass;
-    type Framebuffer = native::FrameBuffer;
+    type Framebuffer = native::Framebuffer;
 
     type UnboundBuffer = native::UnboundBuffer;
     type Buffer = native::Buffer;

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -39,11 +39,21 @@ pub struct RenderPass {
 unsafe impl Send for RenderPass {}
 unsafe impl Sync for RenderPass {}
 
-#[derive(Debug)]
-pub struct FrameBuffer(pub(crate) metal::RenderPassDescriptor);
+#[derive(Clone, Debug, Default)]
+pub struct FramebufferInner {
+    pub extent: image::Extent,
+    pub colors: Vec<(metal::MTLPixelFormat, Option<Channel>)>,
+    pub depth_stencil: Option<metal::MTLPixelFormat>,
+}
 
-unsafe impl Send for FrameBuffer {}
-unsafe impl Sync for FrameBuffer {}
+#[derive(Debug)]
+pub struct Framebuffer {
+    pub(crate) descriptor: metal::RenderPassDescriptor,
+    pub(crate) inner: FramebufferInner,
+}
+
+unsafe impl Send for Framebuffer {}
+unsafe impl Sync for Framebuffer {}
 
 #[derive(Debug)]
 pub struct PipelineLayout {
@@ -140,7 +150,10 @@ unsafe impl Send for BufferView {}
 unsafe impl Sync for BufferView {}
 
 #[derive(Debug)]
-pub struct ImageView(pub(crate) metal::Texture);
+pub struct ImageView {
+    pub(crate) raw: metal::Texture,
+    pub(crate) mtl_format: metal::MTLPixelFormat,
+}
 
 unsafe impl Send for ImageView {}
 unsafe impl Sync for ImageView {}

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -23,7 +23,7 @@ pub type Level = u8;
 pub const MAX_LEVEL: Level = 15;
 
 /// Describes the size of an image, which may be up to three dimensional.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Extent {
     /// Image width


### PR DESCRIPTION
It's great to have that shader-based clear code finally coming handy :)
Known issues: all multi-layered clears fail. Seems to be very similar to #2103. Supposedly, layered rendering in Metal gets totally off the rails when used on an image view, e.g. a texture that has a parent texture with non-zero layer offset. I'll start making a repro case for Apple to address, which will hopefully let us pass all the tests and do it efficiently.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
