### PR TITLE
[mtl] don't panic on missing window

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -176,10 +176,11 @@ impl Instance {
 
             let window: *mut Object = msg_send![view, window];
             if window.is_null() {
-                panic!("surface is not attached to a window");
+                warn!("surface is not attached to a window");
+            } else {
+                let scale_factor: CGFloat = msg_send![window, backingScaleFactor];
+                msg_send![render_layer, setContentsScale:scale_factor];
             }
-            let scale_factor: CGFloat = msg_send![window, backingScaleFactor];
-            msg_send![render_layer, setContentsScale:scale_factor];
 
             window::SurfaceInner {
                 view,


### PR DESCRIPTION
Fixes use of `libportability.dylib` with `vulkaninfo`.
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
