### PR TITLE
Added `clear_raw()` methods to Encoder.

### DIFF
--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -510,20 +510,43 @@ impl<R: Resources, C: command::Buffer<R>> Encoder<R, C> {
     pub fn clear<T: format::RenderFormat>(&mut self,
                  view: &handle::RenderTargetView<R, T>, value: T::View)
     where T::View: Into<command::ClearColor> {
-        let target = self.handles.ref_rtv(view.raw()).clone();
-        self.command_buffer.clear_color(target, value.into())
+        self.clear_raw(view.raw(), value.into());
     }
     /// Clear a depth view with a specified value.
     pub fn clear_depth<T: format::DepthFormat>(&mut self,
                        view: &handle::DepthStencilView<R, T>, depth: Depth) {
-        let target = self.handles.ref_dsv(view.raw()).clone();
-        self.command_buffer.clear_depth_stencil(target, Some(depth), None)
+        self.clear_depth_raw(view.raw(), depth);
     }
 
     /// Clear a stencil view with a specified value.
     pub fn clear_stencil<T: format::StencilFormat>(&mut self,
                          view: &handle::DepthStencilView<R, T>, stencil: Stencil) {
-        let target = self.handles.ref_dsv(view.raw()).clone();
+        self.clear_stencil_raw(view.raw(), stencil);
+    }
+
+
+    /// Clears the supplied `RawRenderTargetView` to the supplied `ClearColor`.
+    pub fn clear_raw(&mut self,
+                     view: &handle::RawRenderTargetView<R>,
+                     value: command::ClearColor) {
+        let target = self.handles.ref_rtv(view).clone();
+        self.command_buffer.clear_color(target, value)
+    }
+
+
+    /// Clear a raw depth view with a specified value.
+    pub fn clear_depth_raw(&mut self,
+                           view: &handle::RawDepthStencilView<R>,
+                           depth: Depth) {
+        let target = self.handles.ref_dsv(view).clone();
+        self.command_buffer.clear_depth_stencil(target, Some(depth), None)
+    }
+
+    /// Clear a raw stencil view with a specified value.
+    pub fn clear_stencil_raw(&mut self,
+                             view: &handle::RawDepthStencilView<R>,
+                             stencil: Stencil) {
+        let target = self.handles.ref_dsv(view).clone();
         self.command_buffer.clear_depth_stencil(target, None, Some(stencil))
     }
 


### PR DESCRIPTION
For color, depth and stencil views.  Also re-wrote the
non-raw versions to just use the raw ones.

Fixes #issue
PR checklist:
- [x] `cargo build` succeeds
- [x] `cargo test` succeeds
- [x] tested examples with the following backends: GL