### PR TITLE
Small fix/doc improvement for colour uniform example

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -181,9 +181,9 @@ fn main() {
     // TODO: check transitions: read/write mapping and vertex buffer read
     {
         let mut vertices = device
-            .acquire_mapping_writer::<Vertex>(&buffer_memory, 0..buffer_len)
+            .acquire_mapping_writer::<Vertex>(&buffer_memory, 0..buffer_req.size)
             .unwrap();
-        vertices.copy_from_slice(&QUAD);
+        vertices[0..QUAD.len()].copy_from_slice(&QUAD);
         device.release_mapping_writer(vertices);
     }
 
@@ -214,7 +214,7 @@ fn main() {
     // copy image data into staging buffer
     {
         let mut data = device
-            .acquire_mapping_writer::<u8>(&image_upload_memory, 0..upload_size)
+            .acquire_mapping_writer::<u8>(&image_upload_memory, 0..image_mem_reqs.size)
             .unwrap();
         for y in 0..height as usize {
             let row = &(*img)


### PR DESCRIPTION
Currently the colour uniform example produces 
```
ERROR gfx_backend_vulkan > [Validation]  [ VUID-VkMappedMemoryRange-size-01390 ] Object: 0x6 (Type = 8) | vkFlushMappedMemoryRanges: Size in pMemRanges[0] is 0x84, which is not a multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize (0x40). The spec valid usage text states 'If size is not equal to VK_WHOLE_SIZE, size must either be a multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize, or offset plus size must equal the size of memory.' (https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#VUID-VkMappedMemoryRange-size-01390)
```
when creating and updating buffers because it is using calculated sizing instead of received buffer size from memory requirements for creating memory mapped ranges.

In addition, added a note that using CPU visible buffers is not scalable for most uses and especially potentially large/unchanging data like vertex buffers.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
