### PR TITLE
Make merge_pipeline_caches to be non-consuming

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -737,7 +737,8 @@ impl hal::Device<Backend> for Device {
 
     fn merge_pipeline_caches<I>(&self, _: &(), _: I)
     where
-        I: IntoIterator<Item = ()>
+        I: IntoIterator,
+        I::Item: Borrow<()>,
     {
         //empty
     }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1480,7 +1480,8 @@ impl d::Device<B> for Device {
 
     fn merge_pipeline_caches<I>(&self, _: &(), _: I)
     where
-        I: IntoIterator<Item = ()>
+        I: IntoIterator,
+        I::Item: Borrow<()>,
     {
         //empty
     }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -159,7 +159,8 @@ impl hal::Device<Backend> for Device {
 
     fn merge_pipeline_caches<I>(&self, _: &(), _: I)
     where
-        I: IntoIterator<Item = ()>
+        I: IntoIterator,
+        I::Item: Borrow<()>,
     {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -551,7 +551,8 @@ impl d::Device<B> for Device {
 
     fn merge_pipeline_caches<I>(&self, _: &(), _: I)
     where
-        I: IntoIterator<Item = ()>
+        I: IntoIterator,
+        I::Item: Borrow<()>,
     {
         //empty
     }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -195,6 +195,7 @@ impl PipelineLayout {
     }
 }
 
+#[derive(Clone)]
 pub struct ModuleInfo {
     pub library: metal::Library,
     pub entry_point_map: EntryPointMap,

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -296,9 +296,10 @@ impl d::Device<B> for Device {
 
     fn merge_pipeline_caches<I>(&self, target: &n::PipelineCache, sources: I)
     where
-        I: IntoIterator<Item = n::PipelineCache>
+        I: IntoIterator,
+        I::Item: Borrow<n::PipelineCache>,
     {
-        let caches = sources.into_iter().map(|s| s.raw).collect::<Vec<_>>();
+        let caches = sources.into_iter().map(|s| s.borrow().raw).collect::<Vec<_>>();
         unsafe  {
             self.raw.0
                 .fp_v1_0()

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -225,7 +225,8 @@ pub trait Device<B: Backend>: Any + Send + Sync {
     /// Merge a number of source pipeline caches into the target one.
     fn merge_pipeline_caches<I>(&self, target: &B::PipelineCache, sources: I)
     where
-        I: IntoIterator<Item = B::PipelineCache>;
+        I: IntoIterator,
+        I::Item: Borrow<B::PipelineCache>;
 
     /// Destroy a pipeline cache object.
     fn destroy_pipeline_cache(&self, cache: B::PipelineCache);


### PR DESCRIPTION
Follow-up to #2294
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
