### PR TITLE
[dx11] add more view support and memory type enum

### DIFF
--- a/src/backend/dx11/shaders/blit.hlsl
+++ b/src/backend/dx11/shaders/blit.hlsl
@@ -22,29 +22,29 @@ VsOutput vs_blit_2d(uint id: SV_VertexID) {
 
 SamplerState BlitSampler : register(s0);
 
-Texture2D<uint4>  BlitSrc_Uint  : register(t0);
-Texture2D<int4>   BlitSrc_Sint  : register(t0);
-Texture2D<float4> BlitSrc_Float : register(t0);
+Texture2DArray<uint4>  BlitSrc_Uint  : register(t0);
+Texture2DArray<int4>   BlitSrc_Sint  : register(t0);
+Texture2DArray<float4> BlitSrc_Float : register(t0);
 
 // TODO: get rid of GetDimensions call
 uint4 Nearest_Uint(float4 uv)
 {
-    float2 size;
-    BlitSrc_Uint.GetDimensions(size.x, size.y);
+    float4 size;
+    BlitSrc_Uint.GetDimensions(0, size.x, size.y, size.z, size.w);
 
-    float2 pix = uv.xy * size;
+    float2 pix = uv.xy * size.xy;
 
-    return BlitSrc_Uint[int2(pix)].xyzw;
+    return BlitSrc_Uint.Load(int4(int2(pix), uv.zw)).xyzw;
 }
 
 int4 Nearest_Sint(float4 uv)
 {
-    float2 size;
-    BlitSrc_Sint.GetDimensions(size.x, size.y);
+    float4 size;
+    BlitSrc_Sint.GetDimensions(0, size.x, size.y, size.z, size.w);
 
-    float2 pix = uv.xy * size;
+    float2 pix = uv.xy * size.xy;
 
-    return BlitSrc_Sint[int2(pix)].xyzw;
+    return BlitSrc_Sint.Load(int4(int2(pix), uv.zw)).xyzw;
 }
 
 uint4 ps_blit_2d_uint(VsOutput input) : SV_Target
@@ -59,5 +59,5 @@ int4 ps_blit_2d_int(VsOutput input) : SV_Target
 
 float4 ps_blit_2d_float(VsOutput input) : SV_Target
 {
-    return BlitSrc_Float.Sample(BlitSampler, input.uv);
+    return BlitSrc_Float.SampleLevel(BlitSampler, input.uv.xyz, input.uv.w);
 }

--- a/src/backend/dx11/shaders/blit.hlsl
+++ b/src/backend/dx11/shaders/blit.hlsl
@@ -34,7 +34,7 @@ uint4 Nearest_Uint(float4 uv)
 
     float2 pix = uv.xy * size.xy;
 
-    return BlitSrc_Uint.Load(int4(int2(pix), uv.zw)).xyzw;
+    return BlitSrc_Uint.Load(int4(int2(pix), uv.zw));
 }
 
 int4 Nearest_Sint(float4 uv)
@@ -44,7 +44,7 @@ int4 Nearest_Sint(float4 uv)
 
     float2 pix = uv.xy * size.xy;
 
-    return BlitSrc_Sint.Load(int4(int2(pix), uv.zw)).xyzw;
+    return BlitSrc_Sint.Load(int4(int2(pix), uv.zw));
 }
 
 uint4 ps_blit_2d_uint(VsOutput input) : SV_Target

--- a/src/backend/dx11/shaders/copy.hlsl
+++ b/src/backend/dx11/shaders/copy.hlsl
@@ -20,24 +20,24 @@ cbuffer CopyConstants : register(b0) {
     BufferImageCopy BufferImageCopies;
 };
 
-uint2 GetImageCopyDst(uint3 dispatch_thread_id)
+uint3 GetImageCopyDst(uint3 dispatch_thread_id)
 {
-    return ImageCopies.Dst.xy + dispatch_thread_id.xy;
+    return uint3(ImageCopies.Dst.xy + dispatch_thread_id.xy, ImageCopies.Dst.z);
 }
 
-uint2 GetImageCopySrc(uint3 dispatch_thread_id)
+uint3 GetImageCopySrc(uint3 dispatch_thread_id)
 {
-    return ImageCopies.Src.xy + dispatch_thread_id.xy;
+    return uint3(ImageCopies.Src.xy + dispatch_thread_id.xy, ImageCopies.Src.z);
 }
 
-uint2 GetImageDst(uint3 dispatch_thread_id)
+uint3 GetImageDst(uint3 dispatch_thread_id)
 {
-    return BufferImageCopies.ImageOffset.xy + dispatch_thread_id.xy;
+    return uint3(BufferImageCopies.ImageOffset.xy + dispatch_thread_id.xy, BufferImageCopies.ImageOffset.z);
 }
 
-uint2 GetImageSrc(uint3 dispatch_thread_id)
+uint3 GetImageSrc(uint3 dispatch_thread_id)
 {
-    return BufferImageCopies.ImageOffset.xy + dispatch_thread_id.xy;
+    return uint3(BufferImageCopies.ImageOffset.xy + dispatch_thread_id.xy, BufferImageCopies.ImageOffset.z);
 }
 
 uint GetBufferDst128(uint3 dispatch_thread_id)
@@ -120,17 +120,17 @@ uint Uint8x2ToUint16(uint2 data)
 ByteAddressBuffer   BufferCopySrc : register(t0);
 RWByteAddressBuffer BufferCopyDst : register(u0);
 
-Texture2D<uint4>   ImageCopySrc     : register(t0);
-RWTexture2D<uint>  ImageCopyDstR    : register(u0);
-RWTexture2D<uint2> ImageCopyDstRg   : register(u0);
-RWTexture2D<uint4> ImageCopyDstRgba : register(u0);
+Texture2DArray<uint4>   ImageCopySrc     : register(t0);
+RWTexture2DArray<uint>  ImageCopyDstR    : register(u0);
+RWTexture2DArray<uint2> ImageCopyDstRg   : register(u0);
+RWTexture2DArray<uint4> ImageCopyDstRgba : register(u0);
 
 // Image<->Image copies
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r8g8_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThreadID)
 {
-    uint2 dst_idx = GetImageCopyDst(dispatch_thread_id);
-    uint2 src_idx = GetImageCopySrc(dispatch_thread_id);
+    uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
+    uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
     ImageCopyDstR[dst_idx] = Uint8x2ToUint16(ImageCopySrc[src_idx]);
 }
@@ -138,8 +138,8 @@ void cs_copy_image2d_r8g8_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThre
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r16_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID)
 {
-    uint2 dst_idx = GetImageCopyDst(dispatch_thread_id);
-    uint2 src_idx = GetImageCopySrc(dispatch_thread_id);
+    uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
+    uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
     ImageCopyDstRg[dst_idx] = Uint16ToUint8x2(ImageCopySrc[src_idx]);
 }
@@ -147,8 +147,8 @@ void cs_copy_image2d_r16_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThre
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r8g8b8a8_image2d_r32(uint3 dispatch_thread_id : SV_DispatchThreadID)
 {
-    uint2 dst_idx = GetImageCopyDst(dispatch_thread_id);
-    uint2 src_idx = GetImageCopySrc(dispatch_thread_id);
+    uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
+    uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
     ImageCopyDstR[dst_idx] = Uint8x4ToUint32(ImageCopySrc[src_idx]);
 }
@@ -156,8 +156,8 @@ void cs_copy_image2d_r8g8b8a8_image2d_r32(uint3 dispatch_thread_id : SV_Dispatch
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r8g8b8a8_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchThreadID)
 {
-    uint2 dst_idx = GetImageCopyDst(dispatch_thread_id);
-    uint2 src_idx = GetImageCopySrc(dispatch_thread_id);
+    uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
+    uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
     ImageCopyDstRg[dst_idx] = Uint32ToUint16x2(Uint8x4ToUint32(ImageCopySrc[src_idx]));
 }
@@ -165,8 +165,8 @@ void cs_copy_image2d_r8g8b8a8_image2d_r16g16(uint3 dispatch_thread_id : SV_Dispa
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r16g16_image2d_r32(uint3 dispatch_thread_id : SV_DispatchThreadID)
 {
-    uint2 dst_idx = GetImageCopyDst(dispatch_thread_id);
-    uint2 src_idx = GetImageCopySrc(dispatch_thread_id);
+    uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
+    uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
     ImageCopyDstR[dst_idx] = Uint16x2ToUint32(ImageCopySrc[src_idx]);
 }
@@ -174,8 +174,8 @@ void cs_copy_image2d_r16g16_image2d_r32(uint3 dispatch_thread_id : SV_DispatchTh
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r16g16_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_DispatchThreadID)
 {
-    uint2 dst_idx = GetImageCopyDst(dispatch_thread_id);
-    uint2 src_idx = GetImageCopySrc(dispatch_thread_id);
+    uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
+    uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
     ImageCopyDstRgba[dst_idx] = Uint32ToUint8x4(Uint16x2ToUint32(ImageCopySrc[src_idx]));
 }
@@ -183,8 +183,8 @@ void cs_copy_image2d_r16g16_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_Dispa
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r32_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchThreadID)
 {
-    uint2 dst_idx = GetImageCopyDst(dispatch_thread_id);
-    uint2 src_idx = GetImageCopySrc(dispatch_thread_id);
+    uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
+    uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
     ImageCopyDstRg[dst_idx] = Uint32ToUint16x2(ImageCopySrc[src_idx]);
 }
@@ -192,8 +192,8 @@ void cs_copy_image2d_r32_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchTh
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r32_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_DispatchThreadID)
 {
-    uint2 dst_idx = GetImageCopyDst(dispatch_thread_id);
-    uint2 src_idx = GetImageCopySrc(dispatch_thread_id);
+    uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
+    uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
     ImageCopyDstRgba[dst_idx] = Uint32ToUint8x4(ImageCopySrc[src_idx]);
 }
@@ -204,7 +204,7 @@ void cs_copy_image2d_r32_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_Dispatch
 // TODO: correct, but slow
 [numthreads(1, 1, 1)]
 void cs_copy_buffer_image2d_r32g32b32a32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint2 dst_idx = GetImageDst(dispatch_thread_id);
+    uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint src_idx = GetBufferSrc128(dispatch_thread_id);
 
     ImageCopyDstRgba[dst_idx] = uint4(
@@ -218,7 +218,7 @@ void cs_copy_buffer_image2d_r32g32b32a32(uint3 dispatch_thread_id : SV_DispatchT
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r32g32b32a32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint dst_idx = GetBufferDst128(dispatch_thread_id);
-    uint2 src_idx = GetImageSrc(dispatch_thread_id);
+    uint3 src_idx = GetImageSrc(dispatch_thread_id);
 
     uint4 data = ImageCopySrc[src_idx];
 
@@ -231,7 +231,7 @@ void cs_copy_image2d_r32g32b32a32_buffer(uint3 dispatch_thread_id : SV_DispatchT
 // R32G32
 [numthreads(1, 1, 1)]
 void cs_copy_buffer_image2d_r32g32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint2 dst_idx = GetImageDst(dispatch_thread_id);
+    uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint src_idx = GetBufferSrc64(dispatch_thread_id);
 
     ImageCopyDstRg[dst_idx] = uint2(
@@ -243,7 +243,7 @@ void cs_copy_buffer_image2d_r32g32(uint3 dispatch_thread_id : SV_DispatchThreadI
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r32g32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint dst_idx = GetBufferDst64(dispatch_thread_id);
-    uint2 src_idx = GetImageSrc(dispatch_thread_id);
+    uint3 src_idx = GetImageSrc(dispatch_thread_id);
 
     uint2 data = ImageCopySrc[src_idx].rg;
 
@@ -254,7 +254,7 @@ void cs_copy_image2d_r32g32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadI
 // R16G16B16A16
 [numthreads(1, 1, 1)]
 void cs_copy_buffer_image2d_r16g16b16a16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint2 dst_idx = GetImageDst(dispatch_thread_id);
+    uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint src_idx = GetBufferSrc64(dispatch_thread_id);
 
     ImageCopyDstRgba[dst_idx] = uint4(
@@ -266,7 +266,7 @@ void cs_copy_buffer_image2d_r16g16b16a16(uint3 dispatch_thread_id : SV_DispatchT
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r16g16b16a16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint dst_idx = GetBufferDst64(dispatch_thread_id);
-    uint2 src_idx = GetImageSrc(dispatch_thread_id);
+    uint3 src_idx = GetImageSrc(dispatch_thread_id);
 
     uint4 data = ImageCopySrc[src_idx];
 
@@ -277,7 +277,7 @@ void cs_copy_image2d_r16g16b16a16_buffer(uint3 dispatch_thread_id : SV_DispatchT
 // R32
 [numthreads(1, 1, 1)]
 void cs_copy_buffer_image2d_r32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint2 dst_idx = GetImageDst(dispatch_thread_id);
+    uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint src_idx = GetBufferSrc32(dispatch_thread_id);
 
     ImageCopyDstR[dst_idx] = BufferCopySrc.Load(src_idx);
@@ -286,7 +286,7 @@ void cs_copy_buffer_image2d_r32(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint dst_idx = GetBufferDst32(dispatch_thread_id);
-    uint2 src_idx = GetImageSrc(dispatch_thread_id);
+    uint3 src_idx = GetImageSrc(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx, ImageCopySrc[src_idx].r);
 }
@@ -294,7 +294,7 @@ void cs_copy_image2d_r32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 // R16G16
 [numthreads(1, 1, 1)]
 void cs_copy_buffer_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint2 dst_idx = GetImageDst(dispatch_thread_id);
+    uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint src_idx = GetBufferSrc32(dispatch_thread_id);
 
     ImageCopyDstRg[dst_idx] = Uint32ToUint16x2(BufferCopySrc.Load(src_idx));
@@ -303,7 +303,7 @@ void cs_copy_buffer_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchThreadI
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r16g16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint dst_idx = GetBufferDst32(dispatch_thread_id);
-    uint2 src_idx = GetImageSrc(dispatch_thread_id);
+    uint3 src_idx = GetImageSrc(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx, Uint16x2ToUint32(ImageCopySrc[src_idx].xy));
 }
@@ -311,7 +311,7 @@ void cs_copy_image2d_r16g16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadI
 // R8G8B8A8
 [numthreads(1, 1, 1)]
 void cs_copy_buffer_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint2 dst_idx = GetImageDst(dispatch_thread_id);
+    uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint src_idx = GetBufferSrc32(dispatch_thread_id);
 
     ImageCopyDstRgba[dst_idx] = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
@@ -320,7 +320,7 @@ void cs_copy_buffer_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_DispatchThrea
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r8g8b8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint dst_idx = GetBufferDst32(dispatch_thread_id);
-    uint2 src_idx = GetImageSrc(dispatch_thread_id);
+    uint3 src_idx = GetImageSrc(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(ImageCopySrc[src_idx]));
 }
@@ -329,22 +329,22 @@ void cs_copy_image2d_r8g8b8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThrea
 [numthreads(1, 1, 1)]
 void cs_copy_buffer_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
 //    uint src_idx = BufferImageCopies.BufferVars.x + dispatch_thread_id.x + dispatch_thread_id.y * BufferImageCopies.BufferVars.y / 2;
-    uint2 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
+    uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
     uint src_idx = GetBufferSrc16(dispatch_thread_id);
     uint2 data = Uint32ToUint16x2(BufferCopySrc.Load(src_idx));
 
-    ImageCopyDstR[dst_idx              ] = data.x;
-    ImageCopyDstR[dst_idx + uint2(1, 0)] = data.y;
+    ImageCopyDstR[dst_idx                 ] = data.x;
+    ImageCopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
 }
 
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     //uint dst_idx = BufferImageCopies.BufferVars.x + dispatch_thread_id.x + dispatch_thread_id.y * BufferImageCopies.BufferVars.y / 2;
     uint dst_idx = GetBufferDst16(dispatch_thread_id);
-    uint2 src_idx = GetImageSrc(uint3(2, 1, 0) * dispatch_thread_id);
+    uint3 src_idx = GetImageSrc(uint3(2, 1, 0) * dispatch_thread_id);
 
     uint upper = ImageCopySrc[src_idx].r;
-    uint lower = ImageCopySrc[src_idx + uint2(1, 0)].r;
+    uint lower = ImageCopySrc[src_idx + uint3(1, 0, 0)].r;
 
     BufferCopyDst.Store(dst_idx, Uint16x2ToUint32(uint2(upper, lower)));
 }
@@ -353,23 +353,23 @@ void cs_copy_image2d_r16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 [numthreads(1, 1, 1)]
 void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
 //    uint src_idx = BufferImageCopies.BufferVars.x + dispatch_thread_id.x + dispatch_thread_id.y * BufferImageCopies.BufferVars.y / 2;
-    uint2 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
+    uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
     uint src_idx = GetBufferSrc16(dispatch_thread_id);
 
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    ImageCopyDstRg[dst_idx              ] = data.xy;
-    ImageCopyDstRg[dst_idx + uint2(1, 0)] = data.zw;
+    ImageCopyDstRg[dst_idx                 ] = data.xy;
+    ImageCopyDstRg[dst_idx + uint3(1, 0, 0)] = data.zw;
 }
 
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r8g8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
 //    uint dst_idx = BufferImageCopies.BufferVars.x + dispatch_thread_id.x + dispatch_thread_id.y * BufferImageCopies.BufferVars.y / 2;
     uint dst_idx = GetBufferDst16(dispatch_thread_id);
-    uint2 src_idx = GetImageSrc(uint3(2, 1, 0) * dispatch_thread_id);
+    uint3 src_idx = GetImageSrc(uint3(2, 1, 0) * dispatch_thread_id);
 
     uint2 lower = ImageCopySrc[src_idx].xy;
-    uint2 upper = ImageCopySrc[src_idx + uint2(1, 0)].xy;
+    uint2 upper = ImageCopySrc[src_idx + uint3(1, 0, 0)].xy;
 
     BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(uint4(lower.x, lower.y, upper.x, upper.y)));
 }
@@ -377,25 +377,25 @@ void cs_copy_image2d_r8g8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID)
 // R8
 [numthreads(1, 1, 1)]
 void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint2 dst_idx = GetImageDst(uint3(4, 1, 0) * dispatch_thread_id);
+    uint3 dst_idx = GetImageDst(uint3(4, 1, 0) * dispatch_thread_id);
     uint src_idx = GetBufferSrc8(dispatch_thread_id);
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
     ImageCopyDstR[dst_idx              ] = data.x;
-    ImageCopyDstR[dst_idx + uint2(1, 0)] = data.y;
-    ImageCopyDstR[dst_idx + uint2(2, 0)] = data.z;
-    ImageCopyDstR[dst_idx + uint2(3, 0)] = data.w;
+    ImageCopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
+    ImageCopyDstR[dst_idx + uint3(2, 0, 0)] = data.z;
+    ImageCopyDstR[dst_idx + uint3(3, 0, 0)] = data.w;
 }
 
 [numthreads(1, 1, 1)]
 void cs_copy_image2d_r8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint dst_idx = GetBufferDst8(dispatch_thread_id);
-    uint2 src_idx = GetImageSrc(uint3(4, 1, 0) * dispatch_thread_id);
+    uint3 src_idx = GetImageSrc(uint3(4, 1, 0) * dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(uint4(
         ImageCopySrc[src_idx].r,
-        ImageCopySrc[src_idx + uint2(1, 0)].r,
-        ImageCopySrc[src_idx + uint2(2, 0)].r,
-        ImageCopySrc[src_idx + uint2(3, 0)].r
+        ImageCopySrc[src_idx + uint3(1, 0, 0)].r,
+        ImageCopySrc[src_idx + uint3(2, 0, 0)].r,
+        ImageCopySrc[src_idx + uint3(3, 0, 0)].r
     )));
 }

--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -230,8 +230,8 @@ pub fn map_rect(rect: &Rect) -> D3D11_RECT {
     D3D11_RECT {
         left: rect.x as _,
         top: rect.y as _,
-        right: rect.w as _,
-        bottom: rect.h as _,
+        right: (rect.x + rect.w) as _,
+        bottom: (rect.y + rect.h) as _,
     }
 }
 


### PR DESCRIPTION
Adds support for creating views of 2d arrays, 3d textures, cube maps and cube map arrays.

Changes the views that image binding creates for copying/blitting etc. from `D2` to `D2Array`

Adds a memory type enum which replaces the previous hardcoded conditionals.