### PR TITLE
[WIP] [mtl] [iOS] hacking on iOS metal support

### DIFF
--- a/src/backend/metal/build.rs
+++ b/src/backend/metal/build.rs
@@ -1,10 +1,10 @@
 // Compiles the shaders used internally by some commands
 
 use std::env;
+use std::ffi::OsStr;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::fs;
-use std::ffi::OsStr;
 
 fn main() {
     let pd = env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -20,12 +20,10 @@ fn main() {
 
     let sdk_name = match (os, arch) {
         ("ios", "aarch64") => "iphoneos",
-        | ("ios", "armv7s")
-        | ("ios", "armv7") => panic!("32-bit iOS does not have metal support"),
-        ("ios", "i386")
-        | ("ios", "x86_64") => panic!("iOS simulator does not have metal support"),
+        ("ios", "armv7s") | ("ios", "armv7") => panic!("32-bit iOS does not have metal support"),
+        ("ios", "i386") | ("ios", "x86_64") => panic!("iOS simulator does not have metal support"),
         ("darwin", _) => "macosx",
-        _ => panic!("unsupported target {}", target)
+        _ => panic!("unsupported target {}", target),
     };
 
     let project_dir = Path::new(&pd);
@@ -44,7 +42,7 @@ fn main() {
             let path = entry.path();
             match path.extension().and_then(OsStr::to_str) {
                 Some("metal") => Some(path),
-                _ => None
+                _ => None,
             }
         });
 
@@ -85,4 +83,3 @@ fn main() {
         panic!("shader library build failed");
     }
 }
-

--- a/src/backend/metal/shaders/blit.metal
+++ b/src/backend/metal/shaders/blit.metal
@@ -1,3 +1,4 @@
+#include "macros.metal"
 #include <metal_stdlib>
 using namespace metal;
 
@@ -9,7 +10,7 @@ typedef struct {
 typedef struct {
     float4 position [[position]];
     float4 uv;
-    uint layer [[render_target_array_index]];
+    uint layer GFX_RENDER_TARGET_ARRAY_INDEX;
 } BlitVertexData;
 
 typedef struct {

--- a/src/backend/metal/shaders/clear.metal
+++ b/src/backend/metal/shaders/clear.metal
@@ -1,3 +1,4 @@
+#include "macros.metal"
 #include <metal_stdlib>
 using namespace metal;
 
@@ -12,7 +13,7 @@ typedef struct {
 
 typedef struct {
     float4 position [[position]];
-    uint layer [[render_target_array_index]];
+    uint layer GFX_RENDER_TARGET_ARRAY_INDEX;
 } ClearVertexData;
 
 vertex ClearVertexData vs_clear(ClearAttributes in [[stage_in]]) {

--- a/src/backend/metal/shaders/macros.metal
+++ b/src/backend/metal/shaders/macros.metal
@@ -1,0 +1,5 @@
+#ifdef __METAL_MACOS__
+#   define GFX_RENDER_TARGET_ARRAY_INDEX [[render_target_array_index]]
+#else
+#   define GFX_RENDER_TARGET_ARRAY_INDEX
+#endif

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -9,8 +9,7 @@ use hal::{self, format, image};
 use hal::{Backbuffer, SwapchainConfig};
 use hal::window::Extent2D;
 
-use cocoa::foundation::{NSRect};
-use core_graphics::geometry::{CGSize};
+use core_graphics::geometry::{CGRect, CGSize};
 use foreign_types::{ForeignType, ForeignTypeRef};
 use parking_lot::{Mutex, MutexGuard};
 use metal;
@@ -27,7 +26,7 @@ pub struct Surface {
 
 #[derive(Debug)]
 pub(crate) struct SurfaceInner {
-    pub(crate) nsview: *mut Object,
+    pub(crate) view: *mut Object,
     pub(crate) render_layer: Mutex<CAMetalLayer>,
 }
 
@@ -36,7 +35,7 @@ unsafe impl Sync for SurfaceInner {}
 
 impl Drop for SurfaceInner {
     fn drop(&mut self) {
-        unsafe { msg_send![self.nsview, release]; }
+        unsafe { msg_send![self.view, release]; }
     }
 }
 
@@ -212,8 +211,8 @@ impl hal::Surface<Backend> for Surface {
 impl SurfaceInner {
     fn dimensions(&self) -> Extent2D {
         unsafe {
-            // NSView bounds are measured in DIPs
-            let bounds: NSRect = msg_send![self.nsview, bounds];
+            // NSView/UIView bounds are measured in DIPs
+            let bounds: CGRect = msg_send![self.view, bounds];
             //let bounds_pixel: NSRect = msg_send![self.nsview, convertRectToBacking:bounds];
             Extent2D {
                 width: bounds.size.width as _,


### PR DESCRIPTION
Here's the start of a PR to introduce support for iOS in gfx-backend-metal. With this PR gfx-backend-metal does build on iOS, but I have yet to get into testing. I'm far from a metal expert, so I would appreciate any feedback.

### Questions
1. `Instance` has two impls, one for iOS and one for macOS. Is there a preferred way to organize these differences? For example, having a platform submodule, with ios.rs, and macos.rs submodules.
2. iOS does not support `[[render_target_array_index]]`, but as far as I can tell, it does fully support array textures depending on the specific iOS version. blit.metal and clear.metal use `[[render_target_array_index]]` so I added a macros.metal file which will conditionally use the attribute. This allows the shaders to build, but I have no idea what the runtime behavior for iOS is. I'm hoping someone more knowledgable could point me in the correct direction.
3. Should whitespace changes via `rustfmt` be a separate PR, or just a standalone commit?

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

TODO:
- [x] ~~`MTLLanguageVersion` detection based on iOS version in device.rs - macOS already needs fixing~~ fixed by #2338 
- [ ] check `broken_viewport_near_depth` in `Shared::new`'s PrivateDisabilities detection. Currently based on `MTLFeatureSet_macOS_GPUFamily1_v4` which might be incorrect for iOS
- [ ] do testing on iOS