### PR TITLE
dx12: Fix wrong memory heap selection for transfer dst usage.

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2037,9 +2037,13 @@ impl d::Device<B> for Device {
             self.raw.clone().GetResourceAllocationInfo(0, 1, &desc)
         };
 
+        // Image usages which require RT/DS heap due to internal implementation.
+        let target_usage = image::Usage::COLOR_ATTACHMENT | image::Usage::DEPTH_STENCIL_ATTACHMENT
+            | image::Usage::TRANSFER_DST;
+
         let type_mask_shift = if self.private_caps.heterogeneous_resource_heaps {
             MEM_TYPE_UNIVERSAL_SHIFT
-        } else if usage.can_target() {
+        } else if usage.intersects(target_usage) {
             MEM_TYPE_TARGET_SHIFT
         } else {
             MEM_TYPE_IMAGE_SHIFT


### PR DESCRIPTION
Tier 1 GPUs require placing images with TRANSFER_DST usage on the RT_DS heap as we internally use render targets for transfer operations.

Fixes #2097 

cc @grovesNL could you test it on your machine?

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
