### PR TITLE
Faster passes and PSO bindings in Metal

### DIFF
--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -138,7 +138,7 @@ pub struct GraphicsPipeline {
     /// adjusted offsets to cover this use case.
     pub(crate) vertex_buffer_map: VertexBufferMap,
     /// Tracked attachment formats for figuring (roughly) renderpass compatibility.
-    pub(crate) attachment_formats: SmallVec<[Option<Format>; 8]>,
+    pub(crate) attachment_formats: Vec<Option<Format>>,
 }
 
 unsafe impl Send for GraphicsPipeline {}

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -500,21 +500,30 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
         match *self {
             DescriptorPool::Emulated { ref inner, ref mut sampler_alloc, ref mut texture_alloc, ref mut buffer_alloc } => {
                 debug!("pool: reset");
+                if sampler_alloc.is_empty() && texture_alloc.is_empty() && buffer_alloc.is_empty() {
+                    return // spare the locking
+                }
                 let mut data = inner.write();
+
+                for range in sampler_alloc.allocated_ranges() {
+                    for sampler in &mut data.samplers[range.start as usize .. range.end as usize] {
+                        *sampler = None;
+                    }
+                }
+                for range in texture_alloc.allocated_ranges() {
+                    for texture in &mut data.textures[range.start as usize .. range.end as usize] {
+                        *texture = None;
+                    }
+                }
+                for range in buffer_alloc.allocated_ranges() {
+                    for buffer in &mut data.buffers[range.start as usize .. range.end as usize] {
+                        buffer.base = None;
+                    }
+                }
 
                 sampler_alloc.reset();
                 texture_alloc.reset();
                 buffer_alloc.reset();
-
-                for sampler in &mut data.samplers {
-                    *sampler = None;
-                }
-                for texture in &mut data.textures {
-                    *texture = None;
-                }
-                for buffer in &mut data.buffers {
-                    buffer.base = None;
-                }
             }
             DescriptorPool::ArgumentBuffer { ref mut range_allocator, .. } => {
                 range_allocator.reset();

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -49,6 +49,7 @@ pub enum RenderCommand<R: Resources> {
     SetDepthBias(hal::pso::DepthBias),
     SetDepthStencilState(R::DepthStencil),
     SetStencilReferenceValues(hal::pso::StencilValue, hal::pso::StencilValue),
+    SetRasterizerState(RasterizerState),
     BindBuffer {
         stage: hal::pso::Stage,
         index: usize,
@@ -70,7 +71,7 @@ pub enum RenderCommand<R: Resources> {
         index: usize,
         sampler: Option<R::Sampler>,
     },
-    BindPipeline(R::RenderPipeline, Option<RasterizerState>),
+    BindPipeline(R::RenderPipeline),
     Draw {
         primitive_type: metal::MTLPrimitiveType,
         vertices: Range<hal::VertexCount>,
@@ -106,6 +107,7 @@ impl RenderCommand<Own> {
             SetDepthBias(bias) => SetDepthBias(bias),
             SetDepthStencilState(ref state) => SetDepthStencilState(&**state),
             SetStencilReferenceValues(front, back) => SetStencilReferenceValues(front, back),
+            SetRasterizerState(ref state) => SetRasterizerState(state.clone()),
             BindBuffer { stage, index, buffer, offset } => BindBuffer {
                 stage,
                 index,
@@ -127,7 +129,7 @@ impl RenderCommand<Own> {
                 index,
                 sampler,
             },
-            BindPipeline(ref pso, ref state) => BindPipeline(&**pso, state.clone()),
+            BindPipeline(ref pso) => BindPipeline(&**pso),
             Draw { primitive_type, ref vertices, ref instances } => Draw {
                 primitive_type,
                 vertices: vertices.clone(),
@@ -165,6 +167,7 @@ impl<'a> RenderCommand<&'a Own> {
             SetDepthBias(bias) => SetDepthBias(bias),
             SetDepthStencilState(state) => SetDepthStencilState(state.to_owned()),
             SetStencilReferenceValues(front, back) => SetStencilReferenceValues(front, back),
+            SetRasterizerState(ref state) => SetRasterizerState(state.clone()),
             BindBuffer { stage, index, buffer, offset } => BindBuffer {
                 stage,
                 index,
@@ -186,7 +189,7 @@ impl<'a> RenderCommand<&'a Own> {
                 index,
                 sampler,
             },
-            BindPipeline(pso, state) => BindPipeline(pso.to_owned(), state),
+            BindPipeline(pso) => BindPipeline(pso.to_owned()),
             Draw { primitive_type, vertices, instances } => Draw {
                 primitive_type,
                 vertices,


### PR DESCRIPTION
This PR has a few changes that lighten up our most heavy operations at the moment: render pass start and PSO binding. In particular, it re-uses the heap allocation properly now at the latter, ~~and the former tries to avoid waiting on a mutex (for the RP descriptor) if there is another spare available~~.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
