### PR TITLE
Remove software_rendering field from AdapterInfo

### DIFF
--- a/src/backend/dx11/src/dxgi.rs
+++ b/src/backend/dx11/src/dxgi.rs
@@ -150,8 +150,7 @@ fn get_adapter_desc(adapter: *mut dxgi::IDXGIAdapter, version: DxgiVersion) -> A
                     DeviceType::VirtualGpu
                 } else {
                     DeviceType::DiscreteGpu
-                },
-                software_rendering: (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0,
+                },                
             }
         }
         DxgiVersion::Dxgi1_2
@@ -177,8 +176,7 @@ fn get_adapter_desc(adapter: *mut dxgi::IDXGIAdapter, version: DxgiVersion) -> A
                     DeviceType::VirtualGpu
                 } else {
                     DeviceType::DiscreteGpu
-                },
-                software_rendering: (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0,
+                },               
             }
         }
     }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -765,8 +765,7 @@ impl hal::Instance for Instance {
                     DeviceType::VirtualGpu
                 } else {
                     DeviceType::DiscreteGpu
-                },
-                software_rendering: (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0,
+                },                
             };
 
             let mut features: d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS = unsafe { mem::zeroed() };

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -216,8 +216,7 @@ impl PhysicalDevice {
                 name,
                 vendor: 0,                                          // TODO
                 device: 0,                                          // TODO
-                device_type: hal::adapter::DeviceType::DiscreteGpu, // TODO Is there a way to detect this?
-                software_rendering: false,                          // not always true ..
+                device_type: hal::adapter::DeviceType::DiscreteGpu, // TODO Is there a way to detect this?                
             },
             physical_device: PhysicalDevice(Starc::new(share)),
             queue_families: vec![QueueFamily],

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -163,8 +163,7 @@ impl hal::Instance for Instance {
                         hal::adapter::DeviceType::IntegratedGpu
                     } else {
                         hal::adapter::DeviceType::DiscreteGpu
-                    },
-                    software_rendering: false,
+                    },                    
                 },
                 physical_device: device::PhysicalDevice::new(Arc::new(Shared::new(dev))),
                 queue_families: vec![QueueFamily {}],

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -292,8 +292,7 @@ impl hal::Instance for Instance {
                         ash::vk::PhysicalDeviceType::DiscreteGpu => DeviceType::DiscreteGpu,
                         ash::vk::PhysicalDeviceType::VirtualGpu => DeviceType::VirtualGpu,
                         ash::vk::PhysicalDeviceType::Cpu => DeviceType::Cpu,
-                    },
-                    software_rendering: properties.device_type == vk::PhysicalDeviceType::Cpu,
+                    },                    
                 };
                 let physical_device = PhysicalDevice {
                     instance: self.raw.clone(),

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -109,9 +109,9 @@ pub enum DeviceType {
     IntegratedGpu = 1,
     /// Discrete
     DiscreteGpu = 2,
-    /// Virtual
+    /// Virtual / Hosted
     VirtualGpu = 3,
-    /// Cpu
+    /// Cpu / Software Rendering
     Cpu = 4,
 }
 
@@ -126,9 +126,7 @@ pub struct AdapterInfo {
     /// PCI id of the adapter
     pub device: usize,
     /// Type of device
-    pub device_type: DeviceType,
-    /// Whether or not the device is based on a software rasterizer
-    pub software_rendering: bool,
+    pub device_type: DeviceType, 
 }
 
 /// The list of `Adapter` instances is obtained by calling `Instance::enumerate_adapters()`.


### PR DESCRIPTION
Now that device_type is exposed, the software_rendering field is no longer necessary. device_type will be `Cpu` when software_rendering would be true.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vuklan,gl
- [x] `rustfmt` run on changed code
