### PR TITLE
[mtl] Add version check to `displaySyncEnabled`

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -302,7 +302,7 @@ struct NSOperatingSystemVersion {
 pub struct PhysicalDevice {
     shared: Arc<Shared>,
     memory_types: [hal::MemoryType; 4],
-    private_caps: PrivateCapabilities,
+    pub(crate) private_caps: PrivateCapabilities,
 }
 unsafe impl Send for PhysicalDevice {}
 unsafe impl Sync for PhysicalDevice {}

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -181,7 +181,7 @@ impl hal::Surface<Backend> for Surface {
     }
 
     fn compatibility(
-        &self, _: &PhysicalDevice,
+        &self, device: &PhysicalDevice,
     ) -> (hal::SurfaceCapabilities, Option<Vec<format::Format>>, Vec<hal::PresentMode>) {
         let current_extent = Some(self.inner.dimensions());
 
@@ -200,10 +200,15 @@ impl hal::Surface<Backend> for Surface {
             format::Format::Bgra8Srgb,
             format::Format::Rgba16Float,
         ];
-        let present_modes = vec![
-            hal::PresentMode::Fifo,
-            hal::PresentMode::Immediate,
-        ];
+
+        let device_caps = &device.private_caps;
+        let can_set_display_sync = device_caps.os_is_mac && device_caps.has_version_at_least(10, 13);
+
+        let present_modes = if can_set_display_sync {
+            vec![hal::PresentMode::Fifo, hal::PresentMode::Immediate]
+        } else {
+            vec![hal::PresentMode::Fifo]
+        };
 
         (caps, Some(formats), present_modes)
     }


### PR DESCRIPTION
Continue fixes for #2342 

Alternatively, we could just not expose `PresentMode::Immediate` for older macOS versions. @kvark what do you prefer?

Also [iOS doesn't list support for `displaySyncEnabled` at all](https://developer.apple.com/documentation/quartzcore/cametallayer/2887087-displaysyncenabled?language=objc). I've disabled it for now, let me know if this is incorrect.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: Metal
- [ ] `rustfmt` run on changed code
