### PR TITLE
adjust clear-image test to hit 128

### DIFF
--- a/reftests/scenes/transfer.ron
+++ b/reftests/scenes/transfer.ron
@@ -143,7 +143,7 @@
 		"clear-image": Transfer(
 			ClearImage(
 				image: "image.output",
-				color: Float((0.5, 0.5, 0.5, 0.5)),
+				color: Float((0.501, 0.501, 0.501, 0.501)),
 				depth_stencil: (0.0, 0),
 				ranges: [
 					(


### PR DESCRIPTION
Fixes #2358 

.5001 is too small, still hits 127, .501 hits 128
make reftests passes now with this change.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
- [x] `rustfmt` run on changed code
