### PR TITLE
[mtl] Experimental concurrent map storage integration

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -33,4 +33,5 @@ core-graphics = "0.14"
 smallvec = "0.6"
 spirv_cross = "0.9"
 antidote = { version = "1.0", optional = true }
-parking_lot = "0.6"
+parking_lot = "0.6.3"
+storage-map = "0.1"

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -983,7 +983,6 @@ impl hal::Device<Backend> for Device {
         // prepare the depth-stencil state now
         self.shared.service_pipes
             .depth_stencil_states
-            .lock()
             .prepare(&pipeline_desc.depth_stencil, &*device);
 
         let attachment_formats = pass_descriptor.main_pass.attachments

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -10,6 +10,7 @@ extern crate core_graphics;
 extern crate block;
 extern crate smallvec;
 extern crate spirv_cross;
+extern crate storage_map;
 
 #[cfg(feature = "antidote")]
 extern crate antidote as lock;


### PR DESCRIPTION
Fixes #2227
Adds dependency to `storage-map` crate for locking on Metal. If it proves to be useful, we'll likely want it to be used for other backends as well.

Dota performance changes:
  - immediate: 90 -> 92 fps
  - deferred: 92 -> 99 fps

PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
