### PR TITLE
[mtl] new autorelease

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -25,10 +25,9 @@ log = { version = "0.4", features = ["release_max_level_error"] }
 winit = { version = "0.16", optional = true }
 metal-rs = "0.10.1"
 foreign-types = "0.3"
-objc = "0.2"
+objc = "0.2.5"
 block = "0.1"
 cocoa = "0.15"
-core-foundation = "0.6"
 core-graphics = "0.14"
 dispatch = "0.1"
 smallvec = "0.6"

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -4,7 +4,6 @@ extern crate metal_rs as metal;
 extern crate cocoa;
 extern crate foreign_types;
 #[macro_use] extern crate objc;
-extern crate core_foundation;
 extern crate core_graphics;
 #[macro_use] extern crate log;
 extern crate block;
@@ -40,7 +39,6 @@ use std::os::raw::c_void;
 use hal::queue::QueueFamilyId;
 
 use objc::runtime::{Class, Object};
-use cocoa::foundation::NSAutoreleasePool;
 use core_graphics::geometry::CGRect;
 use foreign_types::ForeignTypeRef;
 use parking_lot::Mutex;
@@ -220,33 +218,6 @@ struct PrivateCapabilities {
 #[derive(Clone, Copy, Debug)]
 struct PrivateDisabilities {
     broken_viewport_near_depth: bool,
-}
-
-pub struct AutoreleasePool {
-    pool: cocoa::base::id,
-}
-
-impl Drop for AutoreleasePool {
-    fn drop(&mut self) {
-        unsafe {
-            msg_send![self.pool, release]
-        }
-    }
-}
-
-impl AutoreleasePool {
-    pub fn new() -> Self {
-        AutoreleasePool {
-            pool: unsafe {
-                NSAutoreleasePool::new(cocoa::base::nil)
-            },
-        }
-    }
-
-    pub unsafe fn reset(&mut self) {
-        self.pool.drain();
-        self.pool = NSAutoreleasePool::new(cocoa::base::nil);
-    }
 }
 
 fn validate_line_width(width: f32) {


### PR DESCRIPTION
Fixes the time wasted on setting up temporary autorelease pools, mostly. Although the resulting FPS doesn't appear to be affected. At least we no longer depend on core-foundation :)
cc @jrmuizel (and thanks!) for the way it looks now

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
