### PR TITLE
[mtl] minimize creation of render passes

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1168,7 +1168,10 @@ impl hal::Device<Backend> for Device {
             }
         }
 
-        Ok(n::Framebuffer { descriptor, inner })
+        Ok(n::Framebuffer {
+            descriptor: Mutex::new(descriptor),
+            inner,
+        })
     }
 
     fn create_shader_module(&self, raw_data: &[u8]) -> Result<n::ShaderModule, ShaderError> {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -56,7 +56,7 @@ pub struct FramebufferInner {
 
 #[derive(Debug)]
 pub struct Framebuffer {
-    pub(crate) descriptor: metal::RenderPassDescriptor,
+    pub(crate) descriptor: Mutex<metal::RenderPassDescriptor>,
     pub(crate) inner: FramebufferInner,
 }
 


### PR DESCRIPTION
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:

The logic is changed in the following way:
  - a framebuffer still keeps a hold of a render pass descriptor, but now behind a mutex
  - starting a render pass mutates that locked descriptor in place
  - if a command buffer is deferred, only then we copy the whole descriptor out
  - careful treatment of image blits/clears is done to re-use the RP descriptor more often

Note: doesn't seem to affect Dota framerate considerably