### PR TITLE
mtl: Use pointers for temporary state

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1,6 +1,6 @@
 use {
     AutoreleasePool, Backend, PrivateCapabilities, QueueFamily,
-    Shared, Surface, Swapchain, validate_line_width
+    Shared, Surface, Swapchain, validate_line_width, BufferPtr, SamplerPtr, TexturePtr,
 };
 use {conversions as conv, command, native as n};
 use native;
@@ -28,6 +28,7 @@ use metal::{self,
     CaptureManager
 };
 use spirv_cross::{msl, spirv, ErrorCode as SpirvErrorCode};
+use foreign_types::ForeignType;
 
 use range_alloc::RangeAllocator;
 
@@ -1309,7 +1310,7 @@ impl hal::Device<Backend> for Device {
                 n::MemoryHeap::Native(_) => unimplemented!(),
                 n::MemoryHeap::Public(mt, ref cpu_buffer) if 1<<mt.0 != MemoryTypes::SHARED.bits() as usize => {
                     num_syncs += 1;
-                    encoder.synchronize_resource(cpu_buffer.as_ref());
+                    encoder.synchronize_resource(cpu_buffer);
                 }
                 n::MemoryHeap::Public(..) => continue,
                 n::MemoryHeap::Private => panic!("Can't map private memory!"),
@@ -1371,10 +1372,10 @@ impl hal::Device<Backend> for Device {
         let encoder = device.new_argument_encoder(&arg_array);
 
         let total_size = encoder.encoded_length();
-        let buffer = device.new_buffer(total_size, MTLResourceOptions::empty());
+        let raw = device.new_buffer(total_size, MTLResourceOptions::empty());
 
         n::DescriptorPool::ArgumentBuffer {
-            buffer,
+            raw,
             range_allocator: RangeAllocator::new(0..total_size),
         }
     }
@@ -1441,27 +1442,27 @@ impl hal::Device<Backend> for Device {
 
                         match (descriptor.borrow(), set.bindings[binding as usize].as_mut().unwrap()) {
                             (&pso::Descriptor::Sampler(sampler), &mut n::DescriptorSetBinding::Sampler(ref mut vec)) => {
-                                vec[array_offset] = Some(sampler.0.clone());
+                                vec[array_offset] = Some(SamplerPtr(sampler.0.as_ptr()));
                             }
                             (&pso::Descriptor::Image(image, layout), &mut n::DescriptorSetBinding::Image(ref mut vec)) => {
-                                vec[array_offset] = Some((image.raw.clone(), layout));
+                                vec[array_offset] = Some((TexturePtr(image.raw.as_ptr()), layout));
                             }
                             (&pso::Descriptor::Image(image, layout), &mut n::DescriptorSetBinding::Combined(ref mut vec)) => {
-                                vec[array_offset].0 = Some((image.raw.clone(), layout));
+                                vec[array_offset].0 = Some((TexturePtr(image.raw.as_ptr()), layout));
                             }
                             (&pso::Descriptor::CombinedImageSampler(image, layout, sampler), &mut n::DescriptorSetBinding::Combined(ref mut vec)) => {
-                                vec[array_offset] = (Some((image.raw.clone(), layout)), Some(sampler.0.clone()));
+                                vec[array_offset] = (Some((TexturePtr(image.raw.as_ptr()), layout)), Some(SamplerPtr(sampler.0.as_ptr())));
                             }
                             (&pso::Descriptor::UniformTexelBuffer(view), &mut n::DescriptorSetBinding::Image(ref mut vec)) |
                             (&pso::Descriptor::StorageTexelBuffer(view), &mut n::DescriptorSetBinding::Image(ref mut vec)) => {
-                                vec[array_offset] = Some((view.raw.clone(), image::Layout::General));
+                                vec[array_offset] = Some((TexturePtr(view.raw.as_ptr()), image::Layout::General));
                             }
                             (&pso::Descriptor::Buffer(buffer, ref range), &mut n::DescriptorSetBinding::Buffer(ref mut vec)) => {
                                 let buf_length = buffer.raw.length();
                                 let start = range.start.unwrap_or(0);
                                 let end = range.end.unwrap_or(buf_length);
                                 assert!(end <= buf_length);
-                                vec[array_offset].base = Some((buffer.raw.clone(), start));
+                                vec[array_offset].base = Some((BufferPtr(buffer.raw.as_ptr()), start));
                             }
                             (&pso::Descriptor::Sampler(..), _) |
                             (&pso::Descriptor::Image(..), _) |
@@ -1474,10 +1475,10 @@ impl hal::Device<Backend> for Device {
                         }
                     }
                 }
-                n::DescriptorSet::ArgumentBuffer { ref buffer, offset, ref encoder, .. } => {
+                n::DescriptorSet::ArgumentBuffer { ref raw, offset, ref encoder, .. } => {
                     debug_assert!(self.private_caps.argument_buffers);
 
-                    encoder.set_argument_buffer(buffer, offset);
+                    encoder.set_argument_buffer(raw, offset);
                     //TODO: range checks, need to keep some layout metadata around
                     assert_eq!(write.array_offset, 0); //TODO
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -43,6 +43,7 @@ use hal::queue::QueueFamilyId;
 use objc::runtime::{Class, Object};
 use cocoa::foundation::NSAutoreleasePool;
 use core_graphics::geometry::CGRect;
+use foreign_types::ForeignTypeRef;
 
 
 const MAX_ACTIVE_COMMAND_BUFFERS: usize = 1 << 14;
@@ -251,4 +252,55 @@ fn validate_line_width(width: f32) {
     // > If the wide lines feature is not enabled, lineWidth must be 1.0
     // Simply assert and no-op because Metal never exposes `Features::LINE_WIDTH` 
     assert_eq!(width, 1.0);
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct BufferPtr(*mut metal::MTLBuffer);
+
+impl BufferPtr {
+    #[inline]
+    pub fn as_native(&self) -> &metal::BufferRef {
+        unsafe {
+            metal::BufferRef::from_ptr(self.0)
+        }
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *mut metal::MTLBuffer {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TexturePtr(*mut metal::MTLTexture);
+
+impl TexturePtr {
+    #[inline]
+    pub fn as_native(&self) -> &metal::TextureRef {
+        unsafe {
+            metal::TextureRef::from_ptr(self.0)
+        }
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *mut metal::MTLTexture {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SamplerPtr(*mut metal::MTLSamplerState);
+
+impl SamplerPtr {
+    #[inline]
+    pub fn as_native(&self) -> &metal::SamplerStateRef {
+        unsafe {
+            metal::SamplerStateRef::from_ptr(self.0)
+        }
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *mut metal::MTLSamplerState {
+        self.0
+    }
 }

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -10,7 +10,7 @@ use hal::{Backbuffer, SwapchainConfig};
 use hal::window::Extent2D;
 
 use metal;
-use objc::runtime::{Object};
+use objc::runtime::Object;
 use core_graphics::base::CGFloat;
 use core_graphics::geometry::CGRect;
 use cocoa::foundation::{NSRect};


### PR DESCRIPTION
Partially fix to #2161
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:

This replaces buffer/texture/sampler object usage with pointers instead. This allows us to bypass Objective-C's reference counting (i.e. retain/release). The idea is to create the same objects as before, but purposely leak them and acquire a pointer to them instead. When we're finished with the objects, we take back ownership and release as usual. We should be able to do this either through `drop` on the owning struct, or through relevant `destroy_*` functions.

Still heavily WIP (but works with quad/Dota 2) because there are a few places that will cause leaks or use-after-free in its current state (need to fix cases where the same image is returned for an image view, verify `drop` exists on all the correct owners, etc.)