### PR TITLE
hal: Improve buffer documentation and cleanup error handling

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -666,7 +666,7 @@ impl hal::Device<Backend> for Device {
         buffer: &Buffer,
         format: Option<format::Format>,
         range: R,
-    ) -> Result<BufferView, buffer::ViewError> {
+    ) -> Result<BufferView, buffer::ViewCreationError> {
         unimplemented!()
     }
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1910,14 +1910,14 @@ impl d::Device<B> for Device {
         buffer: &n::Buffer,
         format: Option<format::Format>,
         range: R,
-    ) -> Result<n::BufferView, buffer::ViewError> {
+    ) -> Result<n::BufferView, buffer::ViewCreationError> {
         let buffer_features = {
             let idx = format.map(|fmt| fmt as usize).unwrap_or(0);
             self.format_properties[idx].buffer_features
         };
         let (format, format_desc) = match format.and_then(conv::map_format) {
             Some(fmt) => (fmt, format.unwrap().surface_desc()),
-            None => return Err(buffer::ViewError::Unsupported),
+            None => return Err(buffer::ViewCreationError::UnsupportedFormat { format }),
         };
 
         let start = *range.start().unwrap_or(&0);

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -177,7 +177,7 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_buffer_view<R: RangeArg<u64>>(&self, _: &(), _: Option<format::Format>, _: R) -> Result<(), buffer::ViewError> {
+    fn create_buffer_view<R: RangeArg<u64>>(&self, _: &(), _: Option<format::Format>, _: R) -> Result<(), buffer::ViewCreationError> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -672,8 +672,7 @@ impl d::Device<B> for Device {
     ) -> Result<UnboundBuffer, buffer::CreationError> {
         if !self.share.legacy_features.contains(LegacyFeatures::CONSTANT_BUFFER) &&
             usage.contains(buffer::Usage::UNIFORM) {
-            error!("Constant buffers are not supported by this GL version");
-            return Err(buffer::CreationError::Other);
+            return Err(buffer::CreationError::UnsupportedUsage { usage });
         }
 
         let target = if self.share.private_caps.buffer_role_change {
@@ -681,7 +680,7 @@ impl d::Device<B> for Device {
         } else {
             match conv::buffer_usage_to_gl_target(usage) {
                 Some(target) => target,
-                None => return Err(buffer::CreationError::Usage(usage)),
+                None => return Err(buffer::CreationError::UnsupportedUsage { usage }),
             }
         };
 
@@ -838,7 +837,7 @@ impl d::Device<B> for Device {
 
     fn create_buffer_view<R: RangeArg<u64>>(
         &self, _: &n::Buffer, _: Option<Format>, _: R
-    ) -> Result<n::BufferView, buffer::ViewError> {
+    ) -> Result<n::BufferView, buffer::ViewCreationError> {
         unimplemented!()
     }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -930,7 +930,7 @@ impl d::Device<B> for Device {
 
     fn create_buffer_view<R: RangeArg<u64>>(
         &self, buffer: &n::Buffer, format: Option<format::Format>, range: R
-    ) -> Result<n::BufferView, buffer::ViewError> {
+    ) -> Result<n::BufferView, buffer::ViewCreationError> {
         let (offset, size) = conv::map_range_arg(&range);
         let info = vk::BufferViewCreateInfo {
             s_type: vk::StructureType::BufferViewCreateInfo,

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -1,3 +1,5 @@
+//! Logical device
+//!
 //! # Device
 //!
 //! This module exposes the `Device` trait, which provides methods for creating
@@ -306,7 +308,7 @@ pub trait Device<B: Backend>: Any + Send + Sync {
     ///
     fn create_buffer_view<R: RangeArg<u64>>(
         &self, buf: &B::Buffer, fmt: Option<format::Format>, range: R
-    ) -> Result<B::BufferView, buffer::ViewError>;
+    ) -> Result<B::BufferView, buffer::ViewCreationError>;
 
     ///
     fn destroy_buffer_view(&self, view: B::BufferView);


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
