### PR TITLE
Fix typo in hal/src/device.rs, hal/src/command/raw.rs, backend/metal/…

### DIFF
--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -671,6 +671,7 @@ impl CommandQueue {
             panic!("Error {:?} executing command: {:?}", err, cmd)
         }
     }
+    
     fn signal_fence(&mut self, fence: &native::Fence) {
         if self.share.private_caps.sync {
             let gl = &self.share.context;

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2345,7 +2345,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         let vp_borrowable = vps.next().expect("No viewport provided, Metal supports exactly one");
         let vp = vp_borrowable.borrow();
         if vps.next().is_some() {
-            // TODO should we panic here or set buffer in an erronous state?
+            // TODO should we panic here or set buffer in an erroneous state?
             panic!("More than one viewport set; Metal supports only one viewport");
         }
 

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -213,7 +213,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
 
     /// Set the viewport parameters for the rasterizer.
     ///
-    /// Each viewport passed corrosponds to the viewport with the same index,
+    /// Each viewport passed corresponds to the viewport with the same index,
     /// starting from an offset index `first_viewport`.
     ///
     /// # Errors

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -366,7 +366,7 @@ pub trait Device<B: Backend>: Any + Send + Sync {
     /// Create a descriptor pool.
     ///
     /// Descriptor pools allow allocation of descriptor sets.
-    /// Ihe pool can't be modified directly, only through updating descriptor sets.
+    /// The pool can't be modified directly, only through updating descriptor sets.
     fn create_descriptor_pool<I>(&self, max_sets: usize, descriptor_ranges: I) -> B::DescriptorPool
     where
         I: IntoIterator,


### PR DESCRIPTION
…src/command.rs

Add a new line breaks two adjacent function definition in backend/gl/src/queue.rs

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
