### PR TITLE
[mtl] work around incompatible render passes

### DIFF
--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -7,7 +7,7 @@ use std::os::raw::{c_void, c_long};
 use std::sync::{Arc, Condvar, Mutex};
 
 use hal::{self, image, pso};
-use hal::format::{Aspects, FormatDesc};
+use hal::format::{Aspects, Format, FormatDesc};
 
 use cocoa::foundation::{NSUInteger};
 use metal;
@@ -115,6 +115,8 @@ pub struct GraphicsPipeline {
     /// while Metal does not. Thus, we register extra vertex buffer bindings with
     /// adjusted offsets to cover this use case.
     pub(crate) vertex_buffer_map: VertexBufferMap,
+    /// Tracked attachment formats for figuring (roughly) renderpass compatibility.
+    pub(crate) attachment_formats: Vec<Option<Format>>,
 }
 
 unsafe impl Send for GraphicsPipeline {}

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -67,7 +67,7 @@ impl AttachmentOps {
 /// An `Attachment` is a description of a resource provided to a render subpass.
 /// It includes things such as render targets, images that were produced from
 /// previous subpasses, etc.
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Attachment {
     /// Attachment format


### PR DESCRIPTION
Fixes #2121
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:

Interestingly, the scissors still need more work (in follow-ups) to handle rectangle size of 0 somehow.