### PR TITLE
dx12: basic input attachment support

### DIFF
--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -452,6 +452,7 @@ pub fn map_descriptor_range(bind: &DescriptorSetLayoutBinding, register_space: u
         RangeType: match bind.ty {
             pso::DescriptorType::Sampler => D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER,
             pso::DescriptorType::SampledImage |
+            pso::DescriptorType::InputAttachment |
             pso::DescriptorType::UniformTexelBuffer => D3D12_DESCRIPTOR_RANGE_TYPE_SRV,
             pso::DescriptorType::StorageBuffer |
             pso::DescriptorType::StorageTexelBuffer |

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -326,6 +326,12 @@ impl Device {
                .map_err(gen_unexpected_error)?;
         }
 
+        for input in &shader_resources.subpass_inputs {
+            let set = ast.get_decoration(input.id, spirv::Decoration::DescriptorSet).map_err(gen_query_error)?;
+            ast.set_decoration(input.id, spirv::Decoration::DescriptorSet, space_offset + set)
+               .map_err(gen_unexpected_error)?;
+        }
+
         // TODO: other resources
 
         Ok(())
@@ -2239,7 +2245,7 @@ impl d::Device<B> for Device {
 
         Ok(n::ImageView {
             resource: image.resource,
-            handle_srv: if image.usage.contains(image::Usage::SAMPLED) {
+            handle_srv: if image.usage.intersects(image::Usage::SAMPLED | image::Usage::INPUT_ATTACHMENT) {
                 Some(self.view_image_as_shader_resource(info.clone())?)
             } else {
                 None


### PR DESCRIPTION
Basic changes required for supporting input attachments. As vulkan requires to specify input attachments in descriptor sets and additionally via an index, mapping to dx12 is quite easy.
Currently no explicit handling in the renderpass.

PR checklist:
- [x] tested `subpasses` example with the following backends: dx12

![subpasses](https://user-images.githubusercontent.com/7253845/40924307-377bab74-6817-11e8-95c7-139010158c3e.png)

