### PR TITLE
Metal command buffer fences and ignoring empty ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ EXCLUDES:=
 FEATURES_EXTRA:=mint serialize
 FEATURES_HAL:=
 FEATURES_HAL2:=
-CHECK_SPECIAL:=-p gfx-backend-vulkan
 
 SDL2_DEST=$(HOME)/deps
 SDL2_CONFIG=$(SDL2_DEST)/usr/bin/sdl2-config
@@ -33,7 +32,6 @@ else
 	ifeq ($(UNAME_S),Darwin)
 		EXCLUDES+= --exclude gfx-backend-vulkan
 		FEATURES_HAL=metal
-		CHECK_SPECIAL=-p gfx-backend-metal --features antidote
 	endif
 endif
 
@@ -48,7 +46,6 @@ help:
 check:
 	@echo "Note: excluding \`warden\` here, since it depends on serialization"
 	cargo check --all $(EXCLUDES) --exclude gfx-warden
-	#cargo check $(CHECK_SPECIAL) # TODO: Condva API is different between antidote and parking_lot
 	cd examples && cargo check --features "gl"
 	cd examples && cargo check --features "$(FEATURES_HAL)"
 	cd examples && cargo check --features "$(FEATURES_HAL2)"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -32,6 +32,5 @@ core-foundation = "0.6"
 core-graphics = "0.14"
 smallvec = "0.6"
 spirv_cross = "0.9"
-antidote = { version = "1.0", optional = true }
 parking_lot = "0.6.3"
 storage-map = "0.1"

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -4,7 +4,6 @@ use {
 };
 use {conversions as conv, native, soft, window};
 use internal::{BlitVertex, Channel, ClearKey, ClearVertex};
-use lock::Mutex;
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
@@ -22,10 +21,11 @@ use hal::query::{Query, QueryControl, QueryId};
 use hal::queue::{RawCommandQueue, RawSubmission};
 use hal::range::RangeArg;
 
+use block::ConcreteBlock;
+use cocoa::foundation::{NSUInteger, NSInteger, NSRange};
 use foreign_types::{ForeignType, ForeignTypeRef};
 use metal::{self, MTLViewport, MTLScissorRect, MTLPrimitiveType, MTLIndexType, MTLSize};
-use cocoa::foundation::{NSUInteger, NSInteger, NSRange};
-use block::{ConcreteBlock};
+use parking_lot::Mutex;
 use smallvec::SmallVec;
 
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -3,8 +3,8 @@ use {
     Shared, Surface, Swapchain, validate_line_width, BufferPtr, SamplerPtr, TexturePtr,
 };
 use {conversions as conv, command, native as n};
-use lock::Mutex;
 use native;
+use range_alloc::RangeAllocator;
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
@@ -22,17 +22,16 @@ use hal::queue::{QueueFamilyId, Queues};
 use hal::range::RangeArg;
 
 use cocoa::foundation::{NSRange, NSUInteger};
+use foreign_types::ForeignType;
 use metal::{self,
     MTLFeatureSet, MTLLanguageVersion, MTLArgumentAccess, MTLDataType, MTLPrimitiveType, MTLPrimitiveTopologyClass,
     MTLCPUCacheMode, MTLStorageMode, MTLResourceOptions,
     MTLVertexStepFunction, MTLSamplerBorderColor, MTLSamplerMipFilter, MTLTextureType,
     CaptureManager
 };
+use parking_lot::Mutex;
 use smallvec::SmallVec;
 use spirv_cross::{msl, spirv, ErrorCode as SpirvErrorCode};
-use foreign_types::ForeignType;
-
-use range_alloc::RangeAllocator;
 
 
 const RESOURCE_HEAP_SUPPORT: &[MTLFeatureSet] = &[

--- a/src/backend/metal/src/internal.rs
+++ b/src/backend/metal/src/internal.rs
@@ -1,8 +1,7 @@
 use conversions as conv;
-use lock::Mutex;
 
 use metal;
-use lock::RawRwLock;
+use parking_lot::{Mutex, RawRwLock};
 use storage_map::{StorageMap, StorageMapGuard};
 
 use hal::pso;

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -8,14 +8,11 @@ extern crate core_foundation;
 extern crate core_graphics;
 #[macro_use] extern crate log;
 extern crate block;
+extern crate parking_lot;
 extern crate smallvec;
 extern crate spirv_cross;
 extern crate storage_map;
 
-#[cfg(feature = "antidote")]
-extern crate antidote as lock;
-#[cfg(not(feature = "antidote"))]
-extern crate parking_lot as lock;
 #[cfg(feature = "winit")]
 extern crate winit;
 
@@ -39,14 +36,13 @@ use std::mem;
 use std::sync::Arc;
 use std::os::raw::c_void;
 
-use lock::Mutex;
-
 use hal::queue::QueueFamilyId;
 
 use objc::runtime::{Class, Object};
 use cocoa::foundation::NSAutoreleasePool;
 use core_graphics::geometry::CGRect;
 use foreign_types::ForeignTypeRef;
+use parking_lot::Mutex;
 
 
 const MAX_ACTIVE_COMMAND_BUFFERS: usize = 1 << 14;

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1,6 +1,6 @@
 use {Backend, BufferPtr, SamplerPtr, TexturePtr};
 use internal::Channel;
-use lock::{Mutex, RwLock};
+use range_alloc::RangeAllocator;
 use window::SwapchainImage;
 
 use std::cell::RefCell;
@@ -14,12 +14,11 @@ use hal::backend::FastHashMap;
 use hal::format::{Aspects, Format, FormatDesc};
 
 use cocoa::foundation::{NSUInteger};
+use foreign_types::ForeignType;
 use metal;
+use parking_lot::{Mutex, RwLock};
 use smallvec::SmallVec;
 use spirv_cross::{msl, spirv};
-use foreign_types::ForeignType;
-
-use range_alloc::RangeAllocator;
 
 
 pub type EntryPointMap = FastHashMap<String, spirv::EntryPoint>;

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -1,8 +1,7 @@
 use {AutoreleasePool, Backend, QueueFamily};
-use internal::Channel;
-use lock::{Mutex, MutexGuard};
-use native;
 use device::{Device, PhysicalDevice};
+use internal::Channel;
+use native;
 
 use std::sync::Arc;
 
@@ -10,12 +9,13 @@ use hal::{self, format, image};
 use hal::{Backbuffer, SwapchainConfig};
 use hal::window::Extent2D;
 
-use metal;
-use objc::runtime::Object;
 use core_graphics::base::CGFloat;
 use core_graphics::geometry::CGRect;
 use cocoa::foundation::{NSRect};
 use foreign_types::{ForeignType, ForeignTypeRef};
+use parking_lot::{Mutex, MutexGuard};
+use metal;
+use objc::runtime::Object;
 
 
 pub type CAMetalLayer = *mut Object;

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -133,8 +133,7 @@ impl Swapchain {
                 }
             }
             hal::FrameSync::Fence(fence) => {
-                *fence.mutex.lock() = true;
-                fence.condvar.notify_all();
+                *fence.0.borrow_mut() = native::FenceInner::Idle { signaled: true };
             }
         }
     }


### PR DESCRIPTION
Fixes #2252

I'm not 100% convinced this is a good thing to fix, but had to try it anyway, so might as well file the PR :)
Please take a (critical) look.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
