### PR TITLE
Make the Explicit shader support comment more inline with the others.

### DIFF
--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -226,7 +226,7 @@ bitflags! {
         const SAMPLER_LOD_BIAS = 0x2000;
         /// Support setting border texel colors.
         const SAMPLER_BORDER_COLOR = 0x4000;
-        /// No explicit layouts in shader support
+        /// Support explicit layouts in shader.
         const EXPLICIT_LAYOUTS_IN_SHADER = 0x8000;
     }
 }


### PR DESCRIPTION
Signed-off-by: Hal Gentz <zegentzy@protonmail.com>

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
