### PR TITLE
[hal] add support for maxColorAttachment device limit

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -298,6 +298,7 @@ impl hal::Instance for Instance {
                 framebuffer_color_samples_count: 1,     // TODO
                 framebuffer_depth_samples_count: 1,     // TODO
                 framebuffer_stencil_samples_count: 1,   // TODO
+                max_color_attachments: 1,               // TODO
                 non_coherent_atom_size: 0,              // TODO
             };
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1040,6 +1040,7 @@ impl hal::Instance for Instance {
                     framebuffer_color_samples_count: 0b101,
                     framebuffer_depth_samples_count: 0b101,
                     framebuffer_stencil_samples_count: 0b101,
+                    max_color_attachments: 1, // TODO
                     non_coherent_atom_size: 1, //TODO: confirm
                 },
                 format_properties: Arc::new(format_properties),

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -441,6 +441,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             framebuffer_color_samples_count: 0b101, // TODO
             framebuffer_depth_samples_count: 0b101, // TODO
             framebuffer_stencil_samples_count: 0b101, // TODO
+            max_color_attachments: 1, // TODO
 
             // Note: we issue Metal buffer-to-buffer copies on memory flush/invalidate,
             // and those need to operate on sizes being multiples of 4.

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -627,6 +627,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             framebuffer_color_samples_count: limits.framebuffer_color_sample_counts.flags() as _,
             framebuffer_depth_samples_count: limits.framebuffer_depth_sample_counts.flags() as _,
             framebuffer_stencil_samples_count: limits.framebuffer_stencil_sample_counts.flags() as _,
+            max_color_attachments: limits.max_color_attachments as _,
             non_coherent_atom_size: limits.non_coherent_atom_size as _,
         }
     }

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -268,6 +268,8 @@ pub struct Limits {
     pub framebuffer_depth_samples_count: image::NumSamples,
     /// Number of samples supported for stencil attachments of framebuffers.
     pub framebuffer_stencil_samples_count: image::NumSamples,
+    /// Maximum number of color attachments that can be used by a subpass in a render pass.
+    pub max_color_attachments: usize,
     /// Size and alignment in bytes that bounds concurrent access to host-mapped device memory.
     pub non_coherent_atom_size: usize,
 }


### PR DESCRIPTION
Unblocks a couple of CTS cases (`dEQP-VK.pipeline.image` and `dEQP-VK.pipeline.sampler`)