### PR TITLE
Updated SwapchainConfig logic

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1,7 +1,7 @@
 use hal;
 use hal::queue::QueueFamilyId;
 use hal::range::RangeArg;
-use hal::{buffer, device, error, format, image, mapping, memory, pass, pool, pso, query, window};
+use hal::{buffer, device, error, format, image, mapping, memory, pass, pool, pso, query};
 
 use winapi::Interface;
 use winapi::shared::dxgi::{IDXGISwapChain, DXGI_SWAP_CHAIN_DESC, DXGI_SWAP_EFFECT_DISCARD};
@@ -1986,7 +1986,6 @@ impl hal::Device<Backend> for Device {
         surface: &mut Surface,
         config: hal::SwapchainConfig,
         _old_swapchain: Option<Swapchain>,
-        _extent: &window::Extent2D,
     ) -> (Swapchain, hal::Backbuffer<Backend>) {
         // TODO: use IDXGIFactory2 for >=11.1
         // TODO: this function should be able to fail (Result)?
@@ -1998,13 +1997,13 @@ impl hal::Device<Backend> for Device {
         let (non_srgb_format, format) = {
             // NOTE: DXGI doesn't allow sRGB format on the swapchain, but
             //       creating RTV of swapchain buffers with sRGB works
-            let format = match config.color_format {
+            let format = match config.format {
                 format::Format::Bgra8Srgb => format::Format::Bgra8Unorm,
                 format::Format::Rgba8Srgb => format::Format::Rgba8Unorm,
                 format => format,
             };
 
-            (map_format(format).unwrap(), map_format(config.color_format).unwrap())
+            (map_format(format).unwrap(), map_format(config.format).unwrap())
         };
         let decomposed = conv::DecomposedDxgiFormat::from_dxgi_format(format);
 
@@ -2103,7 +2102,7 @@ impl hal::Device<Backend> for Device {
             Image {
                 kind,
                 usage: config.image_usage,
-                format: config.color_format,
+                format: config.format,
                 storage_flags: image::StorageFlags::empty(),
                 // NOTE: not the actual format of the backbuffer(s)
                 decomposed_format: decomposed.clone(),

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -7,7 +7,7 @@ use std::borrow::Borrow;
 use std::ops::Range;
 use hal::{
     buffer, command, device, error, format, image, mapping,
-    memory, pass, pool, pso, query, queue, window
+    memory, pass, pool, pso, query, queue
 };
 use hal::range::RangeArg;
 
@@ -376,7 +376,6 @@ impl hal::Device<Backend> for Device {
         _: &mut Surface,
         _: hal::SwapchainConfig,
         _: Option<Swapchain>,
-        _: &window::Extent2D,
     ) -> (Swapchain, hal::Backbuffer<Backend>) {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use gl;
 use gl::types::{GLint, GLenum, GLfloat};
 
-use hal::{self as c, device as d, error, image as i, memory, pass, pso, buffer, mapping, query, window};
+use hal::{self as c, device as d, error, image as i, memory, pass, pso, buffer, mapping, query};
 use hal::backend::FastHashMap;
 use hal::format::{ChannelType, Format, Swizzle};
 use hal::pool::CommandPoolCreateFlags;
@@ -1409,7 +1409,6 @@ impl d::Device<B> for Device {
         surface: &mut Surface,
         config: c::SwapchainConfig,
         _old_swapchain: Option<Swapchain>,
-        _extent: &window::Extent2D,
     ) -> (Swapchain, c::Backbuffer<B>) {
         self.create_swapchain_impl(surface, config)
     }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::{cmp, mem, slice, thread, time};
 
-use hal::{self, error, image, pass, format, mapping, memory, buffer, pso, query, window};
+use hal::{self, error, image, pass, format, mapping, memory, buffer, pso, query};
 use hal::device::{BindError, OutOfMemory, FramebufferError, ShaderError};
 use hal::memory::Properties;
 use hal::pool::CommandPoolCreateFlags;
@@ -2134,7 +2134,6 @@ impl hal::Device<Backend> for Device {
         surface: &mut Surface,
         config: hal::SwapchainConfig,
         old_swapchain: Option<Swapchain>,
-        _extent: &window::Extent2D,
     ) -> (Swapchain, hal::Backbuffer<Backend>) {
         if let Some(_swapchain) = old_swapchain {
             //swapchain is dropped here

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -3,7 +3,7 @@ use ash::extensions as ext;
 use ash::version::DeviceV1_0;
 use smallvec::SmallVec;
 
-use hal::{buffer, device as d, format, image, mapping, pass, pso, query, queue, window};
+use hal::{buffer, device as d, format, image, mapping, pass, pso, query, queue};
 use hal::{Backbuffer, Features, MemoryTypeId, SwapchainConfig};
 use hal::error::HostExecutionError;
 use hal::memory::Requirements;
@@ -1506,21 +1506,17 @@ impl d::Device<B> for Device {
         surface: &mut w::Surface,
         config: SwapchainConfig,
         provided_old_swapchain: Option<w::Swapchain>,
-        extent: &window::Extent2D,
     ) -> (w::Swapchain, Backbuffer<B>) {
         let functor = ext::Swapchain::new(&surface.raw.instance.0, &self.raw.0)
             .expect("Unable to query swapchain function");
-
-        // TODO: handle depth stencil
-        let format = config.color_format;
 
         let old_swapchain = match provided_old_swapchain {
             Some(osc) => osc.raw,
             None => vk::SwapchainKHR::null(),
         };
 
-        surface.width = extent.width;
-        surface.height = extent.height;
+        surface.width = config.extent.width;
+        surface.height = config.extent.height;
 
         let info = vk::SwapchainCreateInfoKHR {
             s_type: vk::StructureType::SwapchainCreateInfoKhr,
@@ -1528,7 +1524,7 @@ impl d::Device<B> for Device {
             flags: vk::SwapchainCreateFlagsKHR::empty(),
             surface: surface.raw.handle,
             min_image_count: config.image_count,
-            image_format: conv::map_format(format),
+            image_format: conv::map_format(config.format),
             image_color_space: vk::ColorSpaceKHR::SrgbNonlinear,
             image_extent: vk::Extent2D {
                 width: surface.width,

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -310,7 +310,7 @@ impl hal::Surface<Backend> for Surface {
 
         // `0xFFFFFFFF` indicates that the extent depends on the created swapchain.
         let current_extent =
-            if caps.current_extent.width != 0xFFFFFFFF && caps.current_extent.height != 0xFFFFFFFF {
+            if caps.current_extent.width != !0 && caps.current_extent.height != !0 {
                 Some(hal::window::Extent2D {
                     width: caps.current_extent.width,
                     height: caps.current_extent.height,

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -17,7 +17,7 @@ use std::borrow::Borrow;
 use std::error::Error;
 use std::ops::Range;
 
-use {buffer, format, image, mapping, pass, pso, query, window};
+use {buffer, format, image, mapping, pass, pso, query};
 use {Backend, MemoryTypeId};
 
 use error::HostExecutionError;
@@ -645,9 +645,8 @@ pub trait Device<B: Backend>: Any + Send + Sync {
     ///
     /// # let mut surface: empty::Surface = return;
     /// # let device: empty::Device = return;
-    /// # let extent = gfx_hal::window::Extent2D {width: 0, height: 0} ;
-    /// let swapchain_config = SwapchainConfig::new().with_color(Format::Rgba8Srgb);
-    /// device.create_swapchain(&mut surface, swapchain_config, None, &extent);
+    /// let swapchain_config = SwapchainConfig::new(100, 100, Format::Rgba8Srgb, 2);
+    /// device.create_swapchain(&mut surface, swapchain_config, None);
     /// # }
     /// ```
     fn create_swapchain(
@@ -655,7 +654,6 @@ pub trait Device<B: Backend>: Any + Send + Sync {
         surface: &mut B::Surface,
         config: SwapchainConfig,
         old_swapchain: Option<B::Swapchain>,
-        extent: &window::Extent2D,
     ) -> (B::Swapchain, Backbuffer<B>);
 
     ///


### PR DESCRIPTION
Fixes #2322
Addresses the Metal part of #2291

The PR changes our swapchain configuration to reflect the capabilities better and be constructed from it.

It also removes the earlier hack in Metal backend  w.r.t. applying the hiDPI factor, rewriting the logic of how `CAMetalLayer` is created and configured. Now, it's logical and physical spaces strongly correspond to the underlying view. It respects the given extents not by changing the layer, but by configuring the images (drawables) produced from it.
Most importantly, the render space matches *logical* space of the layer. This means that if we have a window of size 1440x900 with hiDPI scale of 2.0, then it will behave as if it's a 1440x900 window and report size and create drawables accordingly. The scaling/stretching is left for the window system to apply. This works for both our examples and Dota. Ultimately, we don't want to be processing more pixels just because our hiDPI is high.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
