### PR TITLE
Dynamic stencil masks

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -692,8 +692,16 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
-    fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue) {
+    fn set_stencil_reference(&mut self, _faces: pso::Face, _value: pso::StencilValue) {
         unimplemented!()
+    }
+
+    fn set_stencil_read_mask(&mut self, _faces: pso::Face, _value: pso::StencilValue) {
+        unimplemented!();
+    }
+
+    fn set_stencil_write_mask(&mut self, _faces: pso::Face, _value: pso::StencilValue) {
+        unimplemented!();
     }
 
     fn set_depth_bounds(&mut self, bounds: Range<f32>) {

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1722,6 +1722,14 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         unsafe { self.raw.OMSetStencilRef(value as _); }
     }
 
+    fn set_stencil_read_mask(&mut self, _faces: pso::Face, _value: pso::StencilValue) {
+        unimplemented!();
+    }
+
+    fn set_stencil_write_mask(&mut self, _faces: pso::Face, _value: pso::StencilValue) {
+        unimplemented!();
+    }
+
     fn set_depth_bounds(&mut self, bounds: Range<f32>) {
         match self.raw.cast::<d3d12::ID3D12GraphicsCommandList1>() {
             Ok(cmd_list1) => unsafe { cmd_list1.OMSetDepthBounds(bounds.start, bounds.end) },

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -521,6 +521,14 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
+    fn set_stencil_read_mask(&mut self, _: pso::Face, _: pso::StencilValue) {
+        unimplemented!()
+    }
+
+    fn set_stencil_write_mask(&mut self, _: pso::Face, _: pso::StencilValue) {
+        unimplemented!()
+    }
+
     fn set_blend_constants(&mut self, _: pso::ColorValue) {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -800,6 +800,14 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         self.cache.stencil_ref = Some((front, back));
     }
 
+    fn set_stencil_read_mask(&mut self, _faces: pso::Face, _value: pso::StencilValue) {
+        unimplemented!();
+    }
+
+    fn set_stencil_write_mask(&mut self, _faces: pso::Face, _value: pso::StencilValue) {
+        unimplemented!();
+    }
+
     fn set_blend_constants(&mut self, cv: pso::ColorValue) {
         if self.cache.blend_color != Some(cv) {
             self.cache.blend_color = Some(cv);

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -80,18 +80,37 @@ impl Default for RasterizerState {
 }
 
 #[derive(Clone, Debug)]
+pub struct StencilState<T> {
+    pub(crate) front_reference: T,
+    pub(crate) back_reference: T,
+    pub(crate) front_read_mask: T,
+    pub(crate) back_read_mask: T,
+    pub(crate) front_write_mask: T,
+    pub(crate) back_write_mask: T,
+}
+
+#[derive(Clone, Debug)]
 pub struct DepthStencilState {
-    pub depth_stencil_desc: Option<metal::DepthStencilState>,
-    pub stencil_front_reference: pso::State<pso::StencilValue>,
-    pub stencil_back_reference: pso::State<pso::StencilValue>,
+    pub depth_stencil_desc: Option<pso::DepthStencilDesc>,
+    pub depth_stencil_desc_raw: Option<metal::DepthStencilDescriptor>,
+    pub depth_stencil_static: Option<metal::DepthStencilState>,
+    pub stencil: StencilState<pso::State<pso::StencilValue>>,
 }
 
 impl Default for DepthStencilState {
     fn default() -> Self {
         DepthStencilState {
             depth_stencil_desc: None,
-            stencil_front_reference: pso::State::Static(0),
-            stencil_back_reference: pso::State::Static(0),
+            depth_stencil_desc_raw: None,
+            depth_stencil_static: None,
+            stencil: StencilState::<pso::State<pso::StencilValue>> {
+                front_reference: pso::State::Static(0),
+                back_reference: pso::State::Static(0),
+                front_read_mask: pso::State::Static(!0),
+                back_read_mask: pso::State::Static(!0),
+                front_write_mask: pso::State::Static(!0),
+                back_write_mask: pso::State::Static(!0),
+            }
         }
     }
 }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -540,6 +540,20 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
+    fn set_stencil_read_mask(&mut self, faces: pso::Face, value: pso::StencilValue) {
+        unsafe {
+            // Vulkan and HAL share same faces bit flags
+            self.device.0.cmd_set_stencil_compare_mask(self.raw, mem::transmute(faces), value);
+        }
+    }
+
+    fn set_stencil_write_mask(&mut self, faces: pso::Face, value: pso::StencilValue) {
+        unsafe {
+            // Vulkan and HAL share same faces bit flags
+            self.device.0.cmd_set_stencil_write_mask(self.raw, mem::transmute(faces), value);
+        }
+    }
+
     fn set_blend_constants(&mut self, color: pso::ColorValue) {
         unsafe {
             self.device.0.cmd_set_blend_constants(self.raw, color);

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -235,6 +235,16 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
+    pub fn set_stencil_read_mask(&mut self, faces: pso::Face, value: pso::StencilValue) {
+        self.raw.set_stencil_read_mask(faces, value);
+    }
+
+    /// Identical to the `RawCommandBuffer` method of the same name.
+    pub fn set_stencil_write_mask(&mut self, faces: pso::Face, value: pso::StencilValue) {
+        self.raw.set_stencil_write_mask(faces, value);
+    }
+
+    /// Identical to the `RawCommandBuffer` method of the same name.
     pub fn set_blend_constants(&mut self, cv: pso::ColorValue) {
         self.raw.set_blend_constants(cv)
     }

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -257,6 +257,12 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     /// store op is Reference.
     fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue);
 
+    /// Sets the stencil read mask.
+    fn set_stencil_read_mask(&mut self, faces: pso::Face, value: pso::StencilValue);
+
+    /// Sets the stencil write mask.
+    fn set_stencil_write_mask(&mut self, faces: pso::Face, value: pso::StencilValue);
+
     /// Set the blend constant values dynamically.
     fn set_blend_constants(&mut self, pso::ColorValue);
 

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -114,6 +114,16 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
     }
 
     ///
+    pub fn set_stencil_read_mask(&mut self, faces: pso::Face, value: pso::StencilValue) {
+        self.0.set_stencil_read_mask(faces, value);
+    }
+
+    ///
+    pub fn set_stencil_write_mask(&mut self, faces: pso::Face, value: pso::StencilValue) {
+        self.0.set_stencil_write_mask(faces, value);
+    }
+
+    ///
     pub fn set_blend_constants(&mut self, cv: pso::ColorValue) {
         self.0.set_blend_constants(cv)
     }
@@ -138,8 +148,6 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
         self.0.set_depth_bias(depth_bias);
     }
 
-    // TODO: set_stencil_compare_mask
-    // TODO: set_stencil_write_mask
     // TODO: pipeline barrier (postponed)
     // TODO: begin/end query
 }

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -92,9 +92,6 @@ pub struct BakedStates {
     pub blend_color: Option<ColorValue>,
     /// Static depth bounds.
     pub depth_bounds: Option<Range<f32>>,
-    //pub stencil_read: Option<Stencil>,
-    //pub stencil_write: Option<Stencil>,
-    //pub stencil_ref: Option<Stencil>,
 }
 
 /// A description of all the settings that can be altered

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -239,3 +239,26 @@ pub enum State<T> {
     /// Dynamic state set through a command buffer.
     Dynamic,
 }
+
+impl<T> State<T> {
+    /// Returns the static value or a default.
+    pub fn static_or(self, default: T) -> T {
+        match self {
+            State::Static(v) => v,
+            State::Dynamic => default,
+        }
+    }
+
+    /// Whether the state is static.
+    pub fn is_static(self) -> bool {
+        match self {
+            State::Static(_) => true,
+            State::Dynamic => false,
+        }
+    }
+
+    /// Whether the state is dynamic.
+    pub fn is_dynamic(self) -> bool {
+        !self.is_static()
+    }
+}

--- a/src/hal/src/pso/output_merger.rs
+++ b/src/hal/src/pso/output_merger.rs
@@ -273,6 +273,20 @@ pub struct StencilFace {
     pub reference: State<StencilValue>,
 }
 
+impl Default for StencilFace {
+    fn default() -> StencilFace {
+        StencilFace {
+            fun: Comparison::Never,
+            mask_read: State::Static(!0),
+            mask_write: State::Static(!0),
+            op_fail: StencilOp::Keep,
+            op_depth_fail: StencilOp::Keep,
+            op_pass: StencilOp::Keep,
+            reference: State::Static(0),
+        }
+    }
+}
+
 /// Defines a stencil test. Stencil testing is an operation
 /// performed to cull fragments;
 /// the new fragment is tested against the value held in the


### PR DESCRIPTION
Implemented only on Vulkan and Metal for now.

As mentioned I think the Metal implementation could be improved a lot by reworking depth stencil descriptors/states to make it more obvious how these states are being passed around and bound.

Fails in Dota 2 apparently due to the same reason as #2121: `self.state.depth_stencil_desc` does not exist at the time we try to update the stencil masks, so the assertion fails – not sure if I can attempt a local fix here..

PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends: all
