### PR TITLE
mtl: Fix depth stencil issues

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2133,7 +2133,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             _ => (value, value),
         };
 
-        let com = self.set_stencil_mask_values(Some((front, back)), None, None);
+        let com = self.set_stencil_mask_values(None, Some((front, back)), None);
         self.inner
             .borrow_mut()
             .sink()

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1542,46 +1542,62 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         descriptor.set_render_target_array_length(num_layers);
                     };
 
-                    if sub.aspects.contains(Aspects::COLOR) {
+                    let clear_color_attachment = sub.aspects.contains(Aspects::COLOR);
+                    if clear_color_attachment || image.format_desc.aspects.contains(Aspects::COLOR) {
                         let attachment = descriptor
                             .color_attachments()
                             .object_at(0)
                             .unwrap();
                         attachment.set_texture(Some(texture));
                         attachment.set_level(level as _);
+                        attachment.set_store_action(metal::MTLStoreAction::Store);
                         if !CLEAR_IMAGE_ARRAY {
                             attachment.set_slice(layer as _);
                         }
-                        attachment.set_load_action(metal::MTLLoadAction::Clear);
-                        attachment.set_store_action(metal::MTLStoreAction::Store);
-                        attachment.set_clear_color(clear_color.clone());
+                        if clear_color_attachment {
+                            attachment.set_load_action(metal::MTLLoadAction::Clear);
+                            attachment.set_clear_color(clear_color.clone());
+                        } else {
+                            attachment.set_load_action(metal::MTLLoadAction::Load);
+                        }
                     }
 
-                    if sub.aspects.contains(Aspects::DEPTH) {
+                    let clear_depth_attachment = sub.aspects.contains(Aspects::DEPTH);
+                    if clear_depth_attachment || image.format_desc.aspects.contains(Aspects::DEPTH) {
                         let attachment = descriptor
                             .depth_attachment()
                             .unwrap();
                         attachment.set_texture(Some(texture));
                         attachment.set_level(level as _);
+                        attachment.set_store_action(metal::MTLStoreAction::Store);
                         if !CLEAR_IMAGE_ARRAY {
                             attachment.set_slice(layer as _);
                         }
-                        attachment.set_load_action(metal::MTLLoadAction::Clear);
-                        attachment.set_store_action(metal::MTLStoreAction::Store);
-                        attachment.set_clear_depth(depth_stencil.depth as _);
+                        if clear_depth_attachment {
+                            attachment.set_load_action(metal::MTLLoadAction::Clear);
+                            attachment.set_clear_depth(depth_stencil.depth as _);
+                        } else {
+                            attachment.set_load_action(metal::MTLLoadAction::Load);
+                        }
                     }
-                    if sub.aspects.contains(Aspects::STENCIL) {
+
+                    let clear_stencil_attachment = sub.aspects.contains(Aspects::STENCIL);
+                    if clear_stencil_attachment || image.format_desc.aspects.contains(Aspects::STENCIL) {
                         let attachment = descriptor
                             .stencil_attachment()
                             .unwrap();
                         attachment.set_texture(Some(texture));
                         attachment.set_level(level as _);
+                        attachment.set_store_action(metal::MTLStoreAction::Store);
                         if !CLEAR_IMAGE_ARRAY {
                             attachment.set_slice(layer as _);
                         }
-                        attachment.set_load_action(metal::MTLLoadAction::Clear);
-                        attachment.set_store_action(metal::MTLStoreAction::Store);
-                        attachment.set_clear_stencil(depth_stencil.stencil);
+                        if clear_stencil_attachment {
+                            attachment.set_load_action(metal::MTLLoadAction::Clear);
+                            attachment.set_clear_stencil(depth_stencil.stencil);
+                        } else {
+                            attachment.set_load_action(metal::MTLLoadAction::Load);
+                        }
                     }
 
                     sink.as_mut()


### PR DESCRIPTION
Fixes #2134

PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends: Metal

Probably easier to read these commits one at a time because they all fix separate issues:

- Always set load/store actions for attachments which aren't being cleared. We need this to preserve values in shared textures, i.e. between two separate depth and stencil attachments with the same backing texture.
- During the changes in #2129, we stopped mapping load/store actions during framebuffer creation. As a result we always used "don't care" which led to unexpected images at the beginning of render passes. For example, if image clears occurred prior to beginning the render pass, we had no guarantee that the image was still cleared at the beginning of the render pass.
- The stencil write mask updates passed the wrong argument, so they were misinterpreted as read mask updates.