### PR TITLE
Added `clear_raw()` methods to Encoder (squashed version of #2193).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,40 @@ cache:
   cargo: true
   directories:
    - $HOME/deps
-rust:
-  - stable
-  - nightly
-os:
-  - linux
-  - osx
+
+matrix:
+  include:
+    # Linux 64bit
+    - os: linux
+      rust: stable
+      compiler: gcc
+    - os: linux
+      rust: nightly
+      compiler: gcc
+
+    # macOS 64bit
+    - env: MACOSX_DEPLOYMENT_TARGET=10.9
+      os: osx
+      rust: stable
+      osx_image: xcode9
+      compiler: clang
+    - env: MACOSX_DEPLOYMENT_TARGET=10.9
+      os: osx
+      rust: nightly
+      osx_image: xcode9
+      compiler: clang
+
+    # iPhoneOS 64bit
+    - env: TARGET=aarch64-apple-ios
+      os: osx
+      osx_image: xcode9
+      rust: nightly
+
+    # Windows 64bit
+    - os: windows
+      rust: stable
+
+
 branches:
   except:
     - staging.tmp
@@ -22,22 +50,28 @@ notifications:
     on_failure: always
     on_start: false
 before_install:
-  - "export DISPLAY=:99.0"
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
+  # Do not run bors builds against the nightly compiler.
+  # We want to find out about nightly bugs, so they're done in master, but we don't block on them.
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" && $TRAVIS_BRANCH == "staging" ]]; then exit; fi
   # Extract SDL2 .deb into a cached directory (see cache section above and LIBRARY_PATH exports below)
   # Will no longer be needed when Trusty build environment goes out of beta at Travis CI
   # (assuming it will have libsdl2-dev and Rust by then)
   # see https://docs.travis-ci.com/user/trusty-ci-environment/
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then scripts/travis-install-sdl2.sh ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl2; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated cmake || brew upgrade cmake; fi
+  - "export DISPLAY=:99.0"
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then scripts/travis-install-sdl2.sh ; fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew install sdl2; fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew outdated cmake || brew upgrade cmake; fi
 
 addons:
   apt:
     sources:
       # install a newer cmake since at this time Travis only has version 2.8.7
       - george-edison55-precise-backports
+      - llvm-toolchain-precise-3.8
+      - ubuntu-toolchain-r-test
+      #- ppa:xorg-edgers/ppa # for libosmesa6-dev
     packages:
       - xdotool
       - cmake
@@ -51,7 +85,12 @@ addons:
       - libosmesa6-dev
       - libxi-dev
       - libxrandr-dev
+      - g++-5
+      - gcc
+
 script:
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" && $TRAVIS_BRANCH == "staging" ]]; then exit; fi
+  - export PATH=$PATH:$HOME/deps/bin
   - export RUST_BACKTRACE=1
   - export CARGO_INCREMENTAL=0 # We are running out of storage with incremental builds
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$PATH:$HOME/deps/bin ; fi
@@ -62,9 +101,10 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then HEADLESS_FEATURE="--features headless"; fi
   - cargo test --all
   - cargo test -p gfx -p gfx_core --features "mint serialize"
-  - cargo test -p gfx_window_sdl --features "sdl"
-  - cargo test -p gfx_window_glfw --features "glfw"
   - cargo test -p gfx_device_gl
   - cargo test -p gfx_window_glutin $HEADLESS_FEATURE
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test -p gfx_window_sdl --features "sdl"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test -p gfx_window_glfw --features "glfw"; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --all --features vulkan; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cargo test --all --features metal; fi
+  #- if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cargo test --all --features d3d11; fi

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
   "continuous-integration/travis-ci/push",
-  "continuous-integration/appveyor/branch"
+  #"continuous-integration/appveyor/branch"
 ]
 
 timeout_sec = 18000 # 5 hours

--- a/src/render/src/encoder.rs
+++ b/src/render/src/encoder.rs
@@ -510,20 +510,43 @@ impl<R: Resources, C: command::Buffer<R>> Encoder<R, C> {
     pub fn clear<T: format::RenderFormat>(&mut self,
                  view: &handle::RenderTargetView<R, T>, value: T::View)
     where T::View: Into<command::ClearColor> {
-        let target = self.handles.ref_rtv(view.raw()).clone();
-        self.command_buffer.clear_color(target, value.into())
+        self.clear_raw(view.raw(), value.into());
     }
     /// Clear a depth view with a specified value.
     pub fn clear_depth<T: format::DepthFormat>(&mut self,
                        view: &handle::DepthStencilView<R, T>, depth: Depth) {
-        let target = self.handles.ref_dsv(view.raw()).clone();
-        self.command_buffer.clear_depth_stencil(target, Some(depth), None)
+        self.clear_depth_raw(view.raw(), depth);
     }
 
     /// Clear a stencil view with a specified value.
     pub fn clear_stencil<T: format::StencilFormat>(&mut self,
                          view: &handle::DepthStencilView<R, T>, stencil: Stencil) {
-        let target = self.handles.ref_dsv(view.raw()).clone();
+        self.clear_stencil_raw(view.raw(), stencil);
+    }
+
+
+    /// Clears the supplied `RawRenderTargetView` to the supplied `ClearColor`.
+    pub fn clear_raw(&mut self,
+                     view: &handle::RawRenderTargetView<R>,
+                     value: command::ClearColor) {
+        let target = self.handles.ref_rtv(view).clone();
+        self.command_buffer.clear_color(target, value)
+    }
+
+
+    /// Clear a raw depth view with a specified value.
+    pub fn clear_depth_raw(&mut self,
+                           view: &handle::RawDepthStencilView<R>,
+                           depth: Depth) {
+        let target = self.handles.ref_dsv(view).clone();
+        self.command_buffer.clear_depth_stencil(target, Some(depth), None)
+    }
+
+    /// Clear a raw stencil view with a specified value.
+    pub fn clear_stencil_raw(&mut self,
+                             view: &handle::RawDepthStencilView<R>,
+                             stencil: Stencil) {
+        let target = self.handles.ref_dsv(view).clone();
         self.command_buffer.clear_depth_stencil(target, None, Some(stencil))
     }
 

--- a/src/render/src/macros/mod.rs
+++ b/src/render/src/macros/mod.rs
@@ -17,6 +17,7 @@
 mod pso;
 mod structure;
 
+/// Defines a shorthand for a format.
 #[macro_export]
 macro_rules! gfx_format {
     ($name:ident : $surface:ident = $container:ident<$channel:ident>) => {
@@ -44,7 +45,7 @@ macro_rules! gfx_format {
 ///         pos: [f32; 4] = "a_Pos",
 ///         tex_coord: [f32; 2] = "a_TexCoord",
 ///     }
-///     
+///
 ///     constant Locals {
 ///         transform: [[f32; 4]; 4] = "u_Transform",
 ///     }
@@ -57,7 +58,7 @@ macro_rules! gfx_format {
 ///         locals: gfx::ConstantBuffer<Locals> = "Locals",
 ///         color: gfx::TextureSampler<[f32; 4]> = "t_Color",
 ///         out_color: gfx::RenderTarget<gfx::format::Rgba8> = "Target0",
-///         out_depth: gfx::DepthTarget<gfx::format::DepthStencil> = 
+///         out_depth: gfx::DepthTarget<gfx::format::DepthStencil> =
 ///             gfx::preset::depth::LESS_EQUAL_WRITE,
 ///     }
 /// }
@@ -111,7 +112,7 @@ macro_rules! gfx_format {
 /// - Single or multiple [constant buffer](pso/buffer/struct.ConstantBuffer.html) components. (DX11 and OpenGL3)
 /// - Single or multiple [global buffer](pso/buffer/struct.Global.html) components.
 /// - Single or multiple [samplers](pso/resource/struct.Sampler.html).
-/// - [Render](pso/target/struct.RenderTarget.html), [blend](pso/target/struct.BlendTarget.html), 
+/// - [Render](pso/target/struct.RenderTarget.html), [blend](pso/target/struct.BlendTarget.html),
 ///   [depth](pso/target/struct.DepthTarget.html), [stencil](pso/target/struct.StencilTarget.html) targets.
 /// - A [shader resource view](pso/resource/struct.ShaderResource.html) (SRV, DX11)
 /// - An [unordered access view](pso/resource/struct.UnorderedAccess.html) (UAV, DX11, not yet implemented in the OpenGL backend)

--- a/src/render/src/macros/pso.rs
+++ b/src/render/src/macros/pso.rs
@@ -14,6 +14,7 @@
 
 //! Macros for implementing PipelineInit and PipelineData.
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! gfx_pipeline_inner {
     {
@@ -222,6 +223,7 @@ macro_rules! gfx_pipeline_inner {
     }
 }
 
+/// Defines a set of pipeline-associated structures.
 #[macro_export]
 macro_rules! gfx_pipeline_base {
     ($module:ident {
@@ -240,6 +242,8 @@ macro_rules! gfx_pipeline_base {
     }
 }
 
+/// Defines a set of pipeline-associated structures, and also
+/// adds `new` constuctor for the `Init` structure.
 #[macro_export]
 macro_rules! gfx_pipeline {
     ($module:ident {

--- a/src/render/src/macros/structure.rs
+++ b/src/render/src/macros/structure.rs
@@ -14,6 +14,7 @@
 
 //! Macro for implementing Structure for vertex and constant buffers.
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! gfx_impl_struct {
     ($runtime_format:ty : $compile_format:path = $root:ident {
@@ -24,7 +25,7 @@ macro_rules! gfx_impl_struct {
         }
     })
 }
-
+#[doc(hidden)]
 #[macro_export]
 macro_rules! gfx_impl_struct_meta {
     ($(#[$attr:meta])* impl_struct_meta $runtime_format:ty : $compile_format:path = $root:ident {
@@ -76,6 +77,7 @@ macro_rules! gfx_impl_struct_meta {
     }
 }
 
+/// Defines a structure that is used in a vertex buffer.
 #[macro_export]
 macro_rules! gfx_vertex_struct {
     ($root:ident {
@@ -87,6 +89,7 @@ macro_rules! gfx_vertex_struct {
     })
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! gfx_vertex_struct_meta {
     ($(#[$attr:meta])* vertex_struct_meta $root:ident {
@@ -100,6 +103,7 @@ macro_rules! gfx_vertex_struct_meta {
     })
 }
 
+/// Defines a structure that is used in a constant buffer.
 #[macro_export]
 macro_rules! gfx_constant_struct {
     ($root:ident {
@@ -111,6 +115,7 @@ macro_rules! gfx_constant_struct {
     })
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! gfx_constant_struct_meta {
     ($(#[$attr:meta])* constant_struct_meta $root:ident {


### PR DESCRIPTION
See #2193 for details.

kvark you monster you made me figure out how to use `git squash` again.  :-P

Which apparently got git confused enough to require a new branch.
