### PR TITLE
Acquire error codes

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -479,7 +479,7 @@ impl<B: Backend> RendererState<B> {
                     .swapchain
                     .as_mut()
                     .unwrap()
-                    .acquire_image(FrameSync::Semaphore(acquire_semaphore))
+                    .acquire_image(!0, FrameSync::Semaphore(acquire_semaphore))
                 {
                     Ok(i) => i,
                     Err(_) => {

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -458,7 +458,7 @@ fn main() {
         device.reset_fence(&frame_fence);
         command_pool.reset();
         let frame: hal::SwapImageIndex = {
-            match swap_chain.acquire_image(FrameSync::Semaphore(&mut frame_semaphore)) {
+            match swap_chain.acquire_image(!0, FrameSync::Semaphore(&mut frame_semaphore)) {
                 Ok(i) => i,
                 Err(_) => {
                     recreate_swapchain = true;

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -688,7 +688,9 @@ unsafe impl Send for Swapchain { }
 unsafe impl Sync for Swapchain { }
 
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_image(&mut self, _sync: hal::FrameSync<Backend>) -> Result<hal::SwapImageIndex, ()> {
+    fn acquire_image(
+        &mut self, _timeout_ns: u64, _sync: hal::FrameSync<Backend>
+    ) -> Result<hal::SwapImageIndex, hal::AcquireError> {
         // TODO: non-`_DISCARD` swap effects have more than one buffer, `FLIP`
         //       effects are dxgi 1.3 (w10+?) in which case there is
         //       `GetCurrentBackBufferIndex()` on the swapchain

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -110,7 +110,9 @@ pub struct Swapchain {
 }
 
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_image(&mut self, _sync: hal::FrameSync<Backend>) -> Result<hal::SwapImageIndex, ()> {
+    fn acquire_image(
+        &mut self, _timout_ns: u64, _sync: hal::FrameSync<Backend>
+    ) -> Result<hal::SwapImageIndex, hal::AcquireError> {
         // TODO: sync
 
         if false {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -828,7 +828,9 @@ impl hal::Surface<Backend> for Surface {
 /// Dummy swapchain.
 pub struct Swapchain;
 impl hal::Swapchain<Backend> for Swapchain {
-    fn acquire_image(&mut self, _: hal::FrameSync<Backend>) -> Result<hal::SwapImageIndex, ()> {
+    fn acquire_image(
+        &mut self, _: u64, _: hal::FrameSync<Backend>
+    ) -> Result<hal::SwapImageIndex, hal::AcquireError> {
         unimplemented!()
     }
 }

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -65,7 +65,9 @@ pub struct Swapchain {
 }
 
 impl hal::Swapchain<B> for Swapchain {
-    fn acquire_image(&mut self, _sync: hal::FrameSync<B>) -> Result<hal::SwapImageIndex, ()> {
+    fn acquire_image(
+        &mut self, _timeout_ns: u64, _sync: hal::FrameSync<B>
+    ) -> Result<hal::SwapImageIndex, hal::AcquireError> {
         // TODO: sync
         Ok(0)
     }

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -29,7 +29,7 @@ mod soft;
 
 pub use command::CommandPool;
 pub use device::{Device, LanguageVersion, PhysicalDevice};
-pub use window::{Surface, Swapchain};
+pub use window::{AcquireMode, Surface, Swapchain};
 
 pub type GraphicsCommandPool = CommandPool;
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -36,7 +36,7 @@ pub use self::queue::{
     Capability, Supports, General, Graphics, Compute, Transfer,
 };
 pub use self::window::{
-    Backbuffer, SwapImageIndex, FrameSync, PresentMode,
+    AcquireError, Backbuffer, SwapImageIndex, FrameSync, PresentMode,
     Surface, SurfaceCapabilities, Swapchain, SwapchainConfig,
 };
 


### PR DESCRIPTION
Fixes #2333
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

I can't exactly figure out how to control the drawables returned by `CAMetalLayer`, so I'm at least going to report anything unusual as an error downstream, instead of crashing.

cc @Mistodon @JohnColanduoni 