### PR TITLE
[mtl] Expose version check

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -308,9 +308,6 @@ unsafe impl Send for PhysicalDevice {}
 unsafe impl Sync for PhysicalDevice {}
 
 impl PhysicalDevice {
-    fn is_mac(raw: &metal::DeviceRef) -> bool {
-        raw.supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v1)
-    }
     fn supports_any(raw: &metal::DeviceRef, features_sets: &[MTLFeatureSet]) -> bool {
         features_sets.iter().cloned().any(|x| raw.supports_feature_set(x))
     }
@@ -318,28 +315,34 @@ impl PhysicalDevice {
     pub(crate) fn new(shared: Arc<Shared>) -> Self {
         let device = shared.device.lock();
 
-        let NSOperatingSystemVersion { major, minor, .. } = unsafe {
+        let version: NSOperatingSystemVersion = unsafe {
             let process_info: *mut Object = msg_send![class!(NSProcessInfo), processInfo];
             msg_send![process_info, operatingSystemVersion]
         };
 
+        let major = version.major as u32;
+        let minor = version.minor as u32;
+        let os_is_mac = device.supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v1);
+
         let private_caps = {
             PrivateCapabilities {
-                msl_version: if Self::is_mac(&device) {
-                    if major >= 10 && minor >= 13 {
+                os_is_mac,
+                os_version: (major as u32, minor as u32),
+                msl_version: if os_is_mac {
+                    if PrivateCapabilities::version_at_least(major, minor, 10, 13) {
                         MTLLanguageVersion::V2_0
-                    } else if major >= 10 && minor >= 12 {
+                    } else if PrivateCapabilities::version_at_least(major, minor, 10, 12) {
                         MTLLanguageVersion::V1_2
-                    } else if major >= 10 && minor >= 11 {
+                    } else if PrivateCapabilities::version_at_least(major, minor, 10, 11) {
                         MTLLanguageVersion::V1_1
                     } else {
                         MTLLanguageVersion::V1_0
                     }
-                } else if major >= 11 {
+                } else if PrivateCapabilities::version_at_least(major, minor, 11, 0) {
                     MTLLanguageVersion::V2_0
-                } else if major >= 10 {
+                } else if PrivateCapabilities::version_at_least(major, minor, 10, 0) {
                     MTLLanguageVersion::V1_2
-                } else if major >= 9 {
+                } else if PrivateCapabilities::version_at_least(major, minor, 9, 0) {
                     MTLLanguageVersion::V1_1
                 } else {
                     MTLLanguageVersion::V1_0
@@ -347,28 +350,28 @@ impl PhysicalDevice {
                 exposed_queues: 1,
                 resource_heaps: Self::supports_any(&device, RESOURCE_HEAP_SUPPORT),
                 argument_buffers: Self::supports_any(&device, ARGUMENT_BUFFER_SUPPORT) && false, //TODO
-                shared_textures: !Self::is_mac(&device),
+                shared_textures: !os_is_mac,
                 base_instance: Self::supports_any(&device, BASE_INSTANCE_SUPPORT),
                 format_depth24_stencil8: device.d24_s8_supported(),
-                format_depth32_stencil8_filter: Self::is_mac(&device),
-                format_depth32_stencil8_none: !Self::is_mac(&device),
-                format_min_srgb_channels: if Self::is_mac(&device) {4} else {1},
-                format_b5: !Self::is_mac(&device),
-                format_bc: Self::is_mac(&device),
-                format_eac_etc: !Self::is_mac(&device),
+                format_depth32_stencil8_filter: os_is_mac,
+                format_depth32_stencil8_none: !os_is_mac,
+                format_min_srgb_channels: if os_is_mac {4} else {1},
+                format_b5: !os_is_mac,
+                format_bc: os_is_mac,
+                format_eac_etc: !os_is_mac,
                 format_astc: Self::supports_any(&device, ASTC_PIXEL_FORMAT_FEATURES),
                 format_r8unorm_srgb_all: Self::supports_any(&device, R8UNORM_SRGB_ALL),
-                format_r8unorm_srgb_no_write: !Self::supports_any(&device, R8UNORM_SRGB_ALL) && !Self::is_mac(&device),
+                format_r8unorm_srgb_no_write: !Self::supports_any(&device, R8UNORM_SRGB_ALL) && !os_is_mac,
                 format_r8snorm_all: !Self::supports_any(&device, R8SNORM_NO_RESOLVE),
-                format_r16_norm_all: Self::is_mac(&device),
+                format_r16_norm_all: os_is_mac,
                 format_rg8unorm_srgb_all: Self::supports_any(&device, RG8UNORM_SRGB_NO_WRITE),
-                format_rg8unorm_srgb_no_write: !Self::supports_any(&device, RG8UNORM_SRGB_NO_WRITE) && !Self::is_mac(&device),
+                format_rg8unorm_srgb_no_write: !Self::supports_any(&device, RG8UNORM_SRGB_NO_WRITE) && !os_is_mac,
                 format_rg8snorm_all: !Self::supports_any(&device, RG8SNORM_NO_RESOLVE),
                 format_r32_all: !Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]),
                 format_r32_no_write: Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]),
-                format_r32float_no_write_no_filter: Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]) && !Self::is_mac(&device),
-                format_r32float_no_filter: !Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]) && !Self::is_mac(&device),
-                format_r32float_all: Self::is_mac(&device),
+                format_r32float_no_write_no_filter: Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]) && !os_is_mac,
+                format_r32float_no_filter: !Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]) && !os_is_mac,
+                format_r32float_all: os_is_mac,
                 format_rgba8_srgb_all: Self::supports_any(&device, RGBA8_SRGB),
                 format_rgba8_srgb_no_write: !Self::supports_any(&device, RGBA8_SRGB),
                 format_rgb10a2_unorm_all: Self::supports_any(&device, RGB10A2UNORM_ALL),
@@ -378,27 +381,27 @@ impl PhysicalDevice {
                 format_rg11b10_all: Self::supports_any(&device, RG11B10FLOAT_ALL),
                 format_rg11b10_no_write: !Self::supports_any(&device, RG11B10FLOAT_ALL),
                 format_rgb9e5_all: Self::supports_any(&device, RGB9E5FLOAT_ALL),
-                format_rgb9e5_no_write: !Self::supports_any(&device, RGB9E5FLOAT_ALL) && !Self::is_mac(&device),
-                format_rgb9e5_filter_only: Self::is_mac(&device),
+                format_rgb9e5_no_write: !Self::supports_any(&device, RGB9E5FLOAT_ALL) && !os_is_mac,
+                format_rgb9e5_filter_only: os_is_mac,
                 format_rg32_color: Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]),
                 format_rg32_color_write: !Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]),
-                format_rg32float_all: Self::is_mac(&device),
+                format_rg32float_all: os_is_mac,
                 format_rg32float_color_blend: Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]),
-                format_rg32float_no_filter: !Self::is_mac(&device) && !Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]),
+                format_rg32float_no_filter: !os_is_mac && !Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]),
                 format_rgba32int_color: Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]),
                 format_rgba32int_color_write: !Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]),
                 format_rgba32float_color: Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]),
-                format_rgba32float_color_write: !Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]) && !Self::is_mac(&device),
-                format_rgba32float_all: Self::is_mac(&device),
+                format_rgba32float_color_write: !Self::supports_any(&device, &[MTLFeatureSet::iOS_GPUFamily1_v1, MTLFeatureSet::iOS_GPUFamily2_v1]) && !os_is_mac,
+                format_rgba32float_all: os_is_mac,
                 format_depth16unorm: Self::supports_any(&device, &[MTLFeatureSet::macOS_GPUFamily1_v2, MTLFeatureSet::macOS_GPUFamily1_v3]),
                 format_depth32float_filter: Self::supports_any(&device, &[MTLFeatureSet::macOS_GPUFamily1_v1, MTLFeatureSet::macOS_GPUFamily1_v2, MTLFeatureSet::macOS_GPUFamily1_v3]),
                 format_depth32float_none: !Self::supports_any(&device, &[MTLFeatureSet::macOS_GPUFamily1_v1, MTLFeatureSet::macOS_GPUFamily1_v2, MTLFeatureSet::macOS_GPUFamily1_v3]),
                 format_bgr10a2_all: Self::supports_any(&device, BGR10A2_ALL),
                 format_bgr10a2_no_write: !Self::supports_any(&device, &[MTLFeatureSet::macOS_GPUFamily1_v3]),
                 max_buffers_per_stage: 31,
-                max_textures_per_stage: if Self::is_mac(&device) {128} else {31},
+                max_textures_per_stage: if os_is_mac {128} else {31},
                 max_samplers_per_stage: 16,
-                buffer_alignment: if Self::is_mac(&device) {256} else {64},
+                buffer_alignment: if os_is_mac {256} else {64},
                 max_buffer_size: if Self::supports_any(&device, &[MTLFeatureSet::macOS_GPUFamily1_v2, MTLFeatureSet::macOS_GPUFamily1_v3]) {
                     1 << 30 // 1GB on macOS 1.2 and up
                 } else {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1452,7 +1452,13 @@ impl hal::Device<Backend> for Device {
         descriptor.set_lod_bias(info.lod_bias.into());
         descriptor.set_lod_min_clamp(info.lod_range.start.into());
         descriptor.set_lod_max_clamp(info.lod_range.end.into());
-        descriptor.set_lod_average(true); // optimization
+        
+        let caps = &self.private_caps;
+        // TODO: Clarify minimum macOS version with Apple (43707452)
+        if (caps.os_is_mac && caps.has_version_at_least(10, 13)) ||
+            (!caps.os_is_mac && caps.has_version_at_least(9, 0)) {
+            descriptor.set_lod_average(true); // optimization
+        }
 
         if let Some(fun) = info.comparison {
             descriptor.set_compare_function(conv::map_compare_function(fun));

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -306,6 +306,8 @@ impl hal::Backend for Backend {
 
 #[derive(Clone, Debug)]
 struct PrivateCapabilities {
+    pub os_is_mac: bool,
+    os_version: (u32, u32),
     msl_version: metal::MTLLanguageVersion,
     exposed_queues: usize,
     resource_heaps: bool,
@@ -364,6 +366,17 @@ struct PrivateCapabilities {
     buffer_alignment: u64,
     max_buffer_size: u64,
     max_texture_size: u64,
+}
+
+impl PrivateCapabilities {
+    fn version_at_least(major: u32, minor: u32, needed_major: u32, needed_minor: u32) -> bool {
+        major > needed_major || (major == needed_major && minor >= needed_minor)
+    }
+
+    fn has_version_at_least(&self, needed_major: u32, needed_minor: u32) -> bool {
+        let (major, minor) = self.os_version;
+        Self::version_at_least(major, minor, needed_major, needed_minor)
+    }
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
Partial fix for #2342 (probably need some more version checks, but I have no simple way to check)
Also fixes the MSL version check for macOS versions beyond (technically `(11, 0)` would've failed)

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: Metal
- [ ] `rustfmt` run on changed code
