### PR TITLE
[mtl] cull face support

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1008,9 +1008,11 @@ fn exec_render<'a>(encoder: &metal::RenderCommandEncoderRef, command: soft::Rend
         }
         Cmd::BindPipeline(pipeline_state, rasterizer) => {
             encoder.set_render_pipeline_state(pipeline_state);
-            if let Some(rasterizer_state) = rasterizer {
-                encoder.set_depth_clip_mode(rasterizer_state.depth_clip);
-                let db = rasterizer_state.depth_bias;
+            if let Some(rs) = rasterizer {
+                encoder.set_front_facing_winding(rs.front_winding);
+                encoder.set_cull_mode(rs.cull_mode);
+                encoder.set_depth_clip_mode(rs.depth_clip);
+                let db = rs.depth_bias;
                 encoder.set_depth_bias(db.const_factor, db.slope_factor, db.clamp);
             }
         }

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -381,3 +381,19 @@ pub fn map_stencil_op(op: StencilOp) -> MTLStencilOperation {
         StencilOp::Invert => MTLStencilOperation::Invert,
     }
 }
+
+pub fn map_winding(face: pso::FrontFace) -> MTLWinding {
+    match face {
+        pso::FrontFace::Clockwise => MTLWinding::Clockwise,
+        pso::FrontFace::CounterClockwise => MTLWinding::CounterClockwise,
+    }
+}
+
+pub fn map_cull_face(face: pso::Face) -> Option<MTLCullMode> {
+    match face {
+        pso::Face::NONE => Some(MTLCullMode::None),
+        pso::Face::FRONT => Some(MTLCullMode::Front),
+        pso::Face::BACK => Some(MTLCullMode::Back),
+        _ => None,
+    }
+}

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -967,6 +967,17 @@ impl hal::Device<Backend> for Device {
         }
 
         let rasterizer_state = Some(n::RasterizerState {
+            front_winding: conv::map_winding(pipeline_desc.rasterizer.front_face),
+            cull_mode: match conv::map_cull_face(pipeline_desc.rasterizer.cull_face) {
+                Some(mode) => mode,
+                None => {
+                    //TODO - Metal validation fails with
+                    // RasterizationEnabled is false but the vertex shader's return type is not void
+                    error!("Culling both sides is not yet supported");
+                    //pipeline.set_rasterization_enabled(false);
+                    metal::MTLCullMode::None
+                }
+            },
             depth_clip: if pipeline_desc.rasterizer.depth_clamping {
                 metal::MTLDepthClipMode::Clamp
             } else {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -78,6 +78,8 @@ pub struct PipelineLayout {
 #[derive(Clone, Debug)]
 pub struct RasterizerState {
     //TODO: more states
+    pub front_winding: metal::MTLWinding,
+    pub cull_mode: metal::MTLCullMode,
     pub depth_clip: metal::MTLDepthClipMode,
     pub depth_bias: pso::DepthBias,
 }
@@ -85,6 +87,8 @@ pub struct RasterizerState {
 impl Default for RasterizerState {
     fn default() -> Self {
         RasterizerState {
+            front_winding: metal::MTLWinding::Clockwise,
+            cull_mode: metal::MTLCullMode::None,
             depth_clip: metal::MTLDepthClipMode::Clip,
             depth_bias: Default::default(),
         }

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -13,13 +13,13 @@ use std::ops::Range;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rect {
     /// X position.
-    pub x: u16,
+    pub x: i16,
     /// Y position.
-    pub y: u16,
+    pub y: i16,
     /// Width.
-    pub w: u16,
+    pub w: i16,
     /// Height.
-    pub h: u16,
+    pub h: i16,
 }
 
 /// A simple struct describing a rect with integer coordinates.


### PR DESCRIPTION
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:

r? anyone

Note: the viewport change is needed because that's what CTS wants to use (with MAINTENANCE1 extension) for the cull tests... although they still fail. It looks like Metal changes the winding order based on the viewport, while Vulkan does not (or the other way around...).