### PR TITLE
[vk] [android] fix winit feature on android

### DIFF
--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -254,9 +254,10 @@ impl Instance {
         #[cfg(target_os = "android")]
         {
             use winit::os::android::WindowExt;
-            let (width, height) = window.get_inner_size().unwrap();
-            self.create_surface_android(window.get_native_window(), width, height)
-
+            let logical_size = window.get_inner_size().unwrap();
+            let width = logical_size.width * window.get_hidpi_factor();
+            let height = logical_size.height * window.get_hidpi_factor();
+            self.create_surface_android(window.get_native_window(), width as _, height as _)
         }
         #[cfg(windows)]
         {


### PR DESCRIPTION
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: android
- [ ] `rustfmt` run on changed code

This PR fixes build issues on android. winit uses `LogicalSize` instead of `(u64, u64)`, and the android code didn't get updated to deal with that.