### PR TITLE
[pre-ll/GL] query current front/back buffer for reading

### DIFF
--- a/examples/gamma/main.rs
+++ b/examples/gamma/main.rs
@@ -86,9 +86,6 @@ pub fn main() {
     };
 
     let mut screenshot = false;
-    let (w, h, _, _) = data.out.get_dimensions();
-    let mut download = factory.create_download_buffer::<SurfaceData>(w as usize * h as usize)
-        .unwrap();
 
     let mut running = true;
     while running {
@@ -108,11 +105,6 @@ pub fn main() {
                     WindowEvent::Resized(size) => {
                         window.resize(size.to_physical(window.get_hidpi_factor()));
                         gfx_window_glutin::update_views(&window, &mut data.out, &mut main_depth);
-                        download = factory
-                            .create_download_buffer(
-                                size.width.round() as usize * size.height.round() as usize,
-                            )
-                            .unwrap();
                     },
                     WindowEvent::KeyboardInput {
                         input: KeyboardInput {
@@ -129,6 +121,8 @@ pub fn main() {
             if screenshot {
                 println!("taking screenshot");
                 let (w, h, _, _) = data.out.get_dimensions();
+                let download = factory.create_download_buffer::<SurfaceData>(w as usize * h as usize)
+                    .unwrap();
                 encoder.copy_texture_to_buffer_raw(
                     data.out.raw().get_texture(),
                     None,

--- a/src/backend/gl/src/tex.rs
+++ b/src/backend/gl/src/tex.rs
@@ -663,8 +663,10 @@ fn bind_read_fbo(gl: &gl::Gl, texture: NewTexture, level: t::Level, fbo: FrameBu
     if texture == NewTexture::Surface(0) {
         //Warning: assuming the back buffer
         unsafe {
+            let mut buffer : gl::types::GLint = 0;
+            gl.GetIntegerv(gl::DRAW_BUFFER, &mut buffer);
             gl.BindFramebuffer(target, 0);
-            gl.ReadBuffer(gl::BACK);
+            gl.ReadBuffer(buffer as u32);
         }
         return
     }


### PR DESCRIPTION
Fixes #2310 

This is more of a temporary fix, and just allows code to run. Not sure what the performance implications of this are - however, since downloading a GPU buffer probably doesn't happen every frame (?) and extra glGet shouldn't hurt too much (?)

EDIT:

I also applied a minor fix to the gamma example which I couldn't get to run, and was needed to test whether the fix works. I'm using i3, which does some funny things with window dimensions, so potentially that was causing the example to fail on my machine.