### PR TITLE
[v0.17] Update winit -> 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ name = "gfx_app"
 [dependencies]
 log = "0.4"
 env_logger = "0.5"
-glutin = "0.16"
-winit = "0.15"
+glutin = "0.17"
+winit = "0.16"
 gfx_core = { path = "src/core", version = "0.8" }
 gfx = { path = "src/render", version = "0.17" }
 gfx_macros = { path = "src/macros", version = "0.2" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.15" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.24" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.25" }
 gfx_window_glfw = { path = "src/window/glfw", version = "0.16", optional = true }
 gfx_window_sdl = { path = "src/window/sdl", version = "0.8", optional = true }
 
@@ -57,7 +57,7 @@ optional = true
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.7" }
-gfx_window_dxgi = { path = "src/window/dxgi", version = "0.15" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.16" }
 
 [[example]]
 name = "blend"

--- a/examples/gamma/main.rs
+++ b/examples/gamma/main.rs
@@ -55,7 +55,7 @@ pub fn main() {
     let mut events_loop = glutin::EventsLoop::new();
     let window_builder = glutin::WindowBuilder::new()
         .with_title("Gamma example".to_string())
-        .with_dimensions(1024, 768);
+        .with_dimensions((1024, 768).into());
 
     let (api, version, vs_code, fs_code) = if cfg!(target_os = "emscripten") {
         (
@@ -90,80 +90,83 @@ pub fn main() {
     let mut download = factory.create_download_buffer::<SurfaceData>(w as usize * h as usize)
         .unwrap();
 
-    events_loop.run_forever(move |event| {
-        use glutin::{ControlFlow, ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
+    let mut running = true;
+    while running {
+        events_loop.poll_events(|event| {
+            use glutin::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 
-        if let Event::WindowEvent { event, .. } = event {
-            match event {
-                WindowEvent::CloseRequested |
-                WindowEvent::KeyboardInput {
-                    input: KeyboardInput {
-                        virtual_keycode: Some(VirtualKeyCode::Escape),
+            if let Event::WindowEvent { event, .. } = event {
+                match event {
+                    WindowEvent::CloseRequested |
+                    WindowEvent::KeyboardInput {
+                        input: KeyboardInput {
+                            virtual_keycode: Some(VirtualKeyCode::Escape),
+                            ..
+                        },
                         ..
+                    } => running = false,
+                    WindowEvent::Resized(size) => {
+                        window.resize(size.to_physical(window.get_hidpi_factor()));
+                        gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);
+                        download = factory
+                            .create_download_buffer(
+                                size.width.round() as usize * size.height.round() as usize,
+                            )
+                            .unwrap();
                     },
-                    ..
-                } => return ControlFlow::Break,
-                WindowEvent::Resized(width, height) => {
-                    window.resize(width, height);
-                    gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);
-                    download = factory.create_download_buffer(width as usize * height as usize)
-                        .unwrap();
-                },
-                WindowEvent::KeyboardInput {
-                    input: KeyboardInput {
-                        virtual_keycode: Some(VirtualKeyCode::S),
-                        state: ElementState::Released,
+                    WindowEvent::KeyboardInput {
+                        input: KeyboardInput {
+                            virtual_keycode: Some(VirtualKeyCode::S),
+                            state: ElementState::Released,
+                            ..
+                        },
                         ..
+                    } => screenshot = true,
+                _ => (),
+                }
+            }
+
+            if screenshot {
+                println!("taking screenshot");
+                let (w, h, _, _) = data.out.get_dimensions();
+                encoder.copy_texture_to_buffer_raw(
+                    data.out.raw().get_texture(),
+                    None,
+                    gfx::texture::RawImageInfo {
+                        xoffset: 0,
+                        yoffset: 0,
+                        zoffset: 0,
+                        width: w,
+                        height: h,
+                        depth: 0,
+                        format: ColorFormat::get_format(),
+                        mipmap: 0,
                     },
-                    ..
-                } => screenshot = true,
-            _ => (),
+                    download.raw(),
+                    0
+                ).unwrap();
+                encoder.flush(&mut device);
+
+                let path = "screen.png";
+                println!("saving screenshot to {}", path);
+                let reader = factory.read_mapping(&download).unwrap();
+                // intermediary buffer only to avoid casting
+                let mut data = Vec::with_capacity(w as usize * h as usize * 4);
+                for pixel in reader.iter() {
+                    data.extend(pixel);
+                }
+                image::save_buffer(path, &data, w as u32, h as u32, image::ColorType::RGBA(8))
+                    .unwrap();
+
+                println!("done!");
+                screenshot = false;
             }
-        }
-
-        if screenshot {
-            println!("taking screenshot");
-            let (w, h, _, _) = data.out.get_dimensions();
-            encoder.copy_texture_to_buffer_raw(
-                data.out.raw().get_texture(),
-                None,
-                gfx::texture::RawImageInfo {
-                    xoffset: 0,
-                    yoffset: 0,
-                    zoffset: 0,
-                    width: w,
-                    height: h,
-                    depth: 0,
-                    format: ColorFormat::get_format(),
-                    mipmap: 0,
-                },
-                download.raw(),
-                0
-            ).unwrap();
-            encoder.flush(&mut device);
-
-            let path = "screen.png";
-            println!("saving screenshot to {}", path);
-            let reader = factory.read_mapping(&download).unwrap();
-            // intermediary buffer only to avoid casting
-            let mut data = Vec::with_capacity(w as usize * h as usize * 4);
-            for pixel in reader.iter() {
-                data.extend(pixel);
-            }
-            image::save_buffer(path, &data, w as u32, h as u32, image::ColorType::RGBA(8))
-                .unwrap();
-
-            println!("done!");
-            screenshot = false;
-        }
-
+        });
         // draw a frame
         encoder.clear(&data.out, CLEAR_COLOR);
         encoder.draw(&slice, &pso, &data);
         encoder.flush(&mut device);
         window.swap_buffers().unwrap();
         device.cleanup();
-
-        ControlFlow::Continue
-    });
+    }
 }

--- a/examples/performance/main.rs
+++ b/examples/performance/main.rs
@@ -363,6 +363,13 @@ fn main() {
         return;
     }
 
+    if cfg!(target_os = "linux") {
+        // example relies on dpi=1 & x11 has weird dpis
+        if env::var("WINIT_HIDPI_FACTOR").is_err() {
+            env::set_var("WINIT_HIDPI_FACTOR", "1");
+        }
+    }
+
     let mode = args.nth(1).unwrap();
     let count: i32 = if args_count == 3 {
         FromStr::from_str(&args.next().unwrap()).ok()
@@ -375,7 +382,7 @@ fn main() {
     let mut events_loop = glutin::EventsLoop::new();
     let builder = glutin::WindowBuilder::new()
         .with_title("Performance example".to_string())
-        .with_dimensions(800, 600);
+        .with_dimensions((800, 600).into());
     let context = glutin::ContextBuilder::new()
         .with_vsync(false);
 
@@ -397,7 +404,7 @@ fn main() {
 
         let proj = {
             let aspect = {
-                let (w, h) = r.window().get_inner_size().unwrap();
+                let (w, h): (u32, u32) = r.window().get_inner_size().unwrap().into();
                 w as f32 / h as f32
             };
             cgmath::perspective(Deg(45.0f32), aspect, 1.0, 10.0)

--- a/src/core/src/texture.rs
+++ b/src/core/src/texture.rs
@@ -196,8 +196,8 @@ impl AaMode {
 
 /// How to [filter](https://en.wikipedia.org/wiki/Texture_filtering) the
 /// texture when sampling. They correspond to increasing levels of quality,
-/// but also cost. They "layer" on top of each other: it is not possible to
-/// have bilinear filtering without mipmapping, for example.
+/// but also cost. Mipmap, trilinear and anisotropic filtering require
+/// mipmapping, but the other filtering methods do not.
 ///
 /// These names are somewhat poor, in that "bilinear" is really just doing
 /// linear filtering on each axis, and it is only bilinear in the case of 2D

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.15.0"
+version = "0.16.0"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,6 +29,6 @@ name = "gfx_window_dxgi"
 [dependencies]
 log = "0.4"
 winapi = { version = "0.3" , features = ["d3d11", "dxgi"] }
-winit = "0.15"
+winit = "0.16"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.7" }

--- a/src/window/dxgi/src/lib.rs
+++ b/src/window/dxgi/src/lib.rs
@@ -146,7 +146,11 @@ pub fn init_raw(wb: winit::WindowBuilder, events_loop: &winit::EventsLoop, color
 pub fn init_existing_raw(inner: winit::Window, color_format: format::Format)
                          -> Result<(Window, Device, Factory, h::RawRenderTargetView<Resources>), InitError>
 {
-    let (width, height) = inner.get_inner_size().unwrap();
+    let (width, height): (u32, u32) = inner
+        .get_inner_size()
+        .unwrap()
+        .to_physical(inner.get_hidpi_factor())
+        .into();
 
     let driver_types = [
         d3dcommon::D3D_DRIVER_TYPE_HARDWARE,
@@ -225,7 +229,7 @@ pub fn update_views<Cf, D>(window: &mut Window, factory: &mut Factory, device: &
             -> Result<h::RenderTargetView<Resources, Cf>, f::TargetViewError>
 where Cf: format::RenderFormat, D: DeviceExt
 {
-    
+
     factory.cleanup();
     device.clear_state();
     device.cleanup();
@@ -235,5 +239,5 @@ where Cf: format::RenderFormat, D: DeviceExt
             error!("Resize failed with code {:X}", hr);
             f::TargetViewError::NotDetached
         }
-    )    
+    )
 }

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.24.0"
+version = "0.25.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,7 +28,7 @@ documentation = "https://docs.rs/gfx_window_glutin"
 name = "gfx_window_glutin"
 
 [dependencies]
-glutin = "0.16"
+glutin = "0.17"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.15" }
 

--- a/src/window/glutin/src/lib.rs
+++ b/src/window/glutin/src/lib.rs
@@ -110,8 +110,8 @@ fn get_window_dimensions(window: &glutin::GlWindow) -> texture::Dimensions {
     let (width, height) = emscripten::get_canvas_size();
     #[cfg(not(target_os = "emscripten"))]
     let (width, height) = {
-        let (w, h) = window.get_inner_size().unwrap();
-        (w as _, h as _)
+        let size = window.get_inner_size().unwrap().to_physical(window.get_hidpi_factor());
+        (size.width as _, size.height as _)
     };
     let aa = window
         .get_pixel_format().multisampling

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -30,7 +30,7 @@ name = "gfx_window_metal"
 log = "0.4"
 cocoa = "0.9"
 objc = "0.2"
-winit = "0.15"
+winit = "0.16"
 metal-rs = "0.4"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.3" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/gfx_window_vulkan"
 name = "gfx_window_vulkan"
 
 [dependencies]
-winit = "0.15"
+winit = "0.16"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.2" }

--- a/src/window/vulkan/src/lib.rs
+++ b/src/window/vulkan/src/lib.rs
@@ -106,7 +106,7 @@ impl<T: Clone> Window<T> {
     }
 
     pub fn get_size(&self) -> (u32, u32) {
-        self.window.get_inner_size_points().unwrap()
+        self.window.get_inner_size().unwrap().into()
     }
 }
 
@@ -185,7 +185,7 @@ pub fn init<T: core::format::RenderFormat>(wb: winit::WindowBuilder, events_loop
         capabilities
     };
 
-    // Determine whether a queue family of a physical device supports presentation to a given surface 
+    // Determine whether a queue family of a physical device supports presentation to a given surface
     let supports_presentation = {
         let (_, vk) = backend.get_instance();
         let dev = backend.get_physical_device();
@@ -226,7 +226,11 @@ pub fn init<T: core::format::RenderFormat>(wb: winit::WindowBuilder, events_loop
         modes
     };
 
-    let (width, height) = window.get_inner_size_points().unwrap();
+    let (width, height): (u32, u32) = window
+        .get_inner_size()
+        .unwrap()
+        .to_physical(window.get_hidpi_factor())
+        .into();
 
     // TODO: Use the queried information to check if our values are supported before creating the swapchain
     let swapchain_info = vk::SwapchainCreateInfoKHR {


### PR DESCRIPTION
* gfx_window_glutin -> `0.25`
* gfx_window_dxgi -> `0.16`
* Use physical dimensions in window projects.
* Use `poll_events` in examples instead of `run_forever` which can only handle one event per frame. _Included in this branch as otherwise testing is a pain_.
* Use WINIT_HIDPI_FACTOR override in performance example to avoid non-1 dpi x11 issues as this example can't handle resizing.

PR checklist:
- [x] tested examples with the following backends: gl
