### PR TITLE
[mtl 2D texel buffer view

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -314,6 +314,7 @@ impl hal::Instance for Instance {
 
             let limits = hal::Limits {
                 max_texture_size: d3d11::D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION as _,
+                max_texel_elements: d3d11::D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION as _, //TODO
                 max_patch_size: 0, // TODO
                 max_viewports: d3d11::D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE as _,
                 max_compute_group_count: [

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1013,6 +1013,7 @@ impl hal::Instance for Instance {
                     if depth_bounds_test_supported { Features::DEPTH_BOUNDS } else { Features::empty() },
                 limits: Limits { // TODO
                     max_texture_size: 0,
+                    max_texel_elements: 0,
                     max_patch_size: 0,
                     max_viewports: 0,
                     max_compute_group_count: [

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -301,6 +301,7 @@ pub fn query_all(gl: &gl::Gl) -> (Info, Features, LegacyFeatures, Limits, Privat
 
     let mut limits = Limits {
         max_texture_size: get_usize(gl, gl::MAX_TEXTURE_SIZE),
+        max_texel_elements: get_usize(gl, gl::MAX_TEXTURE_BUFFER_SIZE),
         max_viewports: 1,
         min_buffer_copy_offset_alignment: 1,
         min_buffer_copy_pitch_alignment: 1,

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -301,6 +301,7 @@ struct PrivateCapabilities {
     max_samplers_per_stage: ResourceIndex,
     buffer_alignment: u64,
     max_buffer_size: u64,
+    max_texture_size: u64,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -632,6 +632,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
         Limits {
             max_texture_size: limits.max_image_dimension3d as _,
+            max_texel_elements: limits.max_texel_buffer_elements as _,
             max_patch_size: limits.max_tessellation_patch_size as PatchSize,
             max_viewports: limits.max_viewports as _,
             max_compute_group_count: [max_group_count[0] as _, max_group_count[1] as _, max_group_count[2] as _],

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -231,6 +231,8 @@ bitflags! {
 pub struct Limits {
     /// Maximum supported texture size.
     pub max_texture_size: usize,
+    /// Maximum number of elements for the BufferView to see.
+    pub max_texel_elements: usize,
     /// Maximum number of vertices for each patch.
     pub max_patch_size: PatchSize,
     /// Maximum number of viewports.


### PR DESCRIPTION
Makes our buffer views bigger, relying on https://github.com/KhronosGroup/SPIRV-Cross/issues/664
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
