### PR TITLE
[dx11] add render passes and debugging

### DIFF
--- a/src/backend/dx11/shaders/copy.hlsl
+++ b/src/backend/dx11/shaders/copy.hlsl
@@ -116,6 +116,11 @@ uint Uint8x2ToUint16(uint2 data)
     return dot(min(data, 0xFF), 1 << uint2(0, 8));
 }
 
+uint4 Float4ToUint8x4(float4 data)
+{
+    return uint4(data * 255 + .5f);
+}
+
 // Buffers are always R32-aligned
 ByteAddressBuffer   BufferCopySrc : register(t0);
 RWByteAddressBuffer BufferCopyDst : register(u0);
@@ -124,6 +129,8 @@ Texture2DArray<uint4>   ImageCopySrc     : register(t0);
 RWTexture2DArray<uint>  ImageCopyDstR    : register(u0);
 RWTexture2DArray<uint2> ImageCopyDstRg   : register(u0);
 RWTexture2DArray<uint4> ImageCopyDstRgba : register(u0);
+
+Texture2DArray<float4>  ImageCopySrcBgra : register(t0);
 
 // Image<->Image copies
 [numthreads(1, 1, 1)]
@@ -323,6 +330,15 @@ void cs_copy_image2d_r8g8b8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThrea
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(ImageCopySrc[src_idx]));
+}
+
+// B8G8R8A8
+[numthreads(1, 1, 1)]
+void cs_copy_image2d_b8g8r8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
+    uint dst_idx = GetBufferDst32(dispatch_thread_id);
+    uint3 src_idx = GetImageSrc(dispatch_thread_id);
+
+    BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(Float4ToUint8x4(ImageCopySrcBgra[src_idx])));
 }
 
 // R16

--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -34,120 +34,6 @@ pub fn viewable_format(format: DXGI_FORMAT) -> DXGI_FORMAT {
     }
 }
 
-pub fn typeless_format(format: DXGI_FORMAT) -> Option<(DXGI_FORMAT, DXGI_FORMAT)> {
-    match format {
-        DXGI_FORMAT_R8G8B8A8_UNORM |
-        DXGI_FORMAT_R8G8B8A8_SNORM |
-        DXGI_FORMAT_R8G8B8A8_UINT |
-        DXGI_FORMAT_R8G8B8A8_SINT |
-        DXGI_FORMAT_R8G8B8A8_UNORM_SRGB => Some((DXGI_FORMAT_R8G8B8A8_TYPELESS, DXGI_FORMAT_R8G8B8A8_UINT)),
-
-        // ?`
-        DXGI_FORMAT_B8G8R8A8_UNORM |
-        DXGI_FORMAT_B8G8R8A8_UNORM_SRGB => Some((DXGI_FORMAT_B8G8R8A8_TYPELESS, DXGI_FORMAT_B8G8R8A8_UNORM)),
-
-        DXGI_FORMAT_R8_UNORM |
-        DXGI_FORMAT_R8_SNORM |
-        DXGI_FORMAT_R8_UINT |
-        DXGI_FORMAT_R8_SINT => Some((DXGI_FORMAT_R8_TYPELESS, DXGI_FORMAT_R8_UINT)),
-
-        DXGI_FORMAT_R8G8_UNORM |
-        DXGI_FORMAT_R8G8_SNORM |
-        DXGI_FORMAT_R8G8_UINT |
-        DXGI_FORMAT_R8G8_SINT => Some((DXGI_FORMAT_R8G8_TYPELESS, DXGI_FORMAT_R8G8_UINT)),
-
-        DXGI_FORMAT_D16_UNORM |
-        DXGI_FORMAT_R16_UNORM |
-        DXGI_FORMAT_R16_SNORM |
-        DXGI_FORMAT_R16_UINT |
-        DXGI_FORMAT_R16_SINT |
-        DXGI_FORMAT_R16_FLOAT => Some((DXGI_FORMAT_R16_TYPELESS, DXGI_FORMAT_R16_UINT)),
-
-        DXGI_FORMAT_R16G16_UNORM |
-        DXGI_FORMAT_R16G16_SNORM |
-        DXGI_FORMAT_R16G16_UINT |
-        DXGI_FORMAT_R16G16_SINT |
-        DXGI_FORMAT_R16G16_FLOAT => Some((DXGI_FORMAT_R16G16_TYPELESS, DXGI_FORMAT_R16G16_UINT)),
-
-        DXGI_FORMAT_R16G16B16A16_UNORM |
-        DXGI_FORMAT_R16G16B16A16_SNORM |
-        DXGI_FORMAT_R16G16B16A16_UINT |
-        DXGI_FORMAT_R16G16B16A16_SINT |
-        DXGI_FORMAT_R16G16B16A16_FLOAT => Some((DXGI_FORMAT_R16G16B16A16_TYPELESS, DXGI_FORMAT_R16G16B16A16_UINT)),
-
-        DXGI_FORMAT_D32_FLOAT_S8X24_UINT => Some((DXGI_FORMAT_R32G8X24_TYPELESS, DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS)),
-
-        DXGI_FORMAT_D32_FLOAT |
-        DXGI_FORMAT_R32_UINT |
-        DXGI_FORMAT_R32_SINT |
-        DXGI_FORMAT_R32_FLOAT => Some((DXGI_FORMAT_R32_TYPELESS, DXGI_FORMAT_R32_UINT)),
-
-        DXGI_FORMAT_R32G32_UINT |
-        DXGI_FORMAT_R32G32_SINT |
-        DXGI_FORMAT_R32G32_FLOAT => Some((DXGI_FORMAT_R32G32_TYPELESS, DXGI_FORMAT_R32G32_UINT)),
-
-        DXGI_FORMAT_R32G32B32_UINT |
-        DXGI_FORMAT_R32G32B32_SINT |
-        DXGI_FORMAT_R32G32B32_FLOAT => Some((DXGI_FORMAT_R32G32B32_TYPELESS, DXGI_FORMAT_R32G32B32_UINT)),
-
-        DXGI_FORMAT_R32G32B32A32_UINT |
-        DXGI_FORMAT_R32G32B32A32_SINT |
-        DXGI_FORMAT_R32G32B32A32_FLOAT => Some((DXGI_FORMAT_R32G32B32A32_TYPELESS, DXGI_FORMAT_R32G32B32A32_UINT)),
-
-        DXGI_FORMAT_R10G10B10A2_UNORM |
-        DXGI_FORMAT_R10G10B10A2_UINT => Some((DXGI_FORMAT_R10G10B10A2_TYPELESS, DXGI_FORMAT_R10G10B10A2_UINT)),
-
-        DXGI_FORMAT_BC1_UNORM |
-        DXGI_FORMAT_BC1_UNORM_SRGB => Some((DXGI_FORMAT_BC1_TYPELESS, DXGI_FORMAT_R32_UINT)),
-
-        DXGI_FORMAT_BC2_UNORM |
-        DXGI_FORMAT_BC2_UNORM_SRGB => Some((DXGI_FORMAT_BC2_TYPELESS, DXGI_FORMAT_R32_UINT)),
-
-        DXGI_FORMAT_BC3_UNORM |
-        DXGI_FORMAT_BC3_UNORM_SRGB => Some((DXGI_FORMAT_BC3_TYPELESS, DXGI_FORMAT_R32_UINT)),
-
-        DXGI_FORMAT_BC4_UNORM |
-        DXGI_FORMAT_BC4_SNORM => Some((DXGI_FORMAT_BC4_TYPELESS, DXGI_FORMAT_R32_UINT)),
-
-        DXGI_FORMAT_BC5_UNORM |
-        DXGI_FORMAT_BC5_SNORM => Some((DXGI_FORMAT_BC5_TYPELESS, DXGI_FORMAT_R32_UINT)),
-
-        DXGI_FORMAT_BC6H_UF16 |
-        DXGI_FORMAT_BC6H_SF16 => Some((DXGI_FORMAT_BC6H_TYPELESS, DXGI_FORMAT_R32_UINT)),
-
-        // TODO: srgb craziness
-        DXGI_FORMAT_BC7_UNORM |
-        DXGI_FORMAT_BC7_UNORM_SRGB => Some((DXGI_FORMAT_BC7_TYPELESS, DXGI_FORMAT_BC7_UNORM)),
-
-
-        /*R5g6b5Unorm => DXGI_FORMAT_B5G6R5_UNORM,
-        R5g5b5a1Unorm => DXGI_FORMAT_B5G5R5A1_UNORM,
-        A2b10g10r10Unorm => DXGI_FORMAT_R10G10B10A2_UNORM,
-        A2b10g10r10Uint => DXGI_FORMAT_R10G10B10A2_UINT,
-        B10g11r11Ufloat => DXGI_FORMAT_R11G11B10_FLOAT,
-        E5b9g9r9Ufloat => DXGI_FORMAT_R9G9B9E5_SHAREDEXP,
-        D16Unorm => DXGI_FORMAT_D16_UNORM,
-        D32Float => DXGI_FORMAT_D32_FLOAT,
-        D32FloatS8Uint => DXGI_FORMAT_D32_FLOAT_S8X24_UINT,
-        Bc1RgbUnorm => DXGI_FORMAT_BC1_UNORM,
-        Bc1RgbSrgb => DXGI_FORMAT_BC1_UNORM_SRGB,
-        Bc2Unorm => DXGI_FORMAT_BC2_UNORM,
-        Bc2Srgb => DXGI_FORMAT_BC2_UNORM_SRGB,
-        Bc3Unorm => DXGI_FORMAT_BC3_UNORM,
-        Bc3Srgb => DXGI_FORMAT_BC3_UNORM_SRGB,
-        Bc4Unorm => DXGI_FORMAT_BC4_UNORM,
-        Bc4Inorm => DXGI_FORMAT_BC4_SNORM,
-        Bc5Unorm => DXGI_FORMAT_BC5_UNORM,
-        Bc5Inorm => DXGI_FORMAT_BC5_SNORM,
-        Bc6hUfloat => DXGI_FORMAT_BC6H_UF16,
-        Bc6hFloat => DXGI_FORMAT_BC6H_SF16,
-        Bc7Unorm => DXGI_FORMAT_BC7_UNORM,
-        Bc7Srgb => DXGI_FORMAT_BC7_UNORM_SRGB,*/
-
-        _ => None,
-    }
-}
-
 // TODO: stolen from d3d12 backend, maybe share function somehow?
 pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
     use hal::format::Format::*;
@@ -223,6 +109,322 @@ pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
     };
 
     Some(format)
+}
+
+#[derive(Debug, Clone)]
+pub struct DecomposedDxgiFormat {
+    pub typeless: DXGI_FORMAT,
+    pub srv: Option<DXGI_FORMAT>,
+    pub rtv: Option<DXGI_FORMAT>,
+    pub uav: Option<DXGI_FORMAT>,
+    pub dsv: Option<DXGI_FORMAT>,
+    // the format we use internally for operating on textures (eg. Rgba8 uses R32 internally for
+    // copies)
+    pub copy_uav: Option<DXGI_FORMAT>,
+    pub copy_srv: Option<DXGI_FORMAT>,
+}
+
+impl DecomposedDxgiFormat {
+    // TODO: we probably want to pass in usage flags or similar to allow for our `typeless_format`
+    //       field to only contain the input format (eg. depth only rather than typeless likely
+    //       improves perf since the driver doesn't need to expose internals)
+    //
+    // TODO: we also want aspect for determining depth/stencil
+    pub fn from_dxgi_format(format: DXGI_FORMAT) -> DecomposedDxgiFormat {
+        match format {
+            DXGI_FORMAT_R8G8B8A8_UNORM |
+            DXGI_FORMAT_R8G8B8A8_SNORM |
+            DXGI_FORMAT_R8G8B8A8_UINT |
+            DXGI_FORMAT_R8G8B8A8_SINT |
+            DXGI_FORMAT_R8G8B8A8_UNORM_SRGB => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R8G8B8A8_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: None,
+                copy_uav: Some(DXGI_FORMAT_R32_UINT),
+                copy_srv: Some(DXGI_FORMAT_R8G8B8A8_UINT),
+            },
+
+            DXGI_FORMAT_B8G8R8A8_UNORM |
+            DXGI_FORMAT_B8G8R8A8_UNORM_SRGB => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_B8G8R8A8_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(DXGI_FORMAT_B8G8R8A8_UNORM),
+                dsv: None,
+                copy_uav: Some(DXGI_FORMAT_R32_UINT),
+                copy_srv: Some(DXGI_FORMAT_B8G8R8A8_UNORM),
+            },
+
+            DXGI_FORMAT_R8_UNORM |
+            DXGI_FORMAT_R8_SNORM |
+            DXGI_FORMAT_R8_UINT |
+            DXGI_FORMAT_R8_SINT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R8_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: None,
+                copy_uav: Some(DXGI_FORMAT_R8_UINT),
+                copy_srv: Some(DXGI_FORMAT_R8_UINT),
+            },
+
+            DXGI_FORMAT_R8G8_UNORM |
+            DXGI_FORMAT_R8G8_SNORM |
+            DXGI_FORMAT_R8G8_UINT |
+            DXGI_FORMAT_R8G8_SINT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R8G8_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: None,
+                copy_uav: Some(DXGI_FORMAT_R8G8_UINT),
+                copy_srv: Some(DXGI_FORMAT_R8G8_UINT),
+            },
+
+            DXGI_FORMAT_D16_UNORM => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R16_TYPELESS,
+                srv: Some(DXGI_FORMAT_R16_FLOAT),
+                rtv: Some(DXGI_FORMAT_R16_FLOAT),
+                uav: Some(DXGI_FORMAT_R16_FLOAT),
+                dsv: Some(format),
+                copy_uav: Some(DXGI_FORMAT_R16_UINT),
+                copy_srv: Some(DXGI_FORMAT_R16_UINT),
+            },
+
+            DXGI_FORMAT_R16_UNORM |
+            DXGI_FORMAT_R16_SNORM |
+            DXGI_FORMAT_R16_UINT |
+            DXGI_FORMAT_R16_SINT |
+            DXGI_FORMAT_R16_FLOAT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R16_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: Some(DXGI_FORMAT_D16_UNORM),
+                copy_uav: Some(DXGI_FORMAT_R16_UINT),
+                copy_srv: Some(DXGI_FORMAT_R16_UINT),
+            },
+
+            DXGI_FORMAT_R16G16_UNORM |
+            DXGI_FORMAT_R16G16_SNORM |
+            DXGI_FORMAT_R16G16_UINT |
+            DXGI_FORMAT_R16G16_SINT |
+            DXGI_FORMAT_R16G16_FLOAT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R16G16_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: None,
+                copy_uav: Some(DXGI_FORMAT_R32_UINT),
+                copy_srv: Some(DXGI_FORMAT_R16G16_UINT),
+            },
+
+            DXGI_FORMAT_R16G16B16A16_UNORM |
+            DXGI_FORMAT_R16G16B16A16_SNORM |
+            DXGI_FORMAT_R16G16B16A16_UINT |
+            DXGI_FORMAT_R16G16B16A16_SINT |
+            DXGI_FORMAT_R16G16B16A16_FLOAT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R16G16B16A16_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: None,
+                copy_uav: Some(DXGI_FORMAT_R16G16B16A16_UINT),
+                copy_srv: Some(DXGI_FORMAT_R16G16B16A16_UINT),
+            },
+
+            DXGI_FORMAT_D32_FLOAT_S8X24_UINT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R32G8X24_TYPELESS,
+                // TODO: depth or stencil?
+                srv: Some(DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS),
+                rtv: None,
+                uav: None,
+                dsv: Some(format),
+                copy_uav: None,
+                copy_srv: Some(DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS),
+            },
+
+            DXGI_FORMAT_D32_FLOAT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R32_TYPELESS,
+                srv: Some(DXGI_FORMAT_R32_FLOAT),
+                rtv: None,
+                uav: None,
+                dsv: Some(format),
+                copy_uav: Some(DXGI_FORMAT_R32_UINT),
+                copy_srv: Some(DXGI_FORMAT_R32_UINT),
+            },
+
+            DXGI_FORMAT_R32_UINT |
+            DXGI_FORMAT_R32_SINT |
+            DXGI_FORMAT_R32_FLOAT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R32_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: Some(DXGI_FORMAT_D32_FLOAT),
+                copy_uav: Some(DXGI_FORMAT_R32_UINT),
+                copy_srv: Some(DXGI_FORMAT_R32_UINT),
+            },
+
+            DXGI_FORMAT_R32G32_UINT |
+            DXGI_FORMAT_R32G32_SINT |
+            DXGI_FORMAT_R32G32_FLOAT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R32G32_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: None,
+                copy_uav: Some(DXGI_FORMAT_R32G32_UINT),
+                copy_srv: Some(DXGI_FORMAT_R32G32_UINT),
+            },
+
+            // TODO: should we just convert to Rgba32 internally?
+            DXGI_FORMAT_R32G32B32_UINT |
+            DXGI_FORMAT_R32G32B32_SINT |
+            DXGI_FORMAT_R32G32B32_FLOAT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R32G32_TYPELESS,
+                srv: Some(format),
+                rtv: None,
+                uav: None,
+                dsv: None,
+                copy_uav: Some(DXGI_FORMAT_R32G32B32_UINT),
+                copy_srv: Some(DXGI_FORMAT_R32G32B32_UINT),
+            },
+
+            DXGI_FORMAT_R32G32B32A32_UINT |
+            DXGI_FORMAT_R32G32B32A32_SINT |
+            DXGI_FORMAT_R32G32B32A32_FLOAT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R32G32B32A32_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: None,
+                copy_uav: Some(DXGI_FORMAT_R32G32B32A32_UINT),
+                copy_srv: Some(DXGI_FORMAT_R32G32B32A32_UINT),
+            },
+
+            DXGI_FORMAT_R10G10B10A2_UNORM |
+            DXGI_FORMAT_R10G10B10A2_UINT => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_R10G10B10A2_TYPELESS,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: None,
+                copy_uav: Some(DXGI_FORMAT_R32_UINT),
+                copy_srv: Some(DXGI_FORMAT_R10G10B10A2_UINT),
+            },
+
+            DXGI_FORMAT_R11G11B10_FLOAT => DecomposedDxgiFormat {
+                typeless: format,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: None,
+                copy_uav: Some(format),
+                copy_srv: Some(format),
+            },
+
+            DXGI_FORMAT_R9G9B9E5_SHAREDEXP => DecomposedDxgiFormat {
+                typeless: format,
+                srv: Some(format),
+                rtv: None,
+                uav: None,
+                dsv: None,
+                // NOTE: read only
+                copy_uav: None,
+                copy_srv: Some(format),
+            },
+
+            DXGI_FORMAT_BC1_UNORM |
+            DXGI_FORMAT_BC1_UNORM_SRGB => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_BC1_TYPELESS,
+                srv: Some(format),
+                rtv: None,
+                uav: None,
+                dsv: None,
+                // NOTE: read only
+                copy_uav: None,
+                copy_srv: Some(format),
+            },
+
+            DXGI_FORMAT_BC2_UNORM |
+            DXGI_FORMAT_BC2_UNORM_SRGB => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_BC2_TYPELESS,
+                srv: Some(format),
+                rtv: None,
+                uav: None,
+                dsv: None,
+                // NOTE: read only
+                copy_uav: None,
+                copy_srv: Some(format),
+            },
+
+            DXGI_FORMAT_BC3_UNORM |
+            DXGI_FORMAT_BC3_UNORM_SRGB => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_BC3_TYPELESS,
+                srv: Some(format),
+                rtv: None,
+                uav: None,
+                dsv: None,
+                // NOTE: read only
+                copy_uav: None,
+                copy_srv: Some(format),
+            },
+
+            DXGI_FORMAT_BC4_UNORM |
+            DXGI_FORMAT_BC4_SNORM => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_BC4_TYPELESS,
+                srv: Some(format),
+                rtv: None,
+                uav: None,
+                dsv: None,
+                // NOTE: read only
+                copy_uav: None,
+                copy_srv: Some(format),
+            },
+
+            DXGI_FORMAT_BC5_UNORM |
+            DXGI_FORMAT_BC5_SNORM => DecomposedDxgiFormat {
+                typeless: format,
+                srv: Some(format),
+                rtv: None,
+                uav: None,
+                dsv: None,
+                // NOTE: read only
+                copy_uav: None,
+                copy_srv: Some(format),
+            },
+
+            DXGI_FORMAT_BC6H_UF16 |
+            DXGI_FORMAT_BC6H_SF16 => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_BC6H_TYPELESS,
+                srv: Some(format),
+                rtv: None,
+                uav: None,
+                dsv: None,
+                // NOTE: read only
+                copy_uav: None,
+                copy_srv: Some(format),
+            },
+
+            // TODO: srgb craziness
+            DXGI_FORMAT_BC7_UNORM |
+            DXGI_FORMAT_BC7_UNORM_SRGB => DecomposedDxgiFormat {
+                typeless: DXGI_FORMAT_BC7_TYPELESS,
+                srv: Some(format),
+                rtv: None,
+                uav: None,
+                dsv: None,
+                // NOTE: read only
+                copy_uav: None,
+                copy_srv: Some(format),
+            },
+
+            _ => unimplemented!(),
+        }
+    }
 }
 
 pub fn map_viewport(viewport: &Viewport) -> D3D11_VIEWPORT {

--- a/src/backend/dx11/src/debug.rs
+++ b/src/backend/dx11/src/debug.rs
@@ -1,0 +1,92 @@
+use winapi::um::d3d11;
+
+use wio::com::ComPtr;
+use wio::wide::ToWide;
+
+use std::ffi::OsStr;
+use std::{env, fmt};
+
+// TODO: replace with new winapi version when available
+#[allow(bad_style, unused)]
+mod temp {
+    use winapi::shared::minwindef::{BOOL, INT}; 
+    use winapi::um::unknwnbase::{IUnknown, IUnknownVtbl}; 
+    use winapi::um::winnt::LPCWSTR; 
+
+    RIDL!{#[uuid(0xb2daad8b, 0x03d4, 0x4dbf, 0x95, 0xeb, 0x32, 0xab, 0x4b, 0x63, 0xd0, 0xab)]
+    interface ID3DUserDefinedAnnotation(ID3DUserDefinedAnnotationVtbl):
+        IUnknown(IUnknownVtbl) {
+        fn BeginEvent(
+            Name: LPCWSTR,
+        ) -> INT,
+        fn EndEvent() -> INT,
+        fn SetMarker(
+            Name: LPCWSTR,
+        ) -> (),
+        fn GetStatus() -> BOOL,
+    }}
+}
+
+#[must_use]
+#[cfg(debug_assertions)]
+pub struct DebugScope {
+    annotation: ComPtr<temp::ID3DUserDefinedAnnotation>
+}
+
+#[cfg(debug_assertions)]
+impl DebugScope {
+    pub fn with_name(context: &ComPtr<d3d11::ID3D11DeviceContext>, args: fmt::Arguments) -> Option<Self> {
+        let name = format!("{}", args);
+
+        // debugging with visual studio and its ilk *really* doesn't like calling this on a
+        // deferred context when replaying a capture, compared to renderdoc
+        if unsafe { context.GetType() } == d3d11::D3D11_DEVICE_CONTEXT_DEFERRED {
+            // TODO: find a better way to detect either if RD or VS is active debugger
+            if env::var("GFX_NO_RENDERDOC").is_ok() {
+                return None;
+            }
+        }
+
+        let annotation = context.cast::<temp::ID3DUserDefinedAnnotation>().unwrap();
+        let msg: &OsStr = name.as_ref();
+        let msg: Vec<u16> = msg.to_wide_null();
+
+        unsafe {
+            annotation.BeginEvent(msg.as_ptr() as _);
+        }
+
+        Some(DebugScope {
+            annotation
+        })
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for DebugScope {
+    fn drop(&mut self) {
+        unsafe {
+            self.annotation.EndEvent();
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+pub fn debug_marker(context: &ComPtr<d3d11::ID3D11DeviceContext>, args: fmt::Arguments) {
+    let name = format!("{}", args);
+
+    // same here
+    if unsafe { context.GetType() } == d3d11::D3D11_DEVICE_CONTEXT_DEFERRED {
+        if env::var("GFX_NO_RENDERDOC").is_ok() {
+            return;
+        }
+    }
+
+    let annotation = context.cast::<temp::ID3DUserDefinedAnnotation>().unwrap();
+    let msg: &OsStr = name.as_ref();
+    let msg: Vec<u16> = msg.to_wide_null();
+
+    unsafe {
+        annotation.SetMarker(msg.as_ptr() as _);
+    }
+}
+

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::borrow::Borrow;
 use std::ops::Range;
+use std::fmt;
 
 use {buffer, pass, pso};
 use {Backend, DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount};
@@ -46,6 +47,15 @@ pub union ClearValueRaw {
     /// Clear depth and stencil
     pub depth_stencil: ClearDepthStencilRaw,
     _align: [u32; 4],
+}
+
+impl fmt::Debug for ClearValueRaw {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ClearValueRaw")
+            .field("color", unsafe { &self.color.uint32 })
+            .field("depth_stencil", unsafe { &self.depth_stencil })
+            .finish()
+    }
 }
 
 /// Offset for dynamic descriptors.


### PR DESCRIPTION
Re-do format conversion to be more comprehensive and less hacky

Add Bgra8 -> Buffer transfer

Add basic render passes (missing partial clear/resolves)

Add debugging using `ID3DUserDefinedAnnotation`. This functionality is behind a `#[cfg(debug_assertions)]` and is further restricted from being used on deferred contexts when RenderDoc is not used.

Separate `MemorySync` into Flush/Invalidate variants

r? @kvark 

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
