### PR TITLE
[mtl] Remove >> level from blit

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2167,17 +2167,17 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 //Note: flipping Y coordinate of the destination here
                 soft::RenderCommand::SetViewport(MTLViewport {
                     originX: 0.0,
-                    originY: (ext.height >> level) as _,
-                    width: (ext.width >> level) as _,
-                    height: -((ext.height >> level) as f64),
+                    originY: ext.height as _,
+                    width: ext.width as _,
+                    height: -(ext.height as f64),
                     znear: 0.0,
                     zfar: 1.0,
                 }),
                 soft::RenderCommand::SetScissor(MTLScissorRect {
                     x: 0,
                     y: 0,
-                    width: (ext.width >> level) as _,
-                    height: (ext.height >> level) as _,
+                    width: ext.width as _,
+                    height: ext.height as _,
                 }),
                 soft::RenderCommand::BindBufferData {
                     stage: pso::Stage::Vertex,


### PR DESCRIPTION
PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [ ] tested examples with the following backends:

The `>> level` is already set in [this call](https://github.com/dati91/gfx/blob/b1e0b438354631aa25150f1c3b4b88fe1a8b81f5/src/backend/metal/src/command.rs#L2164).