### PR TITLE
hal: Reorder stencil op values to match Vulkan

### DIFF
--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -245,22 +245,22 @@ pub struct BlendDesc {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[allow(missing_docs)]
 pub enum LogicOp {
-    Clear,
-    And,
-    AndReverse,
-    AndInverted,
-    Copy,
-    CopyInverted,
-    NoOp,
-    Xor,
-    Nor,
-    Or,
-    OrReverse,
-    OrInverted,
-    Equivalent,
-    Invert,
-    Nand,
-    Set,
+    Clear = 0,
+    And = 1,
+    AndReverse = 2,
+    Copy = 3,
+    AndInverted = 4,
+    NoOp = 5,
+    Xor = 6,
+    Or = 7,
+    Nor = 8,
+    Equivalent = 9,
+    Invert = 10,
+    OrReverse = 11,
+    CopyInverted = 12,
+    OrInverted = 13,
+    Nand = 14,
+    Set = 15,
 }
 
 ///

--- a/src/hal/src/pso/output_merger.rs
+++ b/src/hal/src/pso/output_merger.rs
@@ -10,23 +10,22 @@ use super::State;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Comparison {
     /// `false`
-    Never,
+    Never = 0,
     /// `x < y`
-    Less,
-    /// `x <= y`
-    LessEqual,
+    Less = 1,
     /// `x == y`
-    Equal,
-    /// `x >= y`
-    GreaterEqual,
+    Equal = 2,
+    /// `x <= y`
+    LessEqual = 3,
     /// `x > y`
-    Greater,
+    Greater = 4,
     /// `x != y`
-    NotEqual,
+    NotEqual = 5,
+    /// `x >= y`
+    GreaterEqual = 6,
     /// `true`
-    Always,
+    Always = 7,
 }
-
 
 bitflags!(
     /// Target output color mask.
@@ -62,25 +61,25 @@ impl Default for ColorMask {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Factor {
-    Zero,
-    One,
-    SrcColor,
-    OneMinusSrcColor,
-    DstColor,
-    OneMinusDstColor,
-    SrcAlpha,
-    OneMinusSrcAlpha,
-    DstAlpha,
-    OneMinusDstAlpha,
-    ConstColor,
-    OneMinusConstColor,
-    ConstAlpha,
-    OneMinusConstAlpha,
-    SrcAlphaSaturate,
-    Src1Color,
-    OneMinusSrc1Color,
-    Src1Alpha,
-    OneMinusSrc1Alpha,
+    Zero = 0,
+    One = 1,
+    SrcColor = 2,
+    OneMinusSrcColor = 3,
+    DstColor = 4,
+    OneMinusDstColor = 5,
+    SrcAlpha = 6,
+    OneMinusSrcAlpha = 7,
+    DstAlpha = 8,
+    OneMinusDstAlpha = 9,
+    ConstColor = 10,
+    OneMinusConstColor = 11,
+    ConstAlpha = 12,
+    OneMinusConstAlpha = 13,
+    SrcAlphaSaturate = 14,
+    Src1Color = 15,
+    OneMinusSrc1Color = 16,
+    Src1Alpha = 17,
+    OneMinusSrc1Alpha = 18,
 }
 
 /// Blending operations.
@@ -235,21 +234,21 @@ impl DepthTest {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum StencilOp {
     /// Keep the current value in the stencil buffer (no change).
-    Keep,
+    Keep = 0,
     /// Set the value in the stencil buffer to zero.
-    Zero,
+    Zero = 1,
     /// Set the stencil buffer value to `reference` from `StencilFace`.
-    Replace,
+    Replace = 2,
     /// Increment the stencil buffer value, clamping to its maximum value.
-    IncrementClamp,
-    /// Increment the stencil buffer value, wrapping around to 0 on overflow.
-    IncrementWrap,
+    IncrementClamp = 3,
     /// Decrement the stencil buffer value, clamping to its minimum value.
-    DecrementClamp,
-    /// Decrement the stencil buffer value, wrapping around to the maximum value on overflow.
-    DecrementWrap,
+    DecrementClamp = 4,
     /// Bitwise invert the current value in the stencil buffer.
-    Invert,
+    Invert = 5,
+    /// Increment the stencil buffer value, wrapping around to 0 on overflow.
+    IncrementWrap = 6,
+    /// Decrement the stencil buffer value, wrapping around to the maximum value on overflow.
+    DecrementWrap = 7,
 }
 
 /// Complete stencil state for a given side of a face.


### PR DESCRIPTION
- Reorder `StencilOp`, `LogicOp`, and `Comparison` to match Vulkan ordering and values ([`VkStencilOp`](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkStencilOp.html), [`VkLogicOp`](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkLogicOp.html), [`VkCompareOp`](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCompareOp.html)).
- Add explicit values to (blend) `Factor` to align with Vulkan ([`VkBlendFactor`](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBlendFactor.html)).

This is really trivial but could be a tiny opportunity to skip mapping for portability, so I don't see a reason to avoid aligning these.

