### PR TITLE
[dx11] rework descriptors, add UAV/RTV for subresources

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -21,7 +21,7 @@ use {
     Backend, Buffer, BufferView, CommandPool, ComputePipeline, DescriptorPool, DescriptorSetLayout,
     Fence, Framebuffer, GraphicsPipeline, Image, ImageView, InternalBuffer, InternalImage, Memory,
     PipelineLayout, QueryPool, RenderPass, Sampler, Semaphore, ShaderModule, Surface, Swapchain,
-    UnboundBuffer, UnboundImage, ViewInfo,
+    UnboundBuffer, UnboundImage, ViewInfo, PipelineBinding, Descriptor
 };
 
 use {conv, internal, shader};
@@ -104,8 +104,13 @@ impl Device {
         }
     }
 
-    fn create_input_layout(&self, vs: ComPtr<d3dcommon::ID3DBlob>, vertex_buffers: &[pso::VertexBufferDesc], attributes: &[pso::AttributeDesc], input_assembler: &pso::InputAssemblerDesc) -> Result<(d3d11::D3D11_PRIMITIVE_TOPOLOGY, ComPtr<d3d11::ID3D11InputLayout>), pso::CreationError> {
+    fn create_input_layout(&self, vs: ComPtr<d3dcommon::ID3DBlob>, vertex_buffers: &[pso::VertexBufferDesc], attributes: &[pso::AttributeDesc], input_assembler: &pso::InputAssemblerDesc) -> Result<([u32; d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as usize], d3d11::D3D11_PRIMITIVE_TOPOLOGY, ComPtr<d3d11::ID3D11InputLayout>), pso::CreationError> {
         let mut layout = ptr::null_mut();
+
+        let mut vertex_strides = [0u32; d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as usize];
+        for buffer in vertex_buffers {
+            vertex_strides[buffer.binding as usize] = buffer.stride;
+        }
 
         let input_elements = attributes
             .iter()
@@ -159,7 +164,7 @@ impl Device {
         if winerror::SUCCEEDED(hr) {
             let topology = conv::map_topology(input_assembler.primitive);
 
-            Ok((topology, unsafe { ComPtr::from_raw(layout) }))
+            Ok((vertex_strides, topology, unsafe { ComPtr::from_raw(layout) }))
         } else {
             Err(pso::CreationError::Other)
         }
@@ -222,7 +227,7 @@ impl Device {
         }
     }
 
-    fn view_image_as_shader_resource(&self, info: ViewInfo) -> Result<ComPtr<d3d11::ID3D11ShaderResourceView>, image::ViewError> {
+    fn view_image_as_shader_resource(&self, info: &ViewInfo) -> Result<ComPtr<d3d11::ID3D11ShaderResourceView>, image::ViewError> {
         let mut desc: d3d11::D3D11_SHADER_RESOURCE_VIEW_DESC = unsafe { mem::zeroed() };
         desc.Format = info.format;
 
@@ -258,7 +263,37 @@ impl Device {
         }
     }
 
-    fn view_image_as_render_target(&self, info: ViewInfo) -> Result<ComPtr<d3d11::ID3D11RenderTargetView>, image::ViewError> {
+    fn view_image_as_unordered_access_view(&self, info: &ViewInfo) -> Result<ComPtr<d3d11::ID3D11UnorderedAccessView>, image::ViewError> {
+        let mut desc: d3d11::D3D11_UNORDERED_ACCESS_VIEW_DESC = unsafe { mem::zeroed() };
+        desc.Format = info.format;
+
+        match info.view_kind {
+            image::ViewKind::D2 => {
+                desc.ViewDimension = d3d11::D3D11_UAV_DIMENSION_TEXTURE2D;
+                *unsafe{ desc.u.Texture2D_mut() } = d3d11::D3D11_TEX2D_UAV {
+                    MipSlice: info.range.levels.start as _,
+                }
+            },
+            _ => unimplemented!()
+        }
+
+        let mut uav = ptr::null_mut();
+        let hr = unsafe {
+            self.raw.CreateUnorderedAccessView(
+                info.resource,
+                &desc,
+                &mut uav as *mut *mut _ as *mut *mut _
+            )
+        };
+
+        if winerror::SUCCEEDED(hr) {
+            Ok(unsafe { ComPtr::from_raw(uav) })
+        } else {
+            Err(image::ViewError::Unsupported)
+        }
+    }
+
+    fn view_image_as_render_target(&self, info: &ViewInfo) -> Result<ComPtr<d3d11::ID3D11RenderTargetView>, image::ViewError> {
         let mut desc: d3d11::D3D11_RENDER_TARGET_VIEW_DESC = unsafe { mem::zeroed() };
         desc.Format = info.format;
 
@@ -288,7 +323,7 @@ impl Device {
         }
     }
 
-    fn view_image_as_depth_stencil(&self, info: ViewInfo) -> Result<ComPtr<d3d11::ID3D11DepthStencilView>, image::ViewError> {
+    fn view_image_as_depth_stencil(&self, info: &ViewInfo) -> Result<ComPtr<d3d11::ID3D11DepthStencilView>, image::ViewError> {
         let mut desc: d3d11::D3D11_DEPTH_STENCIL_VIEW_DESC = unsafe { mem::zeroed() };
         desc.Format = info.format;
 
@@ -307,6 +342,7 @@ impl Device {
             self.raw.CreateDepthStencilView(
                 info.resource,
                 &desc,
+
                 &mut dsv as *mut *mut _ as *mut *mut _
             )
         };
@@ -325,9 +361,10 @@ impl hal::Device<Backend> for Device {
         mem_type: hal::MemoryTypeId,
         size: u64,
     ) -> Result<Memory, device::OutOfMemory> {
+        let working_buffer_size = 1 << 15;
         let working_buffer = if mem_type.0 == 1 {
             let desc = d3d11::D3D11_BUFFER_DESC {
-                ByteWidth: 65535,
+                ByteWidth: working_buffer_size,
                 Usage: d3d11::D3D11_USAGE_STAGING,
                 BindFlags: 0,
                 CPUAccessFlags: d3d11::D3D11_CPU_ACCESS_READ | d3d11::D3D11_CPU_ACCESS_WRITE,
@@ -359,6 +396,7 @@ impl hal::Device<Backend> for Device {
             mapped_ptr: RefCell::new(None),
             host_visible: Some(RefCell::new(Vec::with_capacity(size as usize))),
             working_buffer,
+            working_buffer_size: working_buffer_size as u64,
             local_buffers: RefCell::new(Vec::new()),
             local_images: RefCell::new(Vec::new()),
         })
@@ -400,7 +438,7 @@ impl hal::Device<Backend> for Device {
 
     fn create_pipeline_layout<IS, IR>(
         &self,
-        _sets: IS,
+        set_layouts: IS,
         _push_constant_ranges: IR,
     ) -> PipelineLayout
     where
@@ -409,9 +447,96 @@ impl hal::Device<Backend> for Device {
         IR: IntoIterator,
         IR::Item: Borrow<(pso::ShaderStageFlags, Range<u32>)>,
     {
-        // TODO: pipelinelayout
+        let mut set_bindings = Vec::new();
 
-        PipelineLayout
+        for layout in set_layouts {
+            let layout = layout.borrow();
+
+            let bindings = &layout.bindings;
+
+            let stages = [
+                pso::ShaderStageFlags::VERTEX,
+                pso::ShaderStageFlags::HULL,
+                pso::ShaderStageFlags::DOMAIN,
+                pso::ShaderStageFlags::GEOMETRY,
+                pso::ShaderStageFlags::FRAGMENT,
+                pso::ShaderStageFlags::COMPUTE,
+            ];
+
+            let mut optimized_bindings = Vec::new();
+
+            // for every shader stage we get a range of descriptor handles that can be bound with
+            // PS/VS/CSSetXX()
+            for &stage in &stages {
+                let mut current_type = None;
+                let mut current_range = None;
+                // track the starting offset of the handles
+                let mut start_offset = 0;
+                // and where our current tail of the range is
+                let mut current_offset = 0;
+
+                for binding in bindings {
+                    match (current_type, current_range.clone()) {
+                        (None, None) => {
+                            if binding.stage.contains(stage) {
+                                current_type = Some(binding.ty);
+                                current_range = Some(binding.binding_range.clone());
+                                start_offset = binding.handle_offset;
+                            }
+                        }
+                        (Some(ty), Some(ref mut range)) => {
+                            // if we encounter another type or the binding/handle
+                            // range is broken, push our current descriptor range
+                            // and begin a new one.
+                            if ty != binding.ty ||
+                               (range.end) != binding.binding_range.start ||
+                               (current_offset + 1) != binding.handle_offset ||
+                               stage != binding.stage
+                            {
+                                optimized_bindings.push(PipelineBinding {
+                                    stage,
+                                    ty,
+                                    binding_range: range.clone(),
+                                    handle_offset: start_offset
+                                });
+                            
+                                if binding.stage.contains(stage) {
+                                    current_type = Some(binding.ty);
+                                    current_range = Some(binding.binding_range.clone());
+
+                                    start_offset = binding.handle_offset;
+                                    current_offset = binding.handle_offset;
+                                } else {
+                                    current_type = None;
+                                    current_range = None;
+                                }
+                            } else {
+                                range.end += 1;
+                                current_offset += 1;
+                            }
+                        }
+                        // either both Something, or both Nonething
+                        _ => unreachable!()
+                    }
+                }
+
+                // catch trailing descriptors
+                if let (Some(ty), Some(range)) = (current_type, &mut current_range) {
+                    optimized_bindings.push(PipelineBinding {
+                        stage,
+                        ty,
+                        binding_range: range.clone(),
+                        handle_offset: current_offset
+                    });
+                }
+            }
+
+            set_bindings.push(optimized_bindings);
+        }
+
+        PipelineLayout {
+            set_bindings
+        }
     }
 
     fn create_graphics_pipeline<'a>(
@@ -436,7 +561,7 @@ impl hal::Device<Backend> for Device {
         let ds = build_shader(pso::Stage::Domain, desc.shaders.domain.as_ref())?;
         let hs = build_shader(pso::Stage::Hull, desc.shaders.hull.as_ref())?;*/
 
-        let (topology, input_layout) = self.create_input_layout(vs.clone(), &desc.vertex_buffers, &desc.attributes, &desc.input_assembler)?;
+        let (strides, topology, input_layout) = self.create_input_layout(vs.clone(), &desc.vertex_buffers, &desc.attributes, &desc.input_assembler)?;
         let rasterizer_state = self.create_rasterizer_state(&desc.rasterizer)?;
         let blend_state = self.create_blend_state(&desc.blender)?;
         let depth_stencil_state = Some(self.create_depth_stencil_state(&desc.depth_stencil)?);
@@ -457,6 +582,7 @@ impl hal::Device<Backend> for Device {
             blend_state,
             depth_stencil_state,
             baked_states: desc.baked_states.clone(),
+            strides,
         })
     }
 
@@ -748,6 +874,7 @@ impl hal::Device<Backend> for Device {
         image: UnboundImage,
     ) -> Result<Image, device::BindError> {
         use memory::Properties;
+        use image::Usage;
 
         let base_format = image.format.base_format();
         let format_desc = base_format.0.desc();
@@ -807,31 +934,29 @@ impl hal::Device<Backend> for Device {
             _ => unimplemented!()
         };
 
-        // TODO: view dimensions
-        let uav = if image.usage.contains(image::Usage::TRANSFER_DST) {
-            let mut desc = unsafe { mem::zeroed::<d3d11::D3D11_UNORDERED_ACCESS_VIEW_DESC>() };
-            desc.Format = typed_raw_format;
-            desc.ViewDimension = d3d11::D3D11_UAV_DIMENSION_TEXTURE2D;
+        let mut unordered_access_views = Vec::new();
+        
+        if image.usage.contains(Usage::TRANSFER_DST) {
+            for layer in 0..image.kind.num_layers() {
+                for mip in 0..image.mip_levels {
+                    let view = ViewInfo {
+                        resource,
+                        kind: image.kind,
+                        flags: image::StorageFlags::empty(),
+                        view_kind: image::ViewKind::D2,
+                        format: typed_raw_format,
+                        range: image::SubresourceRange {
+                            aspects: format::Aspects::COLOR,
+                            levels: mip..(mip + 1),
+                            layers: layer..(layer + 1)
+                        }
+                    };
 
-            let mut uav = ptr::null_mut();
-            let hr = unsafe {
-                self.raw.CreateUnorderedAccessView(
-                    resource,
-                    &desc,
-                    &mut uav as *mut *mut _ as *mut *mut _
-                )
-            };
-
-            if !winerror::SUCCEEDED(hr) {
-                error!("CreateUnorderedAccessView failed: 0x{:x}", hr);
-
-                return Err(device::BindError::WrongMemory);
+                    unordered_access_views.push(self.view_image_as_unordered_access_view(&view).map_err(|_| device::BindError::WrongMemory)?);
+                }
             }
-
-            Some(unsafe { ComPtr::from_raw(uav) })
-        } else {
-            None
-        };
+        }
+        
 
         let (copy_srv, srv) = if image.usage.contains(image::Usage::TRANSFER_SRC) {
             let mut desc = unsafe { mem::zeroed::<d3d11::D3D11_SHADER_RESOURCE_VIEW_DESC>() };
@@ -840,7 +965,7 @@ impl hal::Device<Backend> for Device {
             // TODO:
             *unsafe{ desc.u.Texture2D_mut() } = d3d11::D3D11_TEX2D_SRV {
                 MostDetailedMip: 0,
-                MipLevels: 1,
+                MipLevels: image.mip_levels as _,
             };
 
             let mut copy_srv = ptr::null_mut();
@@ -880,36 +1005,37 @@ impl hal::Device<Backend> for Device {
             (None, None)
         };
 
-        let rtv = if image.usage.contains(image::Usage::COLOR_ATTACHMENT) ||
-                     image.usage.contains(image::Usage::TRANSFER_DST) {
-            let mut desc = unsafe { mem::zeroed::<d3d11::D3D11_RENDER_TARGET_VIEW_DESC>() };
-            desc.Format = dxgi_format;
-            desc.ViewDimension = d3d11::D3D11_RTV_DIMENSION_TEXTURE2D;
+        let mut render_target_views = Vec::new();
 
-            let mut rtv = ptr::null_mut();
-            let hr = unsafe {
-                self.raw.CreateRenderTargetView(
-                    resource,
-                    &desc,
-                    &mut rtv as *mut *mut _ as *mut *mut _
-                )
-            };
+        if image.usage.contains(image::Usage::COLOR_ATTACHMENT) ||
+           image.usage.contains(image::Usage::TRANSFER_DST)
+        {
+            for layer in 0..image.kind.num_layers() {
+                for mip in 0..image.mip_levels {
+                    let view = ViewInfo {
+                        resource,
+                        kind: image.kind,
+                        flags: image::StorageFlags::empty(),
+                        view_kind: image::ViewKind::D2,
+                        format: dxgi_format,
+                        range: image::SubresourceRange {
+                            aspects: format::Aspects::COLOR,
+                            levels: mip..(mip + 1),
+                            layers: layer..(layer + 1)
+                        }
+                    };
 
-            if !winerror::SUCCEEDED(hr) {
-                return Err(device::BindError::WrongMemory);
+                    render_target_views.push(self.view_image_as_render_target(&view).map_err(|_| device::BindError::WrongMemory)?);
+                }
             }
-
-            Some(unsafe { ComPtr::from_raw(rtv) })
-        } else {
-            None
         };
 
         let internal = InternalImage {
             raw: resource,
             copy_srv,
             srv,
-            uav,
-            rtv,
+            unordered_access_views,
+            render_target_views,
         };
 
         Ok(Image {
@@ -922,6 +1048,7 @@ impl hal::Device<Backend> for Device {
             bytes_per_block: bytes_per_block,
             block_dim: block_dim,
             num_levels: levels as _,
+            num_mips: image.mip_levels as _,
             internal,
         })
     }
@@ -946,19 +1073,19 @@ impl hal::Device<Backend> for Device {
 
         Ok(ImageView {
             srv_handle: if image.usage.contains(image::Usage::SAMPLED) {
-                Some(self.view_image_as_shader_resource(info.clone())?)
+                Some(self.view_image_as_shader_resource(&info)?)
             } else {
                 None
             },
             // TODO:
             rtv_handle: if image.usage.contains(image::Usage::COLOR_ATTACHMENT) {
-                Some(self.view_image_as_render_target(info.clone())?)
+                Some(self.view_image_as_render_target(&info)?)
             } else {
                 None
             },
             uav_handle: None,
             dsv_handle: if image.usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT) {
-                Some(self.view_image_as_depth_stencil(info.clone())?)
+                Some(self.view_image_as_depth_stencil(&info)?)
             } else {
                 None
             },
@@ -1004,20 +1131,26 @@ impl hal::Device<Backend> for Device {
 
     fn create_descriptor_pool<I>(
         &self,
-        _max_sets: usize,
-        _descriptor_pools: I,
+        max_sets: usize,
+        ranges: I,
     ) -> DescriptorPool
     where
         I: IntoIterator,
         I::Item: Borrow<pso::DescriptorRangeDesc>
     {
-        // TODO: descriptor pool
+        let count = ranges.into_iter().map(|r| {
+            let r = r.borrow();
+            r.count * match r.ty {
+                pso::DescriptorType::CombinedImageSampler => 2,
+                _ => 1
+            }
+        }).sum::<usize>() * max_sets;
 
-        DescriptorPool
+        DescriptorPool::with_capacity(count)
     }
 
     fn create_descriptor_set_layout<I, J>(
-        &self, bindings: I, _immutable_samplers: J
+        &self, layout_bindings: I, _immutable_samplers: J
     ) -> DescriptorSetLayout
     where
         I: IntoIterator,
@@ -1025,10 +1158,50 @@ impl hal::Device<Backend> for Device {
         J: IntoIterator,
         J::Item: Borrow<Sampler>,
     {
-        // TODO: descriptorsetlayout
+        let mut max_binding = 0;
+        let mut bindings = Vec::new();
+
+        // convert from DescriptorSetLayoutBinding to our own PipelineBinding, and find the higher
+        // binding number in the layout
+        for binding in layout_bindings {
+            let binding = binding.borrow();
+
+            max_binding = max_binding.max(binding.binding as u32);
+
+            bindings.push(PipelineBinding {
+                stage: binding.stage_flags,
+                ty: binding.ty,
+                binding_range: binding.binding..(binding.binding + 1),
+                handle_offset: 0
+            });
+        }
+
+        // we sort the internal descriptor's handle (the actual dx interface) by some categories to
+        // make it easier to group api calls together
+        bindings.sort_unstable_by(|a, b| {
+            (b.ty as u32).cmp(&(a.ty as u32))
+            .then(b.binding_range.start.cmp(&a.binding_range.start))
+            .then(a.stage.cmp(&b.stage))
+        });
+
+        // we also need to map a binding location to its handle
+        let mut offset_mapping = vec![(0u32, pso::DescriptorType::Sampler); (max_binding + 1) as usize];
+        let mut offset = 0;
+        for mut binding in bindings.iter_mut() {
+            offset_mapping[binding.binding_range.start as usize] = (offset, binding.ty);
+
+            binding.handle_offset = offset;
+            
+            offset += match binding.ty {
+                pso::DescriptorType::CombinedImageSampler => 2,
+                _ => 1
+            };
+        }
 
         DescriptorSetLayout {
-            bindings: bindings.into_iter().map(|b| b.borrow().clone()).collect()
+            bindings,
+            offset_mapping,
+            handle_count: offset
         }
     }
 
@@ -1038,52 +1211,72 @@ impl hal::Device<Backend> for Device {
         J: IntoIterator,
         J::Item: Borrow<pso::Descriptor<'a, Backend>>,
     {
-
         for write in write_iter {
-            let mut offset = write.array_offset as u64;
-            let mut target_binding = write.binding as usize;
-            //let mut bind_info = &write.set.binding_infos[target_binding];
+            let target_binding = write.binding as usize;
+            let (handle_offset, _ty) = write.set.offset_mapping[target_binding];
+
             for descriptor in write.descriptors {
                 // spill over the writes onto the next binding
                 /*while offset >= bind_info.count {
                     assert_eq!(offset, bind_info.count);
                     target_binding += 1;
-                    bind_info = &write.set.binding_infos[target_binding];
+                    handle_offset = write.set.offset_mapping[target_binding];
                     offset = 0;
                 }*/
 
-                debug!("offset={}, target_binding={}", offset, target_binding);
+                let handle = unsafe { write.set.handles.offset(handle_offset as isize) };
+
                 match *descriptor.borrow() {
-                    pso::Descriptor::Buffer(buffer, ref range) => {
-                        write.set.cbv_handles.borrow_mut().push((target_binding as _, buffer.internal.raw));
-                        debug!("buffer={:#?}, range={:#?}", buffer, range);
+                    // TODO: binding range
+                    pso::Descriptor::Buffer(buffer, ref _range) => {
+                        unsafe { *handle = Descriptor(buffer.internal.raw as *mut _); }
                     }
                     pso::Descriptor::Image(image, _layout) => {
-                        write.set.srv_handles.borrow_mut().push((target_binding as _, image.srv_handle.clone().unwrap()));
-                        debug!("image={:#?}, layout={:#?}", image, _layout);
-                    }
-                    pso::Descriptor::CombinedImageSampler(_image, _layout, _sampler) => {
+                        unsafe { *handle = Descriptor(image.srv_handle.clone().unwrap().as_raw() as *mut _); }
                     }
                     pso::Descriptor::Sampler(sampler) => {
-                        write.set.sampler_handles.borrow_mut().push((target_binding as _, sampler.sampler_handle.clone()));
-                        debug!("sampler={:#?}", sampler);
+                        unsafe { *handle = Descriptor(sampler.sampler_handle.as_raw() as *mut _); }
+                    }
+                    pso::Descriptor::CombinedImageSampler(image, _layout, sampler) => {
+                        unsafe { *handle = Descriptor(image.srv_handle.clone().unwrap().as_raw() as *mut _); }
+                        unsafe { *(handle.offset(1)) = Descriptor(sampler.sampler_handle.as_raw() as *mut _); }
                     }
                     pso::Descriptor::UniformTexelBuffer(_buffer_view) => {
                     }
                     pso::Descriptor::StorageTexelBuffer(_buffer_view) => {
                     }
                 }
-                offset += 1;
             }
         }
     }
 
-    fn copy_descriptor_sets<'a, I>(&self, _copy_iter: I)
+    fn copy_descriptor_sets<'a, I>(&self, copy_iter: I)
     where
         I: IntoIterator,
         I::Item: Borrow<pso::DescriptorSetCopy<'a, Backend>>,
     {
-        unimplemented!()
+        for copy in copy_iter {
+            let copy = copy.borrow();
+
+            for offset in 0..copy.count {
+                let (dst_handle_offset, dst_ty) = copy.dst_set.offset_mapping[copy.dst_binding as usize + offset];
+                let (src_handle_offset, src_ty) = copy.src_set.offset_mapping[copy.src_binding as usize + offset];
+                assert_eq!(dst_ty, src_ty);
+
+                let dst_handle = unsafe { copy.dst_set.handles.offset(dst_handle_offset as isize) };
+                let src_handle = unsafe { copy.dst_set.handles.offset(src_handle_offset as isize) };
+
+                match dst_ty {
+                    pso::DescriptorType::CombinedImageSampler => {
+                        unsafe { *dst_handle = *src_handle; }
+                        unsafe { *(dst_handle.offset(1)) = *(src_handle.offset(1)); }
+                    }
+                    _ => {
+                        unsafe { *dst_handle = *src_handle; }
+                    }
+                }
+            }
+        }
     }
 
     fn map_memory<R>(&self, memory: &Memory, range: R) -> Result<*mut u8, mapping::Error>
@@ -1104,13 +1297,6 @@ impl hal::Device<Backend> for Device {
 
     fn unmap_memory(&self, memory: &Memory) {
         assert_eq!(memory.host_visible.is_some(), true);
-
-        /*unsafe {
-            self.context.Unmap(
-                buffer.as_raw() as _,
-                0,
-            );
-        }*/
 
         memory.mapped_ptr.replace(None);
     }
@@ -1365,8 +1551,8 @@ impl hal::Device<Backend> for Device {
                 raw: resource,
                 copy_srv: None,
                 srv: None,
-                uav: None,
-                rtv: Some(unsafe { ComPtr::from_raw(rtv) })
+                unordered_access_views: Vec::new(),
+                render_target_views: vec![unsafe { ComPtr::from_raw(rtv) }]
             };
 
             Image {
@@ -1380,6 +1566,7 @@ impl hal::Device<Backend> for Device {
                 bytes_per_block,
                 block_dim,
                 num_levels: 1,
+                num_mips: 1,
                 internal
             }
         }).collect();

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -20,6 +20,8 @@ use hal::queue::{QueueFamilyId, Queues};
 use hal::backend::RawQueueGroup;
 use hal::range::RangeArg;
 
+use range_alloc::RangeAllocator;
+
 use winapi::shared::{dxgiformat, winerror};
 
 use winapi::shared::dxgi::{IDXGIFactory, IDXGIAdapter, IDXGISwapChain};
@@ -38,13 +40,13 @@ use std::borrow::Borrow;
 
 use std::os::raw::c_void;
 
+#[path = "../../auxil/range_alloc.rs"]
+mod range_alloc;
 mod conv;
 mod dxgi;
 mod shader;
 mod internal;
 mod device;
-
-
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
@@ -709,7 +711,10 @@ pub struct CommandBuffer {
     #[derivative(Debug="ignore")]
     context: ComPtr<d3d11::ID3D11DeviceContext>,
     #[derivative(Debug="ignore")]
-    list: Option<ComPtr<d3d11::ID3D11CommandList>>
+    list: Option<ComPtr<d3d11::ID3D11CommandList>>,
+    vertex_buffers: [*mut d3d11::ID3D11Buffer; d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as usize],
+    vertex_offsets: [u32; d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as usize],
+    vertex_strides: [u32; d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as usize]
 }
 
 unsafe impl Send for CommandBuffer {}
@@ -726,12 +731,82 @@ impl CommandBuffer {
         CommandBuffer {
             internal,
             context: unsafe { ComPtr::from_raw(context) },
-            list: None
+            list: None,
+            vertex_buffers: [ptr::null_mut(); d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as usize],
+            vertex_offsets: [0u32; d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as usize],
+            vertex_strides: [0u32; d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as usize]
         }
     }
 
     fn as_raw_list(&self) -> ComPtr<d3d11::ID3D11CommandList> {
         self.list.clone().unwrap().clone()
+    }
+
+    fn set_graphics_bind_point(&mut self) {
+        // TODO: check if needed
+        unsafe {
+            self.context.IASetVertexBuffers(
+                0,
+                d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT,
+                self.vertex_buffers.as_ptr(),
+                self.vertex_strides.as_ptr(),
+                self.vertex_offsets.as_ptr(),
+            );
+        }
+    }
+
+    unsafe fn bind_vertex_descriptor(&self, context: &ComPtr<d3d11::ID3D11DeviceContext>, binding: &PipelineBinding, handles: *mut Descriptor) {
+        use pso::DescriptorType::*;
+
+        let handles = handles.offset(binding.handle_offset as isize);
+        let start = binding.binding_range.start as UINT;
+        let len = binding.binding_range.end as UINT - start;
+
+        match binding.ty {
+            Sampler => context.VSSetSamplers(start, len, handles as *const *mut _ as *const *mut _),
+            SampledImage => context.VSSetShaderResources(start, len, handles as *const *mut _ as *const *mut _),
+            CombinedImageSampler => {
+                context.VSSetShaderResources(start, len, handles as *const *mut _ as *const *mut _);
+                context.VSSetSamplers(start, len, handles.offset(1) as *const *mut _ as *const *mut _);
+            },
+            UniformBuffer |
+            UniformBufferDynamic => context.VSSetConstantBuffers(start, len, handles as *const *mut _ as *const *mut _),
+            _ => unimplemented!()
+        }
+    }
+
+    unsafe fn bind_fragment_descriptor(&self, context: &ComPtr<d3d11::ID3D11DeviceContext>, binding: &PipelineBinding, handles: *mut Descriptor) {
+        use pso::DescriptorType::*;
+
+        let handles = handles.offset(binding.handle_offset as isize);
+        let start = binding.binding_range.start as UINT;
+        let len = binding.binding_range.end as UINT - start;
+
+        match binding.ty {
+            Sampler => context.PSSetSamplers(start, len, handles as *const *mut _ as *const *mut _),
+            SampledImage => context.PSSetShaderResources(start, len, handles as *const *mut _ as *const *mut _),
+            CombinedImageSampler => {
+                context.PSSetShaderResources(start, len, handles as *const *mut _ as *const *mut _);
+                context.PSSetSamplers(start, len, handles.offset(1) as *const *mut _ as *const *mut _);
+            },
+            UniformBuffer |
+            UniformBufferDynamic => context.PSSetConstantBuffers(start, len, handles as *const *mut _ as *const *mut _),
+            _ => unimplemented!()
+        }
+    }
+
+    fn bind_descriptor(&self, context: &ComPtr<d3d11::ID3D11DeviceContext>, binding: &PipelineBinding, handles: *mut Descriptor) {
+        //use pso::ShaderStageFlags::*;
+
+        unsafe {
+            if binding.stage.contains(pso::ShaderStageFlags::VERTEX) {
+                self.bind_vertex_descriptor(context, binding, handles);
+            }
+
+            if binding.stage.contains(pso::ShaderStageFlags::FRAGMENT) {
+                self.bind_fragment_descriptor(context, binding, handles);
+            }
+        }
     }
 }
 
@@ -803,8 +878,9 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn end_render_pass(&mut self) {
-        // TODO: end render pass
-        //unimplemented!()
+        unsafe {
+            self.context.OMSetRenderTargets(8, [ptr::null_mut(); 8].as_ptr(), ptr::null_mut());
+        }
     }
 
     fn pipeline_barrier<'a, T>(&mut self, _stages: Range<pso::PipelineStage>, _dependencies: memory::Dependencies, _barriers: T)
@@ -826,7 +902,7 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
             let _sub = subresource_range.borrow();
             unsafe {
                 self.context.ClearRenderTargetView(
-                    image.internal.rtv.clone().unwrap().as_raw(),
+                    image.get_rtv(0, 0).unwrap().as_raw(),
                     &color.float32
                 );
             }
@@ -874,22 +950,11 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<Buffer>,
     {
-        let (buffers, offsets): (Vec<*mut d3d11::ID3D11Buffer>, Vec<u32>) = buffers
-            .into_iter()
-            .map(|(buf, offset)| (buf.borrow().internal.raw, offset as u32))
-            .unzip();
+        for (i, (buf, offset)) in buffers.into_iter().enumerate() {
+            let idx = i + first_binding as usize;
 
-        // TODO: strides
-        let strides = [32u32; 16];
-
-        unsafe {
-            self.context.IASetVertexBuffers(
-                first_binding,
-                buffers.len() as _,
-                buffers.as_ptr(),
-                strides.as_ptr(),
-                offsets.as_ptr(),
-            );
+            self.vertex_buffers[idx] = buf.borrow().internal.raw;
+            self.vertex_offsets[idx] = offset as u32;
         }
     }
 
@@ -950,6 +1015,8 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn bind_graphics_pipeline(&mut self, pipeline: &GraphicsPipeline) {
+        self.vertex_strides = pipeline.strides;
+
         unsafe {
             self.context.IASetPrimitiveTopology(pipeline.topology);
             self.context.IASetInputLayout(pipeline.input_layout.as_raw());
@@ -983,28 +1050,23 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn bind_graphics_descriptor_sets<'a, I, J>(&mut self, _layout: &PipelineLayout, _first_set: usize, sets: I, _offsets: J)
+    fn bind_graphics_descriptor_sets<'a, I, J>(&mut self, layout: &PipelineLayout, first_set: usize, sets: I, _offsets: J)
     where
         I: IntoIterator,
         I::Item: Borrow<DescriptorSet>,
         J: IntoIterator,
         J::Item: Borrow<command::DescriptorSetOffset>,
     {
-        for set in sets.into_iter() {
+        //let offsets: Vec<command::DescriptorSetOffset> = offsets.into_iter().map(|o| *o.borrow()).collect();
+
+        let iter = sets.into_iter().zip(layout.set_bindings.iter().skip(first_set));
+
+        for (set, bindings) in iter {
             let set = set.borrow();
 
-            for (binding, cbv) in set.cbv_handles.borrow().iter() {
-                unsafe { self.context.VSSetConstantBuffers(*binding, 1, cbv); }
-            }
-
-            for (binding, srv) in set.srv_handles.borrow().iter() {
-                let srv = srv.as_raw();
-                unsafe { self.context.PSSetShaderResources(*binding, 1, &srv); }
-            }
-
-            for (binding, sampler) in set.sampler_handles.borrow().iter() {
-                let sampler = sampler.as_raw();
-                unsafe { self.context.PSSetSamplers(*binding, 1, &sampler); }
+            // TODO: offsets
+            for binding in bindings.iter() {
+                self.bind_descriptor(&self.context, binding, set.handles);
             }
         }
     }
@@ -1098,6 +1160,8 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn draw(&mut self, vertices: Range<VertexCount>, instances: Range<InstanceCount>) {
+        self.set_graphics_bind_point();
+
         unsafe {
             self.context.DrawInstanced(
                 vertices.end - vertices.start,
@@ -1109,6 +1173,8 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn draw_indexed(&mut self, indices: Range<IndexCount>, base_vertex: VertexOffset, instances: Range<InstanceCount>) {
+        self.set_graphics_bind_point();
+
         unsafe {
             self.context.DrawIndexedInstanced(
                 indices.end - indices.start,
@@ -1181,6 +1247,7 @@ pub struct Memory {
 
     #[derivative(Debug="ignore")]
     working_buffer: Option<ComPtr<d3d11::ID3D11Buffer>>,
+    working_buffer_size: u64,
 
     // list of all buffers bound to this memory
     #[derivative(Debug="ignore")]
@@ -1225,14 +1292,7 @@ impl Memory {
                     context.UpdateSubresource(
                         buffer.raw as _,
                         0,
-                        &d3d11::D3D11_BOX {
-                            left: (range.start - buffer_range.start) as _,
-                            top: 0,
-                            front: 0,
-                            right: (range.end - buffer_range.start) as _,
-                            bottom: 1,
-                            back: 1,
-                        },
+                        ptr::null_mut(),
                         src.offset(range.start as isize) as _,
                         0,
                         0
@@ -1270,38 +1330,53 @@ impl Memory {
         }
     }
 
+    fn download(&self, context: &ComPtr<d3d11::ID3D11DeviceContext>, buffer: *mut d3d11::ID3D11Buffer, range: Range<u64>) {
+        unsafe {
+            context.CopySubresourceRegion(
+                self.working_buffer.clone().unwrap().as_raw() as _,
+                0,
+                0,
+                0,
+                0,
+                buffer as _,
+                0,
+                &d3d11::D3D11_BOX {
+                    left: range.start as _,
+                    top: 0,
+                    front: 0,
+                    right: range.end as _,
+                    bottom: 1,
+                    back: 1,
+                }
+            );
+
+            // copy over to our vec
+            let dst = self.mapped_ptr.borrow().unwrap().offset(range.start as isize);
+            let src = self.map(&context);
+            ptr::copy(src, dst, (range.end - range.start) as usize);
+            self.unmap(&context);
+        }
+
+    }
+
     pub fn invalidate(&self, context: &ComPtr<d3d11::ID3D11DeviceContext>, range: Range<u64>) {
         for &(ref buffer_range, ref buffer) in self.local_buffers.borrow().iter() {
             if let Some(range) = intersection(&range, &buffer_range) {
-                unsafe {
+                let stride = self.working_buffer_size;
+                let len = range.end - range.start;
+                let chunks = len / stride;
+                let remainder = len % stride;
 
-                    // upload to staging buffer
-                    context.CopySubresourceRegion(
-                        self.working_buffer.clone().unwrap().as_raw() as _,
-                        0,
-                        0,
-                        0,
-                        0,
-                        buffer.raw as _,
-                        0,
-                        &d3d11::D3D11_BOX {
-                            left: range.start as _,
-                            top: 0,
-                            front: 0,
-                            right: range.end as _,
-                            bottom: 1,
-                            back: 1,
-                        }
-                    );
+                // we split up the copies into chunks the size of our working buffer
+                for i in 0..chunks {
+                    let offset = range.start + i * stride;
+                    let range = offset..(offset + stride);
 
-                    // TODO: handle memory larger than our hardcoded 1<<15
-                    //       staging buffer
+                    self.download(context, buffer.raw, range);
+                }
 
-                    // copy over to our vec
-                    let dst = self.mapped_ptr.borrow().unwrap().offset(range.start as isize);
-                    let src = self.map(&context);
-                    ptr::copy(src, dst, (range.end - range.start) as usize);
-                    self.unmap(&context);
+                if remainder != 0 {
+                    self.download(context, buffer.raw, (chunks * stride)..range.end);
                 }
             }
         }
@@ -1408,10 +1483,12 @@ pub struct Image {
     format: format::Format,
     storage_flags: image::StorageFlags,
     dxgi_format: dxgiformat::DXGI_FORMAT,
+
     typed_raw_format: dxgiformat::DXGI_FORMAT,
     bytes_per_block: u8,
     block_dim: (u8, u8),
     num_levels: image::Level,
+    num_mips: image::Level,
     internal: InternalImage,
 }
 
@@ -1424,14 +1501,30 @@ pub struct InternalImage {
     copy_srv: Option<ComPtr<d3d11::ID3D11ShaderResourceView>>,
     #[derivative(Debug="ignore")]
     srv: Option<ComPtr<d3d11::ID3D11ShaderResourceView>>,
+    /// Contains UAVs for all subresources
     #[derivative(Debug="ignore")]
-    uav: Option<ComPtr<d3d11::ID3D11UnorderedAccessView>>,
+    unordered_access_views: Vec<ComPtr<d3d11::ID3D11UnorderedAccessView>>,
+    /// Contains RTVs for all subresources
     #[derivative(Debug="ignore")]
-    rtv: Option<ComPtr<d3d11::ID3D11RenderTargetView>>
+    render_target_views: Vec<ComPtr<d3d11::ID3D11RenderTargetView>>,
 }
 
 unsafe impl Send for Image { }
 unsafe impl Sync for Image { }
+
+impl Image {
+    pub fn calc_subresource(&self, mip_level: UINT, layer: UINT) -> UINT {
+        mip_level + (layer * self.num_mips as UINT)
+    }
+
+    pub fn get_uav(&self, mip_level: image::Level, layer: image::Layer) -> Option<&ComPtr<d3d11::ID3D11UnorderedAccessView>> {
+        self.internal.unordered_access_views.get(self.calc_subresource(mip_level as _, layer as _) as usize)
+    }
+
+    pub fn get_rtv(&self, mip_level: image::Level, layer: image::Layer) -> Option<&ComPtr<d3d11::ID3D11RenderTargetView>> {
+        self.internal.render_target_views.get(self.calc_subresource(mip_level as _, layer as _) as usize)
+    }
+}
 
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]
@@ -1486,62 +1579,99 @@ pub struct GraphicsPipeline {
     #[derivative(Debug="ignore")]
     depth_stencil_state: Option<(ComPtr<d3d11::ID3D11DepthStencilState>, pso::State<pso::StencilValue>)>,
     baked_states: pso::BakedStates,
+    strides: [u32; d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as usize],
 }
 
 unsafe impl Send for GraphicsPipeline { }
 unsafe impl Sync for GraphicsPipeline { }
 
-#[derive(Debug)]
-pub struct PipelineLayout;
+#[derive(Clone, Debug)]
+struct PipelineBinding {
+    stage: pso::ShaderStageFlags,
+    ty: pso::DescriptorType,
+    binding_range: Range<u32>,
+    handle_offset: u32,
+}
 
+/// The pipeline layout holds optimized (less api calls) ranges of objects for all descriptor sets
+/// belonging to the pipeline object.
+#[derive(Debug)]
+pub struct PipelineLayout {
+    set_bindings: Vec<Vec<PipelineBinding>>
+}
+
+/// The descriptor set layout contains mappings from a given binding to the offset in our
+/// descriptor pool storage and what type of descriptor it is (combined image sampler takes up two
+/// handles).
 #[derive(Debug)]
 pub struct DescriptorSetLayout {
-    bindings: Vec<pso::DescriptorSetLayoutBinding>,
+    bindings: Vec<PipelineBinding>,
+    offset_mapping: Vec<(u32, pso::DescriptorType)>,
+    handle_count: u32
 }
 
-// TODO: descriptor pool
-#[derive(Debug)]
-pub struct DescriptorPool;
-impl hal::DescriptorPool<Backend> for DescriptorPool {
-    fn allocate_set(&mut self, _layout: &DescriptorSetLayout) -> Result<DescriptorSet, pso::AllocationError> {
-        // TODO: actually look at the layout maybe..
-        Ok(DescriptorSet::new())
-    }
-
-    fn free_sets<I>(&mut self, _descriptor_sets: I)
-    where
-        I: IntoIterator<Item = DescriptorSet>
-    {
-        unimplemented!()
-    }
-
-    fn reset(&mut self) {
-        unimplemented!()
-    }
-}
+/// Newtype around a common interface that all bindable resources inherit from.
+#[derive(Debug, Copy, Clone)]
+#[repr(C)]
+struct Descriptor(*mut d3d11::ID3D11DeviceChild);
 
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct DescriptorSet {
-    // TODO: need to handle arrays and stage flags
-    #[derivative(Debug="ignore")]
-    srv_handles: RefCell<Vec<(u32, ComPtr<d3d11::ID3D11ShaderResourceView>)>>,
-    #[derivative(Debug="ignore")]
-    cbv_handles: RefCell<Vec<(u32, *mut d3d11::ID3D11Buffer)>>,
-    #[derivative(Debug="ignore")]
-    sampler_handles: RefCell<Vec<(u32, ComPtr<d3d11::ID3D11SamplerState>)>>,
+    offset: usize,
+    len: usize,
+    handles: *mut Descriptor,
+    offset_mapping: Vec<(u32, pso::DescriptorType)>,
 }
 
 unsafe impl Send for DescriptorSet {}
 unsafe impl Sync for DescriptorSet {}
 
-impl DescriptorSet {
-    pub fn new() -> Self {
-        DescriptorSet {
-            srv_handles: RefCell::new(Vec::new()),
-            cbv_handles: RefCell::new(Vec::new()),
-            sampler_handles: RefCell::new(Vec::new()),
+#[derive(Debug)]
+pub struct DescriptorPool {
+    handles: Vec<Descriptor>,
+    allocator: RangeAllocator<usize>
+}
+
+unsafe impl Send for DescriptorPool {}
+unsafe impl Sync for DescriptorPool {}
+
+impl DescriptorPool {
+    pub fn with_capacity(size: usize) -> Self {
+        DescriptorPool {
+            handles: vec![Descriptor(ptr::null_mut()); size],
+            allocator: RangeAllocator::new(0..size)
         }
+    }
+}
+
+impl hal::DescriptorPool<Backend> for DescriptorPool {
+    fn allocate_set(&mut self, layout: &DescriptorSetLayout) -> Result<DescriptorSet, pso::AllocationError> {
+        // TODO: make sure this doesn't contradict vulkan semantics
+        // if layout has 0 bindings, allocate 1 handle anyway
+        let len = layout.handle_count.max(1) as _;
+
+        self.allocator.allocate_range(len).map(|range| {
+            DescriptorSet {
+                offset: range.start,
+                len,
+                handles: unsafe { self.handles.as_mut_ptr().offset(range.start as _) },
+                offset_mapping: layout.offset_mapping.clone(),
+            }
+        }).ok_or(pso::AllocationError::OutOfPoolMemory)
+    }
+
+    fn free_sets<I>(&mut self, descriptor_sets: I)
+    where
+        I: IntoIterator<Item = DescriptorSet>
+    {
+        for set in descriptor_sets {
+            self.allocator.free_range(set.offset..(set.offset + set.len))
+        }
+    }
+
+    fn reset(&mut self) {
+        self.allocator.reset();
     }
 }
 
@@ -1577,6 +1707,7 @@ impl hal::Backend for Backend {
     type BufferView = BufferView;
     type UnboundImage = UnboundImage;
     type Image = Image;
+
     type ImageView = ImageView;
     type Sampler = Sampler;
 


### PR DESCRIPTION
Descriptor pools now holds a fixed size `Vec` containing d3d11 interface pointers, managed by `RangeAlloc`. Slices of the `Vec` are given out to descriptor sets .

A descriptor set layout contains information on what binding number maps to what index in the descriptor set's slice of handles. This is copied to descriptor sets on set allocation.

PipelineLayout has optimized ranges (less api calls) of descriptors for each relevant shader stage.

Images now create & store subresource views (only UAV & RTV for now) on image binding.

Also fixes some minor stuff like invalidating memory ranges bigger than `1 << 15` vertex buffer strides & offsets.

r? @kvark 