### PR TITLE
[WIP] Take attachment indices in begin_render_pass

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -526,9 +526,11 @@ impl<B: Backend> RendererState<B> {
                         self.render_pass.render_pass.as_ref().unwrap(),
                         framebuffer,
                         self.viewport.rect,
-                        &[command::ClearValue::Color(command::ClearColor::Float([
-                            cr, cg, cb, 1.0,
-                        ]))],
+                        [
+                            (0, command::ClearValue::Color(command::ClearColor::Float([
+                                cr, cg, cb, 1.0,
+                            ])))
+                        ].iter().cloned()
                     );
                     encoder.draw(0..6, 0..1);
                 }

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -482,9 +482,9 @@ fn main() {
                     &render_pass,
                     &framebuffers[frame as usize],
                     viewport.rect,
-                    &[command::ClearValue::Color(command::ClearColor::Float([
-                        0.8, 0.8, 0.8, 1.0,
-                    ]))],
+                    [
+                        (0, command::ClearValue::Color(command::ClearColor::Float([0.8, 0.8, 0.8, 1.0])))
+                    ].iter().cloned(),
                 );
                 encoder.draw(0..6, 0..1);
             }

--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -85,7 +85,7 @@
 		"empty": Graphics(
 			framebuffer: "fbo",
 			clear_values: [
-				Color(Float((0.8, 0.8, 0.8, 1.0))),
+				(0, Color(Float((0.8, 0.8, 0.8, 1.0)))),
 			],
 			pass: ("pass", {
 				"main": (commands: [
@@ -95,7 +95,7 @@
 		"pass-through": Graphics(
 			framebuffer: "fbo",
 			clear_values: [
-				Color(Float((0.8, 0.8, 0.8, 1.0))),
+				(0, Color(Float((0.8, 0.8, 0.8, 1.0)))),
 			],
 			pass: ("pass", {
 				"main": (commands: [

--- a/reftests/scenes/vertex-offset.ron
+++ b/reftests/scenes/vertex-offset.ron
@@ -154,7 +154,7 @@
         "offset-aligned": Graphics(
             framebuffer: "fbo",
             clear_values: [
-                Color(Float((0.0, 0.0, 0.0, 0.0))),
+                (0, Color(Float((0.0, 0.0, 0.0, 0.0)))),
             ],
             pass: ("pass", {
                 "main": (commands: [
@@ -169,7 +169,7 @@
         "offset-overlap": Graphics(
             framebuffer: "fbo",
             clear_values: [
-                Color(Float((0.0, 0.0, 0.0, 0.0))),
+                (0, Color(Float((0.0, 0.0, 0.0, 0.0)))),
             ],
             pass: ("pass", {
                 "main": (commands: [

--- a/src/backend/auxil/clear_values.rs
+++ b/src/backend/auxil/clear_values.rs
@@ -1,0 +1,37 @@
+use std::{iter, mem};
+use hal::pass::AttachmentId;
+use hal::command::ClearValueRaw;
+use smallvec::SmallVec;
+
+#[allow(dead_code)]
+pub(crate) fn convert_clear_values_iter<I>(values: I) -> impl Iterator<Item=ClearValueRaw>
+where
+    I: Iterator<Item=(AttachmentId, ClearValueRaw)>
+{
+    let dummy = unsafe { mem::zeroed() };
+    collect_by_ids(values, dummy)
+        .into_iter()
+        .chain(iter::repeat(dummy))
+}
+
+pub(crate) fn collect_by_ids<I, V>(values: I, dummy: V) -> SmallVec<[V; 16]>
+where
+    I: Iterator<Item=(AttachmentId, V)>,
+    V: Copy
+{
+    let mut ret = SmallVec::new();
+
+    for (id, value) in values {
+        if id == ret.len() {
+            ret.push(value);
+        } else if id < ret.len() {
+            ret[id] = value;
+        } else {
+            let placeholder_count = id - ret.len();
+            ret.extend(iter::repeat(dummy).take(placeholder_count));
+            ret.push(value);
+        }
+    }
+
+    ret
+}

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -12,6 +12,8 @@ extern crate winapi;
 extern crate winit;
 extern crate wio;
 
+#[path = "../../auxil/clear_values.rs"]
+mod clear_values;
 #[path = "../../auxil/range_alloc.rs"]
 mod range_alloc;
 mod command;

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -575,8 +575,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         _: T,
         _: command::SubpassContents,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ClearValueRaw>,
+        T: Iterator<Item=(pass::AttachmentId, command::ClearValueRaw)>
     {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -8,6 +8,7 @@ use hal::range::RangeArg;
 
 use {native as n, Backend};
 use pool::{self, BufferMemory};
+use clear_values::convert_clear_values_iter;
 
 use std::borrow::Borrow;
 use std::{mem, slice};
@@ -554,8 +555,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         clear_values: T,
         _first_subpass: command::SubpassContents,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ClearValueRaw>,
+        T: Iterator<Item=(pass::AttachmentId, command::ClearValueRaw)>
     {
         // TODO: load ops: clearing strategy
         //  1.  < GL 3.0 / GL ES 2.0: glClear, only single color attachment?
@@ -576,7 +576,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
         let attachment_clears = render_pass.attachments
             .iter()
-            .zip(clear_values.into_iter())
+            .zip(convert_clear_values_iter(clear_values))
             .enumerate()
             .map(|(i, (attachment, clear_value))| {
                 AttachmentClear {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -26,6 +26,8 @@ use hal::queue::{Queues, QueueFamilyId};
 pub use self::device::Device;
 pub use self::info::{Info, PlatformName, Version};
 
+#[path = "../../auxil/clear_values.rs"]
+mod clear_values;
 mod command;
 mod conv;
 mod device;

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -12,7 +12,7 @@ use std::ops::{Deref, Range};
 use std::sync::Arc;
 use std::{iter, mem, slice, time};
 
-use hal::{buffer, command as com, error, memory, pool, pso};
+use hal::{pass, buffer, command as com, error, memory, pool, pso};
 use hal::{DrawCount, SwapImageIndex, VertexCount, VertexOffset, InstanceCount, IndexCount, IndexType, WorkGroupCount};
 use hal::backend::FastHashMap;
 use hal::format::{Aspects, Format, FormatDesc};
@@ -2771,8 +2771,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         clear_values: T,
         _first_subpass: com::SubpassContents,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<com::ClearValueRaw>,
+        T: Iterator<Item=(pass::AttachmentId, com::ClearValueRaw)>
     {
         // FIXME: subpasses
         let desc_guard;

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -17,6 +17,8 @@ extern crate winit;
 #[cfg(feature = "dispatch")]
 extern crate dispatch;
 
+#[path = "../../auxil/clear_values.rs"]
+mod clear_values;
 #[path = "../../auxil/range_alloc.rs"]
 mod range_alloc;
 mod device;

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -42,6 +42,8 @@ use shared_library::dynamic_library::{DynamicLibrary, SpecialHandles};
 #[cfg(feature = "use-rtld-next")]
 use ash::{EntryCustom, LoadingError};
 
+#[path = "../../auxil/clear_values.rs"]
+mod clear_values;
 mod command;
 mod conv;
 mod device;

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -12,6 +12,7 @@ use super::{
     Shot, Level, Primary,
     ClearColorRaw, ClearDepthStencilRaw, ClearValueRaw, DescriptorSetOffset,
 };
+use pass::AttachmentId;
 
 
 /// A universal clear color supporting integer formats
@@ -314,8 +315,7 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot> CommandBuffer<'a, B, C, S, 
         clear_values: T,
     ) -> RenderPassInlineEncoder<B, Primary>
     where
-        T: IntoIterator,
-        T::Item: Borrow<ClearValue>,
+        T: Iterator<Item=(AttachmentId, ClearValue)>
     {
         RenderPassInlineEncoder::new(self, render_pass, frame_buffer, render_area, clear_values)
     }
@@ -329,8 +329,7 @@ impl<'a, B: Backend, C: Supports<Graphics>, S: Shot> CommandBuffer<'a, B, C, S, 
         clear_values: T,
     ) -> RenderPassSecondaryEncoder<B>
     where
-        T: IntoIterator,
-        T::Item: Borrow<ClearValue>,
+        T: Iterator<Item=(AttachmentId, ClearValue)>
     {
         RenderPassSecondaryEncoder::new(self, render_pass, frame_buffer, render_area, clear_values)
     }

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -9,6 +9,7 @@ use image::{Filter, Layout, SubresourceRange};
 use memory::{Barrier, Dependencies};
 use query::{PipelineStatistic, Query, QueryControl, QueryId};
 use range::RangeArg;
+use pass::AttachmentId;
 use super::{
     AttachmentClear, BufferCopy, BufferImageCopy,
     ImageBlit, ImageCopy, ImageResolve, SubpassContents,
@@ -303,8 +304,7 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Any + Send + Sync {
         clear_values: T,
         first_subpass: SubpassContents,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<ClearValueRaw>;
+        T: Iterator<Item=(AttachmentId, ClearValueRaw)>;
 
     /// Steps to the next subpass in the current render pass.
     fn next_subpass(&mut self, contents: SubpassContents);

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -1,10 +1,12 @@
 use std::borrow::Borrow;
 use std::ops::{Range, Deref, DerefMut};
 use std::marker::PhantomData;
+use std::vec::Vec;
 
 use {buffer, pso};
 use {Backend, DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset};
 use queue::{Supports, Graphics};
+use pass::AttachmentId;
 use super::{
     AttachmentClear, ClearValue, ClearValueRaw, CommandBuffer, RawCommandBuffer,
     Shot, Level, Primary, Secondary, Submittable, Submit, DescriptorSetOffset,
@@ -173,18 +175,13 @@ impl<'a, B: Backend, L: Level> RenderPassInlineEncoder<'a, B, L> {
     ) -> Self
     where
         C: Supports<Graphics>,
-        T: IntoIterator,
-        T::Item: Borrow<ClearValue>,
+        T: Iterator<Item=(AttachmentId, ClearValue)>
     {
-        let clear_values = clear_values
-            .into_iter()
-            .map(|cv| ClearValueRaw::from(*cv.borrow()));
-
         cmd_buffer.raw.begin_render_pass(
             render_pass,
             frame_buffer,
             render_area,
-            clear_values,
+            clear_values.map(|(id, value)| (id, ClearValueRaw::from(value))),
             SubpassContents::Inline,
         );
 
@@ -250,18 +247,13 @@ impl<'a, B: Backend> RenderPassSecondaryEncoder<'a, B> {
     ) -> Self
     where
         C: Supports<Graphics>,
-        T: IntoIterator,
-        T::Item: Borrow<ClearValue>,
+        T: Iterator<Item=(AttachmentId, ClearValue)>
     {
-        let clear_values = clear_values
-            .into_iter()
-            .map(|cv| ClearValueRaw::from(*cv.borrow()));
-
         cmd_buffer.raw.begin_render_pass(
             render_pass,
             frame_buffer,
             render_area,
-            clear_values,
+            clear_values.map(|(id, value)| (id, ClearValueRaw::from(value))),
             SubpassContents::SecondaryBuffers,
         );
 

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -911,7 +911,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                         w: extent.width as _,
                         h: extent.height as _,
                     };
-                    let mut encoder = command_buf.begin_render_pass_inline(&rp.handle, fb, rect, clear_values);
+                    let mut encoder = command_buf.begin_render_pass_inline(&rp.handle, fb, rect, clear_values.iter().cloned());
                     encoder.set_scissors(0, Some(rect));
                     encoder.set_viewports(0, Some(pso::Viewport {
                         rect,

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -208,7 +208,7 @@ pub enum Job {
     Transfer(TransferCommand),
     Graphics {
         framebuffer: String,
-        clear_values: Vec<hal::command::ClearValue>,
+        clear_values: Vec<(hal::pass::AttachmentId, hal::command::ClearValue)>,
         pass: (String, HashMap<String, DrawPass>),
     },
     Compute {


### PR DESCRIPTION
Fixes #2248 

I would like to get feedback for this change if it's a good direction.
`begin_render_pass` became a bit verbose. Also I couldn't sort the attachment array without `Vec`

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
