### PR TITLE
Metal parking lot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ EXCLUDES:=
 FEATURES_EXTRA:=mint serialize
 FEATURES_HAL:=
 FEATURES_HAL2:=
+CHECK_SPECIAL:=-p gfx-backend-vulkan
 
 SDL2_DEST=$(HOME)/deps
 SDL2_CONFIG=$(SDL2_DEST)/usr/bin/sdl2-config
@@ -32,6 +33,7 @@ else
 	ifeq ($(UNAME_S),Darwin)
 		EXCLUDES+= --exclude gfx-backend-vulkan
 		FEATURES_HAL=metal
+		CHECK_SPECIAL=-p gfx-backend-metal --features antidote
 	endif
 endif
 
@@ -46,6 +48,7 @@ help:
 check:
 	@echo "Note: excluding \`warden\` here, since it depends on serialization"
 	cargo check --all $(EXCLUDES) --exclude gfx-warden
+	#cargo check $(CHECK_SPECIAL) # TODO: Condva API is different between antidote and parking_lot
 	cd examples && cargo check --features "gl"
 	cd examples && cargo check --features "$(FEATURES_HAL)"
 	cd examples && cargo check --features "$(FEATURES_HAL2)"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -32,3 +32,5 @@ core-foundation = "0.6"
 core-graphics = "0.14"
 smallvec = "0.6"
 spirv_cross = "0.9"
+antidote = { version = "1.0", optional = true }
+parking_lot = "0.6"

--- a/src/backend/metal/src/internal.rs
+++ b/src/backend/metal/src/internal.rs
@@ -1,6 +1,8 @@
 use conversions as conv;
+use lock::Mutex;
 
 use metal;
+
 use hal::pso;
 use hal::backend::FastHashMap;
 use hal::command::ClearColorRaw;
@@ -9,7 +11,6 @@ use hal::image::Filter;
 
 use std::mem;
 use std::path::Path;
-use std::sync::Mutex;
 
 
 #[derive(Clone, Debug)]
@@ -182,7 +183,7 @@ impl DepthStencilStates {
             .or_insert_with(|| {
                 let raw_desc = Self::create_desc(&desc)
                     .expect("Incomplete descriptor provided");
-                device.lock().unwrap().new_depth_stencil_state(&raw_desc)
+                device.lock().new_depth_stencil_state(&raw_desc)
             })
     }
 
@@ -276,7 +277,7 @@ impl ImageClearPipes {
     ) -> &metal::RenderPipelineStateRef {
         self.map
             .entry(key)
-            .or_insert_with(|| Self::create(key, library, &*device.lock().unwrap()))
+            .or_insert_with(|| Self::create(key, library, &*device.lock()))
     }
 
     fn create(
@@ -354,7 +355,7 @@ impl ImageBlitPipes {
     ) -> &metal::RenderPipelineStateRef {
         self.map
             .entry(key)
-            .or_insert_with(|| Self::create(key, library, &*device.lock().unwrap()))
+            .or_insert_with(|| Self::create(key, library, &*device.lock()))
     }
 
     fn create(

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate gfx_hal as hal;
+extern crate metal_rs as metal;
 #[macro_use] extern crate bitflags;
 extern crate cocoa;
 extern crate foreign_types;
@@ -10,8 +11,10 @@ extern crate block;
 extern crate smallvec;
 extern crate spirv_cross;
 
-extern crate metal_rs as metal;
-
+#[cfg(feature = "antidote")]
+extern crate antidote as lock;
+#[cfg(not(feature = "antidote"))]
+extern crate parking_lot as lock;
 #[cfg(feature = "winit")]
 extern crate winit;
 
@@ -32,8 +35,10 @@ pub use window::{Surface, Swapchain};
 pub type GraphicsCommandPool = CommandPool;
 
 use std::mem;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::os::raw::c_void;
+
+use lock::Mutex;
 
 use hal::queue::QueueFamilyId;
 
@@ -91,7 +96,7 @@ impl hal::Instance for Instance {
 
     fn enumerate_adapters(&self) -> Vec<hal::Adapter<Backend>> {
         // TODO: enumerate all devices
-        let name = self.shared.device.lock().unwrap().name().into();
+        let name = self.shared.device.lock().name().into();
 
         vec![
             hal::Adapter {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1,11 +1,12 @@
 use {Backend, BufferPtr, SamplerPtr, TexturePtr};
 use internal::Channel;
+use lock::{Condvar, Mutex, RwLock};
 use window::SwapchainImage;
 
 use std::fmt;
 use std::ops::Range;
 use std::os::raw::{c_void, c_long};
-use std::sync::{Arc, Condvar, Mutex, RwLock};
+use std::sync::Arc;
 
 use hal::{self, image, pso};
 use hal::backend::FastHashMap;
@@ -391,7 +392,7 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
 
                 // step[3]: fill out immutable samplers
                 if has_immutable_samplers {
-                    let mut data = inner.write().unwrap();
+                    let mut data = inner.write();
                     let mut immutable_sampler_offset = 0;
                     let mut sampler_offset = sampler_range.start as usize;
                     let (mut tx_temp, mut bf_temp) = (0, 0);
@@ -447,7 +448,7 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
         match self {
             DescriptorPool::Emulated { ref inner, ref mut sampler_alloc, ref mut texture_alloc, ref mut buffer_alloc } => {
                 debug!("pool: free_sets");
-                let mut data = inner.write().unwrap();
+                let mut data = inner.write();
                 for descriptor_set in descriptor_sets {
                     match descriptor_set {
                         DescriptorSet::Emulated { sampler_range, texture_range, buffer_range, .. } => {
@@ -499,7 +500,7 @@ impl hal::DescriptorPool<Backend> for DescriptorPool {
         match *self {
             DescriptorPool::Emulated { ref inner, ref mut sampler_alloc, ref mut texture_alloc, ref mut buffer_alloc } => {
                 debug!("pool: reset");
-                let mut data = inner.write().unwrap();
+                let mut data = inner.write();
 
                 sampler_alloc.reset();
                 texture_alloc.reset();


### PR DESCRIPTION
Addresses a part of #2229
~~Based on #2240~~
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

~~Unfortunately, I see no performance advantage from switching to `parking_lot` so far. cc @Amanieu~~

After a series of unsuccessful attempts to hook up a third party library (what could possibly be easier, eh?), I got the performance numbers - we are up from 80 to almost 90, which is more than a 10% bump. Given that `parking_lot` is not a drop-in replacement for `std::sync`, I suggest we ship it by default and provide `antidote` as an optional dependency.