### PR TITLE
[mtl] don't stop the capture at present

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -23,7 +23,7 @@ use hal::queue::{RawCommandQueue, RawSubmission};
 use hal::range::RangeArg;
 
 use foreign_types::{ForeignType, ForeignTypeRef};
-use metal::{self, MTLViewport, MTLScissorRect, MTLPrimitiveType, MTLIndexType, MTLSize, CaptureManager};
+use metal::{self, MTLViewport, MTLScissorRect, MTLPrimitiveType, MTLIndexType, MTLSize};
 use cocoa::foundation::{NSUInteger, NSInteger, NSRange};
 use block::{ConcreteBlock};
 use smallvec::SmallVec;
@@ -1347,11 +1347,6 @@ impl RawCommandQueue<Backend> for CommandQueue {
         }
 
         command_buffer.commit();
-
-        let shared_capture_manager = CaptureManager::shared();
-        if shared_capture_manager.is_capturing() {
-            shared_capture_manager.stop_capture();
-        }
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #2204
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal

Apparently, capture is stopping automatically at present(), and we abort if if call `stop_capture` explicitly...
