### PR TITLE
Dynamic buffers

### DIFF
--- a/examples/hal/compute/main.rs
+++ b/examples/hal/compute/main.rs
@@ -130,7 +130,7 @@ fn main() {
             }),
         );
         command_buffer.bind_compute_pipeline(&pipeline);
-        command_buffer.bind_compute_descriptor_sets(&pipeline_layout, 0, &[desc_set]);
+        command_buffer.bind_compute_descriptor_sets(&pipeline_layout, 0, &[desc_set], &[]);
         command_buffer.dispatch([numbers.len() as u32, 1, 1]);
         command_buffer.pipeline_barrier(
             pso::PipelineStage::COMPUTE_SHADER .. pso::PipelineStage::TRANSFER,

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -560,7 +560,7 @@ fn main() {
             cmd_buffer.set_scissors(0, &[viewport.rect]);
             cmd_buffer.bind_graphics_pipeline(&pipeline.as_ref().unwrap());
             cmd_buffer.bind_vertex_buffers(0, pso::VertexBufferSet(vec![(&vertex_buffer, 0)]));
-            cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, Some(&desc_set)); //TODO
+            cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, Some(&desc_set), &[]); //TODO
 
             {
                 let mut encoder = cmd_buffer.begin_render_pass_inline(

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -308,7 +308,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         };
 
         let device = device::Device::new(device, cxt, self.memory_properties.clone());
-        
+
         // TODO: deferred context => 1 cxt/queue?
         let queues = Queues::new(
             families
@@ -490,7 +490,7 @@ pub struct CommandBuffer {
 }
 
 unsafe impl Send for CommandBuffer {}
-unsafe impl Sync for CommandBuffer {} 
+unsafe impl Sync for CommandBuffer {}
 
 impl CommandBuffer {
     fn create_deferred(device: ComPtr<d3d11::ID3D11Device>, internal: internal::BufferImageCopy) -> Self {
@@ -544,7 +544,7 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
 
         let depth_view = framebuffer.attachments.iter().find(|a| a.dsv_handle.is_some());
 
-        
+
         unsafe {
             for (clear, view) in clear_values.into_iter().zip(framebuffer.attachments.iter()) {
                 let clear = clear.borrow();
@@ -729,10 +729,12 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn bind_graphics_descriptor_sets<'a, T>(&mut self, layout: &PipelineLayout, first_set: usize, sets: T)
+    fn bind_graphics_descriptor_sets<'a, I, J>(&mut self, layout: &PipelineLayout, first_set: usize, sets: I, _offsets: J)
     where
-        T: IntoIterator,
-        T::Item: Borrow<DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<command::DescriptorSetOffset>,
     {
         for set in sets.into_iter() {
             let set = set.borrow();
@@ -759,10 +761,12 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
 
-    fn bind_compute_descriptor_sets<T>(&mut self, layout: &PipelineLayout, first_set: usize, sets: T)
+    fn bind_compute_descriptor_sets<I, J>(&mut self, layout: &PipelineLayout, first_set: usize, sets: I, offsets: J)
     where
-        T: IntoIterator,
-        T::Item: Borrow<DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<command::DescriptorSetOffset>,
     {
         unimplemented!()
     }
@@ -900,7 +904,7 @@ pub struct Memory {
 }
 
 unsafe impl Send for Memory {}
-unsafe impl Sync for Memory {} 
+unsafe impl Sync for Memory {}
 
 pub struct CommandPool {
     device: ComPtr<d3d11::ID3D11Device>,
@@ -908,7 +912,7 @@ pub struct CommandPool {
 }
 
 unsafe impl Send for CommandPool {}
-unsafe impl Sync for CommandPool {} 
+unsafe impl Sync for CommandPool {}
 
 impl hal::pool::RawCommandPool<Backend> for CommandPool {
     fn reset(&mut self) {
@@ -996,7 +1000,7 @@ impl Buffer {
 }
 
 unsafe impl Send for Buffer {}
-unsafe impl Sync for Buffer {} 
+unsafe impl Sync for Buffer {}
 
 #[derive(Debug)]
 pub struct BufferView;
@@ -1129,7 +1133,7 @@ pub struct DescriptorSet {
 }
 
 unsafe impl Send for DescriptorSet {}
-unsafe impl Sync for DescriptorSet {} 
+unsafe impl Sync for DescriptorSet {}
 
 impl DescriptorSet {
     pub fn new() -> Self {

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -166,15 +166,18 @@ impl PipelineCache {
         }
     }
 
-    fn bind_descriptor_sets<'a, T>(
+    fn bind_descriptor_sets<'a, I, J>(
         &mut self,
         layout: &n::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) -> [*mut d3d12::ID3D12DescriptorHeap; 2]
     where
-        T: IntoIterator,
-        T::Item: Borrow<n::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<n::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<com::DescriptorSetOffset>,
     {
         let mut sets = sets.into_iter().peekable();
         let (
@@ -1739,16 +1742,19 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn bind_graphics_descriptor_sets<'a, T>(
+    fn bind_graphics_descriptor_sets<'a, I, J>(
         &mut self,
         layout: &n::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<n::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<n::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<com::DescriptorSetOffset>,
     {
-        self.active_descriptor_heaps = self.gr_pipeline.bind_descriptor_sets(layout, first_set, sets);
+        self.active_descriptor_heaps = self.gr_pipeline.bind_descriptor_sets(layout, first_set, sets, offsets);
         self.bind_descriptor_heaps();
     }
 
@@ -1773,16 +1779,19 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.comp_pipeline.pipeline = Some((pipeline.raw, pipeline.signature));
     }
 
-    fn bind_compute_descriptor_sets<T>(
+    fn bind_compute_descriptor_sets<I, J>(
         &mut self,
         layout: &n::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<n::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<n::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<com::DescriptorSetOffset>,
     {
-        self.active_descriptor_heaps = self.comp_pipeline.bind_descriptor_sets(layout, first_set, sets);
+        self.active_descriptor_heaps = self.comp_pipeline.bind_descriptor_sets(layout, first_set, sets, offsets);
         self.bind_descriptor_heaps();
     }
 

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -455,15 +455,16 @@ pub fn map_descriptor_range(bind: &DescriptorSetLayoutBinding, register_space: u
             pso::DescriptorType::InputAttachment |
             pso::DescriptorType::UniformTexelBuffer => D3D12_DESCRIPTOR_RANGE_TYPE_SRV,
             pso::DescriptorType::StorageBuffer |
+            pso::DescriptorType::StorageBufferDynamic |
             pso::DescriptorType::StorageTexelBuffer |
             pso::DescriptorType::StorageImage => D3D12_DESCRIPTOR_RANGE_TYPE_UAV,
-            pso::DescriptorType::UniformBuffer => D3D12_DESCRIPTOR_RANGE_TYPE_CBV,
+            pso::DescriptorType::UniformBuffer |
+            pso::DescriptorType::UniformBufferDynamic => D3D12_DESCRIPTOR_RANGE_TYPE_CBV,
             pso::DescriptorType::CombinedImageSampler => if sampler {
                 D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER
             } else {
                 D3D12_DESCRIPTOR_RANGE_TYPE_SRV
-            },
-            _ => panic!("unsupported binding type {:?}", bind.ty)
+            }
         },
         NumDescriptors: bind.count as _,
         BaseShaderRegister: bind.binding as _,

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -556,12 +556,12 @@ impl HeapProperties {
             pso::DescriptorType::InputAttachment |
             pso::DescriptorType::SampledImage |
             pso::DescriptorType::UniformTexelBuffer |
+            pso::DescriptorType::UniformBufferDynamic |
             pso::DescriptorType::UniformBuffer => HeapProperties::new(true, false, false),
             pso::DescriptorType::StorageImage |
             pso::DescriptorType::StorageTexelBuffer |
+            pso::DescriptorType::StorageBufferDynamic |
             pso::DescriptorType::StorageBuffer => HeapProperties::new(true, false, true),
-            pso::DescriptorType::UniformBufferDynamic |
-            pso::DescriptorType::UniformImageDynamic => unimplemented!(),
         }
 
     }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -563,10 +563,12 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn bind_graphics_descriptor_sets<I>(&mut self, _: &(), _: usize, _: I)
+    fn bind_graphics_descriptor_sets<I, J>(&mut self, _: &(), _: usize, _: I, _: J)
     where
         I: IntoIterator,
         I::Item: Borrow<()>,
+        J: IntoIterator,
+        J::Item: Borrow<command::DescriptorSetOffset>,
     {
         unimplemented!()
     }
@@ -575,10 +577,12 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn bind_compute_descriptor_sets<I>(&mut self, _: &(), _: usize, _: I)
+    fn bind_compute_descriptor_sets<I, J>(&mut self, _: &(), _: usize, _: I, _: J)
     where
         I: IntoIterator,
         I::Item: Borrow<()>,
+        J: IntoIterator,
+        J::Item: Borrow<command::DescriptorSetOffset>,
     {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -834,14 +834,17 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         self.update_blend_targets(blend_targets);
     }
 
-    fn bind_graphics_descriptor_sets<T>(
+    fn bind_graphics_descriptor_sets<I, J>(
         &mut self,
         _layout: &n::PipelineLayout,
         _first_set: usize,
-        _sets: T,
+        _sets: I,
+        _offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<n::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<n::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<command::DescriptorSetOffset>,
     {
         // TODO
     }
@@ -857,14 +860,17 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         }
     }
 
-    fn bind_compute_descriptor_sets<T>(
+    fn bind_compute_descriptor_sets<I, J>(
         &mut self,
         _layout: &n::PipelineLayout,
         _first_set: usize,
-        _sets: T,
+        _sets: I,
+        _offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<n::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<n::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<command::DescriptorSetOffset>,
     {
         // TODO
     }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -683,7 +683,9 @@ impl hal::Device<Backend> for Device {
                             };
                             match set_binding.ty {
                                 pso::DescriptorType::UniformBuffer |
-                                pso::DescriptorType::StorageBuffer => {
+                                pso::DescriptorType::StorageBuffer |
+                                pso::DescriptorType::UniformBufferDynamic |
+                                pso::DescriptorType::StorageBufferDynamic => {
                                     res.buffer_id = counters.buffers as _;
                                     counters.buffers += 1;
                                 }
@@ -705,8 +707,6 @@ impl hal::Device<Backend> for Device {
                                     counters.textures += 1;
                                     counters.samplers += 1;
                                 }
-                                pso::DescriptorType::UniformBufferDynamic |
-                                pso::DescriptorType::UniformImageDynamic => unimplemented!(),
                             };
                             assert_eq!(set_binding.count, 1); //TODO
                             let location = msl::ResourceBindingLocation {
@@ -1378,7 +1378,7 @@ impl hal::Device<Backend> for Device {
                                 let start = range.start.unwrap_or(0);
                                 let end = range.end.unwrap_or(buf_length);
                                 assert!(end <= buf_length);
-                                vec[array_offset] = Some((buffer.raw.clone(), start));
+                                vec[array_offset].base = Some((buffer.raw.clone(), start));
                             }
                             (&pso::Descriptor::Sampler(..), _) |
                             (&pso::Descriptor::Image(..), _) |

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -238,10 +238,12 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
                         }
                         pso::DescriptorType::UniformBuffer |
                         pso::DescriptorType::StorageBuffer => {
-                            DescriptorSetBinding::Buffer(vec![None; layout.count])
+                            DescriptorSetBinding::Buffer(vec![BufferBinding { base: None, dynamic: false }; layout.count])
                         }
                         pso::DescriptorType::UniformBufferDynamic |
-                        pso::DescriptorType::UniformImageDynamic => unimplemented!()
+                        pso::DescriptorType::StorageBufferDynamic => {
+                            DescriptorSetBinding::Buffer(vec![BufferBinding { base: None, dynamic: true }; layout.count])
+                        }
                     };
                     (layout.binding, binding)
                 }).collect();
@@ -336,12 +338,18 @@ pub struct DescriptorSetInner {
 }
 unsafe impl Send for DescriptorSetInner {}
 
+#[derive(Clone, Debug)]
+pub struct BufferBinding {
+    pub base: Option<(metal::Buffer, u64)>,
+    pub dynamic: bool,
+}
+
 #[derive(Debug)]
 pub enum DescriptorSetBinding {
     Sampler(Vec<Option<metal::SamplerState>>),
     Image(Vec<Option<(metal::Texture, image::Layout)>>),
     Combined(Vec<(Option<(metal::Texture, image::Layout)>, Option<metal::SamplerState>)>),
-    Buffer(Vec<Option<(metal::Buffer, u64)>>),
+    Buffer(Vec<BufferBinding>),
     //InputAttachment(Vec<(metal::Texture, image::Layout)>),
 }
 

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -53,18 +53,21 @@ where
 }
 
 impl CommandBuffer {
-    fn bind_descriptor_sets<T>(
+    fn bind_descriptor_sets<I, J>(
         &mut self,
         bind_point: vk::PipelineBindPoint,
         layout: &n::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<n::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<n::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<com::DescriptorSetOffset>,
     {
-        let sets: SmallVec<[vk::DescriptorSet; 16]> = sets.into_iter().map(|set| set.borrow().raw).collect();
-        let dynamic_offsets = &[]; // TODO
+        let sets: SmallVec<[_; 16]> = sets.into_iter().map(|set| set.borrow().raw).collect();
+        let dynamic_offsets: SmallVec<[_; 16]> = offsets.into_iter().map(|offset| *offset.borrow()).collect();
 
         unsafe {
             self.device.0.cmd_bind_descriptor_sets(
@@ -73,7 +76,7 @@ impl CommandBuffer {
                 layout.raw,
                 first_set as u32,
                 &sets,
-                dynamic_offsets,
+                &dynamic_offsets,
             );
         }
     }
@@ -605,20 +608,24 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn bind_graphics_descriptor_sets<T>(
+    fn bind_graphics_descriptor_sets<I, J>(
         &mut self,
         layout: &n::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<n::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<n::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<com::DescriptorSetOffset>,
     {
         self.bind_descriptor_sets(
             vk::PipelineBindPoint::Graphics,
             layout,
             first_set,
             sets,
+            offsets,
         );
     }
 
@@ -632,20 +639,24 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn bind_compute_descriptor_sets<T>(
+    fn bind_compute_descriptor_sets<I, J>(
         &mut self,
         layout: &n::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<n::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<n::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<com::DescriptorSetOffset>,
     {
         self.bind_descriptor_sets(
             vk::PipelineBindPoint::Compute,
             layout,
             first_set,
             sets,
+            offsets,
         );
     }
 

--- a/src/hal/src/command/compute.rs
+++ b/src/hal/src/command/compute.rs
@@ -4,9 +4,8 @@ use std::borrow::Borrow;
 
 use {Backend, WorkGroupCount};
 use buffer::Offset;
-use command::raw::DescriptorSetOffset;
 use queue::capability::{Compute, Supports};
-use super::{CommandBuffer, RawCommandBuffer, Shot, Level};
+use super::{CommandBuffer, DescriptorSetOffset, RawCommandBuffer, Shot, Level};
 
 impl<'a, B: Backend, C: Supports<Compute>, S: Shot, L: Level> CommandBuffer<'a, B, C, S, L> {
     /// Identical to the `RawCommandBuffer` method of the same name.

--- a/src/hal/src/command/compute.rs
+++ b/src/hal/src/command/compute.rs
@@ -4,6 +4,7 @@ use std::borrow::Borrow;
 
 use {Backend, WorkGroupCount};
 use buffer::Offset;
+use command::raw::DescriptorSetOffset;
 use queue::capability::{Compute, Supports};
 use super::{CommandBuffer, RawCommandBuffer, Shot, Level};
 
@@ -14,16 +15,19 @@ impl<'a, B: Backend, C: Supports<Compute>, S: Shot, L: Level> CommandBuffer<'a, 
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
-    pub fn bind_compute_descriptor_sets<T>(
+    pub fn bind_compute_descriptor_sets<I, J>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<B::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<B::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<DescriptorSetOffset>,
     {
-        self.raw.bind_compute_descriptor_sets(layout, first_set, sets)
+        self.raw.bind_compute_descriptor_sets(layout, first_set, sets, offsets)
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 use Backend;
 use {image, pso};
 use buffer::IndexBufferView;
+use command::raw::DescriptorSetOffset;
 use query::{Query, QueryControl, QueryId};
 use queue::capability::{Graphics, GraphicsOrCompute, Supports};
 use super::{
@@ -192,16 +193,19 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
-    pub fn bind_graphics_descriptor_sets<T>(
+    pub fn bind_graphics_descriptor_sets<I, J>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<B::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<B::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<DescriptorSetOffset>,
     {
-        self.raw.bind_graphics_descriptor_sets(layout, first_set, sets)
+        self.raw.bind_graphics_descriptor_sets(layout, first_set, sets, offsets)
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -5,14 +5,13 @@ use std::ops::Range;
 use Backend;
 use {image, pso};
 use buffer::IndexBufferView;
-use command::raw::DescriptorSetOffset;
 use query::{Query, QueryControl, QueryId};
 use queue::capability::{Graphics, GraphicsOrCompute, Supports};
 use super::{
     CommandBuffer, RawCommandBuffer,
     RenderPassInlineEncoder, RenderPassSecondaryEncoder,
     Shot, Level, Primary,
-    ClearColorRaw, ClearDepthStencilRaw, ClearValueRaw,
+    ClearColorRaw, ClearDepthStencilRaw, ClearValueRaw, DescriptorSetOffset,
 };
 
 

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -24,7 +24,10 @@ mod render_pass;
 mod transfer;
 
 pub use self::graphics::*;
-pub use self::raw::{ClearValueRaw, ClearColorRaw, ClearDepthStencilRaw, RawCommandBuffer, CommandBufferFlags, Level as RawLevel, CommandBufferInheritanceInfo};
+pub use self::raw::{
+    ClearValueRaw, ClearColorRaw, ClearDepthStencilRaw, DescriptorSetOffset,
+    RawCommandBuffer, CommandBufferFlags, Level as RawLevel, CommandBufferInheritanceInfo,
+};
 pub use self::render_pass::*;
 pub use self::transfer::*;
 

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -48,6 +48,8 @@ pub union ClearValueRaw {
     _align: [u32; 4],
 }
 
+/// Offset for dynamic descriptors.
+pub type DescriptorSetOffset = u32;
 
 bitflags! {
     /// Option flags for various command buffer settings.
@@ -304,14 +306,17 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
 
     /// Takes an iterator of graphics `DescriptorSet`'s, and binds them to the command buffer.
     /// `first_set` is the index that the first descriptor is mapped to in the command buffer.
-    fn bind_graphics_descriptor_sets<T>(
+    fn bind_graphics_descriptor_sets<I, J>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<B::DescriptorSet>;
+        I: IntoIterator,
+        I::Item: Borrow<B::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<DescriptorSetOffset>;
 
     /// Bind a compute pipeline.
     ///
@@ -326,14 +331,17 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
 
     /// Takes an iterator of compute `DescriptorSet`'s, and binds them to the command buffer,
     /// `first_set` is the index that the first descriptor is mapped to in the command buffer.
-    fn bind_compute_descriptor_sets<T>(
+    fn bind_compute_descriptor_sets<I, J>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<B::DescriptorSet>;
+        I: IntoIterator,
+        I::Item: Borrow<B::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<DescriptorSetOffset>;
 
     /// Execute a workgroup in the compute pipeline. `x`, `y` and `z` are the
     /// number of local workgroups to dispatch along each "axis"; a total of `x`*`y`*`z`

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 
 use {buffer, pso};
 use {Backend, DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset};
+use command::raw::DescriptorSetOffset;
 use queue::{Supports, Graphics};
 use super::{
     AttachmentClear, ClearValue, ClearValueRaw, CommandBuffer, RawCommandBuffer,
@@ -75,16 +76,19 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
     }
 
     ///
-    pub fn bind_graphics_descriptor_sets<T>(
+    pub fn bind_graphics_descriptor_sets<I, J>(
         &mut self,
         layout: &B::PipelineLayout,
         first_set: usize,
-        sets: T,
+        sets: I,
+        offsets: J,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<B::DescriptorSet>,
+        I: IntoIterator,
+        I::Item: Borrow<B::DescriptorSet>,
+        J: IntoIterator,
+        J::Item: Borrow<DescriptorSetOffset>,
     {
-        self.0.bind_graphics_descriptor_sets(layout, first_set, sets)
+        self.0.bind_graphics_descriptor_sets(layout, first_set, sets, offsets)
     }
 
     ///

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -4,11 +4,10 @@ use std::marker::PhantomData;
 
 use {buffer, pso};
 use {Backend, DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset};
-use command::raw::DescriptorSetOffset;
 use queue::{Supports, Graphics};
 use super::{
     AttachmentClear, ClearValue, ClearValueRaw, CommandBuffer, RawCommandBuffer,
-    Shot, Level, Primary, Secondary, Submittable, Submit
+    Shot, Level, Primary, Secondary, Submittable, Submit, DescriptorSetOffset,
 };
 
 /// Specifies how commands for the following renderpasses will be recorded.

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -48,7 +48,7 @@ pub enum DescriptorType {
     ///
     UniformBufferDynamic = 8,
     ///
-    UniformImageDynamic = 9,
+    StorageBufferDynamic = 9,
     /// Allows unfiltered loads of pixel local data in the fragment shader.
     InputAttachment = 10,
 }

--- a/src/render/src/macros/pipeline.rs
+++ b/src/render/src/macros/pipeline.rs
@@ -141,7 +141,7 @@ macro_rules! gfx_graphics_pipeline {
                     $(
                         descs.extend(<$cmp as pso::Component<'a, B>>::descriptor_set(&self.$cmp_name));
                     )*
-                    cmd_buffer.bind_graphics_descriptor_sets(meta.layout.resource(), 0, descs);
+                    cmd_buffer.bind_graphics_descriptor_sets(meta.layout.resource(), 0, descs, &[]);
                     // TODO: difference with viewport ?
                     let extent = self.framebuffer.info().extent;
                     let render_rect = pso::Rect {

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -967,6 +967,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                                                 .get(name)
                                                 .expect(&format!("Missing descriptor set: {}", name))
                                         }),
+                                        &[],
                                     );
                                 }
                                 Dc::Draw { ref vertices, ref instances } => {
@@ -998,6 +999,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                                 .get(name)
                                 .expect(&format!("Missing descriptor set: {}", name))
                         }),
+                        &[],
                     );
                     command_buf.dispatch(dispatch);
                 }


### PR DESCRIPTION
Start defining the basic API for dynamic buffer descriptors. Atm based upon vulkan, not optimal but provides the best performance. Other possbiel API design could use `(set, Option<Offset>)` for descriptor set binding, but involves more work on the portability layer and might be more typing for users.

Feedback appreciated.
More backends to follow ..

Addresses https://github.com/gfx-rs/gfx/issues/1949
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
