### PR TITLE
[dx11] add new memory/buffer management code

### DIFF
--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -102,7 +102,7 @@ impl BufferImageCopy {
 
     pub fn copy_2d(&mut self,
                 context: ComPtr<d3d11::ID3D11DeviceContext>,
-                buffer: ComPtr<d3d11::ID3D11ShaderResourceView>,
+                buffer: *mut d3d11::ID3D11ShaderResourceView,
                 image: ComPtr<d3d11::ID3D11UnorderedAccessView>,
                 info: command::BufferImageCopy) {
         self.update_buffer(context.clone(), info.clone());
@@ -110,7 +110,7 @@ impl BufferImageCopy {
         unsafe {
             context.CSSetShader(self.cs.as_raw(), ptr::null_mut(), 0);
             context.CSSetConstantBuffers(0, 1, &self.copy_info.as_raw());
-            context.CSSetShaderResources(0, 1, &buffer.as_raw());
+            context.CSSetShaderResources(0, 1, &buffer);
             context.CSSetUnorderedAccessViews(0, 1, &image.as_raw(), ptr::null_mut());
 
             context.Dispatch(


### PR DESCRIPTION
Makes `Memory` keep track of ranges that buffers are bound to and allows for multiple buffers to be bound to the same `Memory` now.

This gets us around 50% green in `dEQP-VK.api.buffer`

The other 50% is mostly because of an annoying limitation: https://msdn.microsoft.com/en-us/library/windows/desktop/ff476085(v=vs.85).aspx
> **D3D11_BIND_CONSTANT_BUFFER**
>    Bind a buffer as a constant buffer to a shader stage; this flag may **NOT** be combined with any other bind flag.

So buffers that are both uniform buffers & other things need to duplicate data? :cry:

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
