### PR TITLE
[mtl] fix format_depth24_stencil8 crashes on iOS

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -359,7 +359,7 @@ impl PhysicalDevice {
                 shared_textures: !os_is_mac,
                 base_instance: Self::supports_any(&device, BASE_INSTANCE_SUPPORT),
                 dual_source_blending: Self::supports_any(&device, DUAL_SOURCE_BLEND_SUPPORT),
-                format_depth24_stencil8: device.d24_s8_supported(),
+                format_depth24_stencil8: os_is_mac && device.d24_s8_supported(),
                 format_depth32_stencil8_filter: os_is_mac,
                 format_depth32_stencil8_none: !os_is_mac,
                 format_min_srgb_channels: if os_is_mac {4} else {1},


### PR DESCRIPTION
format_depth24_stencil8 is macOS only feature.

checks on iPhone 8, 7p

Fixes #issue
PR checklist:
- [] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code