### PR TITLE
[WIP] mtl: Disable depth/stencil when off

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -22,7 +22,7 @@ use hal::range::RangeArg;
 use cocoa::foundation::{NSRange, NSUInteger};
 use metal::{self,
     MTLFeatureSet, MTLLanguageVersion, MTLArgumentAccess, MTLDataType, MTLPrimitiveType, MTLPrimitiveTopologyClass,
-    MTLCPUCacheMode, MTLStorageMode, MTLResourceOptions,
+    MTLCPUCacheMode, MTLStorageMode, MTLResourceOptions, MTLCompareFunction,
     MTLVertexStepFunction, MTLSamplerBorderColor, MTLSamplerMipFilter, MTLTextureType,
     CaptureManager
 };
@@ -131,7 +131,10 @@ fn create_depth_stencil_state(
             raw.set_depth_compare_function(conv::map_compare_function(fun));
             raw.set_depth_write_enabled(write);
         }
-        pso::DepthTest::Off => {}
+        pso::DepthTest::Off => {
+            raw.set_depth_compare_function(MTLCompareFunction::Always);
+            raw.set_depth_write_enabled(false);
+        }
     }
     match desc.stencil {
         pso::StencilTest::On { ref front, ref back } => {
@@ -182,7 +185,10 @@ fn create_depth_stencil_state(
 
             raw.set_back_face_stencil(Some(&back_desc));
         }
-        pso::StencilTest::Off => {}
+        pso::StencilTest::Off => {
+            raw.set_front_face_stencil(None);
+            raw.set_back_face_stencil(None);
+        }
     }
 
     if all_masks_static {


### PR DESCRIPTION
Possibly fixes the issue noticed by @kvark?

WIP as I'm not sure whether this is actually useful or necessary – just a guess based on code inspection.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
