### PR TITLE
A bunch of Metal goodies (better image clears and debugging)

### DIFF
--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -407,7 +407,7 @@ pub struct DescriptorHeapSlice {
 
 impl DescriptorHeapSlice {
     pub(crate) fn alloc_handles(&mut self, count: u64) -> Option<DualHandle> {
-        self.range_allocator.allocate_range(count).map(|range| {
+        self.range_allocator.allocate_range(count).ok().map(|range| {
             DualHandle {
                 cpu: d3d12::D3D12_CPU_DESCRIPTOR_HANDLE { ptr: self.start.cpu.ptr + (self.handle_size * range.start) as usize },
                 gpu: d3d12::D3D12_GPU_DESCRIPTOR_HANDLE { ptr: self.start.gpu.ptr + (self.handle_size * range.start) as u64 },

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -19,7 +19,6 @@ auto-capture = []
 name = "gfx_backend_metal"
 
 [dependencies]
-derivative = "1"
 gfx-hal = { path = "../../hal", version = "0.1" }
 bitflags = "1.0"
 log = "0.4"

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -783,7 +783,9 @@ impl CommandSink {
                     //Note: the original descriptor belongs to the framebuffer,
                     // and will me mutated afterwards.
                     desc: unsafe {
-                        msg_send![descriptor, copy]
+                        let desc: metal::RenderPassDescriptor = msg_send![descriptor, copy];
+                        msg_send![desc.as_ptr(), retain];
+                        desc
                     },
                     commands: init_commands.map(soft::RenderCommand::own).collect(),
                 });

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -132,6 +132,7 @@ unsafe impl Sync for Device {}
 impl Drop for Device {
     fn drop(&mut self) {
         if cfg!(feature = "auto-capture") {
+            println!("Metal capture stop");
             let shared_capture_manager = CaptureManager::shared();
             if let Some(default_capture_scope) = shared_capture_manager.default_capture_scope() {
                 default_capture_scope.end_scope();
@@ -239,6 +240,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         let family = *families[0].0;
 
         if cfg!(feature = "auto-capture") {
+            println!("Metal capture start");
             let device = self.shared.device.lock().unwrap();
             let shared_capture_manager = CaptureManager::shared();
             let default_capture_scope = shared_capture_manager.new_capture_scope_with_device(&*device);

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -1,8 +1,6 @@
 extern crate gfx_hal as hal;
 #[macro_use] extern crate bitflags;
 extern crate cocoa;
-#[macro_use]
-extern crate derivative;
 extern crate foreign_types;
 #[macro_use] extern crate objc;
 extern crate core_foundation;

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -303,7 +303,7 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
                 // step[2]: try to allocate the ranges from the pool
                 let mut inner = pool_inner.write().unwrap();
                 let sampler_range = if total_samplers != 0 {
-                    match inner.sampler_alloc.allocate_range(total_samplers as _) {
+                    match inner.sampler_alloc.allocate_range((total_samplers * 2) as _) {
                         Ok(range) => range,
                         Err(e) => {
                             return Err(if e.fragmented_free_length >= total_samplers as u32 {
@@ -317,7 +317,7 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
                     0 .. 0
                 };
                 let texture_range = if total_textures != 0 {
-                    match inner.texture_alloc.allocate_range(total_textures as _) {
+                    match inner.texture_alloc.allocate_range((total_textures * 2) as _) {
                         Ok(range) => range,
                         Err(e) => {
                             if sampler_range.end != 0 {
@@ -334,7 +334,7 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
                     0 .. 0
                 };
                 let buffer_range = if total_buffers != 0 {
-                    match inner.buffer_alloc.allocate_range(total_buffers as _) {
+                    match inner.buffer_alloc.allocate_range((total_buffers * 2) as _) {
                         Ok(range) => range,
                         Err(e) => {
                             if sampler_range.end != 0 {

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -301,12 +301,7 @@ impl Device {
             .iter()
             .map(|frame| native::Image {
                 raw: frame.texture.clone(),
-                extent: image::Extent {
-                    width: pixel_width,
-                    height: pixel_height,
-                    depth: 1,
-                },
-                num_layers: None,
+                kind: image::Kind::D2(pixel_width, pixel_height, 1, 1),
                 format_desc,
                 shader_channel: Channel::Float,
                 mtl_format,

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -519,10 +519,11 @@ pub trait Device<B: Backend>: Any + Send + Sync {
         I::Item: Borrow<B::Fence>,
     {
         use std::{time, thread};
-        let start = time::Instant::now();
         fn to_ms(duration: time::Duration) -> u32 {
             duration.as_secs() as u32 * 1000 + duration.subsec_nanos() / 1_000_000
         }
+
+        let start = time::Instant::now();
         match wait {
             WaitFor::All => {
                 for fence in fences {
@@ -537,7 +538,7 @@ pub trait Device<B: Backend>: Any + Send + Sync {
                     }
                 }
                 true
-            },
+            }
             WaitFor::Any => {
                 let fences: Vec<_> = fences.into_iter().collect();
                 loop {


### PR DESCRIPTION
Fixes a large number of CTS's out-of-pass image clearing tests.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
