### PR TITLE
[iOS] add aarch64-apple-ios travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,31 @@ cache:
 
 matrix:
   include:
+    # Linux 64bit
     - os: linux
       rust: stable
       compiler: gcc
     - os: linux
       rust: nightly
       compiler: gcc
-    - os: osx
+
+    # macOS 64bit
+    - env: MACOSX_DEPLOYMENT_TARGET=10.9
+      os: osx
       rust: stable
       osx_image: xcode9
       compiler: clang
-    - os: osx
+    - env: MACOSX_DEPLOYMENT_TARGET=10.9
+      os: osx
       rust: nightly
       osx_image: xcode9
       compiler: clang
+
+    # iPhoneOS 64bit
+    - env: TARGET=aarch64-apple-ios
+      os: osx
+      osx_image: xcode9
+      rust: nightly
 
 branches:
   except:
@@ -43,7 +54,9 @@ before_install:
   # (assuming it will have libsdl2-dev and Rust by then)
   # see https://docs.travis-ci.com/user/trusty-ci-environment/
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && make travis-sdl2 && export CXX=g++-5; fi
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update && brew install sdl2 && brew upgrade cmake && export CXX=clang++ && export MACOSX_DEPLOYMENT_TARGET=10.9; fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update && brew install sdl2; fi
+  - rustup self update
+  - rustup target add $TARGET; true
 
 addons:
   apt:
@@ -74,5 +87,5 @@ script:
   - export PATH=$PATH:$HOME/deps/bin
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export LIBRARY_PATH=$HOME/deps/usr/lib/x86_64-linux-gnu; fi
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export LD_LIBRARY_PATH=$LIBRARY_PATH; fi
-  - make all
+  - if [[ $TARGET != "aarch64-apple-ios" ]]; then make all; else make check; fi
   #- if [[ $TRAVIS_OS_NAME == "linux" ]]; then make reftests-ci; fi

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ SDL2_DEST=$(HOME)/deps
 SDL2_CONFIG=$(SDL2_DEST)/usr/bin/sdl2-config
 SDL2_PPA=http://ppa.launchpad.net/zoogie/sdl2-snapshots/ubuntu/pool/main/libs/libsdl2
 
+ifeq (,$(TARGET))
+	CHECK_TARGET_FLAG=
+else
+	CHECK_TARGET_FLAG=--target $(TARGET)
+endif
 
 ifeq ($(OS),Windows_NT)
 	EXCLUDES+= --exclude gfx-backend-metal
@@ -31,7 +36,11 @@ else
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		EXCLUDES+= --exclude gfx-backend-vulkan
-		FEATURES_HAL=metal
+		ifeq ($(TARGET),$(filter $(TARGET),x86_64-apple-ios armv7-apple-ios))
+			EXCLUDES += --exclude gfx-backend-metal
+		else
+			FEATURES_HAL=metal
+		endif
 	endif
 endif
 
@@ -45,12 +54,12 @@ help:
 
 check:
 	@echo "Note: excluding \`warden\` here, since it depends on serialization"
-	cargo check --all $(EXCLUDES) --exclude gfx-warden
-	cd examples && cargo check --features "gl"
-	cd examples && cargo check --features "$(FEATURES_HAL)"
-	cd examples && cargo check --features "$(FEATURES_HAL2)"
-	cd src/warden && cargo check --no-default-features
-	cd src/warden && cargo check --features "env_logger gl gl-headless $(FEATURES_HAL) $(FEATURES_HAL2)"
+	cargo check --all $(CHECK_TARGET_FLAG) $(EXCLUDES) --exclude gfx-warden
+	cd examples && cargo check $(CHECK_TARGET_FLAG) --features "gl"
+	cd examples && cargo check $(CHECK_TARGET_FLAG) --features "$(FEATURES_HAL)"
+	cd examples && cargo check $(CHECK_TARGET_FLAG) --features "$(FEATURES_HAL2)"
+	cd src/warden && cargo check $(CHECK_TARGET_FLAG) --no-default-features
+	cd src/warden && cargo check $(CHECK_TARGET_FLAG) --features "env_logger gl gl-headless $(FEATURES_HAL) $(FEATURES_HAL2)"
 
 test:
 	cargo test --all $(EXCLUDES)

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -45,7 +45,7 @@ version = "0.1"
 #features = ["glsl-to-spirv"]
 optional = true
 
-[target.'cfg(target_os = "macos")'.dependencies.gfx-backend-metal]
+[target.'cfg(any(target_os = "macos", all(target_os = "ios", target_arch = "aarch64")))'.dependencies.gfx-backend-metal]
 path = "../src/backend/metal"
 version = "0.1"
 optional = true

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -45,7 +45,7 @@ path = "../../src/backend/dx12"
 version = "0.1"
 optional = true
 
-[target.'cfg(target_os = "macos")'.dependencies.gfx-backend-metal]
+[target.'cfg(any(target_os = "macos", all(target_os = "ios", target_arch = "aarch64")))'.dependencies.gfx-backend-metal]
 path = "../../src/backend/metal"
 version = "0.1"
 features = ["auto-capture"]


### PR DESCRIPTION
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

This PR adds aarch64-apple-ios with rust nightly to travis - the only iOS target supporting metal. Only `make check` is run on this target. The examples, and warden now also pass `make check` on iOS

TODOs:
- there are [ways](https://github.com/rust-lang/libc/blob/master/ci/ios/deploy_and_run_on_ios_simulator.rs) to [run](https://github.com/snipsco/dinghy) tests on simulator; however, metal doesn't work on simulator.
- Figure out the correct value for, and a way to set `-miphoneos-version-min`