### PR TITLE
[dx11] add fences and some debugging

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -24,6 +24,7 @@ gfx-hal = { path = "../../hal", version = "0.1" }
 log = { version = "0.4", features = ["release_max_level_error"] }
 smallvec = "0.6"
 spirv_cross = "0.9"
+parking_lot = "0.6.3"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.16", optional = true }
 wio = "0.2"

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -497,6 +497,7 @@ impl Internal {
         unsafe {
             context.CSSetShader(shader, ptr::null_mut(), 0);
             context.CSSetConstantBuffers(0, 1, &self.copy_info.as_raw());
+
             context.CSSetShaderResources(0, 1, [srv].as_ptr());
             context.CSSetUnorderedAccessViews(0, 1, [uav].as_ptr(), ptr::null_mut());
 
@@ -584,7 +585,6 @@ impl Internal {
                 context.CSSetShader(shader, ptr::null_mut(), 0);
                 context.CSSetConstantBuffers(0, 1, &self.copy_info.as_raw());
                 context.CSSetShaderResources(0, 1, [srv].as_ptr());
-
 
 
                 for copy in regions {


### PR DESCRIPTION
Adds a "software" Fence implementation, taken from the Metal backend. Initially I tried to implement fences using `D3D11_QUERY_EVENT`, but it turns out it would end up looking the same anyway (Queue and Device share the same ID3D11DeviceContext which has to be synchronized between threads).
 
The only difference from the Metal backend is that this isn't using a completed handler to signal the fence when the queue is done, but rather when they are scheduled (after `ExecuteCommandLists`). This should be fine since we only care about protecting our emulated objects (eg. DescriptorSet), while the driver should handle access of objects in use.

Also adds object leak checking through the `ID3D11Debug` interface.

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
