### PR TITLE
Persistent Metal swapchain

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -463,8 +463,8 @@ fn main() {
 
         device.reset_fence(&frame_fence);
         command_pool.reset();
-        let frame: hal::FrameImage = {
-            match swap_chain.acquire_frame(FrameSync::Semaphore(&mut frame_semaphore)) {
+        let frame: hal::SwapImageIndex = {
+            match swap_chain.acquire_image(FrameSync::Semaphore(&mut frame_semaphore)) {
                 Ok(i) => i,
                 Err(_) => {
                     recreate_swapchain = true;

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -599,6 +599,7 @@ fn swapchain_stuff(
     println!("Surface format: {:?}", format);
     let swap_config = SwapchainConfig::new()
         .with_color(format)
+        .with_image_count(caps.image_count.start)
         .with_image_usage(i::Usage::COLOR_ATTACHMENT);
     let (swap_chain, backbuffer) = device.create_swapchain(surface, swap_config, None, &extent);
 

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -15,7 +15,7 @@ extern crate winit;
 extern crate wio;
 
 use hal::{buffer, command, error, format, image, memory, query, pso, Features, Limits, QueueType};
-use hal::{DrawCount, FrameImage, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount};
+use hal::{DrawCount, SwapImageIndex, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount};
 use hal::queue::{QueueFamilyId, Queues};
 use hal::backend::RawQueueGroup;
 use hal::range::RangeArg;
@@ -639,7 +639,7 @@ unsafe impl Send for Swapchain { }
 unsafe impl Sync for Swapchain { }
 
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_frame(&mut self, _sync: hal::FrameSync<Backend>) -> Result<hal::FrameImage, ()> {
+    fn acquire_image(&mut self, _sync: hal::FrameSync<Backend>) -> Result<hal::SwapImageIndex, ()> {
         // TODO: non-`_DISCARD` swap effects have more than one buffer, `FLIP`
         //       effects are dxgi 1.3 (w10+?) in which case there is
         //       `GetCurrentBackBufferIndex()` on the swapchain
@@ -681,7 +681,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
 
     fn present<IS, S, IW>(&mut self, swapchains: IS, _wait_semaphores: IW) -> Result<(), ()>
     where
-        IS: IntoIterator<Item = (S, FrameImage)>,
+        IS: IntoIterator<Item = (S, SwapImageIndex)>,
         S: Borrow<Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<Semaphore>,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -24,7 +24,7 @@ mod pool;
 mod root_constants;
 mod window;
 
-use hal::{error, format as f, image, memory, Features, FrameImage, Limits, QueueType};
+use hal::{error, format as f, image, memory, Features, SwapImageIndex, Limits, QueueType};
 use hal::queue::{QueueFamilyId, Queues};
 use descriptors_cpu::DescriptorCpuPool;
 
@@ -468,7 +468,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
 
     fn present<IS, S, IW>(&mut self, swapchains: IS, _wait_semaphores: IW) -> Result<(), ()>
     where
-        IS: IntoIterator<Item = (S, FrameImage)>,
+        IS: IntoIterator<Item = (S, SwapImageIndex)>,
         S: Borrow<window::Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<native::Semaphore>,

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -109,7 +109,7 @@ pub struct Swapchain {
 }
 
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_frame(&mut self, _sync: hal::FrameSync<Backend>) -> Result<hal::FrameImage, ()> {
+    fn acquire_image(&mut self, _sync: hal::FrameSync<Backend>) -> Result<hal::SwapImageIndex, ()> {
         // TODO: sync
 
         if false {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -98,7 +98,7 @@ impl queue::RawCommandQueue<Backend> for RawCommandQueue {
 
     fn present<IS, S, IW>(&mut self, _: IS, _: IW) -> Result<(), ()>
     where
-        IS: IntoIterator<Item = (S, hal::FrameImage)>,
+        IS: IntoIterator<Item = (S, hal::SwapImageIndex)>,
         S: Borrow<Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<()>,
@@ -785,7 +785,7 @@ impl hal::Surface<Backend> for Surface {
 /// Dummy swapchain.
 pub struct Swapchain;
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_frame(&mut self, _: hal::FrameSync<Backend>) -> Result<hal::FrameImage, ()> {
+    fn acquire_image(&mut self, _: hal::FrameSync<Backend>) -> Result<hal::SwapImageIndex, ()> {
         unimplemented!()
     }
 }

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -722,7 +722,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
     #[cfg(feature = "glutin")]
     fn present<IS, S, IW>(&mut self, swapchains: IS, _wait_semaphores: IW) -> Result<(), ()>
     where
-        IS: IntoIterator<Item = (S, hal::FrameImage)>,
+        IS: IntoIterator<Item = (S, hal::SwapImageIndex)>,
         S: Borrow<window::glutin::Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<native::Semaphore>,

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -65,7 +65,7 @@ pub struct Swapchain {
 }
 
 impl hal::Swapchain<B> for Swapchain {
-    fn acquire_frame(&mut self, _sync: hal::FrameSync<B>) -> Result<hal::FrameImage, ()> {
+    fn acquire_image(&mut self, _sync: hal::FrameSync<B>) -> Result<hal::SwapImageIndex, ()> {
         // TODO: sync
         Ok(0)
     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -10,7 +10,7 @@ use std::{iter, mem};
 use std::slice;
 
 use hal::{buffer, command as com, error, memory, pool, pso};
-use hal::{DrawCount, FrameImage, VertexCount, VertexOffset, InstanceCount, IndexCount, WorkGroupCount};
+use hal::{DrawCount, SwapImageIndex, VertexCount, VertexOffset, InstanceCount, IndexCount, WorkGroupCount};
 use hal::backend::FastHashMap;
 use hal::format::{Aspects, Format, FormatDesc};
 use hal::image::{Extent, Filter, Layout, Level, SubresourceRange};
@@ -1322,7 +1322,7 @@ impl RawCommandQueue<Backend> for CommandQueue {
 
     fn present<IS, S, IW>(&mut self, swapchains: IS, _wait_semaphores: IW) -> Result<(), ()>
     where
-        IS: IntoIterator<Item = (S, FrameImage)>,
+        IS: IntoIterator<Item = (S, SwapImageIndex)>,
         S: Borrow<window::Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<native::Semaphore>,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2024,9 +2024,12 @@ impl hal::Device<Backend> for Device {
         &self,
         surface: &mut Surface,
         config: hal::SwapchainConfig,
-        _old_swapchain: Option<Swapchain>,
+        old_swapchain: Option<Swapchain>,
         _extent: &window::Extent2D,
     ) -> (Swapchain, hal::Backbuffer<Backend>) {
+        if let Some(_swapchain) = old_swapchain {
+            //swapchain is dropped here
+        }
         self.build_swapchain(surface, config)
     }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -198,6 +198,7 @@ impl hal::Backend for Backend {
 
 #[derive(Clone, Copy, Debug)]
 struct PrivateCapabilities {
+    exposed_queues: usize,
     resource_heaps: bool,
     argument_buffers: bool,
     shared_textures: bool,

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -162,7 +162,7 @@ unsafe impl Sync for ComputePipeline {}
 #[derive(Clone, Debug)]
 pub struct Frame {
     pub swapchain: Arc<RwLock<SwapchainInner>>,
-    pub index: hal::FrameImage,
+    pub index: hal::SwapImageIndex,
 }
 
 #[derive(Clone, Debug)]
@@ -199,7 +199,7 @@ pub enum ImageGuard<'a> {
     Texture(&'a metal::TextureRef),
     Frame {
         swapchain: RwLockReadGuard<'a, SwapchainInner>,
-        index: hal::FrameImage,
+        index: hal::SwapImageIndex,
     },
 }
 

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -50,9 +50,9 @@ pub struct SwapchainInner {
     frames: Vec<Frame>,
 }
 
-impl ops::Index<hal::FrameImage> for SwapchainInner {
+impl ops::Index<hal::SwapImageIndex> for SwapchainInner {
     type Output = metal::TextureRef;
-    fn index(&self, index: hal::FrameImage) -> &Self::Output {
+    fn index(&self, index: hal::SwapImageIndex) -> &Self::Output {
         &self.frames[index as usize].texture
     }
 }
@@ -88,7 +88,7 @@ unsafe impl Send for Swapchain {}
 unsafe impl Sync for Swapchain {}
 
 impl Swapchain {
-    pub(crate) fn present(&self, index: hal::FrameImage) {
+    pub(crate) fn present(&self, index: hal::SwapImageIndex) {
         let drawable = self.inner
             .write()
             .unwrap()
@@ -122,7 +122,7 @@ impl hal::Surface<Backend> for Surface {
         };
 
         let caps = hal::SurfaceCapabilities {
-            image_count: 2 .. max_frames as hal::FrameImage,
+            image_count: 2 .. max_frames as hal::SwapImageIndex,
             current_extent: None,
             extents: Extent2D { width: 4, height: 4} .. Extent2D { width: 4096, height: 4096 },
             max_image_layers: 1,
@@ -256,7 +256,7 @@ impl Device {
 }
 
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_frame(&mut self, sync: hal::FrameSync<Backend>) -> Result<hal::FrameImage, ()> {
+    fn acquire_image(&mut self, sync: hal::FrameSync<Backend>) -> Result<hal::SwapImageIndex, ()> {
         let _ap = AutoreleasePool::new(); // for the drawable
 
         unsafe {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -26,7 +26,7 @@ use ash::version::{EntryV1_0, DeviceV1_0, InstanceV1_0, V1_0};
 use ash::vk;
 
 use hal::{format, image, memory, queue};
-use hal::{Features, FrameImage, Limits, PatchSize, QueueType};
+use hal::{Features, SwapImageIndex, Limits, PatchSize, QueueType};
 use hal::error::{DeviceCreationError, HostExecutionError};
 
 use std::{fmt, mem, ptr};
@@ -703,7 +703,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
 
     fn present<IS, S, IW>(&mut self, swapchains: IS, wait_semaphores: IW) -> Result<(), ()>
     where
-        IS: IntoIterator<Item = (S, FrameImage)>,
+        IS: IntoIterator<Item = (S, SwapImageIndex)>,
         S: Borrow<window::Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<native::Semaphore>,

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -386,7 +386,7 @@ pub struct Swapchain {
 
 
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_frame(&mut self, sync: hal::FrameSync<Backend>) -> Result<hal::FrameImage, ()> {
+    fn acquire_image(&mut self, sync: hal::FrameSync<Backend>) -> Result<hal::SwapImageIndex, ()> {
         let (semaphore, fence) = match sync {
             hal::FrameSync::Semaphore(semaphore) => (semaphore.0, vk::Fence::null()),
             hal::FrameSync::Fence(fence) => (vk::Semaphore::null(), fence.0),

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -36,7 +36,7 @@ pub use self::queue::{
     Capability, Supports, General, Graphics, Compute, Transfer,
 };
 pub use self::window::{
-    Backbuffer, FrameImage, FrameSync, PresentMode,
+    Backbuffer, SwapImageIndex, FrameSync, PresentMode,
     Surface, SurfaceCapabilities, Swapchain, SwapchainConfig,
 };
 

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -15,7 +15,7 @@ use std::borrow::Borrow;
 use std::marker::PhantomData;
 
 use error::HostExecutionError;
-use window::FrameImage;
+use window::SwapImageIndex;
 use Backend;
 
 pub use self::capability::{
@@ -65,7 +65,7 @@ pub trait RawCommandQueue<B: Backend>: Any + Send + Sync {
     fn present<IS, S, IW>(&mut self, swapchains: IS, wait_semaphores: IW) -> Result<(), ()>
     where
         Self: Sized,
-        IS: IntoIterator<Item = (S, FrameImage)>,
+        IS: IntoIterator<Item = (S, SwapImageIndex)>,
         S: Borrow<B::Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<B::Semaphore>;
@@ -121,7 +121,7 @@ impl<B: Backend, C> CommandQueue<B, C> {
     /// list more than once.
     pub fn present<IS, S, IW>(&mut self, swapchains: IS, wait_semaphores: IW) -> Result<(), ()>
     where
-        IS: IntoIterator<Item = (S, FrameImage)>,
+        IS: IntoIterator<Item = (S, SwapImageIndex)>,
         S: Borrow<B::Swapchain>,
         IW: IntoIterator,
         IW::Item: Borrow<B::Semaphore>

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -215,7 +215,7 @@ impl core::Swapchain<device_dx11::Backend> for Swapchain11 {
         &self.images
     }
 
-    fn acquire_frame(&mut self, sync: core::FrameSync<device_dx11::Resources>) -> Result<core::Frame, ()> {
+    fn acquire_image(&mut self, sync: core::FrameSync<device_dx11::Resources>) -> Result<core::Frame, ()> {
         // TODO: sync
         Ok(core::Frame::new(0))
     }

--- a/src/window/glfw/src/lib.rs
+++ b/src/window/glfw/src/lib.rs
@@ -54,7 +54,7 @@ impl<'a> core::Swapchain<device_gl::Backend> for Swapchain {
         &self.backbuffer
     }
 
-    fn acquire_frame(&mut self, sync: core::FrameSync<device_gl::Resources>) -> Result<core::Frame, ()> {
+    fn acquire_image(&mut self, sync: core::FrameSync<device_gl::Resources>) -> Result<core::Frame, ()> {
         // TODO: fence sync
         Ok(core::Frame::new(0))
     }

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -100,7 +100,7 @@ impl core::Swapchain<Backend> for Swapchain {
         &self.backbuffer
     }
 
-    fn acquire_frame(&mut self, sync: core::FrameSync<R>) -> Result<core::Frame, ()> {
+    fn acquire_image(&mut self, sync: core::FrameSync<R>) -> Result<core::Frame, ()> {
         // TODO: fence sync
         Ok(core::Frame::new(0))
     }


### PR DESCRIPTION
~~Includes #2164~~
Fixes #2168
Fixes #2143
Removes deferred image resolution (yay!), and also renames some of the outdated concepts.
We have no flickering, and proper frame sync now.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
