### PR TITLE
CAMetalLayer presentation

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -463,7 +463,7 @@ fn main() {
 
         device.reset_fence(&frame_fence);
         command_pool.reset();
-        let frame: hal::Frame = {
+        let frame: hal::FrameImage = {
             match swap_chain.acquire_frame(FrameSync::Semaphore(&mut frame_semaphore)) {
                 Ok(i) => i,
                 Err(_) => {
@@ -507,7 +507,7 @@ fn main() {
         device.wait_for_fence(&frame_fence, !0);
 
         // present frame
-        if let Err(_) = swap_chain.present(&mut queue_group.queues[0], &[]) {
+        if let Err(_) = swap_chain.present(&mut queue_group.queues[0], frame, &[]) {
             recreate_swapchain = true;
         }
     }

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -486,7 +486,7 @@ fn main() {
             {
                 let mut encoder = cmd_buffer.begin_render_pass_inline(
                     &render_pass,
-                    &framebuffers[frame.id()],
+                    &framebuffers[frame as usize],
                     viewport.rect,
                     &[command::ClearValue::Color(command::ClearColor::Float([
                         0.8, 0.8, 0.8, 1.0,

--- a/examples/render/quad_render/main.rs
+++ b/examples/render/quad_render/main.rs
@@ -259,11 +259,11 @@ fn main() {
         {
             let data = pipe::Data {
                 desc: (&desc, &desc_data),
-                color: &frame_rtvs[frame.id()],
+                color: &frame_rtvs[frame as usize],
                 vertices: &vertex_buffer,
                 viewports: &[viewport.clone()],
                 scissors: &[scissor],
-                framebuffer: &framebuffers[frame.id()],
+                framebuffer: &framebuffers[frame as usize],
             };
             encoder.draw(0..6, &pipeline, data);
         }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -24,7 +24,7 @@ mod pool;
 mod root_constants;
 mod window;
 
-use hal::{error, format as f, image, memory, Features, Limits, QueueType};
+use hal::{error, format as f, image, memory, Features, FrameImage, Limits, QueueType};
 use hal::queue::{QueueFamily as HalQueueFamily, QueueFamilyId, Queues};
 use descriptors_cpu::DescriptorCpuPool;
 
@@ -34,7 +34,7 @@ use winapi::um::{d3d12, d3d12sdklayers, d3dcommon, handleapi, synchapi, winbase,
 use wio::com::ComPtr;
 
 use std::{mem, ptr};
-use std::borrow::{Borrow, BorrowMut};
+use std::borrow::Borrow;
 use std::os::windows::ffi::OsStringExt;
 use std::ffi::OsString;
 use std::sync::{Arc, Mutex};
@@ -465,15 +465,15 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
         }
     }
 
-    fn present<IS, IW>(&mut self, swapchains: IS, _wait_semaphores: IW) -> Result<(), ()>
+    fn present<IS, S, IW>(&mut self, swapchains: IS, _wait_semaphores: IW) -> Result<(), ()>
     where
-        IS: IntoIterator,
-        IS::Item: BorrowMut<window::Swapchain>,
+        IS: IntoIterator<Item = (S, FrameImage)>,
+        S: Borrow<window::Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<native::Semaphore>,
     {
         // TODO: semaphores
-        for swapchain in swapchains {
+        for (swapchain, _) in swapchains {
             unsafe { swapchain.borrow().inner.Present(1, 0); }
         }
 

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -105,7 +105,7 @@ pub struct Swapchain {
 }
 
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_frame(&mut self, _sync: hal::FrameSync<Backend>) -> Result<hal::Frame, ()> {
+    fn acquire_frame(&mut self, _sync: hal::FrameSync<Backend>) -> Result<hal::FrameImage, ()> {
         // TODO: sync
 
         if false {
@@ -118,8 +118,7 @@ impl hal::Swapchain<Backend> for Swapchain {
         }
 
         // TODO:
-        let index = unsafe { self.inner.GetCurrentBackBufferIndex() };
-        Ok(hal::Frame::new(index as usize))
+        Ok(unsafe { self.inner.GetCurrentBackBufferIndex() })
     }
 }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -3,7 +3,7 @@
 
 extern crate gfx_hal as hal;
 
-use std::borrow::{Borrow, BorrowMut};
+use std::borrow::Borrow;
 use std::ops::Range;
 use hal::{
     buffer, command, device, error, format, image, mapping,
@@ -96,10 +96,10 @@ impl queue::RawCommandQueue<Backend> for RawCommandQueue {
         unimplemented!()
     }
 
-    fn present<IS, IW>(&mut self, _: IS, _: IW) -> Result<(), ()>
+    fn present<IS, S, IW>(&mut self, _: IS, _: IW) -> Result<(), ()>
     where
-        IS: IntoIterator,
-        IS::Item: BorrowMut<Swapchain>,
+        IS: IntoIterator<Item = (S, hal::FrameImage)>,
+        S: Borrow<Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<()>,
     {
@@ -785,7 +785,7 @@ impl hal::Surface<Backend> for Surface {
 /// Dummy swapchain.
 pub struct Swapchain;
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_frame(&mut self, _: hal::FrameSync<Backend>) -> Result<hal::Frame, ()> {
+    fn acquire_frame(&mut self, _: hal::FrameSync<Backend>) -> Result<hal::FrameImage, ()> {
         unimplemented!()
     }
 }

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1,5 +1,5 @@
 use std::{mem, ptr, slice};
-use std::borrow::{Borrow, BorrowMut};
+use std::borrow::Borrow;
 use Starc;
 
 use hal;
@@ -707,17 +707,17 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
     }
 
     #[cfg(feature = "glutin")]
-    fn present<IS, IW>(&mut self, swapchains: IS, _wait_semaphores: IW) -> Result<(), ()>
+    fn present<IS, S, IW>(&mut self, swapchains: IS, _wait_semaphores: IW) -> Result<(), ()>
     where
-        IS: IntoIterator,
-        IS::Item: BorrowMut<window::glutin::Swapchain>,
+        IS: IntoIterator<Item = (S, hal::FrameImage)>,
+        S: Borrow<window::glutin::Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<native::Semaphore>,
     {
         use glutin::GlContext;
 
         for swapchain in swapchains {
-            swapchain
+            swapchain.0
                 .borrow()
                 .window
                 .swap_buffers()

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -65,9 +65,9 @@ pub struct Swapchain {
 }
 
 impl hal::Swapchain<B> for Swapchain {
-    fn acquire_frame(&mut self, _sync: hal::FrameSync<B>) -> Result<hal::Frame, ()> {
+    fn acquire_frame(&mut self, _sync: hal::FrameSync<B>) -> Result<hal::FrameImage, ()> {
         // TODO: sync
-        Ok(hal::Frame::new(0))
+        Ok(0)
     }
 }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -44,6 +44,11 @@ const ARGUMENT_BUFFER_SUPPORT: &[MTLFeatureSet] = &[
     MTLFeatureSet::macOS_GPUFamily1_v3,
 ];
 
+const BASE_INSTANCE_SUPPORT: &[MTLFeatureSet] = &[
+    MTLFeatureSet::iOS_GPUFamily1_v4,
+    MTLFeatureSet::iOS_GPUFamily3_v1,
+];
+
 const PUSH_CONSTANTS_DESC_SET: u32 = !0;
 const PUSH_CONSTANTS_DESC_BINDING: u32 = 0;
 
@@ -261,6 +266,7 @@ impl PhysicalDevice {
                 resource_heaps: Self::supports_any(device, RESOURCE_HEAP_SUPPORT),
                 argument_buffers: Self::supports_any(device, ARGUMENT_BUFFER_SUPPORT) && false, //TODO
                 shared_textures: !Self::is_mac(device),
+                base_instance: Self::supports_any(device, BASE_INSTANCE_SUPPORT),
                 format_depth24_stencil8: device.d24_s8_supported(),
                 format_depth32_stencil8: true, //TODO: crashing the Metal validation layer upon copying from buffer
                 format_min_srgb_channels: if Self::is_mac(&*device) {4} else {1},

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -127,7 +127,8 @@ impl Instance {
             }
 
             msg_send![view, setWantsLayer: YES];
-            let render_layer: *mut Object = msg_send![Class::get("CALayer").unwrap(), new]; // Returns retained
+            let class = Class::get("CAMetalLayer").unwrap();
+            let render_layer: *mut Object = msg_send![class, new]; // Returns retained
             let view_size: CGRect = msg_send![view, bounds];
             msg_send![render_layer, setFrame: view_size];
             let view_layer: *mut Object = msg_send![view, layer];

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -128,9 +128,6 @@ impl Instance {
             let class = Class::get("CAMetalLayer").unwrap();
             let render_layer: *mut Object = msg_send![class, new];
             msg_send![view, setLayer: render_layer];
-            //let render_layer: *mut Object = msg_send![view, layer];
-            //assert!(msg_send![render_layer, isKindOfClass: class]);
-            //msg_send![render_layer, retain];
             let view_size: CGRect = msg_send![view, bounds];
             msg_send![render_layer, setFrame: view_size];
             msg_send![view, retain];

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -40,8 +40,7 @@ use std::os::raw::c_void;
 
 use hal::queue::QueueFamilyId;
 
-use objc::runtime::{Object, Class};
-use cocoa::base::YES;
+use objc::runtime::{Class, Object};
 use cocoa::foundation::NSAutoreleasePool;
 use core_graphics::geometry::CGRect;
 
@@ -126,13 +125,14 @@ impl Instance {
                 panic!("window does not have a valid contentView");
             }
 
-            msg_send![view, setWantsLayer: YES];
             let class = Class::get("CAMetalLayer").unwrap();
-            let render_layer: *mut Object = msg_send![class, new]; // Returns retained
+            let render_layer: *mut Object = msg_send![class, new];
+            msg_send![view, setLayer: render_layer];
+            //let render_layer: *mut Object = msg_send![view, layer];
+            //assert!(msg_send![render_layer, isKindOfClass: class]);
+            //msg_send![render_layer, retain];
             let view_size: CGRect = msg_send![view, bounds];
             msg_send![render_layer, setFrame: view_size];
-            let view_layer: *mut Object = msg_send![view, layer];
-            msg_send![view_layer, addSublayer: render_layer];
             msg_send![view, retain];
 
             window::SurfaceInner {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -204,6 +204,7 @@ struct PrivateCapabilities {
     resource_heaps: bool,
     argument_buffers: bool,
     shared_textures: bool,
+    base_instance: bool,
     format_depth24_stencil8: bool,
     format_depth32_stencil8: bool,
     format_min_srgb_channels: u8,

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -1,5 +1,5 @@
 use command::{IndexBuffer};
-use native::{ImageRoot, RasterizerState};
+use native::{Frame, ImageRoot, RasterizerState};
 
 use hal;
 use metal;
@@ -35,7 +35,7 @@ pub enum RenderCommand {
     BindTexture {
         stage: hal::pso::Stage,
         index: usize,
-        texture: Option<metal::Texture>,
+        texture: Option<ImageRoot>,
     },
     BindSampler {
         stage: hal::pso::Stage,
@@ -79,18 +79,18 @@ pub enum BlitCommand {
         region: hal::command::BufferCopy,
     },
     CopyImage {
-        src: metal::Texture,
-        dst: metal::Texture,
+        src: ImageRoot,
+        dst: ImageRoot,
         region: hal::command::ImageCopy,
     },
     CopyBufferToImage {
         src: metal::Buffer,
-        dst: metal::Texture,
+        dst: ImageRoot,
         dst_desc: hal::format::FormatDesc,
         region: hal::command::BufferImageCopy,
     },
     CopyImageToBuffer {
-        src: metal::Texture,
+        src: ImageRoot,
         src_desc: hal::format::FormatDesc,
         dst: metal::Buffer,
         region: hal::command::BufferImageCopy,
@@ -110,7 +110,7 @@ pub enum ComputeCommand {
     },
     BindTexture {
         index: usize,
-        texture: Option<metal::Texture>,
+        texture: Option<ImageRoot>,
     },
     BindSampler {
         index: usize,
@@ -130,7 +130,11 @@ pub enum ComputeCommand {
 
 #[derive(Debug)]
 pub enum Pass {
-    Render(metal::RenderPassDescriptor, Vec<RenderCommand>),
+    Render {
+        desc: metal::RenderPassDescriptor,
+        frames: Vec<(usize, Frame)>,
+        commands: Vec<RenderCommand>,
+    },
     Blit(Vec<BlitCommand>),
     Compute(Vec<ComputeCommand>),
 }

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -1,5 +1,5 @@
 use command::{IndexBuffer};
-use native::{RasterizerState};
+use native::{ImageRoot, RasterizerState};
 
 use hal;
 use metal;

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -84,10 +84,6 @@ unsafe impl Send for Swapchain {}
 unsafe impl Sync for Swapchain {}
 
 impl Swapchain {
-    pub(crate) fn matches(&self, other: &Arc<RwLock<SwapchainInner>>) -> bool {
-        Arc::ptr_eq(&self.inner, other)
-    }
-
     pub(crate) fn present(&self, index: hal::FrameImage) {
         let (drawable, _) = self.inner
             .write()
@@ -258,9 +254,6 @@ impl hal::Swapchain<Backend> for Swapchain {
             (drawable, texture)
         });
 
-            let frame = self.frame_index % self.io_surfaces.len();
-            self.frame_index += 1;
-            Ok(frame as _)
-        }
+        Ok(index as _)
     }
 }

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -1,26 +1,24 @@
-use {Backend, QueueFamily};
+use {AutoreleasePool, Backend, QueueFamily};
 use internal::Channel;
 use native;
 use device::{Device, PhysicalDevice};
 
-use std::mem;
-use std::sync::{Arc, Mutex};
+use std::{fmt, ops};
+use std::sync::{Arc, Mutex, RwLock};
 
 use hal::{self, format, image};
 use hal::{Backbuffer, SwapchainConfig};
 use hal::window::Extent2D;
 
-use metal::{self, MTLPixelFormat, MTLTextureUsage};
+use metal;
 use objc::runtime::{Object};
-use core_foundation::base::TCFType;
-use core_foundation::string::CFString;
-use core_foundation::dictionary::CFDictionary;
-use core_foundation::number::CFNumber;
 use core_graphics::base::CGFloat;
 use core_graphics::geometry::CGRect;
 use cocoa::foundation::{NSRect};
-use io_surface::{self, IOSurface};
 
+
+pub type CAMetalLayer = *mut Object;
+pub type CADrawable = *mut Object;
 
 pub struct Surface {
     pub(crate) inner: Arc<SurfaceInner>,
@@ -29,7 +27,7 @@ pub struct Surface {
 
 pub(crate) struct SurfaceInner {
     pub(crate) nsview: *mut Object,
-    pub(crate) render_layer: Mutex<*mut Object>,
+    pub(crate) render_layer: Mutex<CAMetalLayer>,
 }
 
 unsafe impl Send for SurfaceInner {}
@@ -41,27 +39,71 @@ impl Drop for SurfaceInner {
     }
 }
 
+pub struct SwapchainInner {
+    frames: Vec<Option<(CADrawable, metal::Texture)>>,
+}
+
+impl ops::Index<hal::FrameImage> for SwapchainInner {
+    type Output = metal::TextureRef;
+    fn index(&self, index: hal::FrameImage) -> &Self::Output {
+        self.frames[index as usize]
+            .as_ref()
+            .map(|&(_, ref tex)| tex)
+            .expect("Frame texture is not resident!")
+    }
+}
+
+unsafe impl Send for SwapchainInner {}
+unsafe impl Sync for SwapchainInner {}
+
+impl fmt::Debug for SwapchainInner {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Swapchain with {} image", self.frames.len())
+    }
+}
+
+impl Drop for SwapchainInner {
+    fn drop(&mut self) {
+        for maybe in self.frames.drain(..) {
+            if let Some((drawable, _)) = maybe {
+                unsafe {
+                    msg_send![drawable, release];
+                }
+            }
+        }
+    }
+}
+
 pub struct Swapchain {
-     surface: Arc<SurfaceInner>,
+    inner: Arc<RwLock<SwapchainInner>>,
+    surface: Arc<SurfaceInner>,
     _size_pixels: (u64, u64),
-    io_surfaces: Vec<IOSurface>,
-    frame_index: usize,
-    present_index: usize,
 }
 
 unsafe impl Send for Swapchain {}
 unsafe impl Sync for Swapchain {}
 
 impl Swapchain {
-    pub(crate) fn present(&mut self) -> (&SurfaceInner, &mut IOSurface, usize) {
-        let id = self.present_index;
-        self.present_index = (id + 1) % self.io_surfaces.len();
-        (&*self.surface, &mut self.io_surfaces[id], id)
+    pub(crate) fn matches(&self, other: &Arc<RwLock<SwapchainInner>>) -> bool {
+        Arc::ptr_eq(&self.inner, other)
+    }
+
+    pub(crate) fn present(&self, index: hal::FrameImage) {
+        let render_layer_borrow = self.surface.render_layer.lock().unwrap();
+        let (drawable, _) = self.inner
+            .write()
+            .unwrap()
+            .frames[index as usize]
+            .take()
+            .expect("Frame is not ready to present!");
+        unsafe {
+            let render_layer = *render_layer_borrow;
+            msg_send![render_layer, presentDrawable:drawable];
+            msg_send![drawable, release];
+        }
     }
 }
 
-#[allow(bad_style)]
-const kCVPixelFormatType_32RGBA: u32 = (b'R' as u32) << 24 | (b'G' as u32) << 16 | (b'B' as u32) << 8 | b'A' as u32;
 
 impl hal::Surface<Backend> for Surface {
     fn kind(&self) -> image::Kind {
@@ -105,20 +147,26 @@ impl Device {
         surface: &mut Surface,
         config: SwapchainConfig,
     ) -> (Swapchain, Backbuffer<Backend>) {
-        let (mtl_format, cv_format) = match config.color_format {
-            format::Format::Rgba8Srgb => (MTLPixelFormat::RGBA8Unorm_sRGB, kCVPixelFormatType_32RGBA),
-            _ => panic!("unsupported backbuffer format"), // TODO: more formats
-        };
+        let mtl_format = self.private_caps
+            .map_format(config.color_format)
+            .expect("unsupported backbuffer format");
 
         let render_layer_borrow = surface.inner.render_layer.lock().unwrap();
         let render_layer = *render_layer_borrow;
         let nsview = surface.inner.nsview;
-        let pixel_size = config.color_format.base_format().0.desc().bits as i32 / 8;
+        let format_desc = config.color_format.surface_desc();
+        let framebuffer_only = config.image_usage == image::Usage::COLOR_ATTACHMENT;
+        let device = self.shared.device.lock().unwrap();
 
-        unsafe {
+        let (view_size, scale_factor) = unsafe {
+            msg_send![render_layer, setDevice: &device];
+            msg_send![render_layer, setPixelFormat: mtl_format];
+            msg_send![render_layer, setFramebufferOnly: framebuffer_only];
+
             // Update render layer size
             let view_points_size: CGRect = msg_send![nsview, bounds];
             msg_send![render_layer, setBounds: view_points_size];
+
             let view_window: *mut Object = msg_send![nsview, window];
             if view_window.is_null() {
                 panic!("surface is not attached to a window");
@@ -129,68 +177,48 @@ impl Device {
                 1.0
             };
             msg_send![render_layer, setContentsScale: scale_factor];
-
             info!("view points size {:?} scale factor {:?}", view_points_size, scale_factor);
-            let pixel_width = (view_points_size.size.width * scale_factor) as u64;
-            let pixel_height = (view_points_size.size.height * scale_factor) as u64;
+            (view_points_size.size, scale_factor)
+        };
 
-            info!("allocating {} IOSurface backbuffers of size {}x{} with pixel format 0x{:x}", config.image_count, pixel_width, pixel_height, cv_format);
-            // Create swap chain surfaces
-            let io_surfaces: Vec<_> = (0..config.image_count).map(|_| {
-                let dict = CFDictionary::from_CFType_pairs(&[
-                    (CFString::wrap_under_get_rule(io_surface::kIOSurfaceWidth), CFNumber::from(pixel_width as i32)),
-                    (CFString::wrap_under_get_rule(io_surface::kIOSurfaceHeight), CFNumber::from(pixel_height as i32)),
-                    (CFString::wrap_under_get_rule(io_surface::kIOSurfaceBytesPerRow), CFNumber::from(pixel_width as i32 * pixel_size)),
-                    (CFString::wrap_under_get_rule(io_surface::kIOSurfaceBytesPerElement), CFNumber::from(pixel_size)),
-                    (CFString::wrap_under_get_rule(io_surface::kIOSurfacePixelFormat), CFNumber::from(cv_format as i32)),
-                ]);
-                //Note: the transmute is totally bonkers here
-                io_surface::new(mem::transmute(&dict))
-            }).collect();
+        let pixel_width = (view_size.width * scale_factor) as u64;
+        let pixel_height = (view_size.height * scale_factor) as u64;
 
-            let backbuffer_descriptor = metal::TextureDescriptor::new();
-            backbuffer_descriptor.set_pixel_format(mtl_format);
-            backbuffer_descriptor.set_width(pixel_width);
-            backbuffer_descriptor.set_height(pixel_height);
-            backbuffer_descriptor.set_usage(MTLTextureUsage::RenderTarget);
+        let inner = SwapchainInner {
+            frames: (0 .. config.image_count).map(|_| None).collect(),
+        };
 
-            let device = self.shared.device.lock().unwrap();
-            let images = io_surfaces.iter().map(|surface| {
-                let mapped_texture: metal::Texture = msg_send![device.as_ref(),
-                    newTextureWithDescriptor: &*backbuffer_descriptor
-                    iosurface: surface.obj
-                    plane: 0
-                ];
-                native::Image {
-                    raw: mapped_texture,
-                    extent: image::Extent {
-                        width: pixel_width as _,
-                        height: pixel_height as _,
-                        depth: 1,
-                    },
-                    num_layers: None,
-                    format_desc: config.color_format.surface_desc(),
-                    shader_channel: Channel::Float,
-                    mtl_format,
-                    mtl_type: metal::MTLTextureType::D2,
-                }
-            }).collect();
+        let swapchain = Swapchain {
+            inner: Arc::new(RwLock::new(inner)),
+            surface: surface.inner.clone(),
+            _size_pixels: (pixel_width, pixel_height),
+        };
 
-            let swapchain = Swapchain {
-                surface: surface.inner.clone(),
-                _size_pixels: (pixel_width, pixel_height),
-                io_surfaces,
-                frame_index: 0,
-                present_index: 0,
-            };
+        let images = (0 .. config.image_count)
+            .map(|index| native::Image {
+                root: native::ImageRoot::Frame(native::Frame {
+                    swapchain: swapchain.inner.clone(),
+                    index,
+                }),
+                extent: image::Extent {
+                    width: pixel_width as _,
+                    height: pixel_height as _,
+                    depth: 1,
+                },
+                num_layers: None,
+                format_desc,
+                shader_channel: Channel::Float,
+                mtl_format,
+                mtl_type: metal::MTLTextureType::D2,
+            })
+            .collect();
 
-            (swapchain, Backbuffer::Images(images))
-        }
+        (swapchain, Backbuffer::Images(images))
     }
 }
 
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_frame(&mut self, sync: hal::FrameSync<Backend>) -> Result<hal::Frame, ()> {
+    fn acquire_frame(&mut self, sync: hal::FrameSync<Backend>) -> Result<hal::FrameImage, ()> {
         unsafe {
             match sync {
                 hal::FrameSync::Semaphore(semaphore) => {
@@ -199,11 +227,28 @@ impl hal::Swapchain<Backend> for Swapchain {
                 },
                 hal::FrameSync::Fence(_fence) => unimplemented!(),
             }
+        }
 
-            let frame = hal::Frame::new(self.frame_index % self.io_surfaces.len());
+        let layer = self.surface.render_layer.lock().unwrap();
+        let mut inner = self.inner.write().unwrap();
+
+        let index = inner.frames
+            .iter_mut()
+            .position(|d| d.is_some())
+            .expect("No frames available to acquire!");
+
+        let _ap = AutoreleasePool::new(); // for the drawable
+        inner.frames[index] = Some(unsafe {
+            let drawable: *mut Object = msg_send![*layer, nextDrawable];
+            let texture: metal::Texture = msg_send![drawable, getTexture];
+            msg_send![drawable, retain];
+            msg_send![texture, retain];
+            (drawable, texture)
+        });
+
+            let frame = self.frame_index % self.io_surfaces.len();
             self.frame_index += 1;
-            Ok(frame)
+            Ok(frame as _)
         }
     }
 }
-

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1505,7 +1505,6 @@ impl d::Device<B> for Device {
         let swapchain = w::Swapchain {
             raw: swapchain_raw,
             functor,
-            frame_queue: VecDeque::new(),
         };
 
         let images = backbuffer_images

--- a/src/hal/src/backend.rs
+++ b/src/hal/src/backend.rs
@@ -2,7 +2,6 @@
 
 use Backend;
 use queue::{QueueFamily, QueueFamilyId, Queues};
-use window::Frame;
 
 use std::collections::HashMap;
 
@@ -33,13 +32,6 @@ impl<B: Backend> RawQueueGroup<B> {
     pub fn add_queue(&mut self, queue: B::CommandQueue) {
         assert!(self.queues.len() < self.family.max_queues());
         self.queues.push(queue);
-    }
-}
-
-impl Frame {
-    /// Create a new frame.
-    pub fn new(id: usize) -> Self {
-        Frame(id)
     }
 }
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -35,7 +35,7 @@ pub use self::queue::{
     Capability, Supports, General, Graphics, Compute, Transfer,
 };
 pub use self::window::{
-    Backbuffer, Frame, FrameSync, Surface, SurfaceCapabilities, Swapchain, SwapchainConfig,
+    Backbuffer, FrameImage, FrameSync, Surface, SurfaceCapabilities, Swapchain, SwapchainConfig,
 };
 
 pub mod adapter;

--- a/src/hal/src/pso/output_merger.rs
+++ b/src/hal/src/pso/output_merger.rs
@@ -230,6 +230,7 @@ impl DepthTest {
 }
 
 /// The operation to use for stencil masking.
+#[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum StencilOp {

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -11,10 +11,11 @@ pub mod family;
 pub mod submission;
 
 use std::any::Any;
-use std::borrow::{Borrow, BorrowMut};
+use std::borrow::Borrow;
 use std::marker::PhantomData;
 
 use error::HostExecutionError;
+use window::FrameImage;
 use Backend;
 
 pub use self::capability::{
@@ -61,11 +62,11 @@ pub trait RawCommandQueue<B: Backend>: Any + Send + Sync {
     /// list more than once.
     ///
     /// Unsafe for the same reasons as `submit_raw()`.
-    fn present<IS, IW>(&mut self, swapchains: IS, wait_semaphores: IW) -> Result<(), ()>
+    fn present<IS, S, IW>(&mut self, swapchains: IS, wait_semaphores: IW) -> Result<(), ()>
     where
         Self: Sized,
-        IS: IntoIterator,
-        IS::Item: BorrowMut<B::Swapchain>,
+        IS: IntoIterator<Item = (S, FrameImage)>,
+        S: Borrow<B::Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<B::Semaphore>;
 
@@ -118,10 +119,10 @@ impl<B: Backend, C> CommandQueue<B, C> {
     /// Presents the result of the queue to the given swapchains, after waiting on all the
     /// semaphores given in `wait_semaphores`. A given swapchain must not appear in this
     /// list more than once.
-    pub fn present<IS, IW>(&mut self, swapchains: IS, wait_semaphores: IW) -> Result<(), ()>
+    pub fn present<IS, S, IW>(&mut self, swapchains: IS, wait_semaphores: IW) -> Result<(), ()>
     where
-        IS: IntoIterator,
-        IS::Item: BorrowMut<B::Swapchain>,
+        IS: IntoIterator<Item = (S, FrameImage)>,
+        S: Borrow<B::Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<B::Semaphore>
     {

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -89,7 +89,7 @@ pub struct SurfaceCapabilities {
     ///
     /// - `image_count.start` must be at least 1.
     /// - `image_count.end` must be larger of equal to `image_count.start`.
-    pub image_count: Range<u32>,
+    pub image_count: Range<FrameImage>,
 
     /// Current extent of the surface.
     ///
@@ -104,7 +104,7 @@ pub struct SurfaceCapabilities {
     /// Maximum number of layers supported for presentable images.
     ///
     /// Must be at least 1.
-    pub max_image_layers: u32,
+    pub max_image_layers: image::Layer,
 }
 
 /// A `Surface` abstracts the surface of a native window, which will be presented
@@ -132,31 +132,13 @@ pub trait Surface<B: Backend>: Any + Send + Sync {
     fn capabilities_and_formats(&self, physical_device: &B::PhysicalDevice) -> (SurfaceCapabilities, Option<Vec<Format>>);
 }
 
-/// Handle to a backbuffer of the swapchain.
+/// Index of an image in the swapchain.
 ///
 /// The swapchain is a series of one or more images, usually
 /// with one being drawn on while the other is displayed by
 /// the GPU (aka double-buffering). A `Frame` refers to a
 /// particular image in the swapchain.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Frame(pub(crate) usize);
-
-impl Frame {
-    /// Retrieve frame id.
-    ///
-    /// The can be used to access the currently used backbuffer image
-    /// in `Backbuffer::Images`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    ///
-    /// ```
-    pub fn id(&self) -> usize {
-        self.0
-    }
-}
+pub type FrameImage = u32;
 
 /// Synchronization primitives which will be signalled once a frame got retrieved.
 ///
@@ -199,7 +181,7 @@ pub struct SwapchainConfig {
     /// Depth stencil format of the backbuffer images (optional).
     pub depth_stencil_format: Option<Format>,
     /// Number of images in the swapchain.
-    pub image_count: u32,
+    pub image_count: FrameImage,
     /// Image usage of the backbuffer images.
     pub image_usage: image::Usage,
 }
@@ -304,7 +286,7 @@ pub trait Swapchain<B: Backend>: Any + Send + Sync {
     /// ```no_run
     ///
     /// ```
-    fn acquire_frame(&mut self, sync: FrameSync<B>) -> Result<Frame, ()>;
+    fn acquire_frame(&mut self, sync: FrameSync<B>) -> Result<FrameImage, ()>;
 
     /// Present one acquired frame in FIFO order.
     ///

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -103,7 +103,7 @@ pub mod traits {
 
 // public re-exports
 pub use hal::format;
-pub use hal::{Backend, Frame, Primitive};
+pub use hal::{Backend, FrameImage, Primitive};
 pub use hal::queue::{Supports, Transfer, General, Graphics};
 pub use hal::{VertexCount, InstanceCount};
 // pub use hal::{ShaderSet, VertexShader, HullShader, DomainShader, GeometryShader, PixelShader};
@@ -293,7 +293,7 @@ impl<B: Backend, C> Context<B, C>
         Ok((context, backbuffers))
     }
 
-    pub fn acquire_frame(&mut self) -> Frame {
+    pub fn acquire_frame(&mut self) -> FrameImage {
         assert!(self.frame_acquired.is_none());
 
         let mut bundle = self.frame_bundles.pop_front()
@@ -351,6 +351,7 @@ impl<B: Backend, C> Context<B, C>
 
         self.swapchain.present(
             &mut self.queue.group.queues[0],
+            0,
             Some(&bundle.signal_semaphore),
         ).expect("Failed to present.");
 


### PR DESCRIPTION
Fixes/rewrites the presentation mechanics in Metal, improves the API side elsewhere.
Old swapchain was represented by `CALayer` with custom created `IOSurface` frames that we attempted to present. This is nowhere near the recommended presentation path, which is implemented here. Honestly, I don't think the old path ever worked properly:
  - our example (`quad`) doesn't do any animation, and waits after each frame
  - LunarG samples weren't really tested on MacOS
  - gfx_ocean (as well as Dota) showed presentation lags/artifacts IIRC

The new logic creates a `CAMetalLayer`, set's up its format and parameters, and acquires drawables with `nextDrawable`. There is one but important complication with this method: frame images are temporary. Thus, while we can get `MTLTexture` from a drawable, it's not guaranteed to be the same one every time (if I understand correctly - please double-check). Therefore, I had to rewrite all texture handling logic to resolve the actual `MTLTexture` only when live encoding a command buffer. Until then, the regular textures are kept unchanged, but framebuffer ones are stored as a pointer to swapchain plus the frame index. I'd really like us *not* to do this, so please tell me if all of that was unnecessary :)

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Metal

For an icing on the cake, Dota2 now plays well:
![dota-gfx-metal2](https://user-images.githubusercontent.com/107301/41217514-fac62132-6d0c-11e8-93ce-f59db1432063.jpg)


