### PR TITLE
Added support for writing to UniformBufferDynamic descriptors. (#issue 1949)

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1258,14 +1258,14 @@ impl d::Device<B> for Device {
                     raw.p_texel_buffer_view = texel_buffer_views[base..].as_ptr();
                 }
                 Dt::UniformBuffer |
-                Dt::StorageBuffer => {
+                Dt::StorageBuffer |
+                Dt::StorageBufferDynamic |
+                Dt::UniformBufferDynamic => {
                     raw.p_image_info = ptr::null();
                     raw.p_texel_buffer_view = ptr::null();
                     let base = raw.p_buffer_info as usize - raw.descriptor_count as usize;
                     raw.p_buffer_info = buffer_infos[base..].as_ptr();
                 }
-                Dt::StorageBufferDynamic |
-                Dt::UniformBufferDynamic => unimplemented!()
             }
         }
 


### PR DESCRIPTION
Implements for the vulkan backend #issue 1949
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- [x] `rustfmt` run on changed code
