### PR TITLE
Implement BaseTyped for f64

### DIFF
--- a/src/core/src/shade.rs
+++ b/src/core/src/shade.rs
@@ -283,6 +283,7 @@ impl_base_type! {
     i32 = I32,
     u32 = U32,
     f32 = F32,
+    f64 = F64,
     bool = Bool,
 }
 
@@ -328,7 +329,6 @@ bitflags!(
         const HULL     = 0x8;
         /// Used by the pixel shader
         const DOMAIN   = 0x16;
-
     }
 );
 


### PR DESCRIPTION
Fixes #2106 
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
