### PR TITLE
[mtl] debug option to retain references

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -39,6 +39,7 @@ const CLEAR_IMAGE_ARRAY: bool = false;
 pub struct QueueInner {
     raw: metal::CommandQueue,
     reserve: Range<usize>,
+    debug_retain_references: bool,
 }
 
 #[must_use]
@@ -55,10 +56,17 @@ impl Drop for Token {
 }
 
 impl QueueInner {
-    pub(crate) fn new(device: &metal::DeviceRef, pool_size: usize) -> Self {
+    pub(crate) fn new(
+        device: &metal::DeviceRef,
+        pool_size: Option<usize>,
+    ) -> Self {
         QueueInner {
-            raw: device.new_command_queue_with_max_command_buffer_count(pool_size as u64),
-            reserve: 0 .. pool_size,
+            raw: match pool_size {
+                Some(count) => device.new_command_queue_with_max_command_buffer_count(count as u64),
+                None => device.new_command_queue(),
+            },
+            reserve: 0 .. pool_size.unwrap_or(64),
+            debug_retain_references: false,
         }
     }
 
@@ -66,10 +74,16 @@ impl QueueInner {
     pub(crate) fn spawn(&mut self) -> (metal::CommandBuffer, Token) {
         let _pool = AutoreleasePool::new();
         self.reserve.start += 1;
-        let cmd_buf = self.raw
-            .new_command_buffer_with_unretained_references()
-            .to_owned();
+        let cmd_buf = self.spawn_temp().to_owned();
         (cmd_buf, Token { active: true })
+    }
+
+    fn spawn_temp(&self) -> &metal::CommandBufferRef {
+        if self.debug_retain_references {
+            self.raw.new_command_buffer()
+        } else {
+            self.raw.new_command_buffer_with_unretained_references()
+        }
     }
 
     /// Returns a command buffer to a virtual pool.
@@ -1246,6 +1260,7 @@ impl RawCommandQueue<Backend> for CommandQueue {
         IC: IntoIterator,
         IC::Item: Borrow<CommandBuffer>,
     {
+        let _ap = AutoreleasePool::new();
         debug!("submitting with fence {:?}", fence);
 
         self.wait(submit.wait_semaphores.iter().map(|&(s, _)| s));
@@ -1299,7 +1314,7 @@ impl RawCommandQueue<Backend> for CommandQueue {
                 Some(CommandSink::Deferred { ref passes, .. }) => {
                     num_deferred += 1;
                     trace!("\tdeferred with {} passes", passes.len());
-                    temp_cmd_buffer = queue.raw.new_command_buffer_with_unretained_references();
+                    temp_cmd_buffer = queue.spawn_temp();
                     temp_cmd_buffer.set_label("deferred");
                     record_commands(&*temp_cmd_buffer, passes);
                     &*temp_cmd_buffer
@@ -1315,7 +1330,7 @@ impl RawCommandQueue<Backend> for CommandQueue {
         debug!("\t{} immediate, {} deferred command buffers", num_immediate, num_deferred);
 
         if let Some(ref fence) = fence {
-            let command_buffer = queue.raw.new_command_buffer_with_unretained_references();
+            let command_buffer = queue.spawn_temp();
             command_buffer.set_label("fence");
             let fence = Arc::clone(fence);
             let fence_block = ConcreteBlock::new(move |_cb: *mut ()| -> () {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -69,7 +69,7 @@ impl Shared {
     fn new(device: metal::Device) -> Self {
         let feature_macos_10_14: metal::MTLFeatureSet = unsafe { mem::transmute(10004u64) };
         Shared {
-            queue: Mutex::new(command::QueueInner::new(&device, MAX_ACTIVE_COMMAND_BUFFERS)),
+            queue: Mutex::new(command::QueueInner::new(&device, Some(MAX_ACTIVE_COMMAND_BUFFERS))),
             service_pipes: Mutex::new(internal::ServicePipes::new(&device)),
             push_constants_buffer_id: 30,
             disabilities: PrivateDisabilities {


### PR DESCRIPTION
Allows us to quickly test if the reference retaining saves the day.
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
