### PR TITLE
Expose `max_sampler_anisotropy`

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -359,6 +359,7 @@ impl hal::Instance for Instance {
                 framebuffer_stencil_samples_count: 1,    // TODO
                 max_color_attachments: 1,                // TODO
                 non_coherent_atom_size: 1,               // TODO
+                max_sampler_anisotropy: 16.,
             };
 
             let features = get_features(device.clone(), feature_level);

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1078,6 +1078,7 @@ impl hal::Instance for Instance {
                     framebuffer_stencil_samples_count: 0b101,
                     max_color_attachments: 1, // TODO
                     non_coherent_atom_size: 1, //TODO: confirm
+                    max_sampler_anisotropy: 16.,
                 },
                 format_properties: Arc::new(format_properties),
                 private_caps: Capabilities {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -588,6 +588,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             // Note: we issue Metal buffer-to-buffer copies on memory flush/invalidate,
             // and those need to operate on sizes being multiples of 4.
             non_coherent_atom_size: 4,
+            max_sampler_anisotropy: 16.,
         }
     }
 }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -680,6 +680,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 as _,
             max_color_attachments: limits.max_color_attachments as _,
             non_coherent_atom_size: limits.non_coherent_atom_size as _,
+            max_sampler_anisotropy: limits.max_sampler_anisotropy,
         }
     }
 }

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -226,7 +226,7 @@ bitflags! {
 }
 
 /// Resource limits of a particular graphics device.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Limits {
     /// Maximum supported texture size.
@@ -274,6 +274,8 @@ pub struct Limits {
     pub max_color_attachments: usize,
     /// Size and alignment in bytes that bounds concurrent access to host-mapped device memory.
     pub non_coherent_atom_size: usize,
+    /// Maximum degree of sampler anisotropy.
+    pub max_sampler_anisotropy: f32,
 }
 
 /// Describes the type of geometric primitives,


### PR DESCRIPTION
PR checklist:
- [ ] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends: Metal
- [ ] `rustfmt` run on changed code
