### PR TITLE
Attachment clears API refinement, DX12 depth/stencil support

### DIFF
--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -90,27 +90,6 @@ pub fn map_clear_color(value: command::ClearColor) -> vk::ClearColorValue {
     }
 }
 
-pub fn map_clear_depth_stencil(value: command::ClearDepthStencil) -> vk::ClearDepthStencilValue {
-    vk::ClearDepthStencilValue {
-        depth: value.0,
-        stencil: value.1,
-    }
-}
-
-pub fn map_clear_depth(depth: pso::DepthValue) -> vk::ClearDepthStencilValue {
-    vk::ClearDepthStencilValue {
-        depth,
-        stencil: 0,
-    }
-}
-
-pub fn map_clear_stencil(stencil: pso::StencilValue) -> vk::ClearDepthStencilValue {
-    vk::ClearDepthStencilValue {
-        depth: 0.0,
-        stencil,
-    }
-}
-
 pub fn map_offset(offset: image::Offset) -> vk::Offset3D {
     vk::Offset3D {
         x: offset.x,

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -116,15 +116,19 @@ impl From<ClearValue> for ClearValueRaw {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum AttachmentClear {
     /// Clear color attachment.
-    ///
-    /// First tuple element denotes the index of the color attachment.
-    Color(usize, ClearColor),
-    /// Clear depth component of the attachment.
-    Depth(pso::DepthValue),
-    /// Clear stencil component of the attachment.
-    Stencil(pso::StencilValue),
-    /// Clear depth-stencil component of the attachment.
-    DepthStencil(ClearDepthStencil),
+    Color {
+        /// Index inside the `SubpassDesc::colors` array.
+        index: usize,
+        /// Value to clear with.
+        value: ClearColor,
+    },
+    /// Clear depth-stencil attachment.
+    DepthStencil {
+        /// Depth value to clear with.
+        depth: Option<pso::DepthValue>,
+        /// Stencil value to clear with.
+        stencil: Option<pso::StencilValue>,
+    },
 }
 
 /// Parameters for an image resolve operation,


### PR DESCRIPTION
Fixes https://github.com/szeged/webrender/pull/183#issuecomment-395087515
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
