### PR TITLE
[dx11] add partial attachment clears & misc fixes

### DIFF
--- a/src/backend/dx11/shaders/clear.hlsl
+++ b/src/backend/dx11/shaders/clear.hlsl
@@ -1,0 +1,22 @@
+cbuffer ClearColorF32   : register(b0) { float4 ClearF32; };
+cbuffer ClearColorU32   : register(b0) { uint4 ClearU32; };
+cbuffer ClearColorI32   : register(b0) { int4 ClearI32; };
+cbuffer ClearColorDepth : register(b0) { float ClearDepth; };
+
+// fullscreen triangle
+float4 vs_partial_clear(uint id : SV_VertexID) : SV_Position
+{
+    return float4(
+        float(id / 2) * 4.0 - 1.0,
+        float(id % 2) * 4.0 - 1.0,
+        0.0,
+        1.0
+    );
+}
+
+// TODO: send constants through VS as flat attributes
+float4 ps_partial_clear_float() : SV_Target0 { return ClearF32; }
+uint4  ps_partial_clear_uint() : SV_Target0 { return ClearU32; }
+int4   ps_partial_clear_int() : SV_Target0 { return ClearI32; }
+float  ps_partial_clear_depth() : SV_Depth { return ClearDepth; }
+void   ps_partial_clear_stencil() { }

--- a/src/backend/dx11/shaders/copy.hlsl
+++ b/src/backend/dx11/shaders/copy.hlsl
@@ -21,6 +21,15 @@ cbuffer CopyConstants : register(b0) {
     BufferImageCopy BufferImageCopies;
 };
 
+
+uint3 GetDestBounds()
+{
+    return min(
+        BufferImageCopies.ImageOffset + BufferImageCopies.ImageExtent,
+        BufferImageCopies.ImageSize
+    );
+}
+
 uint3 GetImageCopyDst(uint3 dispatch_thread_id)
 {
     return uint3(ImageCopies.Dst.xy + dispatch_thread_id.xy, ImageCopies.Dst.z);
@@ -215,7 +224,8 @@ void cs_copy_image2d_r32_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_Dispatch
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r32g32b32a32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
-    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x || dst_idx.y >= bounds.y) {
         return;
     }
 
@@ -232,7 +242,8 @@ void cs_copy_buffer_image2d_r32g32b32a32(uint3 dispatch_thread_id : SV_DispatchT
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r32g32b32a32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
-    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (src_idx.x >= bounds.x || src_idx.y >= bounds.y) {
         return;
     }
 
@@ -249,7 +260,8 @@ void cs_copy_image2d_r32g32b32a32_buffer(uint3 dispatch_thread_id : SV_DispatchT
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r32g32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
-    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x || dst_idx.y >= bounds.y) {
         return;
     }
 
@@ -264,7 +276,8 @@ void cs_copy_buffer_image2d_r32g32(uint3 dispatch_thread_id : SV_DispatchThreadI
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r32g32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
-    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (src_idx.x >= bounds.x || src_idx.y >= bounds.y) {
         return;
     }
 
@@ -279,7 +292,8 @@ void cs_copy_image2d_r32g32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadI
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r16g16b16a16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
-    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x || dst_idx.y >= bounds.y) {
         return;
     }
 
@@ -294,7 +308,8 @@ void cs_copy_buffer_image2d_r16g16b16a16(uint3 dispatch_thread_id : SV_DispatchT
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r16g16b16a16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
-    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (src_idx.x >= bounds.x || src_idx.y >= bounds.y) {
         return;
     }
 
@@ -309,7 +324,8 @@ void cs_copy_image2d_r16g16b16a16_buffer(uint3 dispatch_thread_id : SV_DispatchT
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
-    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x || dst_idx.y >= bounds.y) {
         return;
     }
 
@@ -321,7 +337,8 @@ void cs_copy_buffer_image2d_r32(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
-    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (src_idx.x >= bounds.x || src_idx.y >= bounds.y) {
         return;
     }
 
@@ -334,7 +351,8 @@ void cs_copy_image2d_r32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
-    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x || dst_idx.y >= bounds.y) {
         return;
     }
 
@@ -346,7 +364,8 @@ void cs_copy_buffer_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchThreadI
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r16g16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
-    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (src_idx.x >= bounds.x || src_idx.y >= bounds.y) {
         return;
     }
 
@@ -359,7 +378,8 @@ void cs_copy_image2d_r16g16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadI
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
-    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x || dst_idx.y >= bounds.y) {
         return;
     }
 
@@ -371,7 +391,8 @@ void cs_copy_buffer_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_DispatchThrea
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8g8b8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
-    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (src_idx.x >= bounds.x || src_idx.y >= bounds.y) {
         return;
     }
 
@@ -384,7 +405,8 @@ void cs_copy_image2d_r8g8b8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThrea
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_b8g8r8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
-    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (src_idx.x >= bounds.x || src_idx.y >= bounds.y) {
         return;
     }
 
@@ -397,7 +419,8 @@ void cs_copy_image2d_b8g8r8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThrea
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
-    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x || dst_idx.y >= bounds.y) {
         return;
     }
 
@@ -411,7 +434,8 @@ void cs_copy_buffer_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(uint3(2, 1, 0) * dispatch_thread_id);
-    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (src_idx.x >= bounds.x || src_idx.y >= bounds.y) {
         return;
     }
 
@@ -427,7 +451,8 @@ void cs_copy_image2d_r16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
-    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x || dst_idx.y >= bounds.y) {
         return;
     }
 
@@ -442,7 +467,8 @@ void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID)
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8g8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(uint3(2, 1, 0) * dispatch_thread_id);
-    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (src_idx.x >= bounds.x || src_idx.y >= bounds.y) {
         return;
     }
 
@@ -458,7 +484,8 @@ void cs_copy_image2d_r8g8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID)
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(uint3(4, 1, 0) * dispatch_thread_id);
-    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x || dst_idx.y >= bounds.y) {
         return;
     }
 
@@ -474,7 +501,8 @@ void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
 [numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(uint3(4, 1, 0) * dispatch_thread_id);
-    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+    uint3 bounds = GetDestBounds();
+    if (src_idx.x >= bounds.x || src_idx.y >= bounds.y) {
         return;
     }
 

--- a/src/backend/dx11/shaders/copy.hlsl
+++ b/src/backend/dx11/shaders/copy.hlsl
@@ -12,6 +12,7 @@ struct BufferImageCopy {
     uint4 BufferVars;
     uint4 ImageOffset;
     uint4 ImageExtent;
+    uint4 ImageSize;
 };
 
 cbuffer CopyConstants : register(b0) {
@@ -205,13 +206,19 @@ void cs_copy_image2d_r32_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_Dispatch
     ImageCopyDstRgba[dst_idx] = Uint32ToUint8x4(ImageCopySrc[src_idx]);
 }
 
+#define COPY_NUM_THREAD_X 8
+#define COPY_NUM_THREAD_Y 8
+
 // Buffer<->Image copies
 
 // R32G32B32A32
-// TODO: correct, but slow
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r32g32b32a32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
+    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
     uint src_idx = GetBufferSrc128(dispatch_thread_id);
 
     ImageCopyDstRgba[dst_idx] = uint4(
@@ -222,12 +229,15 @@ void cs_copy_buffer_image2d_r32g32b32a32(uint3 dispatch_thread_id : SV_DispatchT
     );
 }
 
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r32g32b32a32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint dst_idx = GetBufferDst128(dispatch_thread_id);
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
+    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
 
     uint4 data = ImageCopySrc[src_idx];
+    uint dst_idx = GetBufferDst128(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx,         data.x);
     BufferCopyDst.Store(dst_idx + 1 * 4, data.y);
@@ -236,9 +246,13 @@ void cs_copy_image2d_r32g32b32a32_buffer(uint3 dispatch_thread_id : SV_DispatchT
 }
 
 // R32G32
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r32g32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
+    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
     uint src_idx = GetBufferSrc64(dispatch_thread_id);
 
     ImageCopyDstRg[dst_idx] = uint2(
@@ -247,21 +261,28 @@ void cs_copy_buffer_image2d_r32g32(uint3 dispatch_thread_id : SV_DispatchThreadI
     );
 }
 
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r32g32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint dst_idx = GetBufferDst64(dispatch_thread_id);
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
+    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
 
     uint2 data = ImageCopySrc[src_idx].rg;
+    uint dst_idx = GetBufferDst64(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx        , data.x);
     BufferCopyDst.Store(dst_idx + 1 * 4, data.y);
 }
 
 // R16G16B16A16
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r16g16b16a16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
+    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
     uint src_idx = GetBufferSrc64(dispatch_thread_id);
 
     ImageCopyDstRgba[dst_idx] = uint4(
@@ -270,82 +291,116 @@ void cs_copy_buffer_image2d_r16g16b16a16(uint3 dispatch_thread_id : SV_DispatchT
     );
 }
 
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r16g16b16a16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint dst_idx = GetBufferDst64(dispatch_thread_id);
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
+    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
 
     uint4 data = ImageCopySrc[src_idx];
+    uint dst_idx = GetBufferDst64(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx,         Uint16x2ToUint32(data.xy));
     BufferCopyDst.Store(dst_idx + 1 * 4, Uint16x2ToUint32(data.zw));
 }
 
 // R32
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
+    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
     uint src_idx = GetBufferSrc32(dispatch_thread_id);
 
     ImageCopyDstR[dst_idx] = BufferCopySrc.Load(src_idx);
 }
 
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint dst_idx = GetBufferDst32(dispatch_thread_id);
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
+    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
+    uint dst_idx = GetBufferDst32(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx, ImageCopySrc[src_idx].r);
 }
 
 // R16G16
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
+    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
     uint src_idx = GetBufferSrc32(dispatch_thread_id);
 
     ImageCopyDstRg[dst_idx] = Uint32ToUint16x2(BufferCopySrc.Load(src_idx));
 }
 
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r16g16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint dst_idx = GetBufferDst32(dispatch_thread_id);
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
+    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
+    uint dst_idx = GetBufferDst32(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx, Uint16x2ToUint32(ImageCopySrc[src_idx].xy));
 }
 
 // R8G8B8A8
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
+    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
     uint src_idx = GetBufferSrc32(dispatch_thread_id);
 
     ImageCopyDstRgba[dst_idx] = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 }
 
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8g8b8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint dst_idx = GetBufferDst32(dispatch_thread_id);
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
+    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
+    uint dst_idx = GetBufferDst32(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(ImageCopySrc[src_idx]));
 }
 
 // B8G8R8A8
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_b8g8r8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint dst_idx = GetBufferDst32(dispatch_thread_id);
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
+    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
 
-    BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(Float4ToUint8x4(ImageCopySrcBgra[src_idx])));
+    uint dst_idx = GetBufferDst32(dispatch_thread_id);
+
+    BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(Float4ToUint8x4(ImageCopySrcBgra[src_idx].bgra)));
 }
 
 // R16
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-//    uint src_idx = BufferImageCopies.BufferVars.x + dispatch_thread_id.x + dispatch_thread_id.y * BufferImageCopies.BufferVars.y / 2;
     uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
+    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
     uint src_idx = GetBufferSrc16(dispatch_thread_id);
     uint2 data = Uint32ToUint16x2(BufferCopySrc.Load(src_idx));
 
@@ -353,11 +408,14 @@ void cs_copy_buffer_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThreadID) 
     ImageCopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
 }
 
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    //uint dst_idx = BufferImageCopies.BufferVars.x + dispatch_thread_id.x + dispatch_thread_id.y * BufferImageCopies.BufferVars.y / 2;
-    uint dst_idx = GetBufferDst16(dispatch_thread_id);
     uint3 src_idx = GetImageSrc(uint3(2, 1, 0) * dispatch_thread_id);
+    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
+    uint dst_idx = GetBufferDst16(dispatch_thread_id);
 
     uint upper = ImageCopySrc[src_idx].r;
     uint lower = ImageCopySrc[src_idx + uint3(1, 0, 0)].r;
@@ -366,10 +424,13 @@ void cs_copy_image2d_r16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 }
 
 // R8G8
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-//    uint src_idx = BufferImageCopies.BufferVars.x + dispatch_thread_id.x + dispatch_thread_id.y * BufferImageCopies.BufferVars.y / 2;
     uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
+    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
     uint src_idx = GetBufferSrc16(dispatch_thread_id);
 
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
@@ -378,11 +439,14 @@ void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID)
     ImageCopyDstRg[dst_idx + uint3(1, 0, 0)] = data.zw;
 }
 
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8g8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-//    uint dst_idx = BufferImageCopies.BufferVars.x + dispatch_thread_id.x + dispatch_thread_id.y * BufferImageCopies.BufferVars.y / 2;
-    uint dst_idx = GetBufferDst16(dispatch_thread_id);
     uint3 src_idx = GetImageSrc(uint3(2, 1, 0) * dispatch_thread_id);
+    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
+    uint dst_idx = GetBufferDst16(dispatch_thread_id);
 
     uint2 lower = ImageCopySrc[src_idx].xy;
     uint2 upper = ImageCopySrc[src_idx + uint3(1, 0, 0)].xy;
@@ -391,9 +455,13 @@ void cs_copy_image2d_r8g8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID)
 }
 
 // R8
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(uint3(4, 1, 0) * dispatch_thread_id);
+    if (dst_idx.x >= BufferImageCopies.ImageSize.x || dst_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
     uint src_idx = GetBufferSrc8(dispatch_thread_id);
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
@@ -403,10 +471,14 @@ void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     ImageCopyDstR[dst_idx + uint3(3, 0, 0)] = data.w;
 }
 
-[numthreads(1, 1, 1)]
+[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
-    uint dst_idx = GetBufferDst8(dispatch_thread_id);
     uint3 src_idx = GetImageSrc(uint3(4, 1, 0) * dispatch_thread_id);
+    if (src_idx.x >= BufferImageCopies.ImageSize.x || src_idx.y >= BufferImageCopies.ImageSize.y) {
+        return;
+    }
+
+    uint dst_idx = GetBufferDst8(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(uint4(
         ImageCopySrc[src_idx].r,

--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -157,6 +157,16 @@ impl DecomposedDxgiFormat {
                 copy_srv: Some(DXGI_FORMAT_B8G8R8A8_UNORM),
             },
 
+            DXGI_FORMAT_A8_UNORM => DecomposedDxgiFormat {
+                typeless: format,
+                srv: Some(format),
+                rtv: Some(format),
+                uav: Some(format),
+                dsv: None,
+                copy_uav: Some(format),
+                copy_srv: Some(format),
+            },
+
             DXGI_FORMAT_R8_UNORM |
             DXGI_FORMAT_R8_SNORM |
             DXGI_FORMAT_R8_UINT |
@@ -532,7 +542,7 @@ fn map_blend_factor(factor: Factor) -> D3D11_BLEND {
 
 fn map_alpha_blend_factor(factor: Factor) -> D3D11_BLEND {
     match factor {
-        Factor::Zero |
+        Factor::Zero => D3D11_BLEND_ZERO,
         Factor::One => D3D11_BLEND_ONE,
         Factor::SrcColor |
         Factor::SrcAlpha => D3D11_BLEND_SRC_ALPHA,

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1880,12 +1880,17 @@ impl hal::Device<Backend> for Device {
         J::Item: Borrow<pso::Descriptor<'a, Backend>>,
     {
         for write in write_iter {
+            //println!("WriteDescriptorSets({:?})", write.set.handles);
             let target_binding = write.binding;
             let (ty, first_offset, second_offset) = write.set.get_handle_offset(target_binding);
+            assert!((first_offset as usize) < write.set.len);
+            assert!((second_offset as usize) < write.set.len);
 
             for descriptor in write.descriptors {
                 let handle = unsafe { write.set.handles.offset(first_offset as isize) };
                 let second_handle = unsafe { write.set.handles.offset(second_offset as isize) };
+
+                //println!("  Write(offset={}, handle={:?}) <= {:?}", first_offset, handle, ty);
 
                 match *descriptor.borrow() {
                     pso::Descriptor::Buffer(buffer, ref _range) => {

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -1,8 +1,9 @@
-use hal::pso::{Stage};
-use hal::{image, command};
+use hal::pso::{Viewport, Stage};
+use hal::{command, image, pso};
 
 use winapi::shared::dxgiformat;
 use winapi::shared::winerror;
+use winapi::shared::minwindef::{TRUE, FALSE};
 use winapi::um::d3d11;
 use winapi::um::d3dcommon;
 
@@ -12,9 +13,11 @@ use std::{mem, ptr};
 use std::borrow::Borrow;
 
 use spirv_cross;
-use {shader};
+use smallvec::SmallVec;
 
-use {Buffer, Image};
+use {conv, shader};
+
+use {Buffer, Image, RenderPassCache};
 
 #[repr(C)]
 struct BufferCopy {
@@ -36,6 +39,8 @@ struct BufferImageCopy {
     _padding: u32,
     image_offset: [u32; 4],
     image_extent: [u32; 4],
+    // actual size of the target image
+    image_size: [u32; 4],
 }
 
 #[repr(C)]
@@ -53,14 +58,44 @@ struct BlitInfo {
     level: f32,
 }
 
+#[repr(C)]
+struct PartialClearInfo {
+    // transmute between the types, easier than juggling all different kinds of fields..
+    data: [u32; 4],
+}
+
+// the threadgroup count we use in our copy shaders
+const COPY_THREAD_GROUP_X: u32 = 8;
+const COPY_THREAD_GROUP_Y: u32 = 8;
+
+// Holds everything we need for fallback implementations of features that are not in DX. 
+//
+// TODO: maybe get rid of `Clone`? there's _a lot_ of refcounts here and it is used as a singleton
+//       anyway :s
+//
+// TODO: make struct fields more modular and group them up in structs depending on if it is a
+//       fallback version or not (eg. Option<PartialClear>), should make struct definition and
+//       `new` function smaller
 #[derive(Clone)]
 pub struct Internal {
+
+    // partial clearing
+    vs_partial_clear: ComPtr<d3d11::ID3D11VertexShader>,
+    ps_partial_clear_float: ComPtr<d3d11::ID3D11PixelShader>,
+    ps_partial_clear_uint: ComPtr<d3d11::ID3D11PixelShader>,
+    ps_partial_clear_int: ComPtr<d3d11::ID3D11PixelShader>,
+    ps_partial_clear_depth: ComPtr<d3d11::ID3D11PixelShader>,
+    ps_partial_clear_stencil: ComPtr<d3d11::ID3D11PixelShader>,
+    partial_clear_depth_stencil_state: ComPtr<d3d11::ID3D11DepthStencilState>,
+    partial_clear_depth_state: ComPtr<d3d11::ID3D11DepthStencilState>,
+    partial_clear_stencil_state: ComPtr<d3d11::ID3D11DepthStencilState>,
+
+    // blitting
     vs_blit_2d: ComPtr<d3d11::ID3D11VertexShader>,
 
     sampler_nearest: ComPtr<d3d11::ID3D11SamplerState>,
     sampler_linear: ComPtr<d3d11::ID3D11SamplerState>,
 
-    // blit permutations
     ps_blit_2d_uint: ComPtr<d3d11::ID3D11PixelShader>,
     ps_blit_2d_int: ComPtr<d3d11::ID3D11PixelShader>,
     ps_blit_2d_float: ComPtr<d3d11::ID3D11PixelShader>,
@@ -76,7 +111,7 @@ pub struct Internal {
     cs_copy_image2d_r32_image2d_r16g16: ComPtr<d3d11::ID3D11ComputeShader>,
     cs_copy_image2d_r32_image2d_r8g8b8a8: ComPtr<d3d11::ID3D11ComputeShader>,
 
-    // Buffer<->Image
+    // Image -> Buffer
     cs_copy_image2d_r32g32b32a32_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
     cs_copy_image2d_r32g32_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
     cs_copy_image2d_r16g16b16a16_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
@@ -88,6 +123,7 @@ pub struct Internal {
     cs_copy_image2d_r8_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
     cs_copy_image2d_b8g8r8a8_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
 
+    // Buffer -> Image
     cs_copy_buffer_image2d_r32g32b32a32: ComPtr<d3d11::ID3D11ComputeShader>,
     cs_copy_buffer_image2d_r32g32: ComPtr<d3d11::ID3D11ComputeShader>,
     cs_copy_buffer_image2d_r16g16b16a16: ComPtr<d3d11::ID3D11ComputeShader>,
@@ -98,8 +134,10 @@ pub struct Internal {
     cs_copy_buffer_image2d_r8g8: ComPtr<d3d11::ID3D11ComputeShader>,
     cs_copy_buffer_image2d_r8: ComPtr<d3d11::ID3D11ComputeShader>,
 
-    copy_info: ComPtr<d3d11::ID3D11Buffer>,
+    // internal constant buffer that is used by internal shaders
+    internal_buffer: ComPtr<d3d11::ID3D11Buffer>,
 
+    // public buffer that is used as intermediate storage for some operations (memory invalidation) 
     pub working_buffer: ComPtr<d3d11::ID3D11Buffer>,
     pub working_buffer_size: u64,
 }
@@ -165,7 +203,7 @@ fn compile_cs(device: &ComPtr<d3d11::ID3D11Device>, src: &[u8], entrypoint: &str
 
 impl Internal {
     pub fn new(device: &ComPtr<d3d11::ID3D11Device>) -> Self {
-        let copy_info = {
+        let internal_buffer = {
             let desc = d3d11::D3D11_BUFFER_DESC {
                 ByteWidth: mem::size_of::<BufferImageCopyInfo>() as _,
                 Usage: d3d11::D3D11_USAGE_DYNAMIC,
@@ -186,6 +224,66 @@ impl Internal {
             assert_eq!(true, winerror::SUCCEEDED(hr));
 
             unsafe { ComPtr::from_raw(buffer) }
+        };
+
+        let (depth_stencil_state, depth_state, stencil_state) = {
+            let mut depth_state = ptr::null_mut();
+            let mut stencil_state = ptr::null_mut();
+            let mut depth_stencil_state = ptr::null_mut();
+
+            let mut desc = d3d11::D3D11_DEPTH_STENCIL_DESC {
+                DepthEnable: TRUE,
+                DepthWriteMask: d3d11::D3D11_DEPTH_WRITE_MASK_ALL,
+                DepthFunc: d3d11::D3D11_COMPARISON_ALWAYS,
+                StencilEnable: TRUE,
+                StencilReadMask: 0,
+                StencilWriteMask: !0,
+                FrontFace: d3d11::D3D11_DEPTH_STENCILOP_DESC {
+                    StencilFailOp: d3d11::D3D11_STENCIL_OP_REPLACE,
+                    StencilDepthFailOp: d3d11::D3D11_STENCIL_OP_REPLACE,
+                    StencilPassOp: d3d11::D3D11_STENCIL_OP_REPLACE,
+                    StencilFunc: d3d11::D3D11_COMPARISON_ALWAYS,
+                },
+                BackFace: d3d11::D3D11_DEPTH_STENCILOP_DESC {
+                    StencilFailOp: d3d11::D3D11_STENCIL_OP_REPLACE,
+                    StencilDepthFailOp: d3d11::D3D11_STENCIL_OP_REPLACE,
+                    StencilPassOp: d3d11::D3D11_STENCIL_OP_REPLACE,
+                    StencilFunc: d3d11::D3D11_COMPARISON_ALWAYS,
+                },
+            };
+
+            let hr = unsafe {
+                device.CreateDepthStencilState(
+                    &desc,
+                    &mut depth_stencil_state as *mut *mut _ as *mut *mut _
+                )
+            };
+            assert_eq!(winerror::S_OK, hr);
+
+            desc.DepthEnable = TRUE;
+            desc.StencilEnable = FALSE;
+
+            let hr = unsafe {
+                device.CreateDepthStencilState(
+                    &desc,
+                    &mut depth_state as *mut *mut _ as *mut *mut _
+                )
+            };
+            assert_eq!(winerror::S_OK, hr);
+
+            desc.DepthEnable = FALSE;
+            desc.StencilEnable = TRUE;
+
+            let hr = unsafe {
+                device.CreateDepthStencilState(
+                    &desc,
+                    &mut stencil_state as *mut *mut _ as *mut *mut _
+                )
+            };
+            assert_eq!(winerror::S_OK, hr);
+
+
+            unsafe { (ComPtr::from_raw(depth_stencil_state), ComPtr::from_raw(depth_state), ComPtr::from_raw(stencil_state)) }
         };
 
         let (sampler_nearest, sampler_linear) = {
@@ -249,14 +347,29 @@ impl Internal {
             (unsafe { ComPtr::from_raw(working_buffer) }, working_buffer_size)
         };
 
+        let clear_shaders = include_bytes!("../shaders/clear.hlsl");
         let copy_shaders = include_bytes!("../shaders/copy.hlsl");
         let blit_shaders = include_bytes!("../shaders/blit.hlsl");
 
         Internal {
+            vs_partial_clear: compile_vs(device, clear_shaders, "vs_partial_clear"),
+            ps_partial_clear_float: compile_ps(device, clear_shaders, "ps_partial_clear_float"),
+            ps_partial_clear_uint: compile_ps(device, clear_shaders, "ps_partial_clear_uint"),
+            ps_partial_clear_int: compile_ps(device, clear_shaders, "ps_partial_clear_int"),
+            ps_partial_clear_depth: compile_ps(device, clear_shaders, "ps_partial_clear_depth"),
+            ps_partial_clear_stencil: compile_ps(device, clear_shaders, "ps_partial_clear_stencil"),
+            partial_clear_depth_stencil_state: depth_stencil_state,
+            partial_clear_depth_state: depth_state,
+            partial_clear_stencil_state: stencil_state,
+
             vs_blit_2d: compile_vs(device, blit_shaders, "vs_blit_2d"),
 
             sampler_nearest,
             sampler_linear,
+
+            ps_blit_2d_uint: compile_ps(device, blit_shaders, "ps_blit_2d_uint"),
+            ps_blit_2d_int: compile_ps(device, blit_shaders, "ps_blit_2d_int"),
+            ps_blit_2d_float: compile_ps(device, blit_shaders, "ps_blit_2d_float"),
 
             cs_copy_image2d_r8g8_image2d_r16: compile_cs(device, copy_shaders, "cs_copy_image2d_r8g8_image2d_r16"),
             cs_copy_image2d_r16_image2d_r8g8: compile_cs(device, copy_shaders, "cs_copy_image2d_r16_image2d_r8g8"),
@@ -267,10 +380,6 @@ impl Internal {
             cs_copy_image2d_r16g16_image2d_r8g8b8a8: compile_cs(device, copy_shaders, "cs_copy_image2d_r16g16_image2d_r8g8b8a8"),
             cs_copy_image2d_r32_image2d_r16g16: compile_cs(device, copy_shaders, "cs_copy_image2d_r32_image2d_r16g16"),
             cs_copy_image2d_r32_image2d_r8g8b8a8: compile_cs(device, copy_shaders, "cs_copy_image2d_r32_image2d_r8g8b8a8"),
-
-            ps_blit_2d_uint: compile_ps(device, blit_shaders, "ps_blit_2d_uint"),
-            ps_blit_2d_int: compile_ps(device, blit_shaders, "ps_blit_2d_int"),
-            ps_blit_2d_float: compile_ps(device, blit_shaders, "ps_blit_2d_float"),
 
             cs_copy_image2d_r32g32b32a32_buffer: compile_cs(device, copy_shaders, "cs_copy_image2d_r32g32b32a32_buffer"),
             cs_copy_image2d_r32g32_buffer: compile_cs(device, copy_shaders, "cs_copy_image2d_r32g32_buffer"),
@@ -293,7 +402,7 @@ impl Internal {
             cs_copy_buffer_image2d_r8g8: compile_cs(device, copy_shaders, "cs_copy_buffer_image2d_r8g8"),
             cs_copy_buffer_image2d_r8: compile_cs(device, copy_shaders, "cs_copy_buffer_image2d_r8"),
 
-            copy_info,
+            internal_buffer,
             working_buffer,
             working_buffer_size: working_buffer_size as _
         }
@@ -303,7 +412,7 @@ impl Internal {
         let mut mapped = unsafe { mem::zeroed::<d3d11::D3D11_MAPPED_SUBRESOURCE>() };
         let hr = unsafe {
             context.Map(
-                self.copy_info.as_raw() as _,
+                self.internal_buffer.as_raw() as _,
                 0,
                 d3d11::D3D11_MAP_WRITE_DISCARD,
                 0,
@@ -319,7 +428,7 @@ impl Internal {
     fn unmap(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
         unsafe {
             context.Unmap(
-                self.copy_info.as_raw() as _,
+                self.internal_buffer.as_raw() as _,
                 0,
             );
         }
@@ -337,7 +446,9 @@ impl Internal {
         self.unmap(context);
     }
 
-    fn update_buffer_image(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>, info: &command::BufferImageCopy) {
+    fn update_buffer_image(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>, info: &command::BufferImageCopy, image: &Image) {
+        let size = image.kind.extent();
+
         unsafe { ptr::copy(&BufferImageCopyInfo {
             buffer_image: BufferImageCopy {
                 buffer_offset: info.buffer_offset as _,
@@ -345,6 +456,7 @@ impl Internal {
                 _padding: 0,
                 image_offset: [info.image_offset.x as _, info.image_offset.y as _, (info.image_offset.z + info.image_layers.layers.start as i32) as _, 0],
                 image_extent: [info.image_extent.width, info.image_extent.height, info.image_extent.depth, 0],
+                image_size: [size.width, size.height, size.depth, 0],
             },
             .. mem::zeroed()
         }, self.map(context) as *mut _, 1) };
@@ -387,6 +499,38 @@ impl Internal {
         self.unmap(context);
     }
 
+    fn update_clear_color(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>, clear: command::ClearColor) {
+        match clear {
+            command::ClearColor::Float(value) => {
+                unsafe {
+                    ptr::copy(&PartialClearInfo { data: mem::transmute(value) }, self.map(context) as *mut _, 1)
+                };
+            }
+            command::ClearColor::Uint(value) => {
+                unsafe {
+                    ptr::copy(&PartialClearInfo { data: mem::transmute(value) }, self.map(context) as *mut _, 1)
+                };
+            }
+            command::ClearColor::Int(value) => {
+                unsafe {
+                    ptr::copy(&PartialClearInfo { data: mem::transmute(value) }, self.map(context) as *mut _, 1)
+                };
+            }
+        }
+
+        self.unmap(context);
+    }
+
+    fn update_clear_depth_stencil(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>, depth: Option<f32>, stencil: Option<u32>) {
+        unsafe {
+            ptr::copy(&PartialClearInfo {
+                data: [mem::transmute(depth.unwrap_or(0f32)), stencil.unwrap_or(0), 0, 0]
+            }, self.map(context) as *mut _, 1);
+        }
+
+        self.unmap(context);
+    }
+
     fn find_image_copy_shader(&self, src: &Image, dst: &Image) -> Option<*mut d3d11::ID3D11ComputeShader> {
         use dxgiformat::*;
 
@@ -421,7 +565,7 @@ impl Internal {
 
             unsafe {
                 context.CSSetShader(shader, ptr::null_mut(), 0);
-                context.CSSetConstantBuffers(0, 1, &self.copy_info.as_raw());
+                context.CSSetConstantBuffers(0, 1, &self.internal_buffer.as_raw());
                 context.CSSetShaderResources(0, 1, [srv].as_ptr());
 
 
@@ -451,13 +595,12 @@ impl Internal {
                 // TODO: layer subresources
                 unsafe {
                     context.CopySubresourceRegion(
-
-                        dst.internal.raw as _,
+                        dst.internal.raw.as_raw() as _,
                         src.calc_subresource(info.src_subresource.level as _, 0),
                         info.dst_offset.x as _,
                         info.dst_offset.y as _,
                         info.dst_offset.z as _,
-                        src.internal.raw as _,
+                        src.internal.raw.as_raw() as _,
                         dst.calc_subresource(info.dst_subresource.level as _, 0),
                         &d3d11::D3D11_BOX {
                             left: info.src_offset.x as _,
@@ -473,20 +616,20 @@ impl Internal {
         }
     }
 
-    fn find_image_to_buffer_shader(&self, format: dxgiformat::DXGI_FORMAT) -> Option<(*mut d3d11::ID3D11ComputeShader, f32, f32)> {
+    fn find_image_to_buffer_shader(&self, format: dxgiformat::DXGI_FORMAT) -> Option<(*mut d3d11::ID3D11ComputeShader, u32, u32)> {
         use dxgiformat::*;
 
         match format {
-            DXGI_FORMAT_R32G32B32A32_UINT => Some((self.cs_copy_image2d_r32g32b32a32_buffer.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R32G32_UINT =>       Some((self.cs_copy_image2d_r32g32_buffer.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R16G16B16A16_UINT => Some((self.cs_copy_image2d_r16g16b16a16_buffer.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R32_UINT =>          Some((self.cs_copy_image2d_r32_buffer.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R16G16_UINT =>       Some((self.cs_copy_image2d_r16g16_buffer.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R8G8B8A8_UINT =>     Some((self.cs_copy_image2d_r8g8b8a8_buffer.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R16_UINT =>          Some((self.cs_copy_image2d_r16_buffer.as_raw(), 2f32, 1f32)),
-            DXGI_FORMAT_R8G8_UINT =>         Some((self.cs_copy_image2d_r8g8_buffer.as_raw(), 2f32, 1f32)),
-            DXGI_FORMAT_R8_UINT =>           Some((self.cs_copy_image2d_r8_buffer.as_raw(), 4f32, 1f32)),
-            DXGI_FORMAT_B8G8R8A8_UNORM =>    Some((self.cs_copy_image2d_b8g8r8a8_buffer.as_raw(), 1f32, 1f32)),
+            DXGI_FORMAT_R32G32B32A32_UINT => Some((self.cs_copy_image2d_r32g32b32a32_buffer.as_raw(), 1, 1)),
+            DXGI_FORMAT_R32G32_UINT =>       Some((self.cs_copy_image2d_r32g32_buffer.as_raw(),       1, 1)),
+            DXGI_FORMAT_R16G16B16A16_UINT => Some((self.cs_copy_image2d_r16g16b16a16_buffer.as_raw(), 1, 1)),
+            DXGI_FORMAT_R32_UINT =>          Some((self.cs_copy_image2d_r32_buffer.as_raw(),          1, 1)),
+            DXGI_FORMAT_R16G16_UINT =>       Some((self.cs_copy_image2d_r16g16_buffer.as_raw(),       1, 1)),
+            DXGI_FORMAT_R8G8B8A8_UINT =>     Some((self.cs_copy_image2d_r8g8b8a8_buffer.as_raw(),     1, 1)),
+            DXGI_FORMAT_R16_UINT =>          Some((self.cs_copy_image2d_r16_buffer.as_raw(),          2, 1)),
+            DXGI_FORMAT_R8G8_UINT =>         Some((self.cs_copy_image2d_r8g8_buffer.as_raw(),         2, 1)),
+            DXGI_FORMAT_R8_UINT =>           Some((self.cs_copy_image2d_r8_buffer.as_raw(),           4, 1)),
+            DXGI_FORMAT_B8G8R8A8_UNORM =>    Some((self.cs_copy_image2d_b8g8r8a8_buffer.as_raw(),     1, 1)),
             _ => None
         }
     }
@@ -506,20 +649,20 @@ impl Internal {
 
         unsafe {
             context.CSSetShader(shader, ptr::null_mut(), 0);
-            context.CSSetConstantBuffers(0, 1, &self.copy_info.as_raw());
+            context.CSSetConstantBuffers(0, 1, &self.internal_buffer.as_raw());
 
             context.CSSetShaderResources(0, 1, [srv].as_ptr());
             context.CSSetUnorderedAccessViews(0, 1, [uav].as_ptr(), ptr::null_mut());
 
             for copy in regions {
                 let copy = copy.borrow();
-                self.update_buffer_image(context, &copy);
+                self.update_buffer_image(context, &copy, src);
 
                 debug_marker!(context, "{:?}", copy);
 
                 context.Dispatch(
-                    (copy.image_extent.width as f32 / scale_x) as u32,
-                    (copy.image_extent.height as f32 / scale_y) as u32,
+                    ((copy.image_extent.width + (COPY_THREAD_GROUP_X - 1)) / COPY_THREAD_GROUP_X / scale_x).max(1),
+                    ((copy.image_extent.height + (COPY_THREAD_GROUP_X - 1)) / COPY_THREAD_GROUP_Y / scale_y).max(1),
                     1
                 );
             }
@@ -530,19 +673,19 @@ impl Internal {
         }
     }
 
-    fn find_buffer_to_image_shader(&self, format: dxgiformat::DXGI_FORMAT) -> Option<(*mut d3d11::ID3D11ComputeShader, f32, f32)> {
+    fn find_buffer_to_image_shader(&self, format: dxgiformat::DXGI_FORMAT) -> Option<(*mut d3d11::ID3D11ComputeShader, u32, u32)> {
         use dxgiformat::*;
 
         match format {
-            DXGI_FORMAT_R32G32B32A32_UINT => Some((self.cs_copy_buffer_image2d_r32g32b32a32.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R32G32_UINT =>       Some((self.cs_copy_buffer_image2d_r32g32.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R16G16B16A16_UINT => Some((self.cs_copy_buffer_image2d_r16g16b16a16.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R32_UINT =>          Some((self.cs_copy_buffer_image2d_r32.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R16G16_UINT =>       Some((self.cs_copy_buffer_image2d_r16g16.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R8G8B8A8_UINT =>     Some((self.cs_copy_buffer_image2d_r8g8b8a8.as_raw(), 1f32, 1f32)),
-            DXGI_FORMAT_R16_UINT =>          Some((self.cs_copy_buffer_image2d_r16.as_raw(), 2f32, 1f32)),
-            DXGI_FORMAT_R8G8_UINT =>         Some((self.cs_copy_buffer_image2d_r8g8.as_raw(), 2f32, 1f32)),
-            DXGI_FORMAT_R8_UINT =>           Some((self.cs_copy_buffer_image2d_r8.as_raw(), 4f32, 1f32)),
+            DXGI_FORMAT_R32G32B32A32_UINT => Some((self.cs_copy_buffer_image2d_r32g32b32a32.as_raw(), 1, 1)),
+            DXGI_FORMAT_R32G32_UINT =>       Some((self.cs_copy_buffer_image2d_r32g32.as_raw(),       1, 1)),
+            DXGI_FORMAT_R16G16B16A16_UINT => Some((self.cs_copy_buffer_image2d_r16g16b16a16.as_raw(), 1, 1)),
+            DXGI_FORMAT_R32_UINT =>          Some((self.cs_copy_buffer_image2d_r32.as_raw(),          1, 1)),
+            DXGI_FORMAT_R16G16_UINT =>       Some((self.cs_copy_buffer_image2d_r16g16.as_raw(),       1, 1)),
+            DXGI_FORMAT_R8G8B8A8_UINT =>     Some((self.cs_copy_buffer_image2d_r8g8b8a8.as_raw(),     1, 1)),
+            DXGI_FORMAT_R16_UINT =>          Some((self.cs_copy_buffer_image2d_r16.as_raw(),          2, 1)),
+            DXGI_FORMAT_R8G8_UINT =>         Some((self.cs_copy_buffer_image2d_r8g8.as_raw(),         2, 1)),
+            DXGI_FORMAT_R8_UINT =>           Some((self.cs_copy_buffer_image2d_r8.as_raw(),           4, 1)),
             _ => None
         }
     }
@@ -573,15 +716,15 @@ impl Internal {
 
                 unsafe {
                     context.UpdateSubresource(
-                        dst.internal.raw,
+                        dst.internal.raw.as_raw(),
                         dst.calc_subresource(info.image_layers.level as _, info.image_layers.layers.start as _),
                         &d3d11::D3D11_BOX {
-                            left: info.image_offset.x as _,
-                            top: info.image_offset.y as _,
-                            front: info.image_offset.z as _,
-                            right: info.image_extent.width,
-                            bottom: info.image_extent.height,
-                            back: info.image_extent.depth,
+                            left:   info.image_offset.x as _,
+                            top:    info.image_offset.y as _,
+                            front:  info.image_offset.z as _,
+                            right:  info.image_offset.x as u32 + info.image_extent.width,
+                            bottom: info.image_offset.y as u32 + info.image_extent.height,
+                            back:   info.image_offset.z as u32 + info.image_extent.depth,
                         },
                         src.host_ptr.offset(src.bound_range.start as isize + info.buffer_offset as isize) as _,
                         row_pitch,
@@ -598,13 +741,13 @@ impl Internal {
 
             unsafe {
                 context.CSSetShader(shader, ptr::null_mut(), 0);
-                context.CSSetConstantBuffers(0, 1, &self.copy_info.as_raw());
+                context.CSSetConstantBuffers(0, 1, &self.internal_buffer.as_raw());
                 context.CSSetShaderResources(0, 1, [srv].as_ptr());
 
 
                 for copy in regions {
                     let info = copy.borrow();
-                    self.update_buffer_image(context, &info);
+                    self.update_buffer_image(context, &info, dst);
 
                     debug_marker!(context, "{:?}", info);
 
@@ -617,8 +760,8 @@ impl Internal {
                     context.CSSetUnorderedAccessViews(0, 1, [uav].as_ptr(), ptr::null_mut());
 
                     context.Dispatch(
-                        (info.image_extent.width as f32 / scale_x) as u32,
-                        (info.image_extent.height as f32 / scale_y) as u32,
+                        ((info.image_extent.width + (COPY_THREAD_GROUP_X - 1)) / COPY_THREAD_GROUP_X / scale_x).max(1),
+                        ((info.image_extent.height + (COPY_THREAD_GROUP_X - 1)) / COPY_THREAD_GROUP_Y / scale_y).max(1),
                         1
                     );
                 }
@@ -658,7 +801,7 @@ impl Internal {
         unsafe {
             context.IASetPrimitiveTopology(d3dcommon::D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
             context.VSSetShader(self.vs_blit_2d.as_raw(), ptr::null_mut(), 0);
-            context.VSSetConstantBuffers(0, 1, [self.copy_info.as_raw()].as_ptr());
+            context.VSSetConstantBuffers(0, 1, [self.internal_buffer.as_raw()].as_ptr());
             context.PSSetShader(shader, ptr::null_mut(), 0);
             context.PSSetShaderResources(0, 1, [srv].as_ptr());
             context.PSSetSamplers(0, 1, match filter {
@@ -689,6 +832,126 @@ impl Internal {
 
             context.PSSetShaderResources(0, 1, [ptr::null_mut()].as_ptr());
             context.OMSetRenderTargets(1, [ptr::null_mut()].as_ptr(), ptr::null_mut());
+        }
+    }
+
+    pub fn clear_attachments<T, U>(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>, clears: T, rects: U, cache: &RenderPassCache)
+    where
+        T: IntoIterator,
+        T::Item: Borrow<command::AttachmentClear>,
+        U: IntoIterator,
+        U::Item: Borrow<pso::ClearRect>,
+    {
+        let _scope = debug_scope!(context, "ClearAttachments");
+
+        let clear_rects: SmallVec<[pso::ClearRect; 8]> = rects
+            .into_iter()
+            .map(|rect| rect.borrow().clone())
+            .collect();
+
+        unsafe {
+            context.IASetPrimitiveTopology(d3dcommon::D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+            context.IASetInputLayout(ptr::null_mut());
+            context.VSSetShader(self.vs_partial_clear.as_raw(), ptr::null_mut(), 0);
+            context.PSSetConstantBuffers(0, 1, [self.internal_buffer.as_raw()].as_ptr());
+        }
+
+        let subpass = &cache.render_pass.subpasses[cache.current_subpass];
+
+        for clear in clears {
+            let clear = clear.borrow();
+
+            let _scope = debug_scope!(context, "{:?}", clear);
+
+            match *clear {
+                command::AttachmentClear::Color { index, value } => {
+                    self.update_clear_color(context, value);
+
+                    let attachment = {
+                        let rtv_id = subpass.color_attachments[index];
+                        &cache.framebuffer.attachments[rtv_id.0]
+                    };
+
+                    unsafe {
+                        context.OMSetRenderTargets(1, [attachment.rtv_handle.clone().unwrap().as_raw()].as_ptr(), ptr::null_mut());
+                    }
+
+                    match value {
+                        command::ClearColor::Float(_) => {
+                            unsafe {
+                                context.PSSetShader(self.ps_partial_clear_float.as_raw(), ptr::null_mut(), 0);
+                            }
+                        }
+                        command::ClearColor::Uint(_) => {
+                            unsafe {
+                                context.PSSetShader(self.ps_partial_clear_uint.as_raw(), ptr::null_mut(), 0);
+                            }
+                        }
+                        command::ClearColor::Int(_) => {
+                            unsafe {
+                                context.PSSetShader(self.ps_partial_clear_int.as_raw(), ptr::null_mut(), 0);
+                            }
+                        }
+                    }
+
+                    for clear_rect in &clear_rects {
+                        let viewport = conv::map_viewport(&Viewport {
+                            rect: clear_rect.rect,
+                            depth: 0f32..1f32,
+                        });
+
+                        debug_marker!(context, "{:?}", clear_rect.rect);
+
+                        unsafe {
+                            context.RSSetViewports(1, [viewport].as_ptr());
+                            context.Draw(3, 0);
+                        }
+                    }
+                }
+                command::AttachmentClear::DepthStencil { depth, stencil } => {
+                    self.update_clear_depth_stencil(context, depth, stencil);
+
+                    let attachment = {
+                        let dsv_id = subpass.depth_stencil_attachment.unwrap();
+                        &cache.framebuffer.attachments[dsv_id.0]
+                    };
+
+                    unsafe {
+                        match (depth, stencil) {
+                            (Some(_), Some(stencil)) => {
+                                context.OMSetDepthStencilState(self.partial_clear_depth_stencil_state.as_raw(), stencil);
+                                context.PSSetShader(self.ps_partial_clear_depth.as_raw(), ptr::null_mut(), 0);
+                            },
+
+                            (Some(_), None) => {
+                                context.OMSetDepthStencilState(self.partial_clear_depth_state.as_raw(), 0);
+                                context.PSSetShader(self.ps_partial_clear_depth.as_raw(), ptr::null_mut(), 0);
+                            },
+
+                            (None, Some(stencil)) => {
+                                context.OMSetDepthStencilState(self.partial_clear_stencil_state.as_raw(), stencil);
+                                context.PSSetShader(self.ps_partial_clear_stencil.as_raw(), ptr::null_mut(), 0);
+                            },
+                            (None, None) => {}
+                        }
+
+                        context.OMSetRenderTargets(0, ptr::null_mut(), attachment.dsv_handle.clone().unwrap().as_raw());
+                        context.PSSetShader(self.ps_partial_clear_depth.as_raw(), ptr::null_mut(), 0);
+                    }
+
+                    for clear_rect in &clear_rects {
+                        let viewport = conv::map_viewport(&Viewport {
+                            rect: clear_rect.rect,
+                            depth: 0f32..1f32,
+                        });
+
+                        unsafe {
+                            context.RSSetViewports(1, [viewport].as_ptr());
+                            context.Draw(3, 0);
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -603,12 +603,12 @@ impl Internal {
                         src.internal.raw.as_raw() as _,
                         dst.calc_subresource(info.dst_subresource.level as _, 0),
                         &d3d11::D3D11_BOX {
-                            left: info.src_offset.x as _,
-                            top: info.src_offset.y as _,
-                            front: info.src_offset.z as _,
-                            right: info.extent.width as _,
-                            bottom: info.extent.height as _,
-                            back: info.extent.depth as _,
+                            left:   info.src_offset.x as _,
+                            top:    info.src_offset.y as _,
+                            front:  info.src_offset.z as _,
+                            right:  info.src_offset.x as u32 + info.extent.width as u32,
+                            bottom: info.src_offset.y as u32 + info.extent.height as u32,
+                            back:   info.src_offset.z as u32 + info.extent.depth as u32,
                         }
                     );
                 }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -25,6 +25,8 @@ use hal::{
 use hal::{
     DrawCount, IndexCount, InstanceCount, SwapImageIndex, VertexCount, VertexOffset, WorkGroupCount,
 };
+use hal::format::ChannelType;
+use hal::command::{ClearColor, ClearColorRaw};
 
 use range_alloc::RangeAllocator;
 
@@ -90,8 +92,8 @@ mod shader;
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
 pub(crate) struct ViewInfo {
-    #[derivative(Debug = "ignore")]
-    resource: *mut d3d11::ID3D11Resource,
+    #[derivative(Debug="ignore")]
+    resource: ComPtr<d3d11::ID3D11Resource>,
     kind: image::Kind,
     flags: image::StorageFlags,
     view_kind: image::ViewKind,
@@ -317,13 +319,11 @@ impl hal::Instance for Instance {
                         heap_index: 0,
                     },
                     hal::MemoryType {
-                        properties: Properties::CPU_VISIBLE | Properties::CPU_CACHED,
+                        properties: Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
                         heap_index: 1,
                     },
                     hal::MemoryType {
-                        properties: Properties::CPU_VISIBLE
-                            | Properties::COHERENT
-                            | Properties::CPU_CACHED,
+                        properties: Properties::CPU_VISIBLE | Properties::CPU_CACHED,
                         heap_index: 1,
                     },
                 ],
@@ -819,26 +819,37 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
 
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]
-struct AttachmentClear {
+pub struct AttachmentClear {
     subpass_id: Option<pass::SubpassId>,
-    value: Option<command::ClearValueRaw>,
-    stencil_value: Option<u32>,
+    attachment_id: usize,
+    raw: command::AttachmentClear,
 }
 
 #[derive(Debug, Clone)]
-struct RenderPassCache {
-    render_pass: RenderPass,
-    framebuffer: Framebuffer,
-    attachment_clear_values: Vec<AttachmentClear>,
-    current_subpass: usize,
+pub struct RenderPassCache {
+    pub render_pass: RenderPass,
+    pub framebuffer: Framebuffer,
+    pub attachment_clear_values: Vec<AttachmentClear>,
+    pub target_rect: pso::Rect,
+    pub current_subpass: usize,
 }
 
 impl RenderPassCache {
-    pub fn advance_subpass(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
-        let subpass = &self.render_pass.subpasses[self.current_subpass];
+    pub fn start_subpass(&mut self, internal: &mut internal::Internal, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
+        let attachments = self.attachment_clear_values.iter().filter(|clear| clear.subpass_id == Some(self.current_subpass)).map(|clear| clear.raw);
 
-        let color_views = subpass
-            .color_attachments
+        internal.clear_attachments(
+            context,
+            attachments,
+            &[pso::ClearRect {
+                rect: self.target_rect,
+                layers: 0..1
+            }],
+            &self
+        );
+
+        let subpass = &self.render_pass.subpasses[self.current_subpass];
+        let color_views = subpass.color_attachments
             .iter()
             .map(|&(id, _)| {
                 self.framebuffer.attachments[id]
@@ -862,12 +873,7 @@ impl RenderPassCache {
         }
 
         // performs clears for all the attachments first used in this subpass
-        for (view, clear) in self
-            .framebuffer
-            .attachments
-            .iter()
-            .zip(self.attachment_clear_values.iter())
-        {
+/*        for (view, clear) in self.framebuffer.attachments.iter().zip(self.attachment_clear_values.iter()) {
             if clear.subpass_id != Some(self.current_subpass) {
                 continue;
             }
@@ -901,8 +907,10 @@ impl RenderPassCache {
                     context.ClearDepthStencilView(handle.as_raw(), flags, depth, stencil);
                 }
             }
-        }
+        }*/
+    }
 
+    pub fn next_subpass(&mut self) {
         self.current_subpass += 1;
     }
 }
@@ -941,6 +949,11 @@ pub struct CommandBuffer {
     vertex_buffers: Vec<*mut d3d11::ID3D11Buffer>,
     vertex_offsets: Vec<u32>,
     vertex_strides: Vec<u32>,
+    blend_factor: Option<[f32; 4]>,
+    // we can only support one face (rather, both faces must have the same value)
+    stencil_ref: Option<pso::StencilValue>,
+    stencil_read_mask: Option<pso::StencilValue>,
+    stencil_write_mask: Option<pso::StencilValue>,
 }
 
 unsafe impl Send for CommandBuffer {}
@@ -966,6 +979,10 @@ impl CommandBuffer {
             vertex_buffers: Vec::new(),
             vertex_offsets: Vec::new(),
             vertex_strides: Vec::new(),
+            blend_factor: None,
+            stencil_ref: None,
+            stencil_read_mask: None,
+            stencil_write_mask: None,
         }
     }
 
@@ -1117,24 +1134,41 @@ impl CommandBuffer {
     }
 
     fn defer_coherent_flush(&mut self, buffer: &Buffer) {
-        self.flush_coherent_memory.push(MemoryFlush {
-            host_memory: buffer.host_ptr,
-            sync_range: SyncRange::Whole,
-
-            buffer: buffer.internal.raw,
-        });
+        if !self.flush_coherent_memory.iter().any(|m| m.buffer == buffer.internal.raw) {
+            self.flush_coherent_memory.push(MemoryFlush {
+                host_memory: buffer.host_ptr,
+                sync_range: SyncRange::Whole,
+                buffer: buffer.internal.raw
+            });
+        }
     }
 
     fn defer_coherent_invalidate(&mut self, buffer: &Buffer) {
-        self.invalidate_coherent_memory.push(MemoryInvalidate {
-            working_buffer: Some(self.internal.working_buffer.clone()),
-            working_buffer_size: self.internal.working_buffer_size,
+        if !self.invalidate_coherent_memory.iter().any(|m| m.buffer == buffer.internal.raw) {
+            self.invalidate_coherent_memory.push(MemoryInvalidate {
+                working_buffer: Some(self.internal.working_buffer.clone()),
+                working_buffer_size: self.internal.working_buffer_size,
+                host_memory: buffer.host_ptr,
+                sync_range: buffer.bound_range.clone(),
+                buffer: buffer.internal.raw
+            });
+        }
+    }
 
-            host_memory: buffer.host_ptr,
-            sync_range: buffer.bound_range.clone(),
-
-            buffer: buffer.internal.raw,
-        });
+    fn reset(&mut self) {
+        self.flush_coherent_memory.clear();
+        self.invalidate_coherent_memory.clear();
+        self.render_pass_cache = None;
+        self.bound_bindings = 0;
+        self.required_bindings = None;
+        self.max_bindings = None;
+        self.vertex_buffers.clear();
+        self.vertex_offsets.clear();
+        self.vertex_strides.clear();
+        self.blend_factor = None;
+        self.stencil_ref = None;
+        self.stencil_read_mask = None;
+        self.stencil_write_mask = None;
     }
 }
 
@@ -1142,8 +1176,9 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     fn begin(
         &mut self,
         _flags: command::CommandBufferFlags,
-        _info: command::CommandBufferInheritanceInfo<Backend>,
+        _info: command::CommandBufferInheritanceInfo<Backend>
     ) {
+        self.reset();
     }
 
     fn finish(&mut self) {
@@ -1160,22 +1195,14 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     fn reset(&mut self, _release_resources: bool) {
-        self.flush_coherent_memory.clear();
-        self.invalidate_coherent_memory.clear();
-        self.render_pass_cache = None;
-        self.bound_bindings = 0;
-        self.required_bindings = None;
-        self.max_bindings = None;
-        self.vertex_buffers.clear();
-        self.vertex_offsets.clear();
-        self.vertex_strides.clear();
+        self.reset();
     }
 
     fn begin_render_pass<T>(
         &mut self,
         render_pass: &RenderPass,
         framebuffer: &Framebuffer,
-        _target_rect: pso::Rect,
+        target_rect: pso::Rect,
         clear_values: T,
         _first_subpass: command::SubpassContents,
     ) where
@@ -1183,56 +1210,128 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         T::Item: Borrow<command::ClearValueRaw>,
     {
         let mut clear_iter = clear_values.into_iter();
-        let attachment_clears = render_pass
-            .attachments
-            .iter()
-            .enumerate()
-            .map(|(i, attachment)| {
-                let cv = if attachment.ops.load == pass::AttachmentLoadOp::Clear
-                    || attachment.stencil_ops.load == pass::AttachmentLoadOp::Clear
-                {
-                    Some(*clear_iter.next().unwrap().borrow())
-                } else {
-                    None
-                };
+        let mut attachment_clears = Vec::new();
 
-                AttachmentClear {
-                    subpass_id: render_pass.subpasses.iter().position(|sp| sp.is_using(i)),
-                    value: if attachment.ops.load == pass::AttachmentLoadOp::Clear {
-                        assert!(cv.is_some());
-                        cv
-                    } else {
-                        None
-                    },
-                    stencil_value: if attachment.stencil_ops.load == pass::AttachmentLoadOp::Clear {
-                        Some(unsafe { cv.unwrap().depth_stencil.stencil })
-                    } else {
-                        None
-                    },
+        for (idx, attachment) in render_pass.attachments.iter().enumerate() {
+            use pass::AttachmentLoadOp::*;
+
+            //let attachment = render_pass.attachments[attachment_ref];
+            let format = attachment.format.unwrap();
+            let channel_type = format.base_format().1;
+
+            fn typed_clear_color(ty: ChannelType, raw_clear: ClearColorRaw) -> ClearColor {
+
+                match ty {
+                    ChannelType::Unorm | ChannelType::Inorm | ChannelType::Ufloat |
+                    ChannelType::Float | ChannelType::Uscaled | ChannelType::Iscaled |
+                    ChannelType::Srgb => ClearColor::Float(unsafe { raw_clear.float32}),
+
+                    ChannelType::Uint => ClearColor::Uint(unsafe { raw_clear.uint32}),
+
+                    ChannelType::Int => ClearColor::Int(unsafe { raw_clear.int32}),
                 }
-            })
-            .collect();
+            }
+
+            let subpass_id = render_pass.subpasses.iter().position(|sp| sp.is_using(idx));
+
+            if attachment.ops.load == Clear ||
+               attachment.stencil_ops.load == Clear
+            {
+                let raw_clear_value = *clear_iter.next().unwrap().borrow();
+
+                match (attachment.ops.load, attachment.stencil_ops.load) {
+                    (Clear, Clear) => {
+                        if format.is_depth() {
+                            attachment_clears.push(AttachmentClear {
+                                subpass_id,
+                                attachment_id: idx,
+                                raw: command::AttachmentClear::DepthStencil {
+                                    depth: Some(unsafe { raw_clear_value.depth_stencil.depth }),
+                                    stencil: Some(unsafe { raw_clear_value.depth_stencil.stencil }),
+                                }
+                            });
+                        } else {
+                            attachment_clears.push(AttachmentClear {
+                                subpass_id,
+                                attachment_id: idx,
+                                raw: command::AttachmentClear::Color {
+                                    index: idx,
+                                    value: typed_clear_color(channel_type, unsafe { raw_clear_value.color }),
+                                }
+                            });
+
+                            attachment_clears.push(AttachmentClear {
+                                subpass_id,
+                                attachment_id: idx,
+                                raw: command::AttachmentClear::DepthStencil {
+                                    depth: None,
+                                    stencil: Some(unsafe { raw_clear_value.depth_stencil.stencil }),
+                                }
+                            });
+                        }
+                    },
+                    (Clear, _) => {
+                        if format.is_depth() {
+                            attachment_clears.push(AttachmentClear {
+                                subpass_id,
+                                attachment_id: idx,
+                                raw: command::AttachmentClear::DepthStencil {
+                                    depth: Some(unsafe { raw_clear_value.depth_stencil.depth }),
+                                    stencil: None,
+                                }
+                            });
+                        } else {
+                            attachment_clears.push(AttachmentClear {
+                                subpass_id,
+                                attachment_id: idx,
+                                raw: command::AttachmentClear::Color {
+                                    index: idx,
+                                    value: typed_clear_color(channel_type, unsafe { raw_clear_value.color }),
+                                }
+                            });
+                        }
+                    },
+                    (_, Clear) => {
+                        attachment_clears.push(AttachmentClear {
+                            subpass_id,
+                            attachment_id: idx,
+                            raw: command::AttachmentClear::DepthStencil {
+                                depth: None,
+                                stencil: Some(unsafe { raw_clear_value.depth_stencil.stencil }),
+                            }
+                        });
+                    },
+                    _ => {},
+                }
+            }
+        }
 
         self.render_pass_cache = Some(RenderPassCache {
             render_pass: render_pass.clone(),
             framebuffer: framebuffer.clone(),
             attachment_clear_values: attachment_clears,
+            target_rect,
             current_subpass: 0,
         });
 
         if let Some(ref mut current_render_pass) = self.render_pass_cache {
-            current_render_pass.advance_subpass(&self.context);
+            current_render_pass.start_subpass(&mut self.internal, &self.context);
         }
     }
 
     fn next_subpass(&mut self, _contents: command::SubpassContents) {
         if let Some(ref mut current_render_pass) = self.render_pass_cache {
             // TODO: resolve msaa
-            current_render_pass.advance_subpass(&self.context);
+            current_render_pass.next_subpass();
+            current_render_pass.start_subpass(&mut self.internal, &self.context);
         }
     }
 
     fn end_render_pass(&mut self) {
+        unsafe {
+            self.context.OMSetRenderTargets(8, [ptr::null_mut(); 8].as_ptr(), ptr::null_mut());
+        }
+
         self.render_pass_cache = None;
     }
 
@@ -1263,6 +1362,7 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         for range in subresource_ranges {
             let range = range.borrow();
 
+            // TODO: clear Int/Uint depending on format
             if range.aspects.contains(format::Aspects::COLOR) {
                 for layer in range.layers.clone() {
                     for level in range.levels.clone() {
@@ -1302,14 +1402,18 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn clear_attachments<T, U>(&mut self, _clears: T, _rects: U)
+    fn clear_attachments<T, U>(&mut self, clears: T, rects: U)
     where
         T: IntoIterator,
         T::Item: Borrow<command::AttachmentClear>,
         U: IntoIterator,
         U::Item: Borrow<pso::ClearRect>,
     {
-        // unimplemented!()
+        if let Some(ref pass) = self.render_pass_cache {
+            self.internal.clear_attachments(&self.context, clears, rects, pass);
+        } else {
+            panic!("`clear_attachments` can only be called inside a renderpass")
+        }
     }
 
     fn resolve_image<T>(
@@ -1425,20 +1529,20 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn set_blend_constants(&mut self, _color: pso::ColorValue) {
-        // unimplemented!()
+    fn set_blend_constants(&mut self, color: pso::ColorValue) {
+        self.blend_factor = Some(color);
     }
 
-    fn set_stencil_reference(&mut self, _faces: pso::Face, _value: pso::StencilValue) {
-        // unimplemented!()
+    fn set_stencil_reference(&mut self, _faces: pso::Face, value: pso::StencilValue) {
+        self.stencil_ref = Some(value);
     }
 
-    fn set_stencil_read_mask(&mut self, _faces: pso::Face, _value: pso::StencilValue) {
-        // unimplemented!();
+    fn set_stencil_read_mask(&mut self, _faces: pso::Face, value: pso::StencilValue) {
+        self.stencil_read_mask = Some(value);
     }
 
-    fn set_stencil_write_mask(&mut self, _faces: pso::Face, _value: pso::StencilValue) {
-        // unimplemented!();
+    fn set_stencil_write_mask(&mut self, _faces: pso::Face, value: pso::StencilValue) {
+        self.stencil_write_mask = Some(value);
     }
 
     fn set_depth_bounds(&mut self, _bounds: Range<f32>) {
@@ -1473,6 +1577,15 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
             if let Some(ref ps) = pipeline.ps {
                 self.context.PSSetShader(ps.as_raw(), ptr::null_mut(), 0);
             }
+            if let Some(ref gs) = pipeline.gs {
+                self.context.GSSetShader(gs.as_raw(), ptr::null_mut(), 0);
+            }
+            if let Some(ref hs) = pipeline.hs {
+                self.context.HSSetShader(hs.as_raw(), ptr::null_mut(), 0);
+            }
+            if let Some(ref ds) = pipeline.ds {
+                self.context.DSSetShader(ds.as_raw(), ptr::null_mut(), 0);
+            }
 
             self.context.RSSetState(pipeline.rasterizer_state.as_raw());
             if let Some(ref viewport) = pipeline.baked_states.viewport {
@@ -1484,17 +1597,15 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
                     .RSSetScissorRects(1, [conv::map_rect(&scissor)].as_ptr());
             }
 
-            let blend_color = pipeline.baked_states.blend_color.unwrap_or([1f32; 4]);
+            let blend_color = pipeline.baked_states.blend_color.or(self.blend_factor).unwrap_or([0f32; 4]);
 
-            // TODO: blend constants
-            self.context
-                .OMSetBlendState(pipeline.blend_state.as_raw(), &blend_color, !0);
+            // TODO: MSAA
+            self.context.OMSetBlendState(pipeline.blend_state.as_raw(), &blend_color, !0);
             if let Some((ref state, reference)) = pipeline.depth_stencil_state {
                 let stencil_ref = if let pso::State::Static(reference) = reference {
                     reference
                 } else {
-                    0
-                    // unimplemented!()
+                    self.stencil_ref.unwrap_or(0)
                 };
 
                 self.context
@@ -1873,9 +1984,9 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
 
 bitflags! {
     struct MemoryHeapFlags: u64 {
-        const DEVICE_LOCAL = 1 << 0;
-        const HOST_NONCOHERENT = 1 << 1;
-        const HOST_COHERENT = 1 << 2;
+        const DEVICE_LOCAL = 0x1;
+        const HOST_NONCOHERENT = 0x4 | 0x8;
+        const HOST_COHERENT = 0x2 | 0x4 | 0x8;
     }
 }
 
@@ -2048,7 +2159,7 @@ pub struct Memory {
     properties: memory::Properties,
     size: u64,
 
-    mapped_ptr: RefCell<Option<*mut u8>>,
+    mapped_ptr: *mut u8,
 
     // staging buffer covering the whole memory region, if it's HOST_VISIBLE
     host_visible: Option<RefCell<Vec<u8>>>,
@@ -2079,7 +2190,7 @@ impl Memory {
 
         for &(ref buffer_range, ref buffer) in self.local_buffers.borrow().iter() {
             if let Some(range) = intersection(&range, &buffer_range) {
-                let ptr = self.mapped_ptr.borrow().unwrap();
+                let ptr = self.mapped_ptr;
 
                 // we need to handle 3 cases for updating buffers:
                 //
@@ -2140,7 +2251,7 @@ impl Memory {
                 MemoryInvalidate {
                     working_buffer: Some(working_buffer.clone()),
                     working_buffer_size,
-                    host_memory: self.mapped_ptr.borrow().unwrap(),
+                    host_memory: self.mapped_ptr,
                     sync_range: range.clone(),
                     buffer: buffer.raw,
                 }.do_invalidate(&context);
@@ -2287,9 +2398,9 @@ pub struct Image {
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct InternalImage {
-    #[derivative(Debug = "ignore")]
-    raw: *mut d3d11::ID3D11Resource,
-    #[derivative(Debug = "ignore")]
+    #[derivative(Debug="ignore")]
+    raw: ComPtr<d3d11::ID3D11Resource>,
+    #[derivative(Debug="ignore")]
     copy_srv: Option<ComPtr<d3d11::ID3D11ShaderResourceView>>,
     #[derivative(Debug = "ignore")]
     srv: Option<ComPtr<d3d11::ID3D11ShaderResourceView>>,
@@ -2349,7 +2460,8 @@ impl Image {
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub struct ImageView {
-    #[derivative(Debug = "ignore")]
+    format: format::Format,
+    #[derivative(Debug="ignore")]
     rtv_handle: Option<ComPtr<d3d11::ID3D11RenderTargetView>>,
     #[derivative(Debug = "ignore")]
     srv_handle: Option<ComPtr<d3d11::ID3D11ShaderResourceView>>,
@@ -2390,10 +2502,15 @@ unsafe impl Sync for ComputePipeline {}
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct GraphicsPipeline {
-    // TODO: gs, hs, ds
-    #[derivative(Debug = "ignore")]
+    #[derivative(Debug="ignore")]
     vs: ComPtr<d3d11::ID3D11VertexShader>,
-    #[derivative(Debug = "ignore")]
+    #[derivative(Debug="ignore")]
+    gs: Option<ComPtr<d3d11::ID3D11GeometryShader>>,
+    #[derivative(Debug="ignore")]
+    hs: Option<ComPtr<d3d11::ID3D11HullShader>>,
+    #[derivative(Debug="ignore")]
+    ds: Option<ComPtr<d3d11::ID3D11DomainShader>>,
+    #[derivative(Debug="ignore")]
     ps: Option<ComPtr<d3d11::ID3D11PixelShader>>,
     #[derivative(Debug = "ignore")]
     topology: d3d11::D3D11_PRIMITIVE_TOPOLOGY,


### PR DESCRIPTION
Implemented partial attachment clears with some internal shaders & depth stencil state.

Also some other small(er) fixes:

* Add Geometry & Tessellation shaders to pipeline
* Add D1/D1Array creation
* Image & buffer binding resources are now initialized to the memory contents
* Copy shaders now work in 8x8 thread groups and have bounds checking
* The memory type order has been switched (coherent comes before non-coherent)

r? @kvark 

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
