### PR TITLE
Surface usage flags

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -658,6 +658,7 @@ impl hal::Surface<Backend> for Surface {
             current_extent: Some(extent),
             extents: extent..extent,
             max_image_layers: 1,
+            usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
         };
 
         let formats = vec![

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -75,6 +75,7 @@ impl hal::Surface<Backend> for Surface {
             current_extent: Some(extent),
             extents: extent..extent,
             max_image_layers: 1,
+            usage: i::Usage::COLOR_ATTACHMENT | i::Usage::TRANSFER_SRC,
         };
 
         // Sticking to FLIP swap effects for the moment.

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -138,6 +138,7 @@ impl hal::Surface<B> for Surface {
                 height: ex.height + 1,
             },
             max_image_layers: 1,
+            usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
         };
         let present_modes = vec![hal::PresentMode::Fifo]; //TODO
 

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -3466,22 +3466,22 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn push_graphics_constants(
         &mut self,
-        _layout: &native::PipelineLayout,
+        layout: &native::PipelineLayout,
         stages: pso::ShaderStageFlags,
         offset: u32,
         constants: &[u32],
     ) {
         self.state.update_push_constants(offset, constants);
-        let id = self.shared.push_constants_buffer_id;
-
         if stages.intersects(pso::ShaderStageFlags::GRAPHICS) {
             let mut inner = self.inner.borrow_mut();
             let mut pre = inner.sink().pre_render();
             // Note: the whole range is re-uploaded, which may be inefficient
             if stages.contains(pso::ShaderStageFlags::VERTEX) {
+                let id = layout.push_constant_buffer_index.vs.unwrap();
                 pre.issue(self.state.push_vs_constants(id));
             }
             if stages.contains(pso::ShaderStageFlags::FRAGMENT) {
+                let id = layout.push_constant_buffer_index.ps.unwrap();
                 pre.issue(self.state.push_ps_constants(id));
             }
         }
@@ -3489,12 +3489,12 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn push_compute_constants(
         &mut self,
-        _layout: &native::PipelineLayout,
+        layout: &native::PipelineLayout,
         offset: u32,
         constants: &[u32],
     ) {
         self.state.update_push_constants(offset, constants);
-        let id = self.shared.push_constants_buffer_id;
+        let id = layout.push_constant_buffer_index.cs.unwrap();
 
         // Note: the whole range is re-uploaded, which may be inefficient
         self.inner

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -84,7 +84,6 @@ struct Shared {
     device: Mutex<metal::Device>,
     queue: Mutex<command::QueueInner>,
     service_pipes: internal::ServicePipes,
-    push_constants_buffer_id: ResourceIndex,
     disabilities: PrivateDisabilities,
 }
 
@@ -97,7 +96,6 @@ impl Shared {
         Shared {
             queue: Mutex::new(command::QueueInner::new(&device, Some(MAX_ACTIVE_COMMAND_BUFFERS))),
             service_pipes: internal::ServicePipes::new(&device),
-            push_constants_buffer_id: 30,
             disabilities: PrivateDisabilities {
                 broken_viewport_near_depth: device.name().starts_with("Intel") &&
                     !device.supports_feature_set(feature_macos_10_14),

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -236,6 +236,7 @@ pub struct PipelineLayout {
     pub(crate) shader_compiler_options_point: msl::CompilerOptions,
     pub(crate) infos: Vec<DescriptorSetInfo>,
     pub(crate) total: MultiStageResourceCounters,
+    pub(crate) push_constant_buffer_index: MultiStageData<Option<ResourceIndex>>,
 }
 
 impl PipelineLayout {

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -186,6 +186,7 @@ impl hal::Surface<Backend> for Surface {
             current_extent,
             extents: Extent2D { width: 4, height: 4} .. Extent2D { width: 4096, height: 4096 },
             max_image_layers: 1,
+            usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
         };
 
         let formats = vec![

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -181,6 +181,11 @@ pub fn map_image_usage(usage: image::Usage) -> vk::ImageUsageFlags {
     unsafe { mem::transmute(usage) }
 }
 
+pub fn map_vk_image_usage(usage: vk::ImageUsageFlags) -> image::Usage {
+    // Safe due to equivalence of HAL values and Vulkan values
+    unsafe { mem::transmute(usage) }
+}
+
 pub fn map_descriptor_type(ty: pso::DescriptorType) -> vk::DescriptorType {
     // enums have to match exactly
     unsafe { mem::transmute(ty) }

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -334,6 +334,7 @@ impl hal::Surface<Backend> for Surface {
             current_extent,
             extents: min_extent..max_extent,
             max_image_layers: caps.max_image_array_layers as _,
+            usage: conv::map_vk_image_usage(caps.supported_usage_flags),
         };
 
         // Swapchain formats

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -116,6 +116,9 @@ pub struct SurfaceCapabilities {
     ///
     /// Must be at least 1.
     pub max_image_layers: image::Layer,
+
+    /// Supported image usage flags.
+    pub usage: image::Usage,
 }
 
 /// A `Surface` abstracts the surface of a native window, which will be presented


### PR DESCRIPTION
Fixes  #1908

Also refactors Metal's logic for assigning the push constant IDs. I believe the new method is less hacky.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
