### PR TITLE
[mtl] Retain copied render pass descriptor

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -842,7 +842,9 @@ impl CommandSink {
                     //Note: the original descriptor belongs to the framebuffer,
                     // and will me mutated afterwards.
                     desc: unsafe {
-                        msg_send![descriptor, copy]
+                        let desc: metal::RenderPassDescriptor = msg_send![descriptor, copy];
+                        msg_send![desc.as_ptr(), retain];
+                        desc
                     },
                     commands: init_commands.map(soft::RenderCommand::own).collect(),
                 });


### PR DESCRIPTION
Appears to fix #2199 

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:

With this change, `dEQP-VK.dynamic_state.ds_state` seems to pass consistently again. The reason I looked into this `Deferred` branch is because the autorelease pool wouldn't have covered it previously. So moving it up the callstack caused the copied render pass descriptor to be allocated correctly but freed before its used.

I haven't tested this at all (outside of the CTS), so this may leak in other places, but the reasoning seems to make sense at least.