### PR TITLE
Expose Vulkan's device_type from hal

### DIFF
--- a/src/backend/dx11/src/dxgi.rs
+++ b/src/backend/dx11/src/dxgi.rs
@@ -1,4 +1,5 @@
 use hal::AdapterInfo;
+use hal::adapter::DeviceType;
 
 use winapi::shared::guiddef::GUID;
 use winapi::shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_5, winerror};
@@ -145,6 +146,11 @@ fn get_adapter_desc(adapter: *mut dxgi::IDXGIAdapter, version: DxgiVersion) -> A
                 name: device_name,
                 vendor: desc.VendorId as usize,
                 device: desc.DeviceId as usize,
+                device_type: if (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0 {
+                    DeviceType::VirtualGpu
+                } else {
+                    DeviceType::DiscreteGpu
+                },
                 software_rendering: (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0,
             }
         },
@@ -165,6 +171,11 @@ fn get_adapter_desc(adapter: *mut dxgi::IDXGIAdapter, version: DxgiVersion) -> A
                 name: device_name,
                 vendor: desc.VendorId as usize,
                 device: desc.DeviceId as usize,
+                device_type: if (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0 {
+                    DeviceType::VirtualGpu
+                } else {
+                    DeviceType::DiscreteGpu
+                },
                 software_rendering: (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0,
             }
         }

--- a/src/backend/dx11/src/dxgi.rs
+++ b/src/backend/dx11/src/dxgi.rs
@@ -1,5 +1,5 @@
-use hal::AdapterInfo;
 use hal::adapter::DeviceType;
+use hal::AdapterInfo;
 
 use winapi::shared::guiddef::GUID;
 use winapi::shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_5, winerror};
@@ -8,10 +8,10 @@ use winapi::Interface;
 
 use wio::com::ComPtr;
 
-use std::ptr;
+use std::ffi::OsString;
 use std::mem;
 use std::os::windows::ffi::OsStringExt;
-use std::ffi::OsString;
+use std::ptr;
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum DxgiVersion {
@@ -71,12 +71,7 @@ pub(crate) enum DxgiVersion {
 fn create_dxgi_factory1(guid: &GUID) -> Result<ComPtr<dxgi::IDXGIFactory>, winerror::HRESULT> {
     let mut factory: *mut IUnknown = ptr::null_mut();
 
-    let hr = unsafe {
-        dxgi::CreateDXGIFactory1(
-            guid,
-            &mut factory as *mut *mut _ as *mut *mut _
-        )
-    };
+    let hr = unsafe { dxgi::CreateDXGIFactory1(guid, &mut factory as *mut *mut _ as *mut *mut _) };
 
     if winerror::SUCCEEDED(hr) {
         Ok(unsafe { ComPtr::from_raw(factory as *mut _) })
@@ -85,7 +80,8 @@ fn create_dxgi_factory1(guid: &GUID) -> Result<ComPtr<dxgi::IDXGIFactory>, winer
     }
 }
 
-pub(crate) fn get_dxgi_factory() -> Result<(ComPtr<dxgi::IDXGIFactory>, DxgiVersion), winerror::HRESULT> {
+pub(crate) fn get_dxgi_factory(
+) -> Result<(ComPtr<dxgi::IDXGIFactory>, DxgiVersion), winerror::HRESULT> {
     // TODO: do we even need `create_dxgi_factory2`?
     if let Ok(factory) = create_dxgi_factory1(&dxgi1_5::IDXGIFactory5::uuidof()) {
         return Ok((factory, DxgiVersion::Dxgi1_5));
@@ -109,18 +105,20 @@ pub(crate) fn get_dxgi_factory() -> Result<(ComPtr<dxgi::IDXGIFactory>, DxgiVers
 
     // TODO: any reason why above would fail and this wouldnt?
     match create_dxgi_factory1(&dxgi::IDXGIFactory::uuidof()) {
-        Ok(factory) => {
-            Ok((factory, DxgiVersion::Dxgi1_0))
-        },
-        Err(hr) => Err(hr)
+        Ok(factory) => Ok((factory, DxgiVersion::Dxgi1_0)),
+        Err(hr) => Err(hr),
     }
 }
 
-fn enum_adapters1(idx: u32, factory: *mut dxgi::IDXGIFactory) -> Result<ComPtr<dxgi::IDXGIAdapter>, winerror::HRESULT> {
+fn enum_adapters1(
+    idx: u32,
+    factory: *mut dxgi::IDXGIFactory,
+) -> Result<ComPtr<dxgi::IDXGIAdapter>, winerror::HRESULT> {
     let mut adapter: *mut dxgi::IDXGIAdapter = ptr::null_mut();
 
     let hr = unsafe {
-        (*(factory as *mut dxgi::IDXGIFactory1)).EnumAdapters1(idx, &mut adapter as *mut *mut _ as *mut *mut _)
+        (*(factory as *mut dxgi::IDXGIFactory1))
+            .EnumAdapters1(idx, &mut adapter as *mut *mut _ as *mut *mut _)
     };
 
     if winerror::SUCCEEDED(hr) {
@@ -134,7 +132,9 @@ fn get_adapter_desc(adapter: *mut dxgi::IDXGIAdapter, version: DxgiVersion) -> A
     match version {
         DxgiVersion::Dxgi1_0 => {
             let mut desc: dxgi::DXGI_ADAPTER_DESC1 = unsafe { mem::zeroed() };
-            unsafe { (*(adapter as *mut dxgi::IDXGIAdapter1)).GetDesc1(&mut desc); }
+            unsafe {
+                (*(adapter as *mut dxgi::IDXGIAdapter1)).GetDesc1(&mut desc);
+            }
 
             let device_name = {
                 let len = desc.Description.iter().take_while(|&&c| c != 0).count();
@@ -153,13 +153,15 @@ fn get_adapter_desc(adapter: *mut dxgi::IDXGIAdapter, version: DxgiVersion) -> A
                 },
                 software_rendering: (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0,
             }
-        },
-        DxgiVersion::Dxgi1_2 | 
-        DxgiVersion::Dxgi1_3 | 
-        DxgiVersion::Dxgi1_4 | 
-        DxgiVersion::Dxgi1_5 => {
+        }
+        DxgiVersion::Dxgi1_2
+        | DxgiVersion::Dxgi1_3
+        | DxgiVersion::Dxgi1_4
+        | DxgiVersion::Dxgi1_5 => {
             let mut desc: dxgi1_2::DXGI_ADAPTER_DESC2 = unsafe { mem::zeroed() };
-            unsafe { (*(adapter as *mut dxgi1_2::IDXGIAdapter2)).GetDesc2(&mut desc); }
+            unsafe {
+                (*(adapter as *mut dxgi1_2::IDXGIAdapter2)).GetDesc2(&mut desc);
+            }
 
             let device_name = {
                 let len = desc.Description.iter().take_while(|&&c| c != 0).count();
@@ -182,15 +184,17 @@ fn get_adapter_desc(adapter: *mut dxgi::IDXGIAdapter, version: DxgiVersion) -> A
     }
 }
 
-pub(crate) fn get_adapter(idx: u32, factory: *mut dxgi::IDXGIFactory, version: DxgiVersion) -> Result<(ComPtr<dxgi::IDXGIAdapter>, AdapterInfo), winerror::HRESULT> {
+pub(crate) fn get_adapter(
+    idx: u32,
+    factory: *mut dxgi::IDXGIFactory,
+    version: DxgiVersion,
+) -> Result<(ComPtr<dxgi::IDXGIAdapter>, AdapterInfo), winerror::HRESULT> {
     let adapter = match version {
-        DxgiVersion::Dxgi1_0 | 
-        DxgiVersion::Dxgi1_2 | 
-        DxgiVersion::Dxgi1_3 | 
-        DxgiVersion::Dxgi1_4 | 
-        DxgiVersion::Dxgi1_5 => {
-            enum_adapters1(idx, factory)?
-        },
+        DxgiVersion::Dxgi1_0
+        | DxgiVersion::Dxgi1_2
+        | DxgiVersion::Dxgi1_3
+        | DxgiVersion::Dxgi1_4
+        | DxgiVersion::Dxgi1_5 => enum_adapters1(idx, factory)?,
     };
 
     let desc = get_adapter_desc(adapter.as_raw(), version);

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -26,6 +26,7 @@ mod window;
 
 use hal::{error, format as f, image, memory, Features, SwapImageIndex, Limits, QueueType};
 use hal::queue::{QueueFamilyId, Queues};
+use hal::adapter::DeviceType;
 use descriptors_cpu::DescriptorCpuPool;
 
 use winapi::Interface;
@@ -748,6 +749,11 @@ impl hal::Instance for Instance {
                 name: device_name,
                 vendor: desc.VendorId as usize,
                 device: desc.DeviceId as usize,
+                device_type: if (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0 {
+                    DeviceType::VirtualGpu
+                } else {
+                    DeviceType::DiscreteGpu
+                },
                 software_rendering: (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0,
             };
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -12,8 +12,6 @@ extern crate winapi;
 extern crate winit;
 extern crate wio;
 
-#[path = "../../auxil/range_alloc.rs"]
-mod range_alloc;
 mod command;
 mod conv;
 mod descriptors_cpu;
@@ -21,25 +19,27 @@ mod device;
 mod internal;
 mod native;
 mod pool;
+#[path = "../../auxil/range_alloc.rs"]
+mod range_alloc;
 mod root_constants;
 mod window;
 
-use hal::{error, format as f, image, memory, Features, SwapImageIndex, Limits, QueueType};
-use hal::queue::{QueueFamilyId, Queues};
-use hal::adapter::DeviceType;
 use descriptors_cpu::DescriptorCpuPool;
+use hal::adapter::DeviceType;
+use hal::queue::{QueueFamilyId, Queues};
+use hal::{error, format as f, image, memory, Features, Limits, QueueType, SwapImageIndex};
 
-use winapi::Interface;
-use winapi::shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, winerror};
 use winapi::shared::minwindef::{FALSE, TRUE};
+use winapi::shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, winerror};
 use winapi::um::{d3d12, d3d12sdklayers, d3dcommon, handleapi, synchapi, winbase, winnt};
+use winapi::Interface;
 use wio::com::ComPtr;
 
-use std::{mem, ptr};
 use std::borrow::Borrow;
-use std::os::windows::ffi::OsStringExt;
 use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
 use std::sync::{Arc, Mutex};
+use std::{mem, ptr};
 
 pub(crate) struct HeapProperties {
     pub page_property: d3d12::D3D12_CPU_PAGE_PROPERTY,
@@ -76,7 +76,6 @@ static HEAPS_NUMA: [HeapProperties; NUM_HEAP_PROPERTIES] = [
     HeapProperties {
         page_property: d3d12::D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE,
         memory_pool: d3d12::D3D12_MEMORY_POOL_L0,
-
     },
     // READBACK
     HeapProperties {
@@ -189,12 +188,13 @@ pub struct PhysicalDevice {
     is_open: Arc<Mutex<bool>>,
 }
 
-unsafe impl Send for PhysicalDevice { }
-unsafe impl Sync for PhysicalDevice { }
+unsafe impl Send for PhysicalDevice {}
+unsafe impl Sync for PhysicalDevice {}
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
-        &self, families: &[(&QueueFamily, &[hal::QueuePriority])]
+        &self,
+        families: &[(&QueueFamily, &[hal::QueuePriority])],
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
         let lock = self.is_open.try_lock();
         let mut open_guard = match lock {
@@ -245,11 +245,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             unsafe { ComPtr::<d3d12::ID3D12CommandQueue>::from_raw(queue) }
         };
 
-        let mut device = Device::new(
-            device_raw,
-            &self,
-            present_queue,
-        );
+        let mut device = Device::new(device_raw, &self, present_queue);
 
         let queue_groups = families
             .into_iter()
@@ -286,7 +282,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                             NodeMask: 0,
                         };
 
-                        for _ in 0 .. priorities.len() {
+                        for _ in 0..priorities.len() {
                             let mut queue = ptr::null_mut();
                             let hr = unsafe {
                                 device.raw.CreateCommandQueue(
@@ -329,8 +325,12 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn image_format_properties(
-        &self, format: f::Format, dimensions: u8, tiling: image::Tiling,
-        usage: image::Usage, storage_flags: image::StorageFlags,
+        &self,
+        format: f::Format,
+        dimensions: u8,
+        tiling: image::Tiling,
+        usage: image::Usage,
+        storage_flags: image::StorageFlags,
     ) -> Option<image::FormatProperties> {
         conv::map_format(format)?; //filter out unknown formats
 
@@ -367,7 +367,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             return None;
         }
 
-        let max_resource_size = (d3d12::D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM as usize) << 20;
+        let max_resource_size =
+            (d3d12::D3D12_REQ_RESOURCE_SIZE_IN_MEGABYTES_EXPRESSION_A_TERM as usize) << 20;
         Some(match tiling {
             image::Tiling::Optimal => image::FormatProperties {
                 max_extent: match dimensions {
@@ -394,8 +395,10 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                     2 => d3d12::D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION as _,
                     _ => return None,
                 },
-                sample_count_mask: if dimensions == 2 && !storage_flags.contains(image::StorageFlags::CUBE_VIEW) &&
-                    (usage.contains(image::Usage::COLOR_ATTACHMENT) | usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT))
+                sample_count_mask: if dimensions == 2
+                    && !storage_flags.contains(image::StorageFlags::CUBE_VIEW)
+                    && (usage.contains(image::Usage::COLOR_ATTACHMENT)
+                        | usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT))
                 {
                     0x3F //TODO: use D3D12_FEATURE_DATA_FORMAT_SUPPORT
                 } else {
@@ -424,8 +427,12 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         self.memory_properties.clone()
     }
 
-    fn features(&self) -> Features { self.features }
-    fn limits(&self) -> Limits { self.limits }
+    fn features(&self) -> Features {
+        self.features
+    }
+    fn limits(&self) -> Limits {
+        self.limits
+    }
 }
 
 #[derive(Clone)]
@@ -458,12 +465,11 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
             .into_iter()
             .map(|buf| buf.borrow().as_raw_list())
             .collect::<Vec<_>>();
-        self.raw.ExecuteCommandLists(lists.len() as _, lists.as_mut_ptr());
+        self.raw
+            .ExecuteCommandLists(lists.len() as _, lists.as_mut_ptr());
 
         if let Some(fence) = fence {
-            assert_eq!(winerror::S_OK,
-                self.raw.Signal(fence.raw.as_raw(), 1)
-            );
+            assert_eq!(winerror::S_OK, self.raw.Signal(fence.raw.as_raw(), 1));
         }
     }
 
@@ -476,7 +482,9 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
     {
         // TODO: semaphores
         for (swapchain, _) in swapchains {
-            unsafe { swapchain.borrow().inner.Present(1, 0); }
+            unsafe {
+                swapchain.borrow().inner.Present(1, 0);
+            }
         }
 
         Ok(())
@@ -485,7 +493,10 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
     fn wait_idle(&self) -> Result<(), error::HostExecutionError> {
         unsafe {
             self.raw.Signal(self.idle_fence, 1);
-            assert_eq!(winerror::S_OK, (*self.idle_fence).SetEventOnCompletion(1, self.idle_event));
+            assert_eq!(
+                winerror::S_OK,
+                (*self.idle_fence).SetEventOnCompletion(1, self.idle_event)
+            );
             synchapi::WaitForSingleObject(self.idle_event, winbase::INFINITE);
         }
 
@@ -556,8 +567,10 @@ impl Device {
         // Allocate descriptor heaps
         let rtv_pool = DescriptorCpuPool::new(&device, d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
         let dsv_pool = DescriptorCpuPool::new(&device, d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
-        let srv_uav_pool = DescriptorCpuPool::new(&device, d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-        let sampler_pool = DescriptorCpuPool::new(&device, d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+        let srv_uav_pool =
+            DescriptorCpuPool::new(&device, d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+        let sampler_pool =
+            DescriptorCpuPool::new(&device, d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 
         let heap_srv_cbv_uav = Self::create_descriptor_heap_impl(
             &mut device,
@@ -573,20 +586,14 @@ impl Device {
             2_048,
         );
 
-        let draw_signature = Self::create_command_signature(
-            &mut device,
-            device::CommandSignature::Draw,
-        );
+        let draw_signature =
+            Self::create_command_signature(&mut device, device::CommandSignature::Draw);
 
-        let draw_indexed_signature = Self::create_command_signature(
-            &mut device,
-            device::CommandSignature::DrawIndexed,
-        );
+        let draw_indexed_signature =
+            Self::create_command_signature(&mut device, device::CommandSignature::DrawIndexed);
 
-        let dispatch_signature = Self::create_command_signature(
-            &mut device,
-            device::CommandSignature::Dispatch,
-        );
+        let dispatch_signature =
+            Self::create_command_signature(&mut device, device::CommandSignature::Dispatch);
 
         let signatures = CmdSignatures {
             draw: draw_signature,
@@ -647,8 +654,8 @@ pub struct Instance {
     pub(crate) factory: ComPtr<dxgi1_4::IDXGIFactory4>,
 }
 
-unsafe impl Send for Instance { }
-unsafe impl Sync for Instance { }
+unsafe impl Send for Instance {}
+unsafe impl Sync for Instance {}
 
 impl Instance {
     pub fn create(_: &str, _: u32) -> Instance {
@@ -659,12 +666,15 @@ impl Instance {
             let hr = unsafe {
                 d3d12::D3D12GetDebugInterface(
                     &d3d12sdklayers::ID3D12Debug::uuidof(),
-                    &mut debug_controller as *mut *mut _ as *mut *mut _)
+                    &mut debug_controller as *mut *mut _ as *mut *mut _,
+                )
             };
 
             if winerror::SUCCEEDED(hr) {
                 unsafe { (*debug_controller).EnableDebugLayer() };
-                unsafe { (*debug_controller).Release(); }
+                unsafe {
+                    (*debug_controller).Release();
+                }
             }
         }
 
@@ -675,7 +685,8 @@ impl Instance {
             dxgi1_3::CreateDXGIFactory2(
                 dxgi1_3::DXGI_CREATE_FACTORY_DEBUG,
                 &dxgi1_4::IDXGIFactory4::uuidof(),
-                &mut dxgi_factory as *mut *mut _ as *mut *mut _)
+                &mut dxgi_factory as *mut *mut _ as *mut *mut _,
+            )
         };
 
         if !winerror::SUCCEEDED(hr) {
@@ -701,9 +712,8 @@ impl hal::Instance for Instance {
             let adapter = {
                 let mut adapter: *mut dxgi::IDXGIAdapter1 = ptr::null_mut();
                 let hr = unsafe {
-                    self.factory.EnumAdapters1(
-                        cur_index,
-                        &mut adapter as *mut *mut _)
+                    self.factory
+                        .EnumAdapters1(cur_index, &mut adapter as *mut *mut _)
                 };
 
                 if hr == winerror::DXGI_ERROR_NOT_FOUND {
@@ -737,7 +747,9 @@ impl hal::Instance for Instance {
             // We have found a possible adapter
             // acquire the device information
             let mut desc: dxgi1_2::DXGI_ADAPTER_DESC2 = unsafe { mem::zeroed() };
-            unsafe { adapter.GetDesc2(&mut desc); }
+            unsafe {
+                adapter.GetDesc2(&mut desc);
+            }
 
             let device_name = {
                 let len = desc.Description.iter().take_while(|&&c| c != 0).count();
@@ -766,7 +778,8 @@ impl hal::Instance for Instance {
                 )
             });
 
-            let mut features_architecture: d3d12::D3D12_FEATURE_DATA_ARCHITECTURE = unsafe { mem::zeroed() };
+            let mut features_architecture: d3d12::D3D12_FEATURE_DATA_ARCHITECTURE =
+                unsafe { mem::zeroed() };
             assert_eq!(winerror::S_OK, unsafe {
                 device.CheckFeatureSupport(
                     d3d12::D3D12_FEATURE_ARCHITECTURE,
@@ -776,7 +789,8 @@ impl hal::Instance for Instance {
             });
 
             let depth_bounds_test_supported = {
-                let mut features2: d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS2 = unsafe { mem::zeroed() };
+                let mut features2: d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS2 =
+                    unsafe { mem::zeroed() };
                 let hr = unsafe {
                     device.CheckFeatureSupport(
                         d3d12::D3D12_FEATURE_D3D12_OPTIONS2,
@@ -784,7 +798,7 @@ impl hal::Instance for Instance {
                         mem::size_of::<d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS2>() as _,
                     )
                 };
-                if hr == winerror::S_OK  {
+                if hr == winerror::S_OK {
                     features2.DepthBoundsTestSupported != 0
                 } else {
                     false
@@ -810,12 +824,11 @@ impl hal::Instance for Instance {
                     )
                 });
                 let can_buffer = 0 != data.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_BUFFER;
-                let can_image = 0 != data.Support1 & (
-                    d3d12::D3D12_FORMAT_SUPPORT1_TEXTURE1D |
-                    d3d12::D3D12_FORMAT_SUPPORT1_TEXTURE2D |
-                    d3d12::D3D12_FORMAT_SUPPORT1_TEXTURE3D |
-                    d3d12::D3D12_FORMAT_SUPPORT1_TEXTURECUBE
-                );
+                let can_image = 0 != data.Support1
+                    & (d3d12::D3D12_FORMAT_SUPPORT1_TEXTURE1D
+                        | d3d12::D3D12_FORMAT_SUPPORT1_TEXTURE2D
+                        | d3d12::D3D12_FORMAT_SUPPORT1_TEXTURE3D
+                        | d3d12::D3D12_FORMAT_SUPPORT1_TEXTURECUBE);
                 let can_linear = can_image && !format.surface_desc().is_compressed();
                 if can_image {
                     props.optimal_tiling |= f::ImageFeature::SAMPLED | f::ImageFeature::BLIT_SRC;
@@ -830,9 +843,11 @@ impl hal::Instance for Instance {
                     props.optimal_tiling |= f::ImageFeature::SAMPLED_LINEAR;
                 }
                 if data.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_RENDER_TARGET != 0 {
-                    props.optimal_tiling |= f::ImageFeature::COLOR_ATTACHMENT | f::ImageFeature::BLIT_DST;
+                    props.optimal_tiling |=
+                        f::ImageFeature::COLOR_ATTACHMENT | f::ImageFeature::BLIT_DST;
                     if can_linear {
-                        props.linear_tiling |= f::ImageFeature::COLOR_ATTACHMENT | f::ImageFeature::BLIT_DST;
+                        props.linear_tiling |=
+                            f::ImageFeature::COLOR_ATTACHMENT | f::ImageFeature::BLIT_DST;
                     }
                 }
                 if data.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_BLENDABLE != 0 {
@@ -867,71 +882,86 @@ impl hal::Instance for Instance {
                 //TODO: blits, linear tiling
             }
 
-            let heterogeneous_resource_heaps = features.ResourceHeapTier != d3d12::D3D12_RESOURCE_HEAP_TIER_1;
+            let heterogeneous_resource_heaps =
+                features.ResourceHeapTier != d3d12::D3D12_RESOURCE_HEAP_TIER_1;
 
             let uma = features_architecture.UMA == TRUE;
             let cc_uma = features_architecture.CacheCoherentUMA == TRUE;
 
             let (memory_architecture, heap_properties) = match (uma, cc_uma) {
-                (true, true)  => (MemoryArchitecture::CacheCoherentUMA, &HEAPS_CCUMA),
+                (true, true) => (MemoryArchitecture::CacheCoherentUMA, &HEAPS_CCUMA),
                 (true, false) => (MemoryArchitecture::UMA, &HEAPS_UMA),
-                (false, _)    => (MemoryArchitecture::NUMA, &HEAPS_NUMA),
+                (false, _) => (MemoryArchitecture::NUMA, &HEAPS_NUMA),
             };
 
             // https://msdn.microsoft.com/en-us/library/windows/desktop/dn788678(v=vs.85).aspx
-            let base_memory_types: [hal::MemoryType; NUM_HEAP_PROPERTIES] = match memory_architecture {
-                MemoryArchitecture::NUMA => [
-                    // DEFAULT
-                    hal::MemoryType {
-                        properties: Properties::DEVICE_LOCAL,
-                        heap_index: 0,
-                    },
-                    // UPLOAD
-                    hal::MemoryType {
-                        properties: Properties::CPU_VISIBLE | Properties::COHERENT,
-                        heap_index: 1,
-                    },
-                    // READBACK
-                    hal::MemoryType {
-                        properties: Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
-                        heap_index: 1,
-                    },
-                ],
-                MemoryArchitecture::UMA => [
-                    // DEFAULT
-                    hal::MemoryType {
-                        properties: Properties::DEVICE_LOCAL,
-                        heap_index: 0,
-                    },
-                    // UPLOAD
-                    hal::MemoryType {
-                        properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT,
-                        heap_index: 0,
-                    },
-                    // READBACK
-                    hal::MemoryType {
-                        properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
-                        heap_index: 0,
-                    },
-                ],
-                MemoryArchitecture::CacheCoherentUMA => [
-                    // DEFAULT
-                    hal::MemoryType {
-                        properties: Properties::DEVICE_LOCAL,
-                        heap_index: 0,
-                    },
-                    // UPLOAD
-                    hal::MemoryType {
-                        properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
-                        heap_index: 0,
-                    },
-                    // READBACK
-                    hal::MemoryType {
-                        properties: Properties::DEVICE_LOCAL | Properties::CPU_VISIBLE | Properties::COHERENT | Properties::CPU_CACHED,
-                        heap_index: 0,
-                    },
-                ],
-            };
+            let base_memory_types: [hal::MemoryType; NUM_HEAP_PROPERTIES] =
+                match memory_architecture {
+                    MemoryArchitecture::NUMA => [
+                        // DEFAULT
+                        hal::MemoryType {
+                            properties: Properties::DEVICE_LOCAL,
+                            heap_index: 0,
+                        },
+                        // UPLOAD
+                        hal::MemoryType {
+                            properties: Properties::CPU_VISIBLE | Properties::COHERENT,
+                            heap_index: 1,
+                        },
+                        // READBACK
+                        hal::MemoryType {
+                            properties: Properties::CPU_VISIBLE
+                                | Properties::COHERENT
+                                | Properties::CPU_CACHED,
+                            heap_index: 1,
+                        },
+                    ],
+                    MemoryArchitecture::UMA => [
+                        // DEFAULT
+                        hal::MemoryType {
+                            properties: Properties::DEVICE_LOCAL,
+                            heap_index: 0,
+                        },
+                        // UPLOAD
+                        hal::MemoryType {
+                            properties: Properties::DEVICE_LOCAL
+                                | Properties::CPU_VISIBLE
+                                | Properties::COHERENT,
+                            heap_index: 0,
+                        },
+                        // READBACK
+                        hal::MemoryType {
+                            properties: Properties::DEVICE_LOCAL
+                                | Properties::CPU_VISIBLE
+                                | Properties::COHERENT
+                                | Properties::CPU_CACHED,
+                            heap_index: 0,
+                        },
+                    ],
+                    MemoryArchitecture::CacheCoherentUMA => [
+                        // DEFAULT
+                        hal::MemoryType {
+                            properties: Properties::DEVICE_LOCAL,
+                            heap_index: 0,
+                        },
+                        // UPLOAD
+                        hal::MemoryType {
+                            properties: Properties::DEVICE_LOCAL
+                                | Properties::CPU_VISIBLE
+                                | Properties::COHERENT
+                                | Properties::CPU_CACHED,
+                            heap_index: 0,
+                        },
+                        // READBACK
+                        hal::MemoryType {
+                            properties: Properties::DEVICE_LOCAL
+                                | Properties::CPU_VISIBLE
+                                | Properties::COHERENT
+                                | Properties::CPU_CACHED,
+                            heap_index: 0,
+                        },
+                    ],
+                };
 
             let memory_types = if heterogeneous_resource_heaps {
                 base_memory_types.to_vec()
@@ -949,20 +979,17 @@ impl hal::Instance for Instance {
                 // `device::MEM_TYPE_IMAGE_SHIFT`, `device::MEM_TYPE_TARGET_SHIFT`)
                 // denote the usage group.
                 let mut types = Vec::new();
-                for i in 0 .. MemoryGroup::NumGroups as _ {
-                    types.extend(base_memory_types
-                        .iter()
-                        .map(|mem_type| {
-                            let mut ty = mem_type.clone();
+                for i in 0..MemoryGroup::NumGroups as _ {
+                    types.extend(base_memory_types.iter().map(|mem_type| {
+                        let mut ty = mem_type.clone();
 
-                            // Images and Targets are not host visible as we can't create
-                            // a corresponding buffer for mapping.
-                            if i == MemoryGroup::ImageOnly as _ || i == MemoryGroup::TargetOnly as _ {
-                                ty.properties.remove(Properties::CPU_VISIBLE);
-                            }
-                            ty
-                        })
-                    );
+                        // Images and Targets are not host visible as we can't create
+                        // a corresponding buffer for mapping.
+                        if i == MemoryGroup::ImageOnly as _ || i == MemoryGroup::TargetOnly as _ {
+                            ty.properties.remove(Properties::CPU_VISIBLE);
+                        }
+                        ty
+                    }));
                 }
                 types
             };
@@ -973,22 +1000,24 @@ impl hal::Instance for Instance {
                 let adapter = {
                     let mut adapter: *mut dxgi1_4::IDXGIAdapter3 = ptr::null_mut();
                     unsafe {
-                        assert_eq!(winerror::S_OK, self.factory.EnumAdapterByLuid(
-                            adapter_id,
-                            &dxgi1_4::IDXGIAdapter3::uuidof(),
-                            &mut adapter as *mut *mut _ as *mut *mut _,
-                        ));
+                        assert_eq!(
+                            winerror::S_OK,
+                            self.factory.EnumAdapterByLuid(
+                                adapter_id,
+                                &dxgi1_4::IDXGIAdapter3::uuidof(),
+                                &mut adapter as *mut *mut _ as *mut *mut _,
+                            )
+                        );
                         ComPtr::from_raw(adapter)
                     }
                 };
 
                 let query_memory = |segment: dxgi1_4::DXGI_MEMORY_SEGMENT_GROUP| unsafe {
                     let mut mem_info: dxgi1_4::DXGI_QUERY_VIDEO_MEMORY_INFO = mem::uninitialized();
-                    assert_eq!(winerror::S_OK, adapter.QueryVideoMemoryInfo(
-                        0,
-                        segment,
-                        &mut mem_info,
-                    ));
+                    assert_eq!(
+                        winerror::S_OK,
+                        adapter.QueryVideoMemoryInfo(0, segment, &mut mem_info,)
+                    );
                     mem_info.Budget
                 };
 
@@ -997,7 +1026,7 @@ impl hal::Instance for Instance {
                     MemoryArchitecture::NUMA => {
                         let non_local = query_memory(dxgi1_4::DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL);
                         vec![local, non_local]
-                    },
+                    }
                     _ => vec![local],
                 }
             };

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -215,6 +215,7 @@ impl PhysicalDevice {
                 name,
                 vendor: 0, // TODO
                 device: 0, // TODO
+                device_type: hal::adapter::DeviceType::DiscreteGpu,  // TODO Is there a way to detect this?
                 software_rendering: false, // not always true ..
             },
             physical_device: PhysicalDevice(Starc::new(share)),

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -145,6 +145,12 @@ impl hal::Instance for Instance {
                     name: dev.name().into(),
                     vendor: 0,
                     device: 0,
+                    device_type: 
+                        if dev.is_low_power() {
+                            hal::adapter::DeviceType::IntegratedGpu                        
+                        } else {
+                            hal::adapter::DeviceType::DiscreteGpu  
+                        },
                     software_rendering: false,
                 },
                 physical_device: device::PhysicalDevice::new(Arc::new(Shared::new(dev))),

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -28,6 +28,7 @@ use ash::extensions as ext;
 use ash::version::{EntryV1_0, DeviceV1_0, InstanceV1_0, V1_0};
 use ash::vk;
 
+use hal::adapter::DeviceType;
 use hal::{format, image, memory, queue};
 use hal::{Features, SwapImageIndex, Limits, PatchSize, QueueType};
 use hal::error::{DeviceCreationError, HostExecutionError};
@@ -286,6 +287,13 @@ impl hal::Instance for Instance {
                     },
                     vendor: properties.vendor_id as usize,
                     device: properties.device_id as usize,
+                    device_type: match properties.device_type {
+                        ash::vk::PhysicalDeviceType::Other => DeviceType::Other,
+                        ash::vk::PhysicalDeviceType::IntegratedGpu => DeviceType::IntegratedGpu,
+                        ash::vk::PhysicalDeviceType::DiscreteGpu => DeviceType::DiscreteGpu,
+                        ash::vk::PhysicalDeviceType::VirtualGpu => DeviceType::VirtualGpu,
+                        ash::vk::PhysicalDeviceType::Cpu => DeviceType::Cpu,
+                    },
                     software_rendering: properties.device_type == vk::PhysicalDeviceType::Cpu,
                 };
                 let physical_device = PhysicalDevice {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -6,9 +6,9 @@ extern crate byteorder;
 extern crate gfx_hal as hal;
 #[macro_use]
 extern crate lazy_static;
-extern crate smallvec;
 #[cfg(feature = "use-rtld-next")]
 extern crate shared_library;
+extern crate smallvec;
 
 #[cfg(windows)]
 extern crate winapi;
@@ -22,26 +22,26 @@ extern crate xcb;
 #[cfg(feature = "glsl-to-spirv")]
 extern crate glsl_to_spirv;
 
+use ash::extensions as ext;
+use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0, V1_0};
+use ash::vk;
 #[cfg(not(feature = "use-rtld-next"))]
 use ash::{Entry, LoadingError};
-use ash::extensions as ext;
-use ash::version::{EntryV1_0, DeviceV1_0, InstanceV1_0, V1_0};
-use ash::vk;
 
 use hal::adapter::DeviceType;
-use hal::{format, image, memory, queue};
-use hal::{Features, SwapImageIndex, Limits, PatchSize, QueueType};
 use hal::error::{DeviceCreationError, HostExecutionError};
+use hal::{format, image, memory, queue};
+use hal::{Features, Limits, PatchSize, QueueType, SwapImageIndex};
 
-use std::{fmt, mem, ptr};
 use std::borrow::Borrow;
 use std::ffi::{CStr, CString};
 use std::sync::Arc;
+use std::{fmt, mem, ptr};
 
 #[cfg(feature = "use-rtld-next")]
-use shared_library::dynamic_library::{DynamicLibrary, SpecialHandles};
-#[cfg(feature = "use-rtld-next")]
 use ash::{EntryCustom, LoadingError};
+#[cfg(feature = "use-rtld-next")]
+use shared_library::dynamic_library::{DynamicLibrary, SpecialHandles};
 
 mod command;
 mod conv;
@@ -52,20 +52,13 @@ mod pool;
 mod result;
 mod window;
 
-const LAYERS: &'static [&'static str] = &[
-    #[cfg(debug_assertions)]
-    "VK_LAYER_LUNARG_standard_validation",
-];
-const EXTENSIONS: &'static [&'static str] = &[
-    #[cfg(debug_assertions)]
-    "VK_EXT_debug_report",
-];
-const DEVICE_EXTENSIONS: &'static [&'static str] = &[
-    vk::VK_KHR_SWAPCHAIN_EXTENSION_NAME,
-];
+const LAYERS: &'static [&'static str] = &[#[cfg(debug_assertions)]
+"VK_LAYER_LUNARG_standard_validation"];
+const EXTENSIONS: &'static [&'static str] = &[#[cfg(debug_assertions)]
+"VK_EXT_debug_report"];
+const DEVICE_EXTENSIONS: &'static [&'static str] = &[vk::VK_KHR_SWAPCHAIN_EXTENSION_NAME];
 const SURFACE_EXTENSIONS: &'static [&'static str] = &[
     vk::VK_KHR_SURFACE_EXTENSION_NAME,
-
     // Platform-specific WSI extensions
     vk::VK_KHR_XLIB_SURFACE_EXTENSION_NAME,
     vk::VK_KHR_XCB_SURFACE_EXTENSION_NAME,
@@ -94,7 +87,10 @@ lazy_static! {
         );
 }
 
-pub struct RawInstance(pub ash::Instance<V1_0>, Option<(ext::DebugReport, vk::DebugReportCallbackEXT)>);
+pub struct RawInstance(
+    pub ash::Instance<V1_0>,
+    Option<(ext::DebugReport, vk::DebugReportCallbackEXT)>,
+);
 impl Drop for RawInstance {
     fn drop(&mut self) {
         unsafe {
@@ -118,11 +114,14 @@ pub struct Instance {
 }
 
 fn map_queue_type(flags: vk::QueueFlags) -> QueueType {
-    if flags.subset(vk::QUEUE_GRAPHICS_BIT | vk::QUEUE_COMPUTE_BIT) { // TRANSFER_BIT optional
+    if flags.subset(vk::QUEUE_GRAPHICS_BIT | vk::QUEUE_COMPUTE_BIT) {
+        // TRANSFER_BIT optional
         QueueType::General
-    } else if flags.subset(vk::QUEUE_GRAPHICS_BIT) { // TRANSFER_BIT optional
+    } else if flags.subset(vk::QUEUE_GRAPHICS_BIT) {
+        // TRANSFER_BIT optional
         QueueType::Graphics
-    } else if flags.subset(vk::QUEUE_COMPUTE_BIT) { // TRANSFER_BIT optional
+    } else if flags.subset(vk::QUEUE_COMPUTE_BIT) {
+        // TRANSFER_BIT optional
         QueueType::Compute
     } else if flags.subset(vk::QUEUE_TRANSFER_BIT) {
         QueueType::Transfer
@@ -158,7 +157,9 @@ extern "system" fn callback(
 impl Instance {
     pub fn create(name: &str, version: u32) -> Self {
         // TODO: return errors instead of panic
-        let entry = VK_ENTRY.as_ref().expect("Unable to load Vulkan entry points");
+        let entry = VK_ENTRY
+            .as_ref()
+            .expect("Unable to load Vulkan entry points");
 
         let app_name = CString::new(name).unwrap();
         let app_info = vk::ApplicationInfo {
@@ -187,7 +188,8 @@ impl Instance {
                 instance_extensions
                     .iter()
                     .find(|inst_ext| unsafe {
-                        CStr::from_ptr(inst_ext.extension_name.as_ptr()).to_bytes() == ext.as_bytes()
+                        CStr::from_ptr(inst_ext.extension_name.as_ptr()).to_bytes()
+                            == ext.as_bytes()
                     })
                     .map(|_| ext)
                     .or_else(|| {
@@ -204,7 +206,8 @@ impl Instance {
                 instance_layers
                     .iter()
                     .find(|inst_layer| unsafe {
-                        CStr::from_ptr(inst_layer.layer_name.as_ptr()).to_bytes() == layer.as_bytes()
+                        CStr::from_ptr(inst_layer.layer_name.as_ptr()).to_bytes()
+                            == layer.as_bytes()
                     })
                     .map(|_| layer)
                     .or_else(|| {
@@ -221,10 +224,7 @@ impl Instance {
                 .map(|&s| CString::new(s).unwrap())
                 .collect::<Vec<_>>();
 
-            let str_pointers = cstrings
-                .iter()
-                .map(|s| s.as_ptr())
-                .collect::<Vec<_>>();
+            let str_pointers = cstrings.iter().map(|s| s.as_ptr()).collect::<Vec<_>>();
 
             let create_info = vk::InstanceCreateInfo {
                 s_type: vk::StructureType::InstanceCreateInfo,
@@ -237,9 +237,8 @@ impl Instance {
                 pp_enabled_extension_names: str_pointers[layers.len()..].as_ptr(),
             };
 
-            unsafe {
-                entry.create_instance(&create_info, None)
-            }.expect("Unable to create Vulkan instance")
+            unsafe { entry.create_instance(&create_info, None) }
+                .expect("Unable to create Vulkan instance")
         };
 
         #[cfg(debug_assertions)]
@@ -248,15 +247,13 @@ impl Instance {
             let info = vk::DebugReportCallbackCreateInfoEXT {
                 s_type: vk::StructureType::DebugReportCallbackCreateInfoExt,
                 p_next: ptr::null(),
-                flags: vk::DEBUG_REPORT_WARNING_BIT_EXT |
-                       vk::DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT |
-                       vk::DEBUG_REPORT_ERROR_BIT_EXT,
+                flags: vk::DEBUG_REPORT_WARNING_BIT_EXT
+                    | vk::DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT
+                    | vk::DEBUG_REPORT_ERROR_BIT_EXT,
                 pfn_callback: callback,
                 p_user_data: ptr::null_mut(),
             };
-            let handle = unsafe {
-                ext.create_debug_report_callback_ext(&info, None)
-            }.unwrap();
+            let handle = unsafe { ext.create_debug_report_callback_ext(&info, None) }.unwrap();
             Some((ext, handle))
         };
         #[cfg(not(debug_assertions))]
@@ -273,7 +270,9 @@ impl hal::Instance for Instance {
     type Backend = Backend;
 
     fn enumerate_adapters(&self) -> Vec<hal::Adapter<Backend>> {
-        self.raw.0.enumerate_physical_devices()
+        self.raw
+            .0
+            .enumerate_physical_devices()
             .expect("Unable to enumerate adapter")
             .into_iter()
             .map(|device| {
@@ -301,17 +300,18 @@ impl hal::Instance for Instance {
                     handle: device,
                     properties,
                 };
-                let queue_families = self.raw.0
+                let queue_families = self
+                    .raw
+                    .0
                     .get_physical_device_queue_family_properties(device)
                     .into_iter()
                     .enumerate()
-                    .map(|(i, properties)| {
-                        QueueFamily {
-                            properties,
-                            device,
-                            index: i as u32,
-                        }
-                    }).collect();
+                    .map(|(i, properties)| QueueFamily {
+                        properties,
+                        device,
+                        index: i as u32,
+                    })
+                    .collect();
                 hal::Adapter {
                     info,
                     physical_device,
@@ -341,7 +341,6 @@ impl hal::queue::QueueFamily for QueueFamily {
     }
 }
 
-
 pub struct PhysicalDevice {
     instance: Arc<RawInstance>,
     handle: vk::PhysicalDevice,
@@ -350,7 +349,8 @@ pub struct PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn open(
-        &self, families: &[(&QueueFamily, &[hal::QueuePriority])]
+        &self,
+        families: &[(&QueueFamily, &[hal::QueuePriority])],
     ) -> Result<hal::Gpu<Backend>, DeviceCreationError> {
         let family_infos = families
             .iter()
@@ -374,10 +374,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 .map(|&s| CString::new(s).unwrap())
                 .collect::<Vec<_>>();
 
-            let str_pointers = cstrings
-                .iter()
-                .map(|s| s.as_ptr())
-                .collect::<Vec<_>>();
+            let str_pointers = cstrings.iter().map(|s| s.as_ptr()).collect::<Vec<_>>();
 
             // TODO: derive from `features`
             let enabled_features = unsafe { mem::zeroed() };
@@ -398,11 +395,9 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 self.instance
                     .0
                     .create_device(self.handle, &info, None)
-                    .map_err(|err| {
-                        match err {
-                            ash::DeviceError::LoadError(err) => panic!("{:?}", err),
-                            ash::DeviceError::VkError(err) => Into::<result::Error>::into(err),
-                        }
+                    .map_err(|err| match err {
+                        ash::DeviceError::LoadError(err) => panic!("{:?}", err),
+                        ash::DeviceError::VkError(err) => Into::<result::Error>::into(err),
                     })
                     .map_err(Into::<DeviceCreationError>::into)?
             }
@@ -410,11 +405,9 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
         let swapchain_fn = vk::SwapchainFn::load(|name| unsafe {
             mem::transmute(
-                self.instance.0
-                    .get_device_proc_addr(
-                        device_raw.handle(),
-                        name.as_ptr(),
-                    )
+                self.instance
+                    .0
+                    .get_device_proc_addr(device_raw.handle(), name.as_ptr()),
             )
         }).unwrap();
 
@@ -428,10 +421,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             .map(|&(family, ref priorities)| {
                 let family_index = family.index;
                 let mut family_raw = hal::backend::RawQueueGroup::new(family.clone());
-                for id in 0 .. priorities.len() {
-                    let queue_raw = unsafe {
-                        device_arc.0.get_device_queue(family_index, id as _)
-                    };
+                for id in 0..priorities.len() {
+                    let queue_raw = unsafe { device_arc.0.get_device_queue(family_index, id as _) };
                     family_raw.add_queue(CommandQueue {
                         raw: Arc::new(queue_raw),
                         device: device_arc.clone(),
@@ -449,11 +440,10 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn format_properties(&self, format: Option<format::Format>) -> format::Properties {
-        let properties = self.instance.0
-            .get_physical_device_format_properties(
-                self.handle,
-                format.map_or(vk::Format::Undefined, conv::map_format),
-            );
+        let properties = self.instance.0.get_physical_device_format_properties(
+            self.handle,
+            format.map_or(vk::Format::Undefined, conv::map_format),
+        );
 
         format::Properties {
             linear_tiling: conv::map_image_features(properties.linear_tiling_features),
@@ -463,24 +453,26 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn image_format_properties(
-        &self, format: format::Format, dimensions: u8, tiling: image::Tiling,
-        usage: image::Usage, storage_flags: image::StorageFlags,
+        &self,
+        format: format::Format,
+        dimensions: u8,
+        tiling: image::Tiling,
+        usage: image::Usage,
+        storage_flags: image::StorageFlags,
     ) -> Option<image::FormatProperties> {
-        match self.instance.0
-            .get_physical_device_image_format_properties(
-                self.handle,
-                conv::map_format(format),
-                match dimensions {
-                    1 => vk::ImageType::Type1d,
-                    2 => vk::ImageType::Type2d,
-                    3 => vk::ImageType::Type3d,
-                    _ => panic!("Unexpected image dimensionality: {}", dimensions)
-                },
-                conv::map_tiling(tiling),
-                conv::map_image_usage(usage),
-                conv::map_image_flags(storage_flags),
-            )
-        {
+        match self.instance.0.get_physical_device_image_format_properties(
+            self.handle,
+            conv::map_format(format),
+            match dimensions {
+                1 => vk::ImageType::Type1d,
+                2 => vk::ImageType::Type2d,
+                3 => vk::ImageType::Type3d,
+                _ => panic!("Unexpected image dimensionality: {}", dimensions),
+            },
+            conv::map_tiling(tiling),
+            conv::map_image_usage(usage),
+            conv::map_image_flags(storage_flags),
+        ) {
             Ok(props) => Some(image::FormatProperties {
                 max_extent: image::Extent {
                     width: props.max_extent.width,
@@ -501,30 +493,48 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn memory_properties(&self) -> hal::MemoryProperties {
-        let mem_properties = self.instance.0.get_physical_device_memory_properties(self.handle);
+        let mem_properties = self
+            .instance
+            .0
+            .get_physical_device_memory_properties(self.handle);
         let memory_heaps = mem_properties.memory_heaps[..mem_properties.memory_heap_count as usize]
             .iter()
-            .map(|mem| mem.size).collect();
-        let memory_types = mem_properties
-            .memory_types[..mem_properties.memory_type_count as usize]
+            .map(|mem| mem.size)
+            .collect();
+        let memory_types = mem_properties.memory_types[..mem_properties.memory_type_count as usize]
             .iter()
             .map(|mem| {
                 use memory::Properties;
                 let mut type_flags = Properties::empty();
 
-                if mem.property_flags.intersects(vk::MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
+                if mem
+                    .property_flags
+                    .intersects(vk::MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+                {
                     type_flags |= Properties::DEVICE_LOCAL;
                 }
-                if mem.property_flags.intersects(vk::MEMORY_PROPERTY_HOST_COHERENT_BIT) {
+                if mem
+                    .property_flags
+                    .intersects(vk::MEMORY_PROPERTY_HOST_COHERENT_BIT)
+                {
                     type_flags |= Properties::COHERENT;
                 }
-                if mem.property_flags.intersects(vk::MEMORY_PROPERTY_HOST_CACHED_BIT) {
+                if mem
+                    .property_flags
+                    .intersects(vk::MEMORY_PROPERTY_HOST_CACHED_BIT)
+                {
                     type_flags |= Properties::CPU_CACHED;
                 }
-                if mem.property_flags.intersects(vk::MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
+                if mem
+                    .property_flags
+                    .intersects(vk::MEMORY_PROPERTY_HOST_VISIBLE_BIT)
+                {
                     type_flags |= Properties::CPU_VISIBLE;
                 }
-                if mem.property_flags.intersects(vk::MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) {
+                if mem
+                    .property_flags
+                    .intersects(vk::MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
+                {
                     type_flags |= Properties::LAZILY_ALLOCATED;
                 }
 
@@ -543,9 +553,10 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
     fn features(&self) -> Features {
         // see https://github.com/gfx-rs/gfx/issues/1930
-        let is_windows_intel_kaby = cfg!(windows) &&
-            self.properties.vendor_id == info::intel::VENDOR &&
-            self.properties.device_id & info::intel::DEVICE_KABY_LAKE_MASK == info::intel::DEVICE_KABY_LAKE_MASK;
+        let is_windows_intel_kaby = cfg!(windows)
+            && self.properties.vendor_id == info::intel::VENDOR
+            && self.properties.device_id & info::intel::DEVICE_KABY_LAKE_MASK
+                == info::intel::DEVICE_KABY_LAKE_MASK;
 
         let features = self.instance.0.get_physical_device_features(self.handle);
         let mut bits = Features::empty();
@@ -643,8 +654,16 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             max_texel_elements: limits.max_texel_buffer_elements as _,
             max_patch_size: limits.max_tessellation_patch_size as PatchSize,
             max_viewports: limits.max_viewports as _,
-            max_compute_group_count: [max_group_count[0] as _, max_group_count[1] as _, max_group_count[2] as _],
-            max_compute_group_size: [max_group_size[0] as _, max_group_size[1] as _, max_group_size[2] as _],
+            max_compute_group_count: [
+                max_group_count[0] as _,
+                max_group_count[1] as _,
+                max_group_count[2] as _,
+            ],
+            max_compute_group_size: [
+                max_group_size[0] as _,
+                max_group_size[1] as _,
+                max_group_size[2] as _,
+            ],
             max_vertex_input_attributes: limits.max_vertex_input_attributes as _,
             max_vertex_input_bindings: limits.max_vertex_input_bindings as _,
             max_vertex_input_attribute_offset: limits.max_vertex_input_attribute_offset as _,
@@ -657,7 +676,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment as _,
             framebuffer_color_samples_count: limits.framebuffer_color_sample_counts.flags() as _,
             framebuffer_depth_samples_count: limits.framebuffer_depth_sample_counts.flags() as _,
-            framebuffer_stencil_samples_count: limits.framebuffer_stencil_sample_counts.flags() as _,
+            framebuffer_stencil_samples_count: limits.framebuffer_stencil_sample_counts.flags()
+                as _,
             max_color_attachments: limits.max_color_attachments as _,
             non_coherent_atom_size: limits.non_coherent_atom_size as _,
         }
@@ -673,7 +693,9 @@ impl fmt::Debug for RawDevice {
 }
 impl Drop for RawDevice {
     fn drop(&mut self) {
-        unsafe { self.0.destroy_device(None); }
+        unsafe {
+            self.0.destroy_device(None);
+        }
     }
 }
 
@@ -687,27 +709,31 @@ pub struct CommandQueue {
 }
 
 impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
-    unsafe fn submit_raw<IC>(&mut self,
+    unsafe fn submit_raw<IC>(
+        &mut self,
         submission: hal::queue::RawSubmission<Backend, IC>,
         fence: Option<&native::Fence>,
-    )
-    where
+    ) where
         IC: IntoIterator,
         IC::Item: Borrow<command::CommandBuffer>,
     {
-        let buffers = submission.cmd_buffers
+        let buffers = submission
+            .cmd_buffers
             .into_iter()
             .map(|cmd| cmd.borrow().raw)
             .collect::<Vec<_>>();
-        let waits = submission.wait_semaphores
+        let waits = submission
+            .wait_semaphores
             .iter()
             .map(|&(ref semaphore, _)| semaphore.0)
             .collect::<Vec<_>>();
-        let stages = submission.wait_semaphores
+        let stages = submission
+            .wait_semaphores
             .iter()
             .map(|&(_, stage)| conv::map_pipeline_stage(stage))
             .collect::<Vec<_>>();
-        let signals = submission.signal_semaphores
+        let signals = submission
+            .signal_semaphores
             .iter()
             .map(|semaphore| semaphore.0)
             .collect::<Vec<_>>();
@@ -718,16 +744,18 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
             wait_semaphore_count: waits.len() as u32,
             p_wait_semaphores: waits.as_ptr(),
             // If count is zero, AMD driver crashes if nullptr is not set for stage masks
-            p_wait_dst_stage_mask: if stages.is_empty() { ptr::null() } else { stages.as_ptr() },
+            p_wait_dst_stage_mask: if stages.is_empty() {
+                ptr::null()
+            } else {
+                stages.as_ptr()
+            },
             command_buffer_count: buffers.len() as u32,
             p_command_buffers: buffers.as_ptr(),
             signal_semaphore_count: signals.len() as u32,
             p_signal_semaphores: signals.as_ptr(),
         };
 
-        let fence_raw = fence
-            .map(|fence| fence.0)
-            .unwrap_or(vk::Fence::null());
+        let fence_raw = fence.map(|fence| fence.0).unwrap_or(vk::Fence::null());
 
         let result = self.device.0.queue_submit(*self.raw, &[info], fence_raw);
         assert_eq!(Ok(()), result);
@@ -763,10 +791,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
             p_results: ptr::null_mut(),
         };
 
-        match unsafe {
-            self.swapchain_fn
-                .queue_present_khr(*self.raw, &info)
-        } {
+        match unsafe { self.swapchain_fn.queue_present_khr(*self.raw, &info) } {
             vk::Result::Success => Ok(()),
             vk::Result::SuboptimalKhr | vk::Result::ErrorOutOfDateKhr => Err(()),
             _ => panic!("Failed to present frame"),

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -8,9 +8,9 @@
 
 use std::any::Any;
 
-use {format, image, memory, Backend, Gpu, Features, Limits};
 use error::DeviceCreationError;
 use queue::{Capability, QueueGroup};
+use {format, image, memory, Backend, Features, Gpu, Limits};
 
 /// Scheduling hint for devices about the priority of a queue.  Values range from `0.0` (low) to
 /// `1.0` (high).
@@ -71,18 +71,21 @@ pub trait PhysicalDevice<B: Backend>: Any + Send + Sync {
     /// # }
     /// ```
     fn open(
-        &self, families: &[(&B::QueueFamily, &[QueuePriority])]
+        &self,
+        families: &[(&B::QueueFamily, &[QueuePriority])],
     ) -> Result<Gpu<B>, DeviceCreationError>;
 
     /// Fetch details for a particular format.
-    fn format_properties(
-        &self, format: Option<format::Format>
-    ) -> format::Properties;
+    fn format_properties(&self, format: Option<format::Format>) -> format::Properties;
 
     /// Fetch details for a particular image format.
     fn image_format_properties(
-        &self, format: format::Format, dimensions: u8, tiling: image:: Tiling,
-        usage: image::Usage, storage_flags: image::StorageFlags,
+        &self,
+        format: format::Format,
+        dimensions: u8,
+        tiling: image::Tiling,
+        usage: image::Usage,
+        storage_flags: image::StorageFlags,
     ) -> Option<image::FormatProperties>;
 
     /// Fetch details for the memory regions provided by the device.
@@ -97,7 +100,7 @@ pub trait PhysicalDevice<B: Backend>: Any + Send + Sync {
 }
 
 /// Supported physical device types
-#[derive(Clone,PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DeviceType {
     /// Other
@@ -109,7 +112,7 @@ pub enum DeviceType {
     /// Virtual
     VirtualGpu = 3,
     /// Cpu
-    Cpu = 4
+    Cpu = 4,
 }
 
 /// Metadata about a backend adapter.
@@ -165,7 +168,9 @@ impl<B: Backend> Adapter<B> {
     /// Returns the same errors as `open` and `InitializationFailed` if no suitable
     /// queue family could be found.
     pub fn open_with<F, C>(
-        &mut self, count: usize, selector: F
+        &mut self,
+        count: usize,
+        selector: F,
     ) -> Result<(B::Device, QueueGroup<B, C>), DeviceCreationError>
     where
         F: Fn(&B::QueueFamily) -> bool,
@@ -173,12 +178,13 @@ impl<B: Backend> Adapter<B> {
     {
         use queue::QueueFamily;
 
-        let requested_family = self.queue_families
+        let requested_family = self
+            .queue_families
             .drain(..)
             .filter(|family| {
-                C::supported_by(family.queue_type()) &&
-                    selector(&family) &&
-                    count <= family.max_queues()
+                C::supported_by(family.queue_type())
+                    && selector(&family)
+                    && count <= family.max_queues()
             })
             .next();
 

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -96,6 +96,22 @@ pub trait PhysicalDevice<B: Backend>: Any + Send + Sync {
     fn limits(&self) -> Limits;
 }
 
+/// Supported physical device types
+#[derive(Clone,PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum DeviceType {
+    /// Other
+    Other = 0,
+    /// Integrated
+    IntegratedGpu = 1,
+    /// Discrete
+    DiscreteGpu = 2,
+    /// Virtual
+    VirtualGpu = 3,
+    /// Cpu
+    Cpu = 4
+}
+
 /// Metadata about a backend adapter.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -106,6 +122,8 @@ pub struct AdapterInfo {
     pub vendor: usize,
     /// PCI id of the adapter
     pub device: usize,
+    /// Type of device
+    pub device_type: DeviceType,
     /// Whether or not the device is based on a software rasterizer
     pub software_rendering: bool,
 }


### PR DESCRIPTION
Notes:

make reftests failed, I believe unrelated, see the note below in the PR checklist
I have no way to build the metal backend, so I have not built it. Relying on bors for now.

### Backends

* Vulkan - This gets exposed exactly as it does by Vulkan/ash
* Metal - Metal docs say that is_low_power() is true for integrated, false for discrete. So these are the only two values Metal will return, using this to decide.
* DX11/12 - I return VirtualGpu if software rendering is true, otherwise discrete. I did not find that any more detailed info is exposed, but I am uncertain.
* OpenGL - I always return discrete, it does not appears OpenGL can expose this information.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds  (it did not, filed issue #2358 )
- [x] tested examples with the following backends:Vulkan
- [x] `rustfmt` run on changed code
