### PR TITLE
[dx11] fix some dxgi calls not being present on windows 7

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1246,16 +1246,18 @@ impl hal::Device<Backend> for Device {
             unsafe { ComPtr::from_raw(swapchain) }
         };
 
-        let images = (0..config.image_count).map(|i| {
+        // TODO: for now we clamp to 1 buffer..
+        let images = (0..config.image_count.min(1)).map(|i| {
             let mut resource: *mut d3d11::ID3D11Resource = ptr::null_mut();
 
-            unsafe {
+            let hr = unsafe {
                 swapchain.GetBuffer(
                     i as _,
                     &d3d11::IID_ID3D11Resource,
                     &mut resource as *mut *mut _ as *mut *mut _
-                );
+                )
             };
+            assert_eq!(hr, winerror::S_OK);
 
             let mut desc: d3d11::D3D11_RENDER_TARGET_VIEW_DESC = unsafe { mem::zeroed() };
             desc.Format = format;

--- a/src/backend/dx11/src/dxgi.rs
+++ b/src/backend/dx11/src/dxgi.rs
@@ -105,15 +105,16 @@ fn create_dxgi_factory1(guid: &GUID) -> Result<ComPtr<dxgi::IDXGIFactory>, winer
 pub(crate) fn get_dxgi_factory() -> Result<(ComPtr<dxgi::IDXGIFactory>, DxgiVersion), winerror::HRESULT> {
     let mut factory: *mut IUnknown = ptr::null_mut();
 
-    if let Ok(factory) = create_dxgi_factory2(&dxgi1_5::IDXGIFactory5::uuidof()) {
+    // TODO: do we even need `create_dxgi_factory2`?
+    if let Ok(factory) = create_dxgi_factory1(&dxgi1_5::IDXGIFactory5::uuidof()) {
         return Ok((factory, DxgiVersion::Dxgi1_5));
     }
 
-    if let Ok(factory) = create_dxgi_factory2(&dxgi1_4::IDXGIFactory4::uuidof()) {
+    if let Ok(factory) = create_dxgi_factory1(&dxgi1_4::IDXGIFactory4::uuidof()) {
         return Ok((factory, DxgiVersion::Dxgi1_4));
     }
 
-    if let Ok(factory) = create_dxgi_factory2(&dxgi1_3::IDXGIFactory3::uuidof()) {
+    if let Ok(factory) = create_dxgi_factory1(&dxgi1_3::IDXGIFactory3::uuidof()) {
         return Ok((factory, DxgiVersion::Dxgi1_3));
     }
 


### PR DESCRIPTION
In particular the `CreateDXGIFactory2` was used to create the factory,
but it is not present on older dxgi versions. Other function calls
shouldn't be affected since the factory creation infers the dxgi version
and tip-toes around the newer functions.

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
