### PR TITLE
metal: Hack to fix the first frame of a swapchain

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -144,6 +144,7 @@ impl Instance {
         window::Surface {
             inner: Arc::new(self.create_from_nsview(nsview)),
             apply_pixel_scale: false,
+            has_swapchain: false
         }
     }
 
@@ -153,6 +154,7 @@ impl Instance {
         window::Surface {
             inner: Arc::new(self.create_from_nsview(window.get_nsview())),
             apply_pixel_scale: true,
+            has_swapchain: false,
         }
     }
 }


### PR DESCRIPTION
The freeing up of the drawable now checks if there is anything to free
from the has_swapchain boolean.

The boolean is totally a hack, and might have some edge-cases where it
is wrong, but this happens to fix warnings and red-frame flashes
(present of not drawn frame) from the quad example, with the resizing
still working.

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
