### PR TITLE
[mtl] Fix image view kind

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1907,10 +1907,10 @@ impl hal::Device<Backend> for Device {
             range == full_range &&
             match (kind, image.kind) {
                 (image::ViewKind::D1, image::Kind::D1(..)) |
-                (image::ViewKind::D1Array, image::Kind::D1(..)) |
                 (image::ViewKind::D2, image::Kind::D2(..)) |
-                (image::ViewKind::D2Array, image::Kind::D2(..)) |
                 (image::ViewKind::D3, image::Kind::D3(..)) => true,
+                (image::ViewKind::D1Array, image::Kind::D1(_, layers)) if layers > 1 => true,
+                (image::ViewKind::D2Array, image::Kind::D2(_, _, layers, _)) if layers > 1 => true,
                 (_, _) => false, //TODO: expose more choices here?
             }
         {


### PR DESCRIPTION
Match the `create_image` [logic](https://github.com/gfx-rs/gfx/blob/e5df0879425595619d95db5db77e9b5213ad34e0/src/backend/metal/src/device.rs#L1700-L1703).
PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code