### PR TITLE
Improve Descriptor-related docs and make it more obvious what should be in the DescriptorSetWrite descriptors field

### DIFF
--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -1,8 +1,6 @@
 //! Raw Pipeline State Objects
 //!
-//! This module contains items used to create and manage a raw pipeline state object. Most users
-//! will want to use the typed and safe `PipelineState`. See the `pso` module inside the `gfx`
-//! crate.
+//! This module contains items used to create and manage Pipelines. 
 
 use {device, pass};
 use std::error::Error;


### PR DESCRIPTION
I believe I've been accurate in describing these, let me know if not. I also changed DescriptorSetWrite in a way that makes more sense for people looking through docs to figure out how it's supposed to be used, and I don't think it should have broken anything.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
