### PR TITLE
Optimized descriptor binding

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2857,8 +2857,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         let mut inner = self.inner.borrow_mut();
         let mut pre = inner.sink().pre_render();
 
-        self.state.resources_vs.pre_allocate(&pipe_layout.vs_counters);
-        self.state.resources_ps.pre_allocate(&pipe_layout.ps_counters);
+        self.state.resources_vs.pre_allocate(&pipe_layout.total.vs);
+        self.state.resources_ps.pre_allocate(&pipe_layout.total.ps);
 
         for (set_index, desc_set) in sets.into_iter().enumerate() {
             match *desc_set.borrow() {
@@ -2945,15 +2945,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             }
                         }
 
-                        if layout.content.contains(native::DescriptorContent::BUFFER) {
-                            counters.buffers += 1;
-                        }
-                        if layout.content.contains(native::DescriptorContent::TEXTURE) {
-                            counters.textures += 1;
-                        }
-                        if layout.content.contains(native::DescriptorContent::SAMPLER) {
-                            counters.samplers += 1;
-                        }
+                        counters.add(layout.content);
                     }
                 }
                 native::DescriptorSet::ArgumentBuffer { ref raw, offset, stage_flags, .. } => {
@@ -3022,7 +3014,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         let mut inner = self.inner.borrow_mut();
         let mut pre = inner.sink().pre_compute();
 
-        self.state.resources_cs.pre_allocate(&pipe_layout.cs_counters);
+        self.state.resources_cs.pre_allocate(&pipe_layout.total.cs);
 
         for (set_index, desc_set) in sets.into_iter().enumerate() {
             let resources = &mut self.state.resources_cs;
@@ -3090,15 +3082,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             }
                         }
 
-                        if layout.content.contains(native::DescriptorContent::BUFFER) {
-                            counters.buffers += 1;
-                        }
-                        if layout.content.contains(native::DescriptorContent::TEXTURE) {
-                            counters.textures += 1;
-                        }
-                        if layout.content.contains(native::DescriptorContent::SAMPLER) {
-                            counters.samplers += 1;
-                        }
+                        counters.add(layout.content);
                     }
                 }
                 native::DescriptorSet::ArgumentBuffer { ref raw, offset, stage_flags, .. } => {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -665,7 +665,7 @@ impl hal::Device<Backend> for Device {
                                 let location = msl::ResourceBindingLocation {
                                     stage,
                                     desc_set: set_index as _,
-                                    binding: layout.base,
+                                    binding: layout.binding,
                                 };
                                 res_overrides.insert(location, res);
                             }
@@ -1345,7 +1345,7 @@ impl hal::Device<Backend> for Device {
                         .map(move |array_index| native::DescriptorLayout {
                             stages: stage_flags,
                             content,
-                            base: binding,
+                            binding,
                             array_index,
                         })
                 })
@@ -1384,11 +1384,11 @@ impl hal::Device<Backend> for Device {
                         let mut exact_match = None;
                         //TODO: can pre-compute this
                         for layout in layouts.iter() {
-                            if layout.base == binding && layout.array_index == array_offset {
+                            if layout.binding == binding && layout.array_index == array_offset {
                                 exact_match = Some(layout.content);
                                 break
                             }
-                            if array_offset != 0 && layout.array_index == 0 && layout.base == binding + 1 {
+                            if array_offset != 0 && layout.array_index == 0 && layout.binding == binding + 1 {
                                 debug_assert!(next_binding_layout.is_none());
                                 next_binding_layout = Some((counters.clone(), layout.content));
                             }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -174,7 +174,7 @@ impl ResourceCounters {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MultiStageResourceCounters {
     pub vs: ResourceCounters,
     pub ps: ResourceCounters,

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -55,8 +55,8 @@ unsafe impl Sync for ShaderModule {}
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
 pub struct RenderPassKey {
     // enough room for 4 color targets + depth/stencil
-    operations: SmallVec<[AttachmentOps; 5]>,
-    pub clear_data: SmallVec<[u32; 10]>,
+    pub clear_data: SmallVec<[u32; 20]>,
+    operations: SmallVec<[AttachmentOps; 6]>,
 }
 
 #[derive(Debug)]

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -635,7 +635,7 @@ impl From<pso::DescriptorType> for DescriptorContent {
 pub struct DescriptorLayout {
     pub stages: pso::ShaderStageFlags,
     pub content: DescriptorContent,
-    pub base: pso::DescriptorBinding,
+    pub binding: pso::DescriptorBinding,
     pub array_index: pso::DescriptorArrayIndex,
 }
 

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -53,8 +53,7 @@ pub enum RenderCommand<R: Resources> {
     BindBuffer {
         stage: hal::pso::Stage,
         index: usize,
-        buffer: Option<R::Buffer>,
-        offset: hal::buffer::Offset,
+        buffer: Option<(R::Buffer, hal::buffer::Offset)>,
     },
     BindBufferData {
         stage: hal::pso::Stage,
@@ -108,11 +107,10 @@ impl RenderCommand<Own> {
             SetDepthStencilState(ref state) => SetDepthStencilState(&**state),
             SetStencilReferenceValues(front, back) => SetStencilReferenceValues(front, back),
             SetRasterizerState(ref state) => SetRasterizerState(state.clone()),
-            BindBuffer { stage, index, buffer, offset } => BindBuffer {
+            BindBuffer { stage, index, buffer } => BindBuffer {
                 stage,
                 index,
                 buffer,
-                offset,
             },
             BindBufferData { stage, index, ref words } => BindBufferData {
                 stage,
@@ -168,11 +166,10 @@ impl<'a> RenderCommand<&'a Own> {
             SetDepthStencilState(state) => SetDepthStencilState(state.to_owned()),
             SetStencilReferenceValues(front, back) => SetStencilReferenceValues(front, back),
             SetRasterizerState(ref state) => SetRasterizerState(state.clone()),
-            BindBuffer { stage, index, buffer, offset } => BindBuffer {
+            BindBuffer { stage, index, buffer } => BindBuffer {
                 stage,
                 index,
                 buffer,
-                offset,
             },
             BindBufferData { stage, index, words } => BindBufferData {
                 stage,
@@ -309,8 +306,7 @@ impl<'a> BlitCommand<&'a Own> {
 pub enum ComputeCommand<R: Resources> {
     BindBuffer {
         index: usize,
-        buffer: Option<R::Buffer>,
-        offset: hal::buffer::Offset,
+        buffer: Option<(R::Buffer, hal::buffer::Offset)>,
     },
     BindBufferData {
         index: usize,
@@ -340,10 +336,9 @@ impl ComputeCommand<Own> {
     pub fn as_ref<'a>(&'a self) -> ComputeCommand<&'a Own> {
         use self::ComputeCommand::*;
         match *self {
-            BindBuffer { index, buffer, offset } => BindBuffer {
+            BindBuffer { index, buffer } => BindBuffer {
                 index,
                 buffer,
-                offset,
             },
             BindBufferData { index, ref words } => BindBufferData {
                 index,
@@ -375,10 +370,9 @@ impl<'a> ComputeCommand<&'a Own> {
     pub fn own(self) -> ComputeCommand<Own> {
         use self::ComputeCommand::*;
         match self {
-            BindBuffer { index, buffer, offset } => BindBuffer {
+            BindBuffer { index, buffer } => BindBuffer {
                 index,
                 buffer,
-                offset,
             },
             BindBufferData { index, words } => BindBufferData {
                 index,


### PR DESCRIPTION
Fixes #2270

PR stages:
- [x] simplify the buffer+offset format in software commands
- [x] flatten the descriptor layouts at the descriptor set level. This allows reducing out hot loop depth by one.
- [x] lift up the checks for immediate/deferred/void for descriptor binding
- [x] reorder descriptors to optimize the write/spill

Status: ~~currently the perf is unaffected, but we save 30 LOC :)~~
Deferred recording feels a bit snappier. Total time spent in our code appears to be 12% now (opposed to the old 15%), which is a big win.  Plus, 60 lines of codes saved.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Metal
- [ ] `rustfmt` run on changed code
