### PR TITLE
[mtl] dynamic depth bias, callback coalescence, and more stats

### DIFF
--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -150,6 +150,11 @@ pub fn map_rasterizer(rasterizer: &pso::Rasterizer) -> D3D12_RASTERIZER_DESC {
     use hal::pso::PolygonMode::*;
     use hal::pso::FrontFace::*;
 
+    let bias = match rasterizer.depth_bias { //TODO: support dynamic depth bias
+        Some(pso::State::Static(db)) => db,
+        Some(_) | None => pso::DepthBias::default(),
+    };
+
     D3D12_RASTERIZER_DESC {
         FillMode: match rasterizer.polygon_mode {
             Point => {
@@ -172,9 +177,9 @@ pub fn map_rasterizer(rasterizer: &pso::Rasterizer) -> D3D12_RASTERIZER_DESC {
             Clockwise => FALSE,
             CounterClockwise => TRUE,
         },
-        DepthBias: rasterizer.depth_bias.map_or(0, |bias| bias.const_factor as INT),
-        DepthBiasClamp: rasterizer.depth_bias.map_or(0.0, |bias| bias.clamp),
-        SlopeScaledDepthBias: rasterizer.depth_bias.map_or(0.0, |bias| bias.slope_factor),
+        DepthBias: bias.const_factor as INT,
+        DepthBiasClamp: bias.clamp,
+        SlopeScaledDepthBias: bias.slope_factor,
         DepthClipEnable: !rasterizer.depth_clamping as _,
         MultisampleEnable: FALSE, // TODO: currently not supported
         ForcedSampleCount: 0, // TODO: currently not supported

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -5,7 +5,7 @@ use hal::pso;
 use gl;
 use smallvec::SmallVec;
 
-pub fn bind_polygon_mode(gl: &gl::Gl, mode: pso::PolygonMode, bias: Option<pso::DepthBias>) {
+pub fn bind_polygon_mode(gl: &gl::Gl, mode: pso::PolygonMode, bias: Option<pso::State<pso::DepthBias>>) {
     use hal::pso::PolygonMode::*;
 
     let (gl_draw, gl_offset) = match mode {
@@ -20,11 +20,11 @@ pub fn bind_polygon_mode(gl: &gl::Gl, mode: pso::PolygonMode, bias: Option<pso::
     unsafe { gl.PolygonMode(gl::FRONT_AND_BACK, gl_draw) };
 
     match bias {
-        Some(bias) => unsafe {
+        Some(pso::State::Static(bias)) => unsafe {
             gl.Enable(gl_offset);
             gl.PolygonOffset(bias.slope_factor as _, bias.const_factor as _);
         },
-        None => unsafe {
+        _ => unsafe {
             gl.Disable(gl_offset)
         },
     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -34,8 +34,8 @@ const WORD_ALIGNMENT: u64 = WORD_SIZE as _;
 /// with clear operations set up to implement our `clear_image`
 /// Note: currently doesn't work, needs a repro case for Apple
 const CLEAR_IMAGE_ARRAY: bool = false;
-/// Number of frames to average when reporting the frame wait times.
-const FRAME_WAIT_REPORT_WINDOW: usize = 0;
+/// Number of frames to average when reporting the performance counters.
+const COUNTERS_REPORT_WINDOW: usize = 0;
 
 pub struct QueueInner {
     raw: metal::CommandQueue,
@@ -61,13 +61,17 @@ impl QueueInner {
         device: &metal::DeviceRef,
         pool_size: Option<usize>,
     ) -> Self {
-        QueueInner {
-            raw: match pool_size {
-                Some(count) => device.new_command_queue_with_max_command_buffer_count(count as u64),
-                None => device.new_command_queue(),
+        match pool_size {
+            Some(count) => QueueInner {
+                raw: device.new_command_queue_with_max_command_buffer_count(count as u64),
+                reserve: 0 .. count,
+                debug_retain_references: false,
             },
-            reserve: 0 .. pool_size.unwrap_or(64),
-            debug_retain_references: false,
+            None => QueueInner {
+                raw: device.new_command_queue(),
+                reserve: 0 .. 64,
+                debug_retain_references: true,
+            },
         }
     }
 
@@ -159,6 +163,7 @@ struct State {
     resources_cs: StageResources,
     index_buffer: Option<IndexBuffer<BufferPtr>>,
     rasterizer_state: Option<native::RasterizerState>,
+    depth_bias: pso::DepthBias,
     stencil: native::StencilState<pso::StencilValue>,
     push_constants: Vec<u32>,
     vertex_buffers: Vec<Option<(BufferPtr, u64)>>,
@@ -201,9 +206,7 @@ impl State {
             None
         };
         let com_depth_bias = if aspects.contains(Aspects::DEPTH) {
-            Some(soft::RenderCommand::SetDepthBias(
-                self.rasterizer_state.as_ref().map(|r| r.depth_bias).unwrap_or_default()
-            ))
+            Some(soft::RenderCommand::SetDepthBias(self.depth_bias))
         } else {
             None
         };
@@ -412,14 +415,7 @@ impl State {
     }
 
     fn set_depth_bias<'a>(&mut self, depth_bias: &pso::DepthBias) -> soft::RenderCommand<&'a soft::Own> {
-        if let Some(ref mut r) = self.rasterizer_state {
-            r.depth_bias = *depth_bias;
-        } else {
-            self.rasterizer_state = Some(native::RasterizerState {
-                depth_bias: *depth_bias,
-                ..Default::default()
-            });
-        }
+        self.depth_bias = *depth_bias;
         soft::RenderCommand::SetDepthBias(*depth_bias)
     }
 
@@ -1024,8 +1020,6 @@ fn exec_render<'a>(encoder: &metal::RenderCommandEncoderRef, command: soft::Rend
                 encoder.set_front_facing_winding(rs.front_winding);
                 encoder.set_cull_mode(rs.cull_mode);
                 encoder.set_depth_clip_mode(rs.depth_clip);
-                let db = rs.depth_bias;
-                encoder.set_depth_bias(db.const_factor, db.slope_factor, db.clamp);
             }
         }
         Cmd::Draw { primitive_type, vertices, instances } =>  {
@@ -1236,24 +1230,33 @@ fn record_commands(command_buf: &metal::CommandBufferRef, passes: &[soft::Pass])
 }
 
 #[derive(Default)]
-struct FrameWaitReport {
-    duration: time::Duration,
-    count: usize,
+struct PerformanceCounters {
+    active_command_buffer_count: usize,
+    temporary_command_buffer_count: usize,
+    frame_wait_duration: time::Duration,
+    frame_wait_count: usize,
     frame: usize,
 }
 
 
 pub struct CommandQueue {
     shared: Arc<Shared>,
-    frame_wait: Option<FrameWaitReport>,
+    retained_buffers: Vec<metal::Buffer>,
+    retained_textures: Vec<metal::Texture>,
+    perf_counters: Option<PerformanceCounters>,
 }
+
+unsafe impl Send for CommandQueue {}
+unsafe impl Sync for CommandQueue {}
 
 impl CommandQueue {
     pub(crate) fn new(shared: Arc<Shared>) -> Self {
         CommandQueue {
             shared,
-            frame_wait: if FRAME_WAIT_REPORT_WINDOW != 0 {
-                Some(FrameWaitReport::default())
+            retained_buffers: Vec::new(),
+            retained_textures: Vec::new(),
+            perf_counters: if COUNTERS_REPORT_WINDOW != 0 {
+                Some(PerformanceCounters::default())
             } else {
                 None
             },
@@ -1273,9 +1276,9 @@ impl CommandQueue {
             if let Some(swap_image) = sem.image_ready.lock().unwrap().take() {
                 let start = time::Instant::now();
                 swap_image.wait_until_ready();
-                if let Some(ref mut wait) = self.frame_wait {
-                    wait.count += 1;
-                    wait.duration += start.elapsed();
+                if let Some(ref mut counters) = self.perf_counters {
+                    counters.frame_wait_count += 1;
+                    counters.frame_wait_duration += start.elapsed();
                 }
             }
         }
@@ -1295,23 +1298,6 @@ impl RawCommandQueue<Backend> for CommandQueue {
 
         self.wait(submit.wait_semaphores.iter().map(|&(s, _)| s));
 
-        let system_semaphores = submit.signal_semaphores
-            .into_iter()
-            .filter_map(|semaphore| {
-                semaphore.system.clone()
-            })
-            .collect::<Vec<_>>();
-        let signal_block = if !system_semaphores.is_empty() {
-            //Note: careful with those `ConcreteBlock::copy()` calls!
-            Some(ConcreteBlock::new(move |_cb: *mut ()| -> () {
-                for semaphore in &system_semaphores {
-                    semaphore.signal();
-                }
-            }).copy())
-        } else {
-            None
-        };
-
         let queue = self.shared.queue.lock().unwrap();
         let (mut num_immediate, mut num_deferred) = (0, 0);
 
@@ -1323,52 +1309,72 @@ impl RawCommandQueue<Backend> for CommandQueue {
                 ref mut retained_textures,
             } = *inner;
 
-            let temp_cmd_buffer;
-            let command_buffer: &metal::CommandBufferRef = match *sink {
+            match *sink {
                 Some(CommandSink::Immediate { ref cmd_buffer, ref token, .. }) => {
                     num_immediate += 1;
                     trace!("\timmediate {:?}", token);
-                    // schedule the retained buffers to release after the commands are done
-                    if !retained_buffers.is_empty() || !retained_textures.is_empty() {
-                        let free_buffers = mem::replace(retained_buffers, Vec::new());
-                        let free_textures = mem::replace(retained_textures, Vec::new());
-                        let release_block = ConcreteBlock::new(move |_cb: *mut ()| -> () {
-                            // move and auto-release
-                            let _ = free_buffers;
-                            let _ = free_textures;
-                        }).copy();
-                        msg_send![*cmd_buffer, addCompletedHandler: release_block.deref() as *const _];
-                    }
-                    cmd_buffer
+                    self.retained_buffers.extend(retained_buffers.drain(..));
+                    self.retained_textures.extend(retained_textures.drain(..));
+                    cmd_buffer.commit();
                 }
                 Some(CommandSink::Deferred { ref passes, .. }) => {
                     num_deferred += 1;
                     trace!("\tdeferred with {} passes", passes.len());
-                    temp_cmd_buffer = queue.spawn_temp();
-                    temp_cmd_buffer.set_label("deferred");
-                    record_commands(&*temp_cmd_buffer, passes);
-                    &*temp_cmd_buffer
+                    if let Some(ref mut counters) = self.perf_counters {
+                        counters.temporary_command_buffer_count += 1;;
+                    }
+                    let cmd_buffer = queue.spawn_temp();
+                    cmd_buffer.set_label("deferred");
+                    record_commands(&*cmd_buffer, passes);
+                    cmd_buffer.commit();
                  }
                  _ => panic!("Command buffer not recorded for submission")
-            };
-            if let Some(ref signal_block) = signal_block {
-                msg_send![command_buffer, addCompletedHandler: signal_block.deref() as *const _];
             }
-            command_buffer.commit();
         }
 
         debug!("\t{} immediate, {} deferred command buffers", num_immediate, num_deferred);
 
-        if let Some(ref fence) = fence {
-            let command_buffer = queue.spawn_temp();
-            command_buffer.set_label("fence");
-            let fence = Arc::clone(fence);
-            let fence_block = ConcreteBlock::new(move |_cb: *mut ()| -> () {
-                *fence.mutex.lock().unwrap() = true;
-                fence.condvar.notify_all();
+        const BLOCK_BUCKET: usize = 4;
+        let system_semaphores = submit.signal_semaphores
+            .into_iter()
+            .filter_map(|semaphore| {
+                semaphore.system.clone()
+            })
+            .collect::<SmallVec<[_; BLOCK_BUCKET]>>();
+
+        // Note: completion handlers can stall the GPU, so we only make one
+        // when strictly required, and collect the retained resources otherwise.
+        if fence.is_some() || !system_semaphores.is_empty() {
+            let moved_fence = fence.map(Arc::clone);
+            let free_buffers = self.retained_buffers
+                .drain(..)
+                .collect::<SmallVec<[_; BLOCK_BUCKET]>>();
+            let free_textures = self.retained_textures
+                .drain(..)
+                .collect::<SmallVec<[_; BLOCK_BUCKET]>>();
+
+            let block = ConcreteBlock::new(move |_cb: *mut ()| -> () {
+                // release the fence
+                if let Some(ref f) = moved_fence {
+                    *f.mutex.lock().unwrap() = true;
+                    f.condvar.notify_all();
+                }
+                // signal the semaphores
+                for semaphore in &system_semaphores {
+                    semaphore.signal();
+                }
+                // free all the manually retained resources
+                let _ = free_buffers;
+                let _ = free_textures;
             }).copy();
-            msg_send![command_buffer, addCompletedHandler: fence_block.deref() as *const _];
-            command_buffer.commit();
+
+            if let Some(ref mut counters) = self.perf_counters {
+                counters.temporary_command_buffer_count += 1;;
+            }
+            let cmd_buffer = queue.spawn_temp();
+            cmd_buffer.set_label("signal");
+            msg_send![cmd_buffer, addCompletedHandler: block.deref() as *const _];
+            cmd_buffer.commit();
         }
     }
 
@@ -1393,15 +1399,21 @@ impl RawCommandQueue<Backend> for CommandQueue {
 
         command_buffer.commit();
 
-        if let Some(ref mut wait) = self.frame_wait {
-            wait.frame += 1;
-            if wait.frame >= FRAME_WAIT_REPORT_WINDOW {
-                let time = wait.duration / wait.frame as u32;
-                println!("Frame wait time={}ms count={}",
-                    time.as_secs() as u32 * 1000 + time.subsec_millis(),
-                    wait.count as f32 / wait.frame as f32,
+        if let Some(ref mut counters) = self.perf_counters {
+            counters.active_command_buffer_count += queue.reserve.start;
+            counters.frame += 1;
+            if counters.frame >= COUNTERS_REPORT_WINDOW {
+                let time = counters.frame_wait_duration / counters.frame as u32;
+                println!("Performance counters:");
+                println!("\tActive command buffers: {} plus {} temporaries",
+                    counters.active_command_buffer_count / counters.frame,
+                    counters.temporary_command_buffer_count / counters.frame,
                 );
-                *wait = FrameWaitReport::default();
+                println!("\tFrame wait time:{}ms over {} requests",
+                    time.as_secs() as u32 * 1000 + time.subsec_millis(),
+                    counters.frame_wait_count as f32 / counters.frame as f32,
+                );
+                *counters = PerformanceCounters::default();
             }
         }
 
@@ -1452,7 +1464,8 @@ impl pool::RawCommandPool<Backend> for CommandPool {
                 resources_cs: StageResources::new(),
                 index_buffer: None,
                 rasterizer_state: None,
-                stencil: native::StencilState::<pso::StencilValue> {
+                depth_bias: pso::DepthBias::default(),
+                stencil: native::StencilState {
                     front_reference: 0,
                     back_reference: 0,
                     front_read_mask: !0,
@@ -2582,6 +2595,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 self.state.stencil.front_reference,
                 self.state.stencil.back_reference,
             ));
+        }
+        if let pso::State::Static(value) = pipeline.depth_bias {
+            self.state.depth_bias = value;
+            pre.issue(soft::RenderCommand::SetDepthBias(value));
         }
 
         if let Some(ref vp) = pipeline.baked_states.viewport {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -125,6 +125,8 @@ pub struct Device {
     pub(crate) shared: Arc<Shared>,
     pub(crate) private_caps: PrivateCapabilities,
     memory_types: [hal::MemoryType; 4],
+    /// Add a minimum descritpor count for any created pool,
+    /// only needed to work around a Dota bug.
     debug_min_descriptor_count: usize,
 }
 unsafe impl Send for Device {}
@@ -985,8 +987,9 @@ impl hal::Device<Backend> for Device {
             } else {
                 metal::MTLDepthClipMode::Clip
             },
-            depth_bias: pipeline_desc.rasterizer.depth_bias.unwrap_or_default(),
         });
+        let depth_bias = pipeline_desc.rasterizer.depth_bias
+            .unwrap_or(pso::State::Static(pso::DepthBias::default()));
 
         // prepare the depth-stencil state now
         self.shared.service_pipes
@@ -1009,6 +1012,7 @@ impl hal::Device<Backend> for Device {
                     primitive_type,
                     attribute_buffer_index: pipeline_layout.attribute_buffer_index,
                     rasterizer_state,
+                    depth_bias,
                     depth_stencil_desc: pipeline_desc.depth_stencil.clone(),
                     baked_states: pipeline_desc.baked_states.clone(),
                     vertex_buffer_map,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -125,9 +125,6 @@ pub struct Device {
     pub(crate) shared: Arc<Shared>,
     pub(crate) private_caps: PrivateCapabilities,
     memory_types: [hal::MemoryType; 4],
-    /// Add a minimum descritpor count for any created pool,
-    /// only needed to work around a Dota bug.
-    debug_min_descriptor_count: usize,
 }
 unsafe impl Send for Device {}
 unsafe impl Sync for Device {}
@@ -261,7 +258,6 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             shared: self.shared.clone(),
             private_caps: self.private_caps.clone(),
             memory_types: self.memory_types,
-            debug_min_descriptor_count: 0,
         };
 
         Ok(hal::Gpu {
@@ -1295,9 +1291,7 @@ impl hal::Device<Backend> for Device {
         I: IntoIterator,
         I::Item: Borrow<pso::DescriptorRangeDesc>,
     {
-        let mut num_samplers = self.debug_min_descriptor_count;
-        let mut num_textures = self.debug_min_descriptor_count;
-        let mut num_buffers  = self.debug_min_descriptor_count;
+        let (mut num_samplers, mut num_textures, mut num_buffers) = (0, 0, 0);
 
         if self.private_caps.argument_buffers {
             let mut arguments = Vec::new();

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -2,6 +2,7 @@ use {Backend, BufferPtr, SamplerPtr, TexturePtr};
 use internal::Channel;
 use window::SwapchainImage;
 
+use std::fmt;
 use std::ops::Range;
 use std::os::raw::{c_void, c_long};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
@@ -23,13 +24,25 @@ pub type EntryPointMap = FastHashMap<String, spirv::EntryPoint>;
 
 /// Shader module can be compiled in advance if it's resource bindings do not
 /// depend on pipeline layout, in which case the value would become `Compiled`.
-#[derive(Debug)]
 pub enum ShaderModule {
     Compiled {
         library: metal::Library,
         entry_point_map: EntryPointMap,
     },
     Raw(Vec<u8>),
+}
+
+impl fmt::Debug for ShaderModule {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ShaderModule::Compiled { .. } => {
+                write!(formatter, "ShaderModule::Compiled(..)")
+            }
+            ShaderModule::Raw(ref vec) => {
+                write!(formatter, "ShaderModule::Raw(length = {})", vec.len())
+            }
+        }
+    }
 }
 
 unsafe impl Send for ShaderModule {}

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -81,7 +81,6 @@ pub struct RasterizerState {
     pub front_winding: metal::MTLWinding,
     pub cull_mode: metal::MTLCullMode,
     pub depth_clip: metal::MTLDepthClipMode,
-    pub depth_bias: pso::DepthBias,
 }
 
 impl Default for RasterizerState {
@@ -90,7 +89,6 @@ impl Default for RasterizerState {
             front_winding: metal::MTLWinding::Clockwise,
             cull_mode: metal::MTLCullMode::None,
             depth_clip: metal::MTLDepthClipMode::Clip,
-            depth_bias: Default::default(),
         }
     }
 }
@@ -117,6 +115,7 @@ pub struct GraphicsPipeline {
     pub(crate) primitive_type: metal::MTLPrimitiveType,
     pub(crate) attribute_buffer_index: u32,
     pub(crate) rasterizer_state: Option<RasterizerState>,
+    pub(crate) depth_bias: pso::State<pso::DepthBias>,
     pub(crate) depth_stencil_desc: pso::DepthStencilDesc,
     pub(crate) baked_states: pso::BakedStates,
     /// The mapping of additional vertex buffer bindings over the original ones.

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -70,10 +70,7 @@ pub enum RenderCommand<R: Resources> {
         index: usize,
         sampler: Option<R::Sampler>,
     },
-    BindPipeline(
-        R::RenderPipeline,
-        Option<RasterizerState>,
-    ),
+    BindPipeline(R::RenderPipeline, Option<RasterizerState>),
     Draw {
         primitive_type: metal::MTLPrimitiveType,
         vertices: Range<hal::VertexCount>,

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -149,19 +149,23 @@ pub struct SwapchainImage {
 
 impl SwapchainImage {
     /// Waits until the specified swapchain index is available for rendering.
-    pub fn wait_until_ready(&self) {
+    /// Returns the number of frames it had to wait.
+    pub fn wait_until_ready(&self) -> usize {
         // check the target frame first
         {
             let frame = self.frames[self.index as usize].inner.lock().unwrap();
             assert!(!frame.available);
             if frame.drawable.is_some() {
-                return
+                return 0;
             }
         }
         // wait for new frames to come until we meet the chosen one
+        let mut count = 1;
         while self.surface.next_frame(&self.frames).0 != self.index as usize {
+            count += 1;
         }
-        debug!("Swapchain image is ready")
+        debug!("Swapchain image is ready after {} frames", count);
+        count
     }
 }
 

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -134,6 +134,7 @@ impl Swapchain {
             }
             hal::FrameSync::Fence(fence) => {
                 *fence.mutex.lock().unwrap() = true;
+                fence.condvar.notify_all();
             }
         }
     }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -405,6 +405,14 @@ impl d::Device<B> for Device {
                 topology: conv::map_topology(desc.input_assembler.primitive),
                 primitive_restart_enable: vk::VK_FALSE,
             });
+            let depth_bias = match desc.rasterizer.depth_bias {
+                Some(pso::State::Static(db)) => db,
+                Some(pso::State::Dynamic) => {
+                    dynamic_states.push(vk::DynamicState::DepthBias);
+                    pso::DepthBias::default()
+                },
+                None => pso::DepthBias::default(),
+            };
 
             info_rasterization_states.push(vk::PipelineRasterizationStateCreateInfo {
                 s_type: vk::StructureType::PipelineRasterizationStateCreateInfo,
@@ -425,9 +433,9 @@ impl d::Device<B> for Device {
                 cull_mode: conv::map_cull_face(desc.rasterizer.cull_face),
                 front_face: conv::map_front_face(desc.rasterizer.front_face),
                 depth_bias_enable: if desc.rasterizer.depth_bias.is_some() { vk::VK_TRUE } else { vk::VK_FALSE },
-                depth_bias_constant_factor: desc.rasterizer.depth_bias.map_or(0.0, |off| off.const_factor),
-                depth_bias_clamp: desc.rasterizer.depth_bias.map_or(0.0, |off| off.clamp),
-                depth_bias_slope_factor: desc.rasterizer.depth_bias.map_or(0.0, |off| off.slope_factor),
+                depth_bias_constant_factor: depth_bias.const_factor,
+                depth_bias_clamp: depth_bias.clamp,
+                depth_bias_slope_factor: depth_bias.slope_factor,
                 line_width,
             });
 

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -1,7 +1,7 @@
 //! Graphics pipeline descriptor.
 
 use {image, pass, Backend, Primitive};
-use super::{BasePipeline, EntryPoint, PipelineCreationFlags};
+use super::{BasePipeline, EntryPoint, PipelineCreationFlags, State};
 use super::input_assembler::{AttributeDesc, InputAssemblerDesc, VertexBufferDesc};
 use super::output_merger::{ColorBlendDesc, DepthStencilDesc, Face};
 
@@ -213,7 +213,7 @@ pub struct Rasterizer {
     /// they will be clamped to the min or max z value.
     pub depth_clamping: bool,
     /// What depth bias, if any, to use for the drawn primitives.
-    pub depth_bias: Option<DepthBias>,
+    pub depth_bias: Option<State<DepthBias>>,
     /// Controls how triangles will be rasterized depending on their overlap with pixels.
     pub conservative: bool,
 }


### PR DESCRIPTION
Fixes #2170

Expands our Metal stats to report the number of active and temporary command buffers. Coalesces the completion handlers, and finally fixes the depth bias issue we've been seeing (HAL breaking change).

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
