### PR TITLE
Change timeout_ms parameter in wait_for_fence(s) to nanoseconds and u64

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1795,7 +1795,7 @@ impl hal::Device<Backend> for Device {
         // TODO:
     }
 
-    fn wait_for_fences<I>(&self, _fences: I, _wait: device::WaitFor, _timeout_ms: u32) -> bool
+    fn wait_for_fences<I>(&self, _fences: I, _wait: device::WaitFor, _timeout_ns: u64) -> bool
     where
         I: IntoIterator,
         I::Item: Borrow<Fence>,

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1281,11 +1281,11 @@ impl d::Device<B> for Device {
         }
     }
 
-    fn wait_for_fence(&self, fence: &n::Fence, timeout_ms: u32) -> bool {
+    fn wait_for_fence(&self, fence: &n::Fence, timeout_ns: u64) -> bool {
         if !self.share.private_caps.sync {
             return true;
         }
-        match wait_fence(fence, &self.share.context, timeout_ms) {
+        match wait_fence(fence, &self.share.context, timeout_ns) {
             gl::TIMEOUT_EXPIRED => false,
             gl::WAIT_FAILED => {
                 if let Err(err) = self.share.check() {
@@ -1409,11 +1409,10 @@ impl d::Device<B> for Device {
     }
 }
 
-pub fn wait_fence(fence: &n::Fence, gl: &gl::Gl, timeout_ms: u32) -> GLenum {
-    let timeout = timeout_ms as u64 * 1_000_000;
+pub fn wait_fence(fence: &n::Fence, gl: &gl::Gl, timeout_ns: u64) -> GLenum {
     // TODO:
     // This can be called by multiple objects wanting to ensure they have exclusive
     // access to a resource. How much does this call costs ? The status of the fence
     // could be cached to avoid calling this more than once (in core or in the backend ?).
-    unsafe { gl.ClientWaitSync(fence.0.get(), gl::SYNC_FLUSH_COMMANDS_BIT, timeout) }
+    unsafe { gl.ClientWaitSync(fence.0.get(), gl::SYNC_FLUSH_COMMANDS_BIT, timeout_ns) }
 }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1393,7 +1393,7 @@ impl d::Device<B> for Device {
         });
     }
 
-    fn wait_for_fences<I>(&self, fences: I, wait: d::WaitFor, timeout_ms: u32) -> bool
+    fn wait_for_fences<I>(&self, fences: I, wait: d::WaitFor, timeout_ns: u64) -> bool
     where
         I: IntoIterator,
         I::Item: Borrow<n::Fence>,
@@ -1404,7 +1404,7 @@ impl d::Device<B> for Device {
             d::WaitFor::All => true,
         };
         let result = unsafe {
-            self.raw.0.wait_for_fences(&fences, all, timeout_ms as u64 * 1000)
+            self.raw.0.wait_for_fences(&fences, all, timeout_ns)
         };
         match result {
             Ok(()) | Err(vk::Result::Success) => true,


### PR DESCRIPTION
Fixes #2243

### Converting nanoseconds to milliseconds

This is needed by the DX12 backend. I tried to round up when converting, because it would be strange to convert 1 nanoseconds to 0 milliseconds and not wait anything. Is this correct behavior?

### Integer overflow

`u64` with nanoseconds can express much longer time period than `u32` milliseconds. I use `<u32>::max_value()` in case of overflow, but that means to wait INFINITY in win32.

### Code duplication

There is a loop in the HAL's `wait_for_fences` implementation, mostly it is the same as the metal backend's wait loop. Should I create a function for it? But I don't know where to place it.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: dx12, vulkan
- [ ] `rustfmt` run on changed code
