### PR TITLE
[mtl] carefully restore resources and push constants on pipeline change

### DIFF
--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -292,7 +292,7 @@ pub struct StencilState<T> {
     pub back_write_mask: T,
 }
 
-pub type VertexBufferVec = Vec<Option<(pso::VertexBufferDesc, pso::ElemOffset)>>;
+pub type VertexBufferVec = Vec<(pso::VertexBufferDesc, pso::ElemOffset)>;
 
 #[derive(Debug)]
 pub struct GraphicsPipeline {
@@ -303,6 +303,8 @@ pub struct GraphicsPipeline {
     pub(crate) raw: metal::RenderPipelineState,
     pub(crate) primitive_type: metal::MTLPrimitiveType,
     pub(crate) attribute_buffer_index: ResourceIndex,
+    pub(crate) vs_pc_buffer_index: Option<ResourceIndex>,
+    pub(crate) ps_pc_buffer_index: Option<ResourceIndex>,
     pub(crate) rasterizer_state: Option<RasterizerState>,
     pub(crate) depth_bias: pso::State<pso::DepthBias>,
     pub(crate) depth_stencil_desc: pso::DepthStencilDesc,
@@ -324,6 +326,7 @@ pub struct ComputePipeline {
     pub(crate) cs_lib: metal::Library,
     pub(crate) raw: metal::ComputePipelineState,
     pub(crate) work_group_size: metal::MTLSize,
+    pub(crate) pc_buffer_index: Option<ResourceIndex>,
 }
 
 unsafe impl Send for ComputePipeline {}


### PR DESCRIPTION
Fixes the only Metal validation issue occurring in Mario Kart run via Doplhin.
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: quad
- [ ] `rustfmt` run on changed code

This is tricky but super important to get right for us. First part, a minor one, is that the ID of the push constants depend on the pipeline layout (which was a recent change), and thus we didn't re-bind them properly on a pipeline change. This PR does it.

The second part is most complex. Both push constants and descriptors are bound with the pipeline layout, but the vertex buffers are bound according to a particular graphics pipeline. And they tend to collide with the others. Vertex buffers may occupy any slots starting from `attribute_buffer_index` member of the layout (which is also copied to the pipeline on creation). Thus, when a new pipeline is getting assigned, we can't trust any vertex buffers at this index and above. The new logic attempts to re-bind the push constants and vertex buffers affected.

In an ideal world, vertex buffers would be a part of the pipeline layout, and we wound't have to resort to any state restoration like this. Life would be easier, and we'd all ride unicorns.