### PR TITLE
Add `MTLTriangleFillMode`, `MTLVisibilityResultMode` and comment to `…

### DIFF
--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -78,8 +78,15 @@ pub struct PipelineLayout {
 #[derive(Clone, Debug)]
 pub struct RasterizerState {
     //TODO: more states
+    /// The vertex winding rule that determines a front-facing primitive.
     pub front_winding: metal::MTLWinding,
+    /// determines whether to perform culling and which type of primitive to cull.
     pub cull_mode: metal::MTLCullMode,
+    /// determines how to rasterize triangle and triangle strip primitives
+    // pub triangle_fill_mode: metal::MTLTriangleFillMode,
+    /// determines whether samples pass the depth and stencil tests and whether to monitor the samples that pass.
+    // pub visibility_result_mode: metal::MTLVisibilityResultMode,
+    /// determines how to deal with fragments outside of the near or far planes.
     pub depth_clip: metal::MTLDepthClipMode,
     pub depth_bias: pso::DepthBias,
 }
@@ -89,6 +96,8 @@ impl Default for RasterizerState {
         RasterizerState {
             front_winding: metal::MTLWinding::Clockwise,
             cull_mode: metal::MTLCullMode::None,
+            // triangle_fill_mode: metal::MTLTriangleFillMode::Fill,
+            // visibility_result_mode: metal::MTLVisibilityResultMode::Disabled,
             depth_clip: metal::MTLDepthClipMode::Clip,
             depth_bias: Default::default(),
         }

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -10,7 +10,7 @@ use hal::{Backbuffer, SwapchainConfig};
 use hal::window::Extent2D;
 
 use metal;
-use objc::runtime::Object;
+use objc::runtime::{Object, YES, BOOL};
 use core_graphics::base::CGFloat;
 use core_graphics::geometry::CGRect;
 use cocoa::foundation::{NSRect};
@@ -242,8 +242,13 @@ impl Device {
             msg_send![render_layer, setPixelFormat: mtl_format];
             msg_send![render_layer, setFramebufferOnly: framebuffer_only];
             msg_send![render_layer, setMaximumDrawableCount: config.image_count as u64];
-            //TODO: only set it where supported
-            msg_send![render_layer, setDisplaySyncEnabled: display_sync];
+            // determines whether the Metal layer
+            // and it's drawables are synchronized with the display's refresh rate.
+            let can_responds_to_display_sync_enabled: BOOL = msg_send![render_layer, respondsToSelector:sel!(setDisplaySyncEnabled:)];
+            if can_responds_to_display_sync_enabled == YES {
+                // `setDisplaySyncEnabled` currently only supported on macOS 10.13+
+                msg_send![render_layer, setDisplaySyncEnabled: display_sync];
+            }
 
             // Update render layer size
             let view_points_size: CGRect = msg_send![nsview, bounds];


### PR DESCRIPTION
…RasterizerState` defined in metal/src/native.rs

Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
