### PR TITLE
Heap-less descriptor sets in Metal

### DIFF
--- a/src/backend/auxil/range_alloc.rs
+++ b/src/backend/auxil/range_alloc.rs
@@ -19,11 +19,12 @@ where
     pub fn new(range: Range<T>) -> Self {
         RangeAllocator {
             initial_range: range.clone(),
-            free_ranges: vec![range.clone()],
+            free_ranges: vec![range],
         }
     }
 
     pub fn allocate_range(&mut self, length: T) -> Option<Range<T>> {
+        assert_ne!(length + length, length);
         let mut best_fit: Option<(usize, Range<T>)> = None;
         for (index, range) in self.free_ranges.iter().cloned().enumerate() {
             let range_length = range.end - range.start;

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1525,7 +1525,10 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
         Ok(DescriptorSet::new())
     }
 
-    fn free_sets(&mut self, descriptor_sets: &[DescriptorSet]) {
+    fn free_sets<I>(&mut self, _descriptor_sets: I)
+    where
+        I: IntoIterator<Item = DescriptorSet>
+    {
         unimplemented!()
     }
 

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -494,7 +494,10 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
         })
     }
 
-    fn free_sets(&mut self, descriptor_sets: &[DescriptorSet]) {
+    fn free_sets<I>(&mut self, descriptor_sets: I)
+    where
+        I: IntoIterator<Item = DescriptorSet>
+    {
         for descriptor_set in descriptor_sets {
             for binding_info in &descriptor_set.binding_infos {
                 if let Some(ref view_range) = binding_info.view_range {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -755,7 +755,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 #[derive(Debug)]
 pub struct DescriptorPool;
 impl pso::DescriptorPool<Backend> for DescriptorPool {
-    fn free_sets(&mut self, _descriptor_sets: &[()]) {
+    fn free_sets<I>(&mut self, _descriptor_sets: I)
+    where
+        I: IntoIterator<Item = ()>
+    {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -185,7 +185,10 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         })).collect()
     }
 
-    fn free_sets(&mut self, _descriptor_sets: &[DescriptorSet]) {
+    fn free_sets<I>(&mut self, _descriptor_sets: I)
+    where
+        I: IntoIterator<Item = DescriptorSet>
+    {
         // Poof!  Does nothing, because OpenGL doesn't have a meaningful concept of a `DescriptorSet`.
     }
 

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -628,30 +628,64 @@ enum CommandSink {
     },
 }
 
-//TODO: scope-based command submission, to avoid doing any work (including just storing the command lists)
-// if they are going to be discarded (e.g. by `pre_render_commands`)
+/// A helper temporary object that consumes state-setting commands only
+/// applicable to a render pass currently encoded.
+enum PreRender<'a> {
+    Immediate(&'a metal::RenderCommandEncoder),
+    Deferred(&'a mut Vec<soft::RenderCommand<soft::Own>>),
+    Void,
+}
+
+impl<'a> PreRender<'a> {
+    fn is_void(&self) -> bool {
+        match *self {
+            PreRender::Void => true,
+            _ => false,
+        }
+    }
+
+    fn issue<'b>(&mut self, command: soft::RenderCommand<&'b soft::Own>) {
+        match *self {
+            PreRender::Immediate(encoder) => exec_render(encoder, command),
+            PreRender::Deferred(ref mut list) => list.push(command.own()),
+            PreRender::Void => (),
+        }
+    }
+}
+
+/// A helper temporary object that consumes state-setting commands only
+/// applicable to a compute pass currently encoded.
+enum PreCompute<'a> {
+    Immediate(&'a metal::ComputeCommandEncoder),
+    Deferred(&'a mut Vec<soft::ComputeCommand<soft::Own>>),
+    Void,
+}
+
+impl<'a> PreCompute<'a> {
+    fn issue<'b>(&mut self, command: soft::ComputeCommand<&'b soft::Own>) {
+        match *self {
+            PreCompute::Immediate(encoder) => exec_compute(encoder, command),
+            PreCompute::Deferred(ref mut list) => list.push(command.own()),
+            PreCompute::Void => (),
+        }
+    }
+}
 
 impl CommandSink {
-    /// Issue provided (state-setting) commands only when there is already
-    /// a render pass being actively encoded.
-    /// The caller is expected to change the cached state accordingly, so these commands
-    /// are going to be issued when a next pass starts, if not at this very moment.
-    fn pre_render_commands<'a, I>(&mut self, commands: I)
-    where
-        I: IntoIterator<Item = soft::RenderCommand<&'a soft::Own>>,
-    {
+    /// Start issuing pre-render commands. Those can be rejected, so the caller is responsible
+    /// for updating the state cache accordingly, so that it's set upon the start of a next pass.
+    fn pre_render(&mut self) -> PreRender {
         match *self {
             CommandSink::Immediate { encoder_state: EncoderState::Render(ref encoder), .. } => {
-                for command in commands {
-                    exec_render(encoder, command);
-                }
+                PreRender::Immediate(encoder)
             }
             CommandSink::Deferred { ref mut passes, is_encoding: true } => {
-                if let Some(&mut soft::Pass::Render { commands: ref mut list, .. }) = passes.last_mut() {
-                    list.extend(commands.into_iter().map(soft::RenderCommand::own));
+                match passes.last_mut() {
+                    Some(&mut soft::Pass::Render { commands: ref mut list, .. }) => PreRender::Deferred(list),
+                    _ => PreRender::Void,
                 }
             }
-            _ => {}
+            _ => PreRender::Void
         }
     }
 
@@ -724,26 +758,20 @@ impl CommandSink {
         }
     }
 
-    /// Issue provided (state-setting) commands only when there is already
-    /// a compute pass being actively encoded.
-    /// The caller is expected to change the cached state accordingly, so these commands
-    /// are going to be issued when a next pass starts, if not at this very moment.
-    fn pre_compute_commands<'a, I>(&mut self, commands: I)
-    where
-        I: IntoIterator<Item = soft::ComputeCommand<&'a soft::Own>>,
-    {
+    /// Start issuing pre-compute commands. Those can be rejected, so the caller is responsible
+    /// for updating the state cache accordingly, so that it's set upon the start of a next pass.
+    fn pre_compute(&mut self) -> PreCompute {
         match *self {
             CommandSink::Immediate { encoder_state: EncoderState::Compute(ref encoder), .. } => {
-                for command in commands {
-                    exec_compute(encoder, command);
-                }
+                PreCompute::Immediate(encoder)
             }
             CommandSink::Deferred { ref mut passes, is_encoding: true } => {
-                if let Some(&mut soft::Pass::Compute(ref mut list)) = passes.last_mut() {
-                    list.extend(commands.into_iter().map(soft::ComputeCommand::own));
+                match passes.last_mut() {
+                    Some(&mut soft::Pass::Compute(ref mut list)) => PreCompute::Deferred(list),
+                    _ => PreCompute::Void,
                 }
             }
-            _ => {}
+            _ => PreCompute::Void
         }
     }
 
@@ -2216,11 +2244,13 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
         let mask = self.state.set_vertex_buffers();
         if mask != 0 {
-            let commands = self.state.iter_vertex_buffers(mask);
-            self.inner
-                .borrow_mut()
-                .sink()
-                .pre_render_commands(commands);
+            let mut inner = self.inner.borrow_mut();
+            let mut pre = inner.sink().pre_render();
+            if !pre.is_void() {
+                for com in self.state.iter_vertex_buffers(mask) {
+                    pre.issue(com);
+                }
+            }
         }
     }
 
@@ -2245,7 +2275,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.inner
             .borrow_mut()
             .sink()
-            .pre_render_commands(iter::once(com));
+            .pre_render()
+            .issue(com);
     }
 
     fn set_scissors<T>(&mut self, first_scissor: u32, rects: T)
@@ -2268,7 +2299,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.inner
             .borrow_mut()
             .sink()
-            .pre_render_commands(iter::once(com));
+            .pre_render()
+            .issue(com);
     }
 
     fn set_blend_constants(&mut self, color: pso::ColorValue) {
@@ -2276,7 +2308,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.inner
             .borrow_mut()
             .sink()
-            .pre_render_commands(iter::once(com));
+            .pre_render()
+            .issue(com);
     }
 
     fn set_depth_bounds(&mut self, _: Range<f32>) {
@@ -2292,7 +2325,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.inner
             .borrow_mut()
             .sink()
-            .pre_render_commands(iter::once(com));
+            .pre_render()
+            .issue(com);
     }
 
     fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue) {
@@ -2305,11 +2339,11 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         };
 
         let com = self.state.set_stencil_reference_values(front, back);
-
         self.inner
             .borrow_mut()
             .sink()
-            .pre_render_commands(iter::once(com));
+            .pre_render()
+            .issue(com);
     }
 
     fn set_stencil_read_mask(&mut self, faces: pso::Face, value: pso::StencilValue) {
@@ -2321,11 +2355,13 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             _ => (value, value),
         };
 
-        let com = self.state.set_stencil_mask_values(&self.shared, Some((front, back)), None, None);
-        self.inner
-            .borrow_mut()
-            .sink()
-            .pre_render_commands(com);
+        if let Some(com) = self.state.set_stencil_mask_values(&self.shared, Some((front, back)), None, None) {
+            self.inner
+                .borrow_mut()
+                .sink()
+                .pre_render()
+                .issue(com);
+        }
     }
 
     fn set_stencil_write_mask(&mut self, faces: pso::Face, value: pso::StencilValue) {
@@ -2337,11 +2373,13 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             _ => (value, value),
         };
 
-        let com = self.state.set_stencil_mask_values(&self.shared, None, Some((front, back)), None);
-        self.inner
-            .borrow_mut()
-            .sink()
-            .pre_render_commands(com);
+        if let Some(com) = self.state.set_stencil_mask_values(&self.shared, None, Some((front, back)), None) {
+            self.inner
+                .borrow_mut()
+                .sink()
+                .pre_render()
+                .issue(com);
+        }
     }
 
     fn begin_render_pass<T>(
@@ -2446,26 +2484,27 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         let vertex_mask = self.state.set_vertex_buffers();
 
         let mut inner = self.inner.borrow_mut();
-        let mut commands = SmallVec::<[soft::RenderCommand<_>; 5]>::new();
-        commands.push(soft::RenderCommand::BindPipeline(
+        let mut pre = inner.sink().pre_render();
+        pre.issue(soft::RenderCommand::BindPipeline(
             &*pipeline.raw,
             pipeline.rasterizer_state.clone(),
         ));
 
         if let Some(ref vp) = pipeline.baked_states.viewport {
-            commands.push(self.state.set_viewport(vp, &self.shared.disabilities));
+            pre.issue(self.state.set_viewport(vp, &self.shared.disabilities));
         }
         if let Some(ref rect) = pipeline.baked_states.scissor {
-            commands.push(self.state.set_scissor(rect));
+            pre.issue(self.state.set_scissor(rect));
         }
         if let Some(ref color) = pipeline.baked_states.blend_color {
-            commands.push(self.state.set_blend_color(color));
+            pre.issue(self.state.set_blend_color(color));
         }
 
         // re-bind vertex buffers
         if vertex_mask != 0 {
-            let vertex_commands = self.state.iter_vertex_buffers(vertex_mask);
-            inner.sink().pre_render_commands(vertex_commands);
+            for command in self.state.iter_vertex_buffers(vertex_mask) {
+                pre.issue(command);
+            }
         }
 
         let ds = &pipeline.depth_stencil_state;
@@ -2475,29 +2514,27 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             let front_ref = ds.stencil.front_reference.static_or(self.state.stencil.front_reference);
             let back_ref = ds.stencil.back_reference.static_or(self.state.stencil.back_reference);
             if ds.stencil.front_reference.is_static() || ds.stencil.back_reference.is_static() {
-                commands.push(self.state.set_stencil_reference_values(front_ref, back_ref));
+                pre.issue(self.state.set_stencil_reference_values(front_ref, back_ref));
             }
 
-            let command = match ds.depth_stencil_static {
-                Some(ref raw) => Some(self.state.set_depth_stencil_desc(&desc, raw)),
+            match ds.depth_stencil_static {
+                Some(ref raw) => pre.issue(self.state.set_depth_stencil_desc(&desc, raw)),
                 None => {
                     let front_r = ds.stencil.front_read_mask.static_or(self.state.stencil.front_read_mask);
                     let back_r = ds.stencil.back_read_mask.static_or(self.state.stencil.back_read_mask);
                     let front_w = ds.stencil.front_write_mask.static_or(self.state.stencil.front_write_mask);
                     let back_w = ds.stencil.back_write_mask.static_or(self.state.stencil.back_write_mask);
-                    self.state.set_stencil_mask_values(
+                    if let Some(com) = self.state.set_stencil_mask_values(
                         &self.shared,
                         Some((front_r, back_r)),
                         Some((front_w, back_w)),
                         ds.depth_stencil_desc_raw.as_ref().map(Borrow::borrow),
-                    )
+                    ) {
+                        pre.issue(com);
+                    }
                 }
             };
-
-            commands.extend(command);
         }
-
-        inner.sink().pre_render_commands(commands);
     }
 
     fn bind_graphics_descriptor_sets<'a, I, J>(
@@ -2516,11 +2553,12 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
         let mut offset_iter = offsets.into_iter();
         let mut dynamic_offsets = SmallVec::<[u64; 16]>::new();
+        let mut inner = self.inner.borrow_mut();
+        let mut pre = inner.sink().pre_render();
 
         for (set_index, desc_set) in sets.into_iter().enumerate() {
             match *desc_set.borrow() {
                 native::DescriptorSet::Emulated { ref pool, ref layouts, ref sampler_range, ref texture_range, ref buffer_range } => {
-                    let mut commands = Vec::new();
                     let pool = pool.read().unwrap();
                     let mut sampler_base = sampler_range.start as usize;
                     let mut texture_base = texture_range.start as usize;
@@ -2575,7 +2613,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                     pipe_layout.res_overrides[&loc].sampler_id as usize,
                                     &pool.samplers[sm_range.clone()],
                                     |index, sampler| {
-                                        commands.push(soft::RenderCommand::BindSampler { stage, index, sampler });
+                                        pre.issue(soft::RenderCommand::BindSampler { stage, index, sampler });
                                     },
                                 );
                             }
@@ -2585,7 +2623,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                     pipe_layout.res_overrides[&loc].texture_id as usize,
                                     &pool.textures[tx_range.clone()],
                                     |index, texture| {
-                                        commands.push(soft::RenderCommand::BindTexture { stage, index, texture });
+                                        pre.issue(soft::RenderCommand::BindTexture { stage, index, texture });
                                     },
                                 );
                             }
@@ -2608,7 +2646,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                         }
                                         None => (None, 0),
                                     };
-                                    commands.push(soft::RenderCommand::BindBuffer {
+                                    pre.issue(soft::RenderCommand::BindBuffer {
                                         stage,
                                         index: start + i,
                                         buffer,
@@ -2618,14 +2656,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             }
                         }
                     }
-
-                    self.inner
-                        .borrow_mut()
-                        .sink()
-                        .pre_render_commands(commands);
                 }
                 native::DescriptorSet::ArgumentBuffer { ref raw, offset, stage_flags, .. } => {
-                    let com_vs = if stage_flags.contains(pso::ShaderStageFlags::VERTEX) {
+                    if stage_flags.contains(pso::ShaderStageFlags::VERTEX) {
                         let loc = msl::ResourceBindingLocation {
                             stage: spirv::ExecutionModel::Vertex,
                             desc_set: (first_set + set_index) as _,
@@ -2633,19 +2666,15 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         };
                         let slot = pipe_layout.res_overrides[&loc].buffer_id;
                         if self.state.resources_vs.set_buffer(slot as _, BufferPtr(raw.as_ptr()), offset as _) {
-                            Some(soft::RenderCommand::BindBuffer {
+                            pre.issue(soft::RenderCommand::BindBuffer {
                                 stage: pso::Stage::Vertex,
                                 index: slot as _,
                                 buffer: Some(BufferPtr(raw.as_ptr())),
                                 offset,
-                            })
-                        } else {
-                            None
+                            });
                         }
-                    } else {
-                        None
-                    };
-                    let com_fs = if stage_flags.contains(pso::ShaderStageFlags::FRAGMENT) {
+                    }
+                    if stage_flags.contains(pso::ShaderStageFlags::FRAGMENT) {
                         let loc = msl::ResourceBindingLocation {
                             stage: spirv::ExecutionModel::Fragment,
                             desc_set: (first_set + set_index) as _,
@@ -2653,23 +2682,14 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         };
                         let slot = pipe_layout.res_overrides[&loc].buffer_id;
                         if self.state.resources_fs.set_buffer(slot as _, BufferPtr(raw.as_ptr()), offset as _) {
-                            Some(soft::RenderCommand::BindBuffer {
+                            pre.issue(soft::RenderCommand::BindBuffer {
                                 stage: pso::Stage::Fragment,
                                 index: slot as _,
                                 buffer: Some(BufferPtr(raw.as_ptr())),
                                 offset,
-                            })
-                        } else {
-                            None
+                            });
                         }
-                    } else {
-                        None
-                    };
-                    let commands = com_vs.into_iter().chain(com_fs);
-                    self.inner
-                        .borrow_mut()
-                        .sink()
-                        .pre_render_commands(commands);
+                    }
                 }
             }
         }
@@ -2680,11 +2700,11 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.state.work_group_size = pipeline.work_group_size;
 
         let command = soft::ComputeCommand::BindPipeline(&*pipeline.raw);
-
         self.inner
             .borrow_mut()
             .sink()
-            .pre_compute_commands(iter::once(command));
+            .pre_compute()
+            .issue(command);
     }
 
     fn bind_compute_descriptor_sets<'a, I, J>(
@@ -2703,6 +2723,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
         let mut offset_iter = offsets.into_iter();
         let mut dynamic_offsets = SmallVec::<[u64; 16]>::new();
+        let mut inner = self.inner.borrow_mut();
+        let mut pre = inner.sink().pre_compute();
 
         for (set_index, desc_set) in sets.into_iter().enumerate() {
             let resources = &mut self.state.resources_cs;
@@ -2713,7 +2735,6 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             }];
             match *desc_set.borrow() {
                 native::DescriptorSet::Emulated { ref pool, ref layouts, ref sampler_range, ref texture_range, ref buffer_range } => {
-                    let mut commands = Vec::new();
                     let pool = pool.read().unwrap();
                     let mut sampler_base = sampler_range.start as usize;
                     let mut texture_base = texture_range.start as usize;
@@ -2745,7 +2766,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                 res_override.sampler_id as usize,
                                 &pool.samplers[sm_range],
                                 |index, sampler| {
-                                    commands.push(soft::ComputeCommand::BindSampler { index, sampler });
+                                    pre.issue(soft::ComputeCommand::BindSampler { index, sampler });
                                 },
                             );
                         }
@@ -2755,7 +2776,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                 res_override.texture_id as usize,
                                 &pool.textures[tx_range],
                                 |index, texture| {
-                                    commands.push(soft::ComputeCommand::BindTexture { index, texture });
+                                    pre.issue(soft::ComputeCommand::BindTexture { index, texture });
                                 },
                             );
                         }
@@ -2778,7 +2799,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                     }
                                     None => (None, 0),
                                 };
-                                commands.push(soft::ComputeCommand::BindBuffer {
+                                pre.issue(soft::ComputeCommand::BindBuffer {
                                     index: start + i,
                                     buffer,
                                     offset,
@@ -2786,26 +2807,17 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             }
                         }
                     }
-
-                    self.inner
-                        .borrow_mut()
-                        .sink()
-                        .pre_compute_commands(commands);
                 }
                 native::DescriptorSet::ArgumentBuffer { ref raw, offset, stage_flags, .. } => {
                     if stage_flags.contains(pso::ShaderStageFlags::COMPUTE) {
                         let index = res_override.buffer_id as usize;
                         let buffer = BufferPtr(raw.as_ptr());
                         if resources.set_buffer(index, buffer, offset as _) {
-                            let com = soft::ComputeCommand::BindBuffer {
+                            pre.issue(soft::ComputeCommand::BindBuffer {
                                 index,
                                 buffer: Some(buffer),
                                 offset,
-                            };
-                            self.inner
-                                .borrow_mut()
-                                .sink()
-                                .pre_compute_commands(iter::once(com));
+                            });
                         }
                     }
                 }
@@ -3148,22 +3160,14 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         let id = self.shared.push_constants_buffer_id;
 
         if stages.intersects(pso::ShaderStageFlags::GRAPHICS) {
-            // Note: it's a waste to heap allocate the bytes here in case
-            // of no active render pass.
+            let mut inner = self.inner.borrow_mut();
+            let mut pre = inner.sink().pre_render();
             // Note: the whole range is re-uploaded, which may be inefficient
             if stages.contains(pso::ShaderStageFlags::VERTEX) {
-                let com = self.state.push_vs_constants(id);
-                self.inner
-                    .borrow_mut()
-                    .sink()
-                    .pre_render_commands(iter::once(com));
+                pre.issue(self.state.push_vs_constants(id));
             }
             if stages.contains(pso::ShaderStageFlags::FRAGMENT) {
-                let com = self.state.push_ps_constants(id);
-                self.inner
-                    .borrow_mut()
-                    .sink()
-                    .pre_render_commands(iter::once(com));
+                pre.issue(self.state.push_ps_constants(id));
             }
         }
     }
@@ -3177,15 +3181,12 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.state.update_push_constants(offset, constants);
         let id = self.shared.push_constants_buffer_id;
 
-        // Note: it's a waste to heap allocate the bytes here in case
-        // of no active render pass.
         // Note: the whole range is re-uploaded, which may be inefficient
-        let command = self.state.push_cs_constants(id);
-
         self.inner
             .borrow_mut()
             .sink()
-            .pre_compute_commands(iter::once(command));
+            .pre_compute()
+            .issue(self.state.push_cs_constants(id));
     }
 
     fn execute_commands<I>(

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -256,7 +256,7 @@ fn validate_line_width(width: f32) {
     assert_eq!(width, 1.0);
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BufferPtr(*mut metal::MTLBuffer);
 
 impl BufferPtr {
@@ -273,7 +273,7 @@ impl BufferPtr {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TexturePtr(*mut metal::MTLTexture);
 
 impl TexturePtr {
@@ -290,7 +290,7 @@ impl TexturePtr {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SamplerPtr(*mut metal::MTLSamplerState);
 
 impl SamplerPtr {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -390,12 +390,15 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
         }
     }
 
-    fn free_sets(&mut self, descriptor_sets: &[DescriptorSet]) {
+    fn free_sets<I>(&mut self, descriptor_sets: I)
+    where
+        I: IntoIterator<Item = DescriptorSet>
+    {
         match self {
             DescriptorPool::Emulated(pool_inner) => {
                 let mut inner = pool_inner.write().unwrap();
                 for descriptor_set in descriptor_sets {
-                    match *descriptor_set {
+                    match descriptor_set {
                         DescriptorSet::Emulated { ref sampler_range, ref texture_range, ref buffer_range, .. } => {
                             if sampler_range.start != sampler_range.end {
                                 inner.sampler_alloc.free_range(sampler_range.clone());
@@ -429,7 +432,7 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
                             panic!("Tried to free a DescriptorSet not given out by this DescriptorPool!")
                         }
                         DescriptorSet::ArgumentBuffer { offset, encoder, .. } => {
-                            let handle_range = (*offset)..offset + encoder.encoded_length();
+                            let handle_range = offset .. offset + encoder.encoded_length();
                             range_allocator.free_range(handle_range);
                         }
                     }

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -140,9 +140,12 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         }
     }
 
-    fn free_sets(&mut self, descriptor_sets: &[DescriptorSet]) {
+    fn free_sets<I>(&mut self, descriptor_sets: I)
+    where
+        I: IntoIterator<Item = DescriptorSet>
+    {
         self.set_free_vec.clear();
-        self.set_free_vec.extend(descriptor_sets.iter().map(|d| d.raw));
+        self.set_free_vec.extend(descriptor_sets.into_iter().map(|d| d.raw));
         unsafe {
             self.device.0.free_descriptor_sets(self.raw, &self.set_free_vec);
         }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -221,7 +221,10 @@ pub trait Device<B: Backend>: Any + Send + Sync {
         I: IntoIterator,
         I::Item: Borrow<pso::GraphicsPipelineDesc<'a, B>>,
     {
-        descs.into_iter().map(|desc| self.create_graphics_pipeline(desc.borrow())).collect()
+        descs
+            .into_iter()
+            .map(|desc| self.create_graphics_pipeline(desc.borrow()))
+            .collect()
     }
 
     /// Destroys a graphics pipeline.
@@ -246,7 +249,10 @@ pub trait Device<B: Backend>: Any + Send + Sync {
         I: IntoIterator,
         I::Item: Borrow<pso::ComputePipelineDesc<'a, B>>,
     {
-        descs.into_iter().map(|desc| self.create_compute_pipeline(desc.borrow())).collect()
+        descs
+            .into_iter()
+            .map(|desc| self.create_compute_pipeline(desc.borrow()))
+            .collect()
     }
 
     /// Destroys a compute pipeline.

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -138,6 +138,7 @@ pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
             .collect()
     }
 
+    //TODO: change the API to use an iterator
     /// Free the descriptor sets given, after calling this all descriptor sets in `descriptor_sets`
     /// will be invalid.
     fn free_sets(&mut self, descriptor_sets: &[B::DescriptorSet]);

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -138,10 +138,10 @@ pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
             .collect()
     }
 
-    //TODO: change the API to use an iterator
-    /// Free the descriptor sets given, after calling this all descriptor sets in `descriptor_sets`
-    /// will be invalid.
-    fn free_sets(&mut self, descriptor_sets: &[B::DescriptorSet]);
+    /// Free the given descriptor sets provided as an iterator.
+    fn free_sets<I>(&mut self, descriptor_sets: I)
+    where
+        I: IntoIterator<Item = B::DescriptorSet>;
 
     /// Resets a descriptor pool, releasing all resources from all the descriptor sets
     /// allocated from it and freeing the descriptor sets. Invalidates all descriptor


### PR DESCRIPTION
Fixes the heap allocations in descriptor sets, to help #2161.
Edit: the improvement is there, but it's not the one we were looking for.

Adds real value semantics for the `DescriptorPool`, which now owns the allocation and has the actual descriptor sets pointing to it.
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal

~~Note: it doesn't work correctly yet, but I'd be happy to get the review comments and notes. Perhaps, you can spot the mistake? ;)
Sadly, my CTS is non-operational atm, so it's not easy to figure out a test case.
Note2: the individual commits are not build-able. Will squash once finished.~~