### PR TITLE
Use `uuidof` instead of the raw IID

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -3,6 +3,7 @@ use hal::queue::QueueFamilyId;
 use hal::range::RangeArg;
 use hal::{buffer, device, error, format, image, mapping, memory, pass, pool, pso, query, window};
 
+use winapi::Interface;
 use winapi::shared::dxgi::{IDXGISwapChain, DXGI_SWAP_CHAIN_DESC, DXGI_SWAP_EFFECT_DISCARD};
 use winapi::shared::minwindef::{TRUE};
 use winapi::shared::{dxgiformat, dxgitype, winerror};
@@ -1255,7 +1256,7 @@ impl hal::Device<Backend> for Device {
             let hr = unsafe {
                 swapchain.GetBuffer(
                     i as _,
-                    &d3d11::IID_ID3D11Resource,
+                    &d3d11::ID3D11Resource::uuidof(),
                     &mut resource as *mut *mut _ as *mut *mut _
                 )
             };

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -10,6 +10,7 @@ use std::borrow::Borrow;
 use std::ops::Range;
 use std::sync::Arc;
 
+use winapi::Interface;
 use winapi::um::{d3d12, d3dcommon};
 use winapi::shared::minwindef::{FALSE, UINT, TRUE};
 use winapi::shared::{dxgiformat, winerror};
@@ -2005,7 +2006,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     &desc,
                     d3d12::D3D12_RESOURCE_STATE_COMMON,
                     ptr::null(),
-                    &d3d12::IID_ID3D12Resource,
+                    &d3d12::ID3D12Resource::uuidof(),
                     &mut alias,
                 )
             });

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -500,7 +500,7 @@ impl Device {
             device.CreateCommandSignature(
                 &desc,
                 ptr::null_mut(),
-                &d3d12::IID_ID3D12CommandSignature,
+                &d3d12::ID3D12CommandSignature::uuidof(),
                 &mut signature as *mut *mut _ as *mut *mut _,
             )
         };
@@ -535,7 +535,7 @@ impl Device {
         let descriptor_size = unsafe {
             device.CreateDescriptorHeap(
                 &desc,
-                &d3d12::IID_ID3D12DescriptorHeap,
+                &d3d12::ID3D12DescriptorHeap::uuidof(),
                 &mut heap as *mut *mut _ as *mut *mut _,
             );
             device.GetDescriptorHandleIncrementSize(heap_type) as usize
@@ -955,7 +955,7 @@ impl Device {
             self.raw.clone().CreateFence(
                 if signalled { 1 } else { 0 },
                 d3d12::D3D12_FENCE_FLAG_NONE,
-                &d3d12::IID_ID3D12Fence,
+                &d3d12::ID3D12Fence::uuidof(),
                 &mut handle,
             )
         });
@@ -1000,7 +1000,7 @@ impl d::Device<B> for Device {
 
         let mut heap = ptr::null_mut();
         let hr = unsafe {
-            self.raw.clone().CreateHeap(&desc, &d3d12::IID_ID3D12Heap, &mut heap)
+            self.raw.clone().CreateHeap(&desc, &d3d12::ID3D12Heap::uuidof(), &mut heap)
         };
         if hr == winerror::E_OUTOFMEMORY {
             return Err(d::OutOfMemory);
@@ -1067,7 +1067,7 @@ impl d::Device<B> for Device {
         let hr = unsafe {
             self.raw.clone().CreateCommandAllocator(
                 list_type,
-                &d3d12::IID_ID3D12CommandAllocator,
+                &d3d12::ID3D12CommandAllocator::uuidof(),
                 &mut command_allocator as *mut *mut _ as *mut *mut _,
             )
         };
@@ -1456,7 +1456,7 @@ impl d::Device<B> for Device {
                 0,
                 (*signature_raw).GetBufferPointer(),
                 (*signature_raw).GetBufferSize(),
-                &d3d12::IID_ID3D12RootSignature,
+                &d3d12::ID3D12RootSignature::uuidof(),
                 &mut signature as *mut *mut _ as *mut *mut _,
             );
             (*signature_raw).Release();
@@ -1677,7 +1677,7 @@ impl d::Device<B> for Device {
                     unsafe {
                         device2.CreatePipelineState(
                             &pss_desc,
-                            &d3d12::IID_ID3D12PipelineState,
+                            &d3d12::ID3D12PipelineState::uuidof(),
                             &mut pipeline as *mut *mut _ as *mut *mut _)
                     }
                 }
@@ -1686,7 +1686,7 @@ impl d::Device<B> for Device {
             unsafe {
                 self.raw.clone().CreateGraphicsPipelineState(
                     &pso_desc,
-                    &d3d12::IID_ID3D12PipelineState,
+                    &d3d12::ID3D12PipelineState::uuidof(),
                     &mut pipeline as *mut *mut _ as *mut *mut _)
             }
         };
@@ -1747,7 +1747,7 @@ impl d::Device<B> for Device {
         let hr = unsafe {
             self.raw.clone().CreateComputePipelineState(
                 &pso_desc,
-                &d3d12::IID_ID3D12PipelineState,
+                &d3d12::ID3D12PipelineState::uuidof(),
                 &mut pipeline as *mut *mut _ as *mut *mut _)
         };
 
@@ -1864,7 +1864,7 @@ impl d::Device<B> for Device {
                 &desc,
                 d3d12::D3D12_RESOURCE_STATE_COMMON,
                 ptr::null(),
-                &d3d12::IID_ID3D12Resource,
+                &d3d12::ID3D12Resource::uuidof(),
                 &mut resource,
             )
         });
@@ -2131,7 +2131,7 @@ impl d::Device<B> for Device {
                 &image.desc,
                 d3d12::D3D12_RESOURCE_STATE_COMMON,
                 ptr::null(),
-                &d3d12::IID_ID3D12Resource,
+                &d3d12::ID3D12Resource::uuidof(),
                 &mut resource,
             )
         });
@@ -2841,7 +2841,7 @@ impl d::Device<B> for Device {
         assert_eq!(winerror::S_OK, unsafe {
             self.raw.clone().CreateQueryHeap(
                 &desc,
-                &d3d12::IID_ID3D12QueryHeap,
+                &d3d12::ID3D12QueryHeap::uuidof(),
                 &mut handle,
             )
         });
@@ -2999,7 +2999,7 @@ impl d::Device<B> for Device {
             unsafe {
                 swap_chain.GetBuffer(
                     i as _,
-                    &d3d12::IID_ID3D12Resource,
+                    &d3d12::ID3D12Resource::uuidof(),
                     &mut resource as *mut *mut _ as *mut *mut _);
             }
 

--- a/src/backend/dx12/src/internal.rs
+++ b/src/backend/dx12/src/internal.rs
@@ -5,6 +5,7 @@ use std::{mem, ptr};
 use std::sync::Mutex;
 
 use d3d12;
+use winapi::Interface;
 use winapi::shared::{dxgiformat, dxgitype, winerror};
 use winapi::shared::minwindef::{FALSE, TRUE};
 use winapi::um::d3d12::*;
@@ -133,7 +134,7 @@ impl ServicePipes {
                 0,
                 (*signature_raw).GetBufferPointer(),
                 (*signature_raw).GetBufferSize(),
-                &d3d12::IID_ID3D12RootSignature,
+                &d3d12::ID3D12RootSignature::uuidof(),
                 &mut signature as *mut *mut _ as *mut *mut _,
             );
             (*signature_raw).Release();
@@ -219,7 +220,7 @@ impl ServicePipes {
         let hr = unsafe {
             self.device.CreateGraphicsPipelineState(
                 &pso_desc,
-                &d3d12::IID_ID3D12PipelineState,
+                &d3d12::ID3D12PipelineState::uuidof(),
                 &mut pipeline as *mut *mut _ as *mut *mut _)
         };
         assert_eq!(hr, winerror::S_OK);

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -28,6 +28,7 @@ use hal::{error, format as f, image, memory, Features, FrameImage, Limits, Queue
 use hal::queue::{QueueFamilyId, Queues};
 use descriptors_cpu::DescriptorCpuPool;
 
+use winapi::Interface;
 use winapi::shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, winerror};
 use winapi::shared::minwindef::{FALSE, TRUE};
 use winapi::um::{d3d12, d3d12sdklayers, d3dcommon, handleapi, synchapi, winbase, winnt};
@@ -207,7 +208,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 d3d12::D3D12CreateDevice(
                     self.adapter.as_raw() as *mut _,
                     d3dcommon::D3D_FEATURE_LEVEL_11_0, // Minimum required feature level
-                    &d3d12::IID_ID3D12Device,
+                    &d3d12::ID3D12Device::uuidof(),
                     &mut device_raw as *mut *mut _ as *mut *mut _,
                 )
             };
@@ -231,7 +232,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             let hr = unsafe {
                 device_raw.CreateCommandQueue(
                     &queue_desc,
-                    &d3d12::IID_ID3D12CommandQueue,
+                    &d3d12::ID3D12CommandQueue::uuidof(),
                     &mut queue as *mut *mut _ as *mut *mut _,
                 )
             };
@@ -289,7 +290,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                             let hr = unsafe {
                                 device.raw.CreateCommandQueue(
                                     &queue_desc,
-                                    &d3d12::IID_ID3D12CommandQueue,
+                                    &d3d12::ID3D12CommandQueue::uuidof(),
                                     &mut queue as *mut *mut _ as *mut *mut _,
                                 )
                             };
@@ -656,7 +657,7 @@ impl Instance {
             let mut debug_controller: *mut d3d12sdklayers::ID3D12Debug = ptr::null_mut();
             let hr = unsafe {
                 d3d12::D3D12GetDebugInterface(
-                    &d3d12sdklayers::IID_ID3D12Debug,
+                    &d3d12sdklayers::ID3D12Debug::uuidof(),
                     &mut debug_controller as *mut *mut _ as *mut *mut _)
             };
 
@@ -672,7 +673,7 @@ impl Instance {
         let hr = unsafe {
             dxgi1_3::CreateDXGIFactory2(
                 dxgi1_3::DXGI_CREATE_FACTORY_DEBUG,
-                &dxgi1_4::IID_IDXGIFactory4,
+                &dxgi1_4::IDXGIFactory4::uuidof(),
                 &mut dxgi_factory as *mut *mut _ as *mut *mut _)
         };
 
@@ -721,7 +722,7 @@ impl hal::Instance for Instance {
                     d3d12::D3D12CreateDevice(
                         adapter.as_raw() as *mut _,
                         d3dcommon::D3D_FEATURE_LEVEL_11_0,
-                        &d3d12::IID_ID3D12Device,
+                        &d3d12::ID3D12Device::uuidof(),
                         &mut device as *mut *mut _ as *mut *mut _,
                     )
                 };
@@ -968,7 +969,7 @@ impl hal::Instance for Instance {
                     unsafe {
                         assert_eq!(winerror::S_OK, self.factory.EnumAdapterByLuid(
                             adapter_id,
-                            &dxgi1_4::IID_IDXGIAdapter3,
+                            &dxgi1_4::IDXGIAdapter3::uuidof(),
                             &mut adapter as *mut *mut _ as *mut *mut _,
                         ));
                         ComPtr::from_raw(adapter)

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -2,6 +2,7 @@ use wio::com::ComPtr;
 use std::ptr;
 use std::sync::Arc;
 
+use winapi::Interface;
 use winapi::um::d3d12;
 use winapi::shared::winerror::SUCCEEDED;
 
@@ -27,7 +28,7 @@ impl RawCommandPool {
                     self.list_type,
                     self.inner.as_raw(),
                     ptr::null_mut(),
-                    &d3d12::IID_ID3D12GraphicsCommandList,
+                    &d3d12::ID3D12GraphicsCommandList::uuidof(),
                     &mut command_list as *mut *mut _ as *mut *mut _,
                 )
             };

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -134,7 +134,7 @@ impl core::Surface<device_dx11::Backend> for Surface11 {
             unsafe {
                 swap_chain.GetBuffer(
                     0,
-                    &dxguid::IID_ID3D11Texture2D,
+                    &dxguid::ID3D11Texture2D::uuidof(),
                     &mut back_buffer as *mut *mut winapi::ID3D11Texture2D as *mut *mut _);
             }
 


### PR DESCRIPTION
Since the crate now uses `winapi` 0.3, we can use the `Interface` trait's `uuidof` method instead of accessing the `IID_*` constants.

Fixes #1142 

PR checklist:
- [X] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:

(I don't use Windows but since they compile and no ID has been changed it should work).
