### PR TITLE
Optimize Metal resource binding

### DIFF
--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -317,7 +317,7 @@ pub fn map_texture_type(view_kind: image::ViewKind) -> MTLTextureType {
     }
 }
 
-pub fn map_index_type(index_type: IndexType) -> MTLIndexType {
+pub fn _map_index_type(index_type: IndexType) -> MTLIndexType {
     match index_type {
         IndexType::U16 => MTLIndexType::UInt16,
         IndexType::U32 => MTLIndexType::UInt32,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1,5 +1,5 @@
 use {
-    Backend, PrivateCapabilities, QueueFamily, OnlineRecording,
+    Backend, PrivateCapabilities, QueueFamily, ResourceIndex, OnlineRecording,
     Shared, Surface, Swapchain,
     validate_line_width, BufferPtr, SamplerPtr, TexturePtr,
 };
@@ -217,7 +217,7 @@ impl PhysicalDevice {
         };
 
         let shared = Arc::new(Shared::new(device));
-        assert!((shared.push_constants_buffer_id as usize) < private_caps.max_buffers_per_stage);
+        assert!(shared.push_constants_buffer_id < private_caps.max_buffers_per_stage);
 
         PhysicalDevice {
             shared,
@@ -658,9 +658,9 @@ impl hal::Device<Backend> for Device {
         IR::Item: Borrow<(pso::ShaderStageFlags, Range<u32>)>
     {
         let mut stage_infos = [
-            (pso::ShaderStageFlags::VERTEX,   spirv::ExecutionModel::Vertex,    n::ResourceCounters::new()),
-            (pso::ShaderStageFlags::FRAGMENT, spirv::ExecutionModel::Fragment,  n::ResourceCounters::new()),
-            (pso::ShaderStageFlags::COMPUTE,  spirv::ExecutionModel::GlCompute, n::ResourceCounters::new()),
+            (pso::ShaderStageFlags::VERTEX,   spirv::ExecutionModel::Vertex,    n::ResourceCounters::<ResourceIndex>::new()),
+            (pso::ShaderStageFlags::FRAGMENT, spirv::ExecutionModel::Fragment,  n::ResourceCounters::<ResourceIndex>::new()),
+            (pso::ShaderStageFlags::COMPUTE,  spirv::ExecutionModel::GlCompute, n::ResourceCounters::<ResourceIndex>::new()),
         ];
         let mut res_overrides = BTreeMap::new();
         let mut offsets = Vec::new();
@@ -741,7 +741,7 @@ impl hal::Device<Backend> for Device {
         for (limit, &mut (_, stage, ref mut counters)) in pc_limits.iter().zip(&mut stage_infos) {
             // handle the push constant buffer assignment and shader overrides
             if *limit != 0 {
-                let buffer_id = self.shared.push_constants_buffer_id;
+                let index = self.shared.push_constants_buffer_id;
                 res_overrides.insert(
                     msl::ResourceBindingLocation {
                         stage,
@@ -749,13 +749,13 @@ impl hal::Device<Backend> for Device {
                         binding: PUSH_CONSTANTS_DESC_BINDING,
                     },
                     msl::ResourceBinding {
-                        buffer_id,
+                        buffer_id: index as _,
                         texture_id: !0,
                         sampler_id: !0,
                         force_used: false,
                     },
                 );
-                assert!(counters.buffers < buffer_id as usize);
+                assert!(counters.buffers < index);
             } else {
                 assert!(counters.buffers <= self.private_caps.max_buffers_per_stage);
             }
@@ -834,7 +834,7 @@ impl hal::Device<Backend> for Device {
         let pipeline_layout = &pipeline_desc.layout;
         let pass_descriptor = &pipeline_desc.subpass;
 
-        if pipeline_layout.attribute_buffer_index() as usize + pipeline_desc.vertex_buffers.len() > self.private_caps.max_buffers_per_stage {
+        if pipeline_layout.attribute_buffer_index() + pipeline_desc.vertex_buffers.len() as ResourceIndex > self.private_caps.max_buffers_per_stage {
             let msg = format!("Too many buffers inputs of the vertex stage: {} attributes + {} resources",
                 pipeline_desc.vertex_buffers.len(), pipeline_layout.attribute_buffer_index());
             return Err(pso::CreationError::Shader(ShaderError::InterfaceMismatch(msg)));
@@ -971,12 +971,12 @@ impl hal::Device<Backend> for Device {
                 }
                 Entry::Vacant(e) => {
                     e.insert(pso::VertexBufferDesc {
-                        binding: next_buffer_index,
+                        binding: next_buffer_index as _,
                         stride: original.stride,
                         rate: original.rate,
                     });
                     next_buffer_index += 1;
-                    next_buffer_index - 1
+                    next_buffer_index as u32 - 1
                 }
                 Entry::Occupied(e) => e.get().binding,
             };
@@ -1348,20 +1348,20 @@ impl hal::Device<Backend> for Device {
         I: IntoIterator,
         I::Item: Borrow<pso::DescriptorRangeDesc>,
     {
-        let (mut num_samplers, mut num_textures, mut num_buffers) = (0, 0, 0);
+        let mut counters = n::ResourceCounters::<pso::DescriptorBinding>::new();
 
         if self.private_caps.argument_buffers {
             let mut arguments = Vec::new();
             for desc_range in descriptor_ranges {
                 let desc = desc_range.borrow();
                 let offset_ref = match desc.ty {
-                    pso::DescriptorType::Sampler => &mut num_samplers,
-                    pso::DescriptorType::SampledImage => &mut num_textures,
-                    pso::DescriptorType::UniformBuffer | pso::DescriptorType::StorageBuffer => &mut num_buffers,
+                    pso::DescriptorType::Sampler => &mut counters.samplers,
+                    pso::DescriptorType::SampledImage => &mut counters.textures,
+                    pso::DescriptorType::UniformBuffer | pso::DescriptorType::StorageBuffer => &mut counters.buffers,
                     _ => unimplemented!()
                 };
                 let index = *offset_ref;
-                *offset_ref += desc.count;
+                *offset_ref += desc.count as pso::DescriptorBinding;
                 let arg_desc = Self::describe_argument(desc.ty, index as _, desc.count);
                 arguments.push(arg_desc);
             }
@@ -1379,19 +1379,10 @@ impl hal::Device<Backend> for Device {
             }
         } else {
             for desc_range in descriptor_ranges {
-                let desc = desc_range.borrow();
-                let content = n::DescriptorContent::from(desc.ty);
-                if content.contains(n::DescriptorContent::BUFFER) {
-                    num_buffers += desc.count;
-                }
-                if content.contains(n::DescriptorContent::TEXTURE) {
-                    num_textures += desc.count;
-                }
-                if content.contains(n::DescriptorContent::SAMPLER) {
-                    num_samplers += desc.count;
-                }
+                let dr = desc_range.borrow();
+                counters.add_many(n::DescriptorContent::from(dr.ty), dr.count as pso::DescriptorBinding);
             }
-            n::DescriptorPool::new_emulated(num_samplers, num_textures, num_buffers)
+            n::DescriptorPool::new_emulated(counters)
         }
     }
 
@@ -1477,9 +1468,9 @@ impl hal::Device<Backend> for Device {
             match *write.set {
                 n::DescriptorSet::Emulated { ref pool, ref layouts, ref sampler_range, ref texture_range, ref buffer_range } => {
                     let mut counters = n::ResourceCounters {
-                        buffers: buffer_range.start as usize,
-                        textures: texture_range.start as usize,
-                        samplers: sampler_range.start as usize,
+                        buffers: buffer_range.start,
+                        textures: texture_range.start,
+                        samplers: sampler_range.start,
                     };
                     let mut start = None; //TODO: can pre-compute this
                     for (i, layout) in layouts.iter().enumerate() {
@@ -1496,27 +1487,27 @@ impl hal::Device<Backend> for Device {
                         match *descriptor.borrow() {
                             pso::Descriptor::Sampler(sampler) => {
                                 debug_assert!(!layout.content.contains(n::DescriptorContent::IMMUTABLE_SAMPLER));
-                                data.samplers[counters.samplers] = Some(SamplerPtr(sampler.0.as_ptr()));
+                                data.samplers[counters.samplers as usize] = Some(SamplerPtr(sampler.0.as_ptr()));
                             }
                             pso::Descriptor::Image(image, il) => {
-                                data.textures[counters.textures] = Some((TexturePtr(image.raw.as_ptr()), il));
+                                data.textures[counters.textures as usize] = Some((TexturePtr(image.raw.as_ptr()), il));
                             }
                             pso::Descriptor::CombinedImageSampler(image, il, sampler) => {
                                 if !layout.content.contains(n::DescriptorContent::IMMUTABLE_SAMPLER) {
-                                    data.samplers[counters.samplers] = Some(SamplerPtr(sampler.0.as_ptr()));
+                                    data.samplers[counters.samplers as usize] = Some(SamplerPtr(sampler.0.as_ptr()));
                                 }
-                                data.textures[counters.textures] = Some((TexturePtr(image.raw.as_ptr()), il));
+                                data.textures[counters.textures as usize] = Some((TexturePtr(image.raw.as_ptr()), il));
                             }
                             pso::Descriptor::UniformTexelBuffer(view) |
                             pso::Descriptor::StorageTexelBuffer(view) => {
-                                data.textures[counters.textures] = Some((TexturePtr(view.raw.as_ptr()), image::Layout::General));
+                                data.textures[counters.textures as usize] = Some((TexturePtr(view.raw.as_ptr()), image::Layout::General));
                             }
                             pso::Descriptor::Buffer(buffer, ref range) => {
                                 let buf_length = buffer.raw.length();
                                 let start = range.start.unwrap_or(0);
                                 let end = range.end.unwrap_or(buf_length);
                                 assert!(end <= buf_length);
-                                data.buffers[counters.buffers] = Some((BufferPtr(buffer.raw.as_ptr()), start));
+                                data.buffers[counters.buffers as usize] = Some((BufferPtr(buffer.raw.as_ptr()), start));
                             }
                         }
                         counters.add(layout.content);

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1,7 +1,7 @@
 use {
-    Backend, PrivateCapabilities, QueueFamily, ResourceIndex, OnlineRecording,
+    AsNative, Backend, PrivateCapabilities, QueueFamily, ResourceIndex, OnlineRecording,
     Shared, Surface, Swapchain,
-    validate_line_width, BufferPtr, SamplerPtr, TexturePtr,
+    validate_line_width,
 };
 use {conversions as conv, command, native as n};
 use internal::FastStorageMap;
@@ -1487,27 +1487,27 @@ impl hal::Device<Backend> for Device {
                         match *descriptor.borrow() {
                             pso::Descriptor::Sampler(sampler) => {
                                 debug_assert!(!layout.content.contains(n::DescriptorContent::IMMUTABLE_SAMPLER));
-                                data.samplers[counters.samplers as usize] = Some(SamplerPtr(sampler.0.as_ptr()));
+                                data.samplers[counters.samplers as usize] = Some(AsNative::from(sampler.0.as_ref()));
                             }
                             pso::Descriptor::Image(image, il) => {
-                                data.textures[counters.textures as usize] = Some((TexturePtr(image.raw.as_ptr()), il));
+                                data.textures[counters.textures as usize] = Some((AsNative::from(image.raw.as_ref()), il));
                             }
                             pso::Descriptor::CombinedImageSampler(image, il, sampler) => {
                                 if !layout.content.contains(n::DescriptorContent::IMMUTABLE_SAMPLER) {
-                                    data.samplers[counters.samplers as usize] = Some(SamplerPtr(sampler.0.as_ptr()));
+                                    data.samplers[counters.samplers as usize] = Some(AsNative::from(sampler.0.as_ref()));
                                 }
-                                data.textures[counters.textures as usize] = Some((TexturePtr(image.raw.as_ptr()), il));
+                                data.textures[counters.textures as usize] = Some((AsNative::from(image.raw.as_ref()), il));
                             }
                             pso::Descriptor::UniformTexelBuffer(view) |
                             pso::Descriptor::StorageTexelBuffer(view) => {
-                                data.textures[counters.textures as usize] = Some((TexturePtr(view.raw.as_ptr()), image::Layout::General));
+                                data.textures[counters.textures as usize] = Some((AsNative::from(view.raw.as_ref()), image::Layout::General));
                             }
                             pso::Descriptor::Buffer(buffer, ref range) => {
                                 let buf_length = buffer.raw.length();
                                 let start = range.start.unwrap_or(0);
                                 let end = range.end.unwrap_or(buf_length);
                                 assert!(end <= buf_length);
-                                data.buffers[counters.buffers as usize] = Some((BufferPtr(buffer.raw.as_ptr()), start));
+                                data.buffers[counters.buffers as usize] = Some((AsNative::from(buffer.raw.as_ref()), start));
                             }
                         }
                         counters.add(layout.content);

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -45,6 +45,10 @@ use foreign_types::ForeignTypeRef;
 use parking_lot::Mutex;
 
 
+//TODO: investigate why exactly using `u8` here is slower (~5% total).
+/// A type representing Metal binding's resource index.
+type ResourceIndex = u32;
+
 /// Method of recording one-time-submit command buffers.
 #[derive(Clone, Debug, Hash, PartialEq)]
 pub enum OnlineRecording {
@@ -78,7 +82,7 @@ struct Shared {
     device: Mutex<metal::Device>,
     queue: Mutex<command::QueueInner>,
     service_pipes: internal::ServicePipes,
-    push_constants_buffer_id: u32,
+    push_constants_buffer_id: ResourceIndex,
     disabilities: PrivateDisabilities,
 }
 
@@ -224,9 +228,9 @@ struct PrivateCapabilities {
     format_depth32_stencil8: bool,
     format_min_srgb_channels: u8,
     format_b5: bool,
-    max_buffers_per_stage: usize,
-    max_textures_per_stage: usize,
-    max_samplers_per_stage: usize,
+    max_buffers_per_stage: ResourceIndex,
+    max_textures_per_stage: ResourceIndex,
+    max_samplers_per_stage: ResourceIndex,
     buffer_alignment: u64,
     max_buffer_size: u64,
 }

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -34,8 +34,9 @@ pub use window::{Surface, Swapchain};
 pub type GraphicsCommandPool = CommandPool;
 
 use std::mem;
-use std::sync::Arc;
+use std::ptr::NonNull;
 use std::os::raw::c_void;
+use std::sync::Arc;
 
 use hal::queue::QueueFamilyId;
 
@@ -247,53 +248,61 @@ fn validate_line_width(width: f32) {
     assert_eq!(width, 1.0);
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct BufferPtr(*mut metal::MTLBuffer);
 
-impl BufferPtr {
+trait AsNative {
+    type Native;
+    fn from(&Self::Native) -> Self;
+    fn as_native(&self) -> &Self::Native;
+}
+
+pub type BufferPtr = NonNull<metal::MTLBuffer>;
+pub type TexturePtr = NonNull<metal::MTLTexture>;
+pub type SamplerPtr = NonNull<metal::MTLSamplerState>;
+
+impl AsNative for BufferPtr {
+    type Native = metal::BufferRef;
     #[inline]
-    pub fn as_native(&self) -> &metal::BufferRef {
+    fn from(native: &metal::BufferRef) -> Self {
         unsafe {
-            metal::BufferRef::from_ptr(self.0)
+            NonNull::new_unchecked(native.as_ptr())
         }
     }
-
     #[inline]
-    pub fn as_ptr(&self) -> *mut metal::MTLBuffer {
-        self.0
+    fn as_native(&self) -> &metal::BufferRef {
+        unsafe {
+            metal::BufferRef::from_ptr(self.as_ptr())
+        }
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct TexturePtr(*mut metal::MTLTexture);
-
-impl TexturePtr {
+impl AsNative for TexturePtr {
+    type Native = metal::TextureRef;
     #[inline]
-    pub fn as_native(&self) -> &metal::TextureRef {
+    fn from(native: &metal::TextureRef) -> Self {
         unsafe {
-            metal::TextureRef::from_ptr(self.0)
+            NonNull::new_unchecked(native.as_ptr())
         }
     }
-
     #[inline]
-    pub fn as_ptr(&self) -> *mut metal::MTLTexture {
-        self.0
+    fn as_native(&self) -> &metal::TextureRef {
+        unsafe {
+            metal::TextureRef::from_ptr(self.as_ptr())
+        }
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct SamplerPtr(*mut metal::MTLSamplerState);
-
-impl SamplerPtr {
+impl AsNative for SamplerPtr {
+    type Native = metal::SamplerStateRef;
     #[inline]
-    pub fn as_native(&self) -> &metal::SamplerStateRef {
+    fn from(native: &metal::SamplerStateRef) -> Self {
         unsafe {
-            metal::SamplerStateRef::from_ptr(self.0)
+            NonNull::new_unchecked(native.as_ptr())
         }
     }
-
     #[inline]
-    pub fn as_ptr(&self) -> *mut metal::MTLSamplerState {
-        self.0
+    fn as_native(&self) -> &metal::SamplerStateRef {
+        unsafe {
+            metal::SamplerStateRef::from_ptr(self.as_ptr())
+        }
     }
 }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1,4 +1,4 @@
-use {Backend, ResourceIndex, BufferPtr, SamplerPtr, TexturePtr};
+use {AsNative, Backend, ResourceIndex, BufferPtr, SamplerPtr, TexturePtr};
 use internal::{Channel, FastStorageMap};
 use range_alloc::RangeAllocator;
 use window::SwapchainImage;
@@ -19,7 +19,6 @@ use hal::pass::{Attachment, AttachmentLoadOp, AttachmentOps};
 use hal::range::RangeArg;
 
 use cocoa::foundation::{NSUInteger};
-use foreign_types::ForeignType;
 use metal;
 use parking_lot::{Mutex, RwLock};
 use smallvec::SmallVec;
@@ -496,8 +495,8 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
                     for layout in layouts.iter() {
                         if layout.content.contains(DescriptorContent::SAMPLER) {
                             if layout.content.contains(DescriptorContent::IMMUTABLE_SAMPLER) {
-                                let value = sampler_iter.next().unwrap().as_ptr();
-                                data.samplers[data_index] = Some(SamplerPtr(value));
+                                let value = sampler_iter.next().unwrap().as_ref();
+                                data.samplers[data_index] = Some(AsNative::from(value));
                             }
                             data_index += 1;
                         }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1,4 +1,4 @@
-use {Backend, BufferPtr, SamplerPtr, TexturePtr};
+use {Backend, ResourceIndex, BufferPtr, SamplerPtr, TexturePtr};
 use internal::{Channel, FastStorageMap};
 use range_alloc::RangeAllocator;
 use window::SwapchainImage;
@@ -144,13 +144,13 @@ unsafe impl Sync for Framebuffer {}
 
 
 #[derive(Clone, Debug)]
-pub struct ResourceCounters {
-    pub buffers: usize,
-    pub textures: usize,
-    pub samplers: usize,
+pub struct ResourceCounters<T> {
+    pub buffers: T,
+    pub textures: T,
+    pub samplers: T,
 }
 
-impl ResourceCounters {
+impl ResourceCounters<pso::DescriptorBinding> {
     pub fn new() -> Self {
         ResourceCounters {
             buffers: 0,
@@ -158,25 +158,42 @@ impl ResourceCounters {
             samplers: 0,
         }
     }
-
-    pub fn add(&mut self, content: DescriptorContent) {
+}
+/*
+impl ResourceCounters<ResourceIndex> {
+    pub fn new() -> Self {
+        ResourceCounters {
+            buffers: 0,
+            textures: 0,
+            samplers: 0,
+        }
+    }
+}
+*/
+impl ResourceCounters<pso::DescriptorBinding> {
+    #[inline]
+    pub fn add_many(&mut self, content: DescriptorContent, count: pso::DescriptorBinding) {
         if content.contains(DescriptorContent::BUFFER) {
-            self.buffers += 1;
+            self.buffers += count;
         }
         if content.contains(DescriptorContent::TEXTURE) {
-            self.textures += 1;
+            self.textures += count;
         }
         if content.contains(DescriptorContent::SAMPLER) {
-            self.samplers += 1;
+            self.samplers += count;
         }
+    }
+    #[inline]
+    pub fn add(&mut self, content: DescriptorContent) {
+        self.add_many(content, 1)
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct MultiStageResourceCounters {
-    pub vs: ResourceCounters,
-    pub ps: ResourceCounters,
-    pub cs: ResourceCounters,
+    pub vs: ResourceCounters<ResourceIndex>,
+    pub ps: ResourceCounters<ResourceIndex>,
+    pub cs: ResourceCounters<ResourceIndex>,
 }
 
 #[derive(Debug)]
@@ -190,7 +207,7 @@ pub struct PipelineLayout {
 impl PipelineLayout {
     /// Get the first vertex buffer index to be used by attributes.
     #[inline(always)]
-    pub(crate) fn attribute_buffer_index(&self) -> u32 {
+    pub(crate) fn attribute_buffer_index(&self) -> ResourceIndex {
         self.total.vs.buffers as _
     }
 }
@@ -250,7 +267,7 @@ pub struct GraphicsPipeline {
     pub(crate) fs_lib: Option<metal::Library>,
     pub(crate) raw: metal::RenderPipelineState,
     pub(crate) primitive_type: metal::MTLPrimitiveType,
-    pub(crate) attribute_buffer_index: u32,
+    pub(crate) attribute_buffer_index: ResourceIndex,
     pub(crate) rasterizer_state: Option<RasterizerState>,
     pub(crate) depth_bias: pso::State<pso::DepthBias>,
     pub(crate) depth_stencil_desc: pso::DepthStencilDesc,
@@ -371,17 +388,17 @@ pub struct DescriptorPoolInner {
 }
 
 impl DescriptorPool {
-    pub(crate) fn new_emulated(num_samplers: usize, num_textures: usize, num_buffers: usize) -> Self {
+    pub(crate) fn new_emulated(counters: ResourceCounters<pso::DescriptorBinding>) -> Self {
         let inner = DescriptorPoolInner {
-            samplers: vec![None; num_samplers],
-            textures: vec![None; num_textures],
-            buffers: vec![None; num_buffers],
+            samplers: vec![None; counters.samplers as usize],
+            textures: vec![None; counters.textures as usize],
+            buffers: vec![None; counters.buffers as usize],
         };
         DescriptorPool::Emulated {
             inner: Arc::new(RwLock::new(inner)),
-            sampler_alloc: RangeAllocator::new(0 .. num_samplers as pso::DescriptorBinding),
-            texture_alloc: RangeAllocator::new(0 .. num_textures as pso::DescriptorBinding),
-            buffer_alloc: RangeAllocator::new(0 .. num_buffers as pso::DescriptorBinding),
+            sampler_alloc: RangeAllocator::new(0 .. counters.samplers),
+            texture_alloc: RangeAllocator::new(0 .. counters.textures),
+            buffer_alloc: RangeAllocator::new(0 .. counters.buffers),
         }
     }
 
@@ -411,7 +428,7 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
                 };
 
                 // step[1]: count the total number of descriptors needed
-                let mut total = ResourceCounters::new();
+                let mut total = ResourceCounters::<pso::DescriptorBinding>::new();
                 for layout in layouts.iter() {
                     total.add(layout.content);
                 }
@@ -422,7 +439,7 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
                     match sampler_alloc.allocate_range(total.samplers as _) {
                         Ok(range) => range,
                         Err(e) => {
-                            return Err(if e.fragmented_free_length >= total.samplers as u32 {
+                            return Err(if e.fragmented_free_length >= total.samplers {
                                 pso::AllocationError::FragmentedPool
                             } else {
                                 pso::AllocationError::OutOfPoolMemory
@@ -439,7 +456,7 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
                             if sampler_range.end != 0 {
                                 sampler_alloc.free_range(sampler_range);
                             }
-                            return Err(if e.fragmented_free_length >= total.samplers as u32 {
+                            return Err(if e.fragmented_free_length >= total.samplers {
                                 pso::AllocationError::FragmentedPool
                             } else {
                                 pso::AllocationError::OutOfPoolMemory
@@ -459,7 +476,7 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
                             if texture_range.end != 0 {
                                 texture_alloc.free_range(texture_range);
                             }
-                            return Err(if e.fragmented_free_length >= total.samplers as u32 {
+                            return Err(if e.fragmented_free_length >= total.samplers {
                                 pso::AllocationError::FragmentedPool
                             } else {
                                 pso::AllocationError::OutOfPoolMemory

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -33,7 +33,7 @@ impl<'a> Resources for &'a Own {
 
 #[derive(Clone, Debug)]
 pub enum RenderCommand<R: Resources> {
-    SetViewport(metal::MTLViewport),
+    SetViewport(hal::pso::Rect, Range<f32>),
     SetScissor(metal::MTLScissorRect),
     SetBlendColor(hal::pso::ColorValue),
     SetDepthBias(hal::pso::DepthBias),
@@ -90,7 +90,7 @@ impl<'a> RenderCommand<&'a Own> {
     pub fn own(self) -> RenderCommand<Own> {
         use self::RenderCommand::*;
         match self {
-            SetViewport(vp) => SetViewport(vp),
+            SetViewport(rect, depth) => SetViewport(rect, depth),
             SetScissor(rect) => SetScissor(rect),
             SetBlendColor(color) => SetBlendColor(color),
             SetDepthBias(bias) => SetDepthBias(bias),
@@ -244,7 +244,8 @@ pub enum Pass {
     Compute,
 }
 
-fn _test_render_command_size(com: RenderCommand<Own>) -> [usize; 7] {
+
+fn _test_render_command_size(com: RenderCommand<Own>) -> [usize; 6] {
     use std::mem;
     unsafe { mem::transmute(com) }
 }

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -243,3 +243,8 @@ pub enum Pass {
     Blit,
     Compute,
 }
+
+fn _test_render_command_size(com: RenderCommand<Own>) -> [usize; 7] {
+    use std::mem;
+    unsafe { mem::transmute(com) }
+}

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -1,4 +1,4 @@
-use {BufferPtr, SamplerPtr, TexturePtr};
+use {ResourceIndex, BufferPtr, SamplerPtr, TexturePtr};
 use command::IndexBuffer;
 use native::RasterizerState;
 
@@ -42,22 +42,22 @@ pub enum RenderCommand<R: Resources> {
     SetRasterizerState(RasterizerState),
     BindBuffer {
         stage: hal::pso::Stage,
-        index: usize,
+        index: ResourceIndex,
         buffer: Option<(BufferPtr, hal::buffer::Offset)>,
     },
     BindBufferData {
         stage: hal::pso::Stage,
-        index: usize,
+        index: ResourceIndex,
         words: R::Data,
     },
     BindTexture {
         stage: hal::pso::Stage,
-        index: usize,
+        index: ResourceIndex,
         texture: Option<TexturePtr>,
     },
     BindSampler {
         stage: hal::pso::Stage,
-        index: usize,
+        index: ResourceIndex,
         sampler: Option<SamplerPtr>,
     },
     BindPipeline(R::RenderPipeline),
@@ -175,19 +175,19 @@ pub enum BlitCommand {
 #[derive(Clone, Debug)]
 pub enum ComputeCommand<R: Resources> {
     BindBuffer {
-        index: usize,
+        index: ResourceIndex,
         buffer: Option<(BufferPtr, hal::buffer::Offset)>,
     },
     BindBufferData {
-        index: usize,
+        index: ResourceIndex,
         words: R::Data,
     },
     BindTexture {
-        index: usize,
+        index: ResourceIndex,
         texture: Option<TexturePtr>,
     },
     BindSampler {
-        index: usize,
+        index: ResourceIndex,
         sampler: Option<SamplerPtr>,
     },
     BindPipeline(R::ComputePipeline),


### PR DESCRIPTION
~~Fixes~~ preparation for #2295

This PR is best to review by commits:
  - first one just makes things tidier. I was hoping to get denser command format (by using `u8`) but this regressed the performance, so leaving `ResourceIndex` as `u32` for now
  - second one makes it cheaper to store options of resource pointers

PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
