### PR TITLE
dx12: Add dynamically sized CPU descriptor heaps

### DIFF
--- a/src/backend/dx12/src/descriptors_cpu.rs
+++ b/src/backend/dx12/src/descriptors_cpu.rs
@@ -1,4 +1,7 @@
 
+use std::collections::HashSet;
+use std::ptr;
+use winapi::Interface;
 use winapi::um::d3d12;
 use wio::com::ComPtr;
 
@@ -17,7 +20,32 @@ impl HeapLinear {
         ty: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE,
         size: usize,
     ) -> Self {
-        unimplemented!()
+        let desc = d3d12::D3D12_DESCRIPTOR_HEAP_DESC {
+            Type: ty,
+            NumDescriptors: size as u32,
+            Flags: d3d12::D3D12_DESCRIPTOR_HEAP_FLAG_NONE,
+            NodeMask: 0,
+        };
+
+        let mut heap: *mut d3d12::ID3D12DescriptorHeap = ptr::null_mut();
+        let handle_size = unsafe {
+            device.CreateDescriptorHeap(
+                &desc,
+                &d3d12::ID3D12DescriptorHeap::uuidof(),
+                &mut heap as *mut *mut _ as *mut *mut _,
+            );
+            device.GetDescriptorHandleIncrementSize(ty) as usize
+        };
+
+        let start = unsafe { (*heap).GetCPUDescriptorHandleForHeapStart() };
+
+        HeapLinear {
+            handle_size,
+            num: 0,
+            size,
+            start,
+            raw: unsafe { ComPtr::from_raw(heap) },
+        }
     }
 
     pub fn alloc_handle(&mut self) -> d3d12::D3D12_CPU_DESCRIPTOR_HANDLE {
@@ -32,7 +60,7 @@ impl HeapLinear {
     }
 
     pub fn full(&self) -> bool {
-        self.num < self.size
+        self.num >= self.size
     }
 
     pub fn clear(&mut self) {
@@ -41,7 +69,7 @@ impl HeapLinear {
 }
 
 // Fixed-size (64) free-list allocator for CPU descriptors.
-pub struct Heap {
+struct Heap {
     occupancy: u64,
     handle_size: usize,
     start: d3d12::D3D12_CPU_DESCRIPTOR_HANDLE,
@@ -50,7 +78,30 @@ pub struct Heap {
 
 impl Heap {
     pub fn new(device: &ComPtr<d3d12::ID3D12Device>, ty: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE) -> Self {
-        unimplemented!()
+        let desc = d3d12::D3D12_DESCRIPTOR_HEAP_DESC {
+            Type: ty,
+            NumDescriptors: 64,
+            Flags: d3d12::D3D12_DESCRIPTOR_HEAP_FLAG_NONE,
+            NodeMask: 0,
+        };
+
+        let mut heap: *mut d3d12::ID3D12DescriptorHeap = ptr::null_mut();
+        let handle_size = unsafe {
+            device.CreateDescriptorHeap(
+                &desc,
+                &d3d12::ID3D12DescriptorHeap::uuidof(),
+                &mut heap as *mut *mut _ as *mut *mut _,
+            );
+            device.GetDescriptorHandleIncrementSize(ty) as usize
+        };
+        let start = unsafe { (*heap).GetCPUDescriptorHandleForHeapStart() };
+
+        Heap {
+            handle_size,
+            occupancy: 0,
+            start,
+            raw: unsafe { ComPtr::from_raw(heap) },
+        }
     }
 
     pub fn alloc_handle(&mut self) -> d3d12::D3D12_CPU_DESCRIPTOR_HANDLE {
@@ -74,15 +125,41 @@ pub struct DescriptorCpuPool {
     device: ComPtr<d3d12::ID3D12Device>,
     ty: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE,
     heaps: Vec<Heap>,
-    handle_size: usize,
+    free_list: HashSet<usize>,
 }
 
 impl DescriptorCpuPool {
     pub fn new(device: &ComPtr<d3d12::ID3D12Device>, ty: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE) -> Self {
-        unimplemented!()
+        DescriptorCpuPool {
+            device: device.clone(),
+            ty,
+            heaps: Vec::new(),
+            free_list: HashSet::new(),
+        }
     }
 
     pub fn alloc_handle(&mut self) -> d3d12::D3D12_CPU_DESCRIPTOR_HANDLE {
-        unimplemented!()
+        let heap_id = self
+            .free_list
+            .iter()
+            .cloned()
+            .next()
+            .unwrap_or_else(|| {
+                // Allocate a new heap
+                let id = self.heaps.len();
+                self.heaps.push(Heap::new(&self.device, self.ty));
+                self.free_list.insert(id);
+                id
+            });
+
+        let heap = &mut self.heaps[heap_id];
+        let handle = heap.alloc_handle();
+        if heap.full() {
+            self.free_list.remove(&heap_id);
+        }
+
+        handle
     }
+
+    // TODO: free handles
 }

--- a/src/backend/dx12/src/descriptors_cpu.rs
+++ b/src/backend/dx12/src/descriptors_cpu.rs
@@ -1,0 +1,88 @@
+
+use winapi::um::d3d12;
+use wio::com::ComPtr;
+
+// Linear stack allocator for CPU descriptor heaps.
+pub struct HeapLinear {
+    handle_size: usize,
+    num: usize,
+    size: usize,
+    start: d3d12::D3D12_CPU_DESCRIPTOR_HANDLE,
+    raw: ComPtr<d3d12::ID3D12DescriptorHeap>,
+}
+
+impl HeapLinear {
+    pub fn new(
+        device: &ComPtr<d3d12::ID3D12Device>,
+        ty: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE,
+        size: usize,
+    ) -> Self {
+        unimplemented!()
+    }
+
+    pub fn alloc_handle(&mut self) -> d3d12::D3D12_CPU_DESCRIPTOR_HANDLE {
+        assert!(!self.full());
+
+        let slot = self.num;
+        self.num += 1;
+
+        d3d12::D3D12_CPU_DESCRIPTOR_HANDLE {
+            ptr: self.start.ptr + self.handle_size * slot,
+        }
+    }
+
+    pub fn full(&self) -> bool {
+        self.num < self.size
+    }
+
+    pub fn clear(&mut self) {
+        self.num = 0;
+    }
+}
+
+// Fixed-size (64) free-list allocator for CPU descriptors.
+pub struct Heap {
+    occupancy: u64,
+    handle_size: usize,
+    start: d3d12::D3D12_CPU_DESCRIPTOR_HANDLE,
+    raw: ComPtr<d3d12::ID3D12DescriptorHeap>,
+}
+
+impl Heap {
+    pub fn new(device: &ComPtr<d3d12::ID3D12Device>, ty: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE) -> Self {
+        unimplemented!()
+    }
+
+    pub fn alloc_handle(&mut self) -> d3d12::D3D12_CPU_DESCRIPTOR_HANDLE {
+        // Find first free slot
+        let slot = (0..64)
+            .position(|i| self.occupancy & (1 << i) == 0)
+            .expect("Descriptor heap is full");
+        self.occupancy |= 1 << slot;
+
+        d3d12::D3D12_CPU_DESCRIPTOR_HANDLE {
+            ptr: self.start.ptr + self.handle_size * slot,
+        }
+    }
+
+    pub fn full(&self) -> bool {
+        self.occupancy == !0
+    }
+}
+
+pub struct DescriptorCpuPool {
+    device: ComPtr<d3d12::ID3D12Device>,
+    ty: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE,
+    heaps: Vec<Heap>,
+    handle_size: usize,
+}
+
+impl DescriptorCpuPool {
+    pub fn new(device: &ComPtr<d3d12::ID3D12Device>, ty: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE) -> Self {
+        unimplemented!()
+    }
+
+    pub fn alloc_handle(&mut self) -> d3d12::D3D12_CPU_DESCRIPTOR_HANDLE {
+        unimplemented!()
+    }
+}

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2440,7 +2440,7 @@ impl d::Device<B> for Device {
                         }
                         let heap = descriptor_update_pools.last_mut().unwrap();
                         let handle = heap.alloc_handle();
-                        if heap.full() {
+                        if heap.is_full() {
                             // pool is full, move to the next one
                             update_pool_index += 1;
                         }

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -152,11 +152,13 @@ pub struct Framebuffer {
     pub(crate) layers: image::Layer,
 }
 
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct Buffer {
     pub(crate) resource: *mut d3d12::ID3D12Resource,
     pub(crate) size_in_bytes: u32,
-    pub(crate) clear_uav: Option<DualHandle>,
+    #[derivative(Debug="ignore")]
+    pub(crate) clear_uav: Option<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE>,
 }
 unsafe impl Send for Buffer { }
 unsafe impl Sync for Buffer { }
@@ -388,23 +390,6 @@ impl DescriptorHeap {
             gpu: d3d12::D3D12_GPU_DESCRIPTOR_HANDLE { ptr: self.start.gpu.ptr + self.handle_size * index },
             size,
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct DescriptorCpuPool {
-    pub(crate) heap: DescriptorHeap,
-    pub(crate) offset: u64,
-    pub(crate) size: u64,
-    pub(crate) max_size: u64,
-}
-
-impl DescriptorCpuPool {
-    pub(crate) fn alloc_handles(&mut self, count: u64) -> DualHandle {
-        assert!(self.size + count <= self.max_size);
-        let index = self.offset + self.size;
-        self.size += count;
-        self.heap.at(index, count)
     }
 }
 


### PR DESCRIPTION
Dynamic allocator for CPU descriptor heaps. We currently have 2 ways of allocating CPU descriptors: from a device global heap and command local linear allocators. This PR cleans up the two paths a bit and fixes the current size limitation for the first kind by dynamically creating new small fixed size CPU heaps.

Freeing currently not support but that's not an regression as we didn't support it before either.
Small 'regression' concerning `fill_buffer` which was implemented incorrectly as far as I can see. Probably would work only on AMD. This breaks the fill reftests.

Fixes #1945 
PR checklist:
- [x] tested quad, relevant CTS and a few vulkan samples with the following backends: dx12
