### PR TITLE
Metal pools improved

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2648,7 +2648,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         for (set_index, desc_set) in sets.into_iter().enumerate() {
             match *desc_set.borrow() {
                 native::DescriptorSet::Emulated { ref pool, ref layouts, ref sampler_range, ref texture_range, ref buffer_range } => {
-                    let pool = pool.read().unwrap();
+                    let data = pool.read().unwrap();
                     let mut sampler_base = sampler_range.start as usize;
                     let mut texture_base = texture_range.start as usize;
                     let mut buffer_base = buffer_range.start as usize;
@@ -2662,7 +2662,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
                         if buffer_base != bf_range.start {
                             dynamic_offsets.clear();
-                            for bref in &pool.buffers[bf_range.clone()] {
+                            for bref in &data.buffers[bf_range.clone()] {
                                 if bref.base.is_some() && bref.dynamic {
                                     dynamic_offsets.push(*offset_iter
                                         .next()
@@ -2700,7 +2700,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                 debug_assert_eq!(sampler_base, sm_range.end);
                                 resources.set_samplers(
                                     pipe_layout.res_overrides[&loc].sampler_id as usize,
-                                    &pool.samplers[sm_range.clone()],
+                                    &data.samplers[sm_range.clone()],
                                     |index, sampler| {
                                         pre.issue(soft::RenderCommand::BindSampler { stage, index, sampler });
                                     },
@@ -2710,7 +2710,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                 debug_assert_eq!(texture_base, tx_range.end);
                                 resources.set_textures(
                                     pipe_layout.res_overrides[&loc].texture_id as usize,
-                                    &pool.textures[tx_range.clone()],
+                                    &data.textures[tx_range.clone()],
                                     |index, texture| {
                                         pre.issue(soft::RenderCommand::BindTexture { stage, index, texture });
                                     },
@@ -2718,7 +2718,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             }
                             if buffer_base != bf_range.start {
                                 debug_assert_eq!(buffer_base, bf_range.end);
-                                let buffers = &pool.buffers[bf_range.clone()];
+                                let buffers = &data.buffers[bf_range.clone()];
                                 let start = pipe_layout.res_overrides[&loc].buffer_id as usize;
                                 let mut dynamic_index = 0;
                                 for (i, bref) in buffers.iter().enumerate() {
@@ -2824,7 +2824,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             }];
             match *desc_set.borrow() {
                 native::DescriptorSet::Emulated { ref pool, ref layouts, ref sampler_range, ref texture_range, ref buffer_range } => {
-                    let pool = pool.read().unwrap();
+                    let data = pool.read().unwrap();
                     let mut sampler_base = sampler_range.start as usize;
                     let mut texture_base = texture_range.start as usize;
                     let mut buffer_base = buffer_range.start as usize;
@@ -2838,7 +2838,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
                         if buffer_base != bf_range.start {
                             dynamic_offsets.clear();
-                            for bref in &pool.buffers[bf_range.clone()] {
+                            for bref in &data.buffers[bf_range.clone()] {
                                 if bref.base.is_some() && bref.dynamic {
                                     dynamic_offsets.push(*offset_iter
                                         .next()
@@ -2853,7 +2853,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             debug_assert_eq!(sampler_base, sm_range.end);
                             resources.set_samplers(
                                 res_override.sampler_id as usize,
-                                &pool.samplers[sm_range],
+                                &data.samplers[sm_range],
                                 |index, sampler| {
                                     pre.issue(soft::ComputeCommand::BindSampler { index, sampler });
                                 },
@@ -2863,7 +2863,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             debug_assert_eq!(texture_base, tx_range.end);
                             resources.set_textures(
                                 res_override.texture_id as usize,
-                                &pool.textures[tx_range],
+                                &data.textures[tx_range],
                                 |index, texture| {
                                     pre.issue(soft::ComputeCommand::BindTexture { index, texture });
                                 },
@@ -2871,7 +2871,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         }
                         if buffer_base != bf_range.start {
                             debug_assert_eq!(buffer_base, bf_range.end);
-                            let buffers = &pool.buffers[bf_range];
+                            let buffers = &data.buffers[bf_range];
                             let start = res_override.buffer_id as usize;
                             let mut dynamic_index = 0;
                             for (i, bref) in buffers.iter().enumerate() {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -9,7 +9,7 @@ use std::borrow::Borrow;
 use std::collections::hash_map::Entry;
 use std::ops::Range;
 use std::path::Path;
-use std::sync::{Arc, Condvar, Mutex, RwLock};
+use std::sync::{Arc, Condvar, Mutex};
 use std::{cmp, mem, slice, time};
 
 use hal::{self, error, image, pass, format, mapping, memory, buffer, pso, query, window};
@@ -1317,8 +1317,7 @@ impl hal::Device<Backend> for Device {
                 n::DescriptorPool::count_bindings(desc.ty, desc.count,
                     &mut num_samplers, &mut num_textures, &mut num_buffers);
             }
-            let inner = n::DescriptorPoolInner::new(num_samplers, num_textures, num_buffers);
-            n::DescriptorPool::Emulated(Arc::new(RwLock::new(inner)))
+            n::DescriptorPool::new_emulated(num_samplers, num_textures, num_buffers)
         }
     }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -583,26 +583,17 @@ impl Device {
 
 impl hal::Device<Backend> for Device {
     fn create_command_pool(
-        &self, _family: QueueFamilyId, flags: CommandPoolCreateFlags
+        &self, _family: QueueFamilyId, _flags: CommandPoolCreateFlags
     ) -> command::CommandPool {
         command::CommandPool {
             shared: self.shared.clone(),
-            managed: if flags.contains(CommandPoolCreateFlags::RESET_INDIVIDUAL) {
-                None
-            } else {
-                Some(Vec::new())
-            },
+            allocated: Vec::new(),
         }
     }
 
-    fn destroy_command_pool(&self, pool: command::CommandPool) {
-        if let Some(vec) = pool.managed {
-            for cmd_buf in vec {
-                cmd_buf
-                    .borrow_mut()
-                    .reset(&self.shared);
-            }
-        }
+    fn destroy_command_pool(&self, mut pool: command::CommandPool) {
+        use hal::pool::RawCommandPool;
+        pool.reset();
     }
 
     fn create_render_pass<'a, IA, IS, ID>(


### PR DESCRIPTION
Addresses part of  #2229 by ~~removing the descriptor pool lock entirely - it's meant to be externally synchronized by Vulkan anyway~~ moving the ranges out of the descriptor lock.
Fixes the correctness of a pool reset that's not created with the individual reset flag.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
