### PR TITLE
Various Metal performance optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ else
 endif
 
 
-.PHONY: all check test reftests travis-sdl2
+.PHONY: all check quad test reftests travis-sdl2
 
 all: check test
 
@@ -61,6 +61,9 @@ reftests:
 reftests-ci:
 	cd src/warden && cargo test --features "gl"
 	cd src/warden && cargo run --features "gl" -- ci #TODO: "gl-headless"
+
+quad:
+	cd examples && cargo run --bin quad --features ${FEATURES_HAL}
 
 travis-sdl2:
 	#TODO

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -30,8 +30,8 @@ use hal::pso::{PipelineStage, ShaderStageFlags, Specialization};
 use hal::queue::Submission;
 
 use std::fs;
-use std::io::Cursor;
-use std::io::Read;
+use std::io::{Cursor, Read};
+
 
 const ENTRY_NAME: &str = "main";
 
@@ -480,7 +480,7 @@ fn main() {
             cmd_buffer.set_viewports(0, &[viewport.clone()]);
             cmd_buffer.set_scissors(0, &[viewport.rect]);
             cmd_buffer.bind_graphics_pipeline(&pipeline);
-            cmd_buffer.bind_vertex_buffers(0, pso::VertexBufferSet(vec![(&vertex_buffer, 0)]));
+            cmd_buffer.bind_vertex_buffers(0, Some((&vertex_buffer, 0)));
             cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, Some(&desc_set), &[]); //TODO
 
             {

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -866,9 +866,14 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn bind_vertex_buffers(&mut self, first_binding: u32, vbs: pso::VertexBufferSet<Backend>) {
-        let (buffers, offsets): (Vec<*mut d3d11::ID3D11Buffer>, Vec<u32>) = vbs.0.iter()
-            .map(|(buf, offset)| (buf.internal.raw, *offset as u32))
+    fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    where
+        I: IntoIterator<Item = (T, buffer::Offset)>,
+        T: Borrow<Buffer>,
+    {
+        let (buffers, offsets): (Vec<*mut d3d11::ID3D11Buffer>, Vec<u32>) = buffers
+            .into_iter()
+            .map(|(buf, offset)| (buf.borrow().internal.raw, offset as u32))
             .unzip();
 
         // TODO: strides

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1641,13 +1641,13 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     {
         // Only cache the vertex buffer views as we don't know the stride (PSO).
         assert!(first_binding as usize <= MAX_VERTEX_BUFFERS);
-        for (&(buffer, offset), view) in buffers
+        for ((buffer, offset), view) in buffers
             .into_iter()
             .zip(self.vertex_buffer_views[first_binding as _..].iter_mut())
         {
             let b = buffer.borrow();
             let base = unsafe { (*b.resource).GetGPUVirtualAddress() };
-            view.BufferLocation = base + offset as u64;
+            view.BufferLocation = base + offset;
             view.SizeInBytes = b.size_in_bytes - offset as u32;
         }
     }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -499,7 +499,11 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    fn bind_vertex_buffers(&mut self, _: u32, _: pso::VertexBufferSet<Backend>) {
+    fn bind_vertex_buffers<I, T>(&mut self, _: u32, _: I)
+    where
+        I: IntoIterator<Item = (T, buffer::Offset)>,
+        T: Borrow<()>,
+    {
         unimplemented!()
     }
 

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -821,11 +821,11 @@ impl CommandSink {
     ) where
         I: Iterator<Item = soft::RenderCommand<&'a soft::Own>>,
     {
+        //assert!(AutoReleasePool::is_active());
         self.stop_encoding();
 
         match *self {
             CommandSink::Immediate { ref cmd_buffer, ref mut encoder_state, .. } => {
-                let _ap = AutoreleasePool::new();
                 let encoder = cmd_buffer.new_render_command_encoder(descriptor);
                 for command in init_commands {
                     exec_render(encoder, command);
@@ -1446,7 +1446,7 @@ impl pool::RawCommandPool<Backend> for CommandPool {
                 framebuffer_inner: native::FramebufferInner {
                     extent: Extent::default(),
                     aspects: Aspects::empty(),
-                    colors: Vec::new(),
+                    colors: SmallVec::new(),
                     depth_stencil: None,
                 }
             },
@@ -1653,6 +1653,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<SubresourceRange>,
     {
+        let _ap = AutoreleasePool::new();
+
         let CommandBufferInner {
             ref mut retained_textures,
             ref mut sink,
@@ -2017,6 +2019,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<com::ImageBlit>
     {
+        let _ap = AutoreleasePool::new();
+
         let vertices = &mut self.temp.blit_vertices;
         vertices.clear();
 
@@ -2220,7 +2224,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 .chain(&extra)
                 .cloned();
 
-            inner.sink().begin_render_pass(false, &descriptor, commands);
+            inner
+                .sink()
+                .begin_render_pass(false, &descriptor, commands);
         }
     }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -27,6 +27,7 @@ use metal::{self,
     MTLVertexStepFunction, MTLSamplerBorderColor, MTLSamplerMipFilter, MTLTextureType,
     CaptureManager
 };
+use smallvec::SmallVec;
 use spirv_cross::{msl, spirv, ErrorCode as SpirvErrorCode};
 use foreign_types::ForeignType;
 
@@ -1124,7 +1125,7 @@ impl hal::Device<Backend> for Device {
         let mut inner = n::FramebufferInner {
             extent,
             aspects: format::Aspects::empty(),
-            colors: Vec::new(),
+            colors: SmallVec::new(),
             depth_stencil: None,
         };
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -6,14 +6,13 @@ use {conversions as conv, command, native as n};
 use native;
 
 use std::borrow::Borrow;
-use std::collections::hash_map::{Entry, HashMap};
+use std::collections::hash_map::Entry;
 use std::ops::Range;
 use std::path::Path;
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::{cmp, mem, slice, time};
 
 use hal::{self, error, image, pass, format, mapping, memory, buffer, pso, query, window};
-use hal::backend::FastHashMap;
 use hal::device::{BindError, OutOfMemory, FramebufferError, ShaderError};
 use hal::memory::Properties;
 use hal::pool::CommandPoolCreateFlags;
@@ -496,7 +495,7 @@ impl Device {
         {
             Ok(library) => Ok(n::ShaderModule::Compiled {
                 library,
-                entry_point_map: FastHashMap::default(),
+                entry_point_map: n::EntryPointMap::default(),
             }),
             Err(err) => Err(ShaderError::CompilationFailed(err.into())),
         }
@@ -506,8 +505,8 @@ impl Device {
         &self,
         raw_data: &[u8],
         primitive_class: MTLPrimitiveTopologyClass,
-        overrides: &HashMap<msl::ResourceBindingLocation, msl::ResourceBinding>,
-    ) -> Result<(metal::Library, FastHashMap<String, spirv::EntryPoint>), ShaderError> {
+        overrides: &n::ResourceOverrideMap,
+    ) -> Result<(metal::Library, n::EntryPointMap), ShaderError> {
         // spec requires "codeSize must be a multiple of 4"
         assert_eq!(raw_data.len() & 3, 0);
 
@@ -528,7 +527,10 @@ impl Device {
         compiler_options.resolve_specialized_array_lengths = true;
         compiler_options.vertex.invert_y = true;
         // fill the overrides
-        compiler_options.resource_binding_overrides = overrides.clone();
+        compiler_options.resource_binding_overrides = overrides
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
 
         ast.set_compiler_options(&compiler_options)
             .map_err(|err| {
@@ -557,7 +559,7 @@ impl Device {
                 ShaderError::CompilationFailed(msg)
             })?;
 
-        let mut entry_point_map = FastHashMap::default();
+        let mut entry_point_map = n::EntryPointMap::default();
         for entry_point in entry_points {
             info!("Entry point {:?}", entry_point);
             let cleansed = ast.get_cleansed_entry_point_name(&entry_point.name, entry_point.execution_model)
@@ -727,7 +729,7 @@ impl hal::Device<Backend> for Device {
             (ShaderStageFlags::FRAGMENT, spirv::ExecutionModel::Fragment,  Counters { buffers:0, textures:0, samplers:0 }),
             (ShaderStageFlags::COMPUTE,  spirv::ExecutionModel::GlCompute, Counters { buffers:0, textures:0, samplers:0 }),
         ];
-        let mut res_overrides = HashMap::new();
+        let mut res_overrides = n::ResourceOverrideMap::default();
 
         for (set_index, set_layout) in set_layouts.into_iter().enumerate() {
             match set_layout.borrow() {
@@ -1185,7 +1187,7 @@ impl hal::Device<Backend> for Device {
             let (library, entry_point_map) = self.compile_shader_library(
                 raw_data,
                 MTLPrimitiveTopologyClass::Unspecified,
-                &HashMap::new(),
+                &n::ResourceOverrideMap::default(),
             )?;
             n::ShaderModule::Compiled {
                 library,

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -13,6 +13,7 @@ use hal::format::{Aspects, Format, FormatDesc};
 
 use cocoa::foundation::{NSUInteger};
 use metal;
+use smallvec::SmallVec;
 use spirv_cross::{msl, spirv};
 use foreign_types::ForeignType;
 
@@ -51,7 +52,7 @@ pub struct ColorAttachment {
 pub struct FramebufferInner {
     pub extent: image::Extent,
     pub aspects: Aspects,
-    pub colors: Vec<ColorAttachment>,
+    pub colors: SmallVec<[ColorAttachment; 4]>,
     pub depth_stencil: Option<metal::MTLPixelFormat>,
 }
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -2,7 +2,6 @@ use {Backend, BufferPtr, SamplerPtr, TexturePtr};
 use internal::Channel;
 use window::SwapchainImage;
 
-use std::collections::HashMap;
 use std::ops::Range;
 use std::os::raw::{c_void, c_long};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
@@ -20,13 +19,15 @@ use foreign_types::ForeignType;
 use range_alloc::RangeAllocator;
 
 
+pub type EntryPointMap = FastHashMap<String, spirv::EntryPoint>;
+
 /// Shader module can be compiled in advance if it's resource bindings do not
 /// depend on pipeline layout, in which case the value would become `Compiled`.
 #[derive(Debug)]
 pub enum ShaderModule {
     Compiled {
         library: metal::Library,
-        entry_point_map: FastHashMap<String, spirv::EntryPoint>,
+        entry_point_map: EntryPointMap,
     },
     Raw(Vec<u8>),
 }
@@ -65,11 +66,13 @@ pub struct Framebuffer {
 unsafe impl Send for Framebuffer {}
 unsafe impl Sync for Framebuffer {}
 
+pub type ResourceOverrideMap = FastHashMap<msl::ResourceBindingLocation, msl::ResourceBinding>;
+
 #[derive(Debug)]
 pub struct PipelineLayout {
     // First vertex buffer index to be used by attributes
     pub(crate) attribute_buffer_index: u32,
-    pub(crate) res_overrides: HashMap<msl::ResourceBindingLocation, msl::ResourceBinding>,
+    pub(crate) res_overrides: ResourceOverrideMap,
 }
 
 #[derive(Clone, Debug)]

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -3,8 +3,7 @@ use std::borrow::Borrow;
 use std::ops::Range;
 
 use Backend;
-use {image, pso};
-use buffer::IndexBufferView;
+use {buffer, image, pso};
 use query::{Query, QueryControl, QueryId};
 use queue::capability::{Graphics, GraphicsOrCompute, Supports};
 use super::{
@@ -181,13 +180,17 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<'a,
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
-    pub fn bind_index_buffer(&mut self, ibv: IndexBufferView<B>) {
+    pub fn bind_index_buffer(&mut self, ibv: buffer::IndexBufferView<B>) {
         self.raw.bind_index_buffer(ibv)
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
-    pub fn bind_vertex_buffers(&mut self, first_binding: u32, vbs: pso::VertexBufferSet<B>) {
-        self.raw.bind_vertex_buffers(first_binding, vbs)
+    pub fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    where
+        I: IntoIterator<Item = (T, buffer::Offset)>,
+        T: Borrow<B::Buffer>,
+    {
+        self.raw.bind_vertex_buffers(first_binding, buffers)
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -206,7 +206,10 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
     ///
     /// Each buffer passed corresponds to the vertex input binding with the same index,
     /// starting from an offset index `first_binding`.
-    fn bind_vertex_buffers(&mut self, first_binding: u32, pso::VertexBufferSet<B>);
+    fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    where
+        I: IntoIterator<Item = (T, buffer::Offset)>,
+        T: Borrow<B::Buffer>;
 
     /// Set the viewport parameters for the rasterizer.
     ///

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -65,8 +65,12 @@ impl<'a, B: Backend> RenderSubpassCommon<'a, B> {
     }
 
     ///
-    pub fn bind_vertex_buffers(&mut self, first_binding: u32, vbs: pso::VertexBufferSet<B>) {
-        self.0.bind_vertex_buffers(first_binding, vbs);
+    pub fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    where
+        I: IntoIterator<Item = (T, buffer::Offset)>,
+        T: Borrow<B::Buffer>,
+    {
+        self.0.bind_vertex_buffers(first_binding, buffers);
     }
 
     ///

--- a/src/hal/src/pso/input_assembler.rs
+++ b/src/hal/src/pso/input_assembler.rs
@@ -2,8 +2,7 @@
 //! The input assembler collects raw vertex and index data.
 
 use format;
-use buffer::Offset;
-use {Backend, Primitive};
+use {Primitive};
 
 /// Shader binding location.
 pub type Location = u32;
@@ -86,19 +85,5 @@ impl InputAssemblerDesc {
             primitive,
             primitive_restart: PrimitiveRestart::Disabled,
         }
-    }
-}
-
-/// A complete set of vertex buffers to be used for vertex import in PSO.
-#[derive(Clone, Debug)]
-pub struct VertexBufferSet<'a, B: Backend>(
-    /// Array of buffer handles with offsets in them
-    pub Vec<(&'a B::Buffer, Offset)>,
-);
-
-impl<'a, B: Backend> VertexBufferSet<'a, B> {
-    /// Create an empty set
-    pub fn new() -> Self {
-        VertexBufferSet(Vec::new())
     }
 }

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -945,10 +945,8 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                                                 .expect(&format!("Missing vertex buffer: {}", name))
                                                 .handle;
                                             (buf, offset)
-                                        })
-                                        .collect::<Vec<_>>();
-                                    let set = pso::VertexBufferSet(buffers_raw);
-                                    encoder.bind_vertex_buffers(0, set);
+                                        });
+                                    encoder.bind_vertex_buffers(0, buffers_raw);
                                 }
                                 Dc::BindPipeline(ref name) => {
                                     let pso = resources.graphics_pipelines


### PR DESCRIPTION
Helps #2161 . I'm now getting 80-85 fps on the test run.
Aside from Metal, also changes HAL to avoid heap allocation for vertex buffer binding.
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
