### PR TITLE
[vulkan] Use `generator` branch of `ash` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .vscode/
 .#*
+.idea
 
 # Compiled
 /doc

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "1"
 log = { version = "0.4", features = ["release_max_level_error"] }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
-ash = "0.24.4"
+ash = { git = "https://github.com/MaikKlein/ash.git", branch = "generator" }
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.17", optional = true }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -22,8 +22,8 @@ pub struct CommandBuffer {
 
 fn map_subpass_contents(contents: com::SubpassContents) -> vk::SubpassContents {
     match contents {
-        com::SubpassContents::Inline => vk::SubpassContents::Inline,
-        com::SubpassContents::SecondaryBuffers => vk::SubpassContents::SecondaryCommandBuffers,
+        com::SubpassContents::Inline => vk::SubpassContents::INLINE,
+        com::SubpassContents::SecondaryBuffers => vk::SubpassContents::SECONDARY_COMMAND_BUFFERS,
     }
 }
 
@@ -85,18 +85,18 @@ impl CommandBuffer {
 impl com::RawCommandBuffer<Backend> for CommandBuffer {
     fn begin(&mut self, flags: com::CommandBufferFlags, info: com::CommandBufferInheritanceInfo<Backend>) {
         let inheritance_info = vk::CommandBufferInheritanceInfo {
-            s_type: vk::StructureType::CommandBufferInheritanceInfo,
+            s_type: vk::StructureType::COMMAND_BUFFER_INHERITANCE_INFO,
             p_next: ptr::null(),
-            render_pass: info.subpass.map_or(vk::types::RenderPass::null(), |subpass| subpass.main_pass.raw),
+            render_pass: info.subpass.map_or(vk::RenderPass::null(), |subpass| subpass.main_pass.raw),
             subpass: info.subpass.map_or(0, |subpass| subpass.index as u32),
-            framebuffer: info.framebuffer.map_or(vk::types::Framebuffer::null(), |buffer| buffer.raw),
-            occlusion_query_enable: if info.occlusion_query_enable { vk::VK_TRUE } else { vk::VK_FALSE },
+            framebuffer: info.framebuffer.map_or(vk::Framebuffer::null(), |buffer| buffer.raw),
+            occlusion_query_enable: if info.occlusion_query_enable { vk::TRUE } else { vk::FALSE },
             query_flags: conv::map_query_control_flags(info.occlusion_query_flags),
             pipeline_statistics: conv::map_pipeline_statistics(info.pipeline_statistics),
         };
 
         let info = vk::CommandBufferBeginInfo {
-            s_type: vk::StructureType::CommandBufferBeginInfo,
+            s_type: vk::StructureType::COMMAND_BUFFER_BEGIN_INFO,
             p_next: ptr::null(),
             flags: conv::map_command_buffer_flags(flags),
             p_inheritance_info: &inheritance_info,
@@ -115,7 +115,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     fn reset(&mut self, release_resources: bool) {
         let flags = if release_resources {
-            vk::COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT
+            vk::CommandBufferResetFlags::RELEASE_RESOURCES
         } else {
             vk::CommandBufferResetFlags::empty()
         };
@@ -148,7 +148,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 .collect();
 
         let info = vk::RenderPassBeginInfo {
-            s_type: vk::StructureType::RenderPassBeginInfo,
+            s_type: vk::StructureType::RENDER_PASS_BEGIN_INFO,
             p_next: ptr::null(),
             render_pass: render_pass.raw,
             framebuffer: frame_buffer.raw,
@@ -197,7 +197,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             match *barrier.borrow() {
                 memory::Barrier::AllBuffers(ref access) => {
                     global_bars.push(vk::MemoryBarrier {
-                        s_type: vk::StructureType::MemoryBarrier,
+                        s_type: vk::StructureType::MEMORY_BARRIER,
                         p_next: ptr::null(),
                         src_access_mask: conv::map_buffer_access(access.start),
                         dst_access_mask: conv::map_buffer_access(access.end),
@@ -205,7 +205,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 }
                 memory::Barrier::AllImages(ref access) => {
                     global_bars.push(vk::MemoryBarrier {
-                        s_type: vk::StructureType::MemoryBarrier,
+                        s_type: vk::StructureType::MEMORY_BARRIER,
                         p_next: ptr::null(),
                         src_access_mask: conv::map_image_access(access.start),
                         dst_access_mask: conv::map_image_access(access.end),
@@ -213,28 +213,28 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 }
                 memory::Barrier::Buffer { ref states, target} => {
                     buffer_bars.push(vk::BufferMemoryBarrier {
-                        s_type: vk::StructureType::BufferMemoryBarrier,
+                        s_type: vk::StructureType::BUFFER_MEMORY_BARRIER,
                         p_next: ptr::null(),
                         src_access_mask: conv::map_buffer_access(states.start),
                         dst_access_mask: conv::map_buffer_access(states.end),
-                        src_queue_family_index: vk::VK_QUEUE_FAMILY_IGNORED, // TODO
-                        dst_queue_family_index: vk::VK_QUEUE_FAMILY_IGNORED, // TODO
+                        src_queue_family_index: vk::QUEUE_FAMILY_IGNORED, // TODO
+                        dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED, // TODO
                         buffer: target.raw,
                         offset: 0,
-                        size: vk::VK_WHOLE_SIZE,
+                        size: vk::WHOLE_SIZE,
                     });
                 }
                 memory::Barrier::Image { ref states, target, ref range } => {
                     let subresource_range = conv::map_subresource_range(range);
                     image_bars.push(vk::ImageMemoryBarrier {
-                        s_type: vk::StructureType::ImageMemoryBarrier,
+                        s_type: vk::StructureType::IMAGE_MEMORY_BARRIER,
                         p_next: ptr::null(),
                         src_access_mask: conv::map_image_access(states.start.0),
                         dst_access_mask: conv::map_image_access(states.end.0),
                         old_layout: conv::map_image_layout(states.start.1),
                         new_layout: conv::map_image_layout(states.end.1),
-                        src_queue_family_index: vk::VK_QUEUE_FAMILY_IGNORED, // TODO
-                        dst_queue_family_index: vk::VK_QUEUE_FAMILY_IGNORED, // TODO
+                        src_queue_family_index: vk::QUEUE_FAMILY_IGNORED, // TODO
+                        dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED, // TODO
                         image: target.raw,
                         subresource_range,
                     });
@@ -365,18 +365,18 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 match *clear.borrow() {
                     com::AttachmentClear::Color { index, value } => {
                         vk::ClearAttachment {
-                            aspect_mask: vk::IMAGE_ASPECT_COLOR_BIT,
+                            aspect_mask: vk::ImageAspectFlags::COLOR,
                             color_attachment: index as _,
                             clear_value: vk::ClearValue { color: conv::map_clear_color(value) },
                         }
                     }
                     com::AttachmentClear::DepthStencil { depth, stencil } => {
                         vk::ClearAttachment {
-                            aspect_mask: if depth.is_some() { vk::IMAGE_ASPECT_DEPTH_BIT } else { vk::ImageAspectFlags::empty() } |
-                                if stencil.is_some() { vk::IMAGE_ASPECT_STENCIL_BIT } else { vk::ImageAspectFlags::empty() },
+                            aspect_mask: if depth.is_some() { vk::ImageAspectFlags::DEPTH } else { vk::ImageAspectFlags::empty() } |
+                                if stencil.is_some() { vk::ImageAspectFlags::STENCIL } else { vk::ImageAspectFlags::empty() },
                             color_attachment: 0,
                             clear_value: vk::ClearValue {
-                                depth: vk::ClearDepthStencilValue {
+                                depth_stencil: vk::ClearDepthStencilValue {
                                     depth: depth.unwrap_or_default(),
                                     stencil: stencil.unwrap_or_default(),
                                 },
@@ -591,7 +591,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         unsafe {
             self.device.0.cmd_bind_pipeline(
                 self.raw,
-                vk::PipelineBindPoint::Graphics,
+                vk::PipelineBindPoint::GRAPHICS,
                 pipeline.0,
             )
         }
@@ -610,7 +610,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         J::Item: Borrow<com::DescriptorSetOffset>,
     {
         self.bind_descriptor_sets(
-            vk::PipelineBindPoint::Graphics,
+            vk::PipelineBindPoint::GRAPHICS,
             layout,
             first_set,
             sets,
@@ -622,7 +622,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         unsafe {
             self.device.0.cmd_bind_pipeline(
                 self.raw,
-                vk::PipelineBindPoint::Compute,
+                vk::PipelineBindPoint::COMPUTE,
                 pipeline.0,
             )
         }
@@ -641,7 +641,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         J::Item: Borrow<com::DescriptorSetOffset>,
     {
         self.bind_descriptor_sets(
-            vk::PipelineBindPoint::Compute,
+            vk::PipelineBindPoint::COMPUTE,
             layout,
             first_set,
             sets,
@@ -930,7 +930,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             self.device.0.cmd_push_constants(
                 self.raw,
                 layout.raw,
-                vk::SHADER_STAGE_COMPUTE_BIT,
+                vk::ShaderStageFlags::COMPUTE,
                 offset * 4,
                 memory::cast_slice(constants),
             );

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -19,11 +19,11 @@ pub fn map_format(format: format::Format) -> vk::Format {
 }
 
 pub fn map_vk_format(format: vk::Format) -> Option<format::Format> {
-    if (format as usize) < format::NUM_FORMATS &&
-        format != vk::Format::Undefined
+    if (format.as_raw() as usize) < format::NUM_FORMATS &&
+        format != vk::Format::UNDEFINED
     {
         // Safe due to equivalence of HAL format values and Vulkan format values
-        Some(unsafe { mem::transmute(format) })
+        Some(unsafe { mem::transmute(format.as_raw()) })
     } else {
         None
     }
@@ -36,8 +36,8 @@ pub fn map_tiling(tiling: image::Tiling) -> vk::ImageTiling {
 pub fn map_component(component: format::Component) -> vk::ComponentSwizzle {
     use hal::format::Component::*;
     match component {
-        Zero => vk::ComponentSwizzle::Zero,
-        One  => vk::ComponentSwizzle::One,
+        Zero => vk::ComponentSwizzle::ZERO,
+        One  => vk::ComponentSwizzle::ONE,
         R    => vk::ComponentSwizzle::R,
         G    => vk::ComponentSwizzle::G,
         B    => vk::ComponentSwizzle::B,
@@ -56,24 +56,24 @@ pub fn map_swizzle(swizzle: format::Swizzle) -> vk::ComponentMapping {
 
 pub fn map_index_type(index_type: IndexType) -> vk::IndexType {
     match index_type {
-        IndexType::U16 => vk::IndexType::Uint16,
-        IndexType::U32 => vk::IndexType::Uint32,
+        IndexType::U16 => vk::IndexType::UINT16,
+        IndexType::U32 => vk::IndexType::UINT32,
     }
 }
 
 pub fn map_image_layout(layout: image::Layout) -> vk::ImageLayout {
     use hal::image::Layout as Il;
     match layout {
-        Il::General => vk::ImageLayout::General,
-        Il::ColorAttachmentOptimal => vk::ImageLayout::ColorAttachmentOptimal,
-        Il::DepthStencilAttachmentOptimal => vk::ImageLayout::DepthStencilAttachmentOptimal,
-        Il::DepthStencilReadOnlyOptimal => vk::ImageLayout::DepthStencilReadOnlyOptimal,
-        Il::ShaderReadOnlyOptimal => vk::ImageLayout::ShaderReadOnlyOptimal,
-        Il::TransferSrcOptimal => vk::ImageLayout::TransferSrcOptimal,
-        Il::TransferDstOptimal => vk::ImageLayout::TransferDstOptimal,
-        Il::Undefined => vk::ImageLayout::Undefined,
-        Il::Preinitialized => vk::ImageLayout::Preinitialized,
-        Il::Present => vk::ImageLayout::PresentSrcKhr,
+        Il::General => vk::ImageLayout::GENERAL,
+        Il::ColorAttachmentOptimal => vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+        Il::DepthStencilAttachmentOptimal => vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        Il::DepthStencilReadOnlyOptimal => vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+        Il::ShaderReadOnlyOptimal => vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+        Il::TransferSrcOptimal => vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+        Il::TransferDstOptimal => vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+        Il::Undefined => vk::ImageLayout::UNDEFINED,
+        Il::Preinitialized => vk::ImageLayout::PREINITIALIZED,
+        Il::Present => vk::ImageLayout::PRESENT_SRC_KHR,
     }
 }
 
@@ -142,17 +142,17 @@ pub fn map_subresource_range(
 pub fn map_attachment_load_op(op: pass::AttachmentLoadOp) -> vk::AttachmentLoadOp {
     use hal::pass::AttachmentLoadOp as Alo;
     match op {
-        Alo::Load => vk::AttachmentLoadOp::Load,
-        Alo::Clear => vk::AttachmentLoadOp::Clear,
-        Alo::DontCare => vk::AttachmentLoadOp::DontCare,
+        Alo::Load => vk::AttachmentLoadOp::LOAD,
+        Alo::Clear => vk::AttachmentLoadOp::CLEAR,
+        Alo::DontCare => vk::AttachmentLoadOp::DONT_CARE,
     }
 }
 
 pub fn map_attachment_store_op(op: pass::AttachmentStoreOp) -> vk::AttachmentStoreOp {
     use hal::pass::AttachmentStoreOp as Aso;
     match op {
-        Aso::Store => vk::AttachmentStoreOp::Store,
-        Aso::DontCare => vk::AttachmentStoreOp::DontCare,
+        Aso::Store => vk::AttachmentStoreOp::STORE,
+        Aso::DontCare => vk::AttachmentStoreOp::DONT_CARE,
     }
 }
 
@@ -210,86 +210,86 @@ pub fn map_mip_filter(filter: image::Filter) -> vk::SamplerMipmapMode {
 pub fn map_wrap(wrap: image::WrapMode) -> vk::SamplerAddressMode {
     use hal::image::WrapMode as Wm;
     match wrap {
-        Wm::Tile   => vk::SamplerAddressMode::Repeat,
-        Wm::Mirror => vk::SamplerAddressMode::MirroredRepeat,
-        Wm::Clamp  => vk::SamplerAddressMode::ClampToEdge,
-        Wm::Border => vk::SamplerAddressMode::ClampToBorder,
+        Wm::Tile   => vk::SamplerAddressMode::REPEAT,
+        Wm::Mirror => vk::SamplerAddressMode::MIRRORED_REPEAT,
+        Wm::Clamp  => vk::SamplerAddressMode::CLAMP_TO_EDGE,
+        Wm::Border => vk::SamplerAddressMode::CLAMP_TO_BORDER,
     }
 }
 
 pub fn map_border_color(col: image::PackedColor) -> Option<vk::BorderColor> {
     match col.0 {
-        0x00000000 => Some(vk::BorderColor::FloatTransparentBlack),
-        0xFF000000 => Some(vk::BorderColor::FloatOpaqueBlack),
-        0xFFFFFFFF => Some(vk::BorderColor::FloatOpaqueWhite),
+        0x00000000 => Some(vk::BorderColor::FLOAT_TRANSPARENT_BLACK),
+        0xFF000000 => Some(vk::BorderColor::FLOAT_OPAQUE_BLACK),
+        0xFFFFFFFF => Some(vk::BorderColor::FLOAT_OPAQUE_WHITE),
         _ => None
     }
 }
 
 pub fn map_topology(prim: Primitive) -> vk::PrimitiveTopology {
     match prim {
-        Primitive::PointList              => vk::PrimitiveTopology::PointList,
-        Primitive::LineList               => vk::PrimitiveTopology::LineList,
-        Primitive::LineListAdjacency      => vk::PrimitiveTopology::LineListWithAdjacency,
-        Primitive::LineStrip              => vk::PrimitiveTopology::LineStrip,
-        Primitive::LineStripAdjacency     => vk::PrimitiveTopology::LineStripWithAdjacency,
-        Primitive::TriangleList           => vk::PrimitiveTopology::TriangleList,
-        Primitive::TriangleListAdjacency  => vk::PrimitiveTopology::TriangleListWithAdjacency,
-        Primitive::TriangleStrip          => vk::PrimitiveTopology::TriangleStrip,
-        Primitive::TriangleStripAdjacency => vk::PrimitiveTopology::TriangleStripWithAdjacency,
-        Primitive::PatchList(_)           => vk::PrimitiveTopology::PatchList,
+        Primitive::PointList              => vk::PrimitiveTopology::POINT_LIST,
+        Primitive::LineList               => vk::PrimitiveTopology::LINE_LIST,
+        Primitive::LineListAdjacency      => vk::PrimitiveTopology::LINE_LIST_WITH_ADJACENCY,
+        Primitive::LineStrip              => vk::PrimitiveTopology::LINE_STRIP,
+        Primitive::LineStripAdjacency     => vk::PrimitiveTopology::LINE_STRIP_WITH_ADJACENCY,
+        Primitive::TriangleList           => vk::PrimitiveTopology::TRIANGLE_LIST,
+        Primitive::TriangleListAdjacency  => vk::PrimitiveTopology::TRIANGLE_LIST_WITH_ADJACENCY,
+        Primitive::TriangleStrip          => vk::PrimitiveTopology::TRIANGLE_STRIP,
+        Primitive::TriangleStripAdjacency => vk::PrimitiveTopology::TRIANGLE_STRIP_WITH_ADJACENCY,
+        Primitive::PatchList(_)           => vk::PrimitiveTopology::PATCH_LIST,
     }
 }
 
 pub fn map_polygon_mode(rm: pso::PolygonMode) -> (vk::PolygonMode, f32) {
     match rm {
-        pso::PolygonMode::Point   => (vk::PolygonMode::Point, 1.0),
-        pso::PolygonMode::Line(w) => (vk::PolygonMode::Line, w),
-        pso::PolygonMode::Fill    => (vk::PolygonMode::Fill, 1.0),
+        pso::PolygonMode::Point   => (vk::PolygonMode::POINT, 1.0),
+        pso::PolygonMode::Line(w) => (vk::PolygonMode::LINE, w),
+        pso::PolygonMode::Fill    => (vk::PolygonMode::FILL, 1.0),
     }
 }
 
 pub fn map_cull_face(cf: pso::Face) -> vk::CullModeFlags {
     match cf {
-        pso::Face::NONE => vk::CULL_MODE_NONE,
-        pso::Face::FRONT => vk::CULL_MODE_FRONT_BIT,
-        pso::Face::BACK => vk::CULL_MODE_BACK_BIT,
-        _ => vk::CULL_MODE_FRONT_AND_BACK,
+        pso::Face::NONE => vk::CullModeFlags::NONE,
+        pso::Face::FRONT => vk::CullModeFlags::FRONT,
+        pso::Face::BACK => vk::CullModeFlags::BACK,
+        _ => vk::CullModeFlags::FRONT_AND_BACK,
     }
 }
 
 pub fn map_front_face(ff: pso::FrontFace) -> vk::FrontFace {
     match ff {
-        pso::FrontFace::Clockwise        => vk::FrontFace::Clockwise,
-        pso::FrontFace::CounterClockwise => vk::FrontFace::CounterClockwise,
+        pso::FrontFace::Clockwise        => vk::FrontFace::CLOCKWISE,
+        pso::FrontFace::CounterClockwise => vk::FrontFace::COUNTER_CLOCKWISE,
     }
 }
 
 pub fn map_comparison(fun: pso::Comparison) -> vk::CompareOp {
     use hal::pso::Comparison::*;
     match fun {
-        Never        => vk::CompareOp::Never,
-        Less         => vk::CompareOp::Less,
-        LessEqual    => vk::CompareOp::LessOrEqual,
-        Equal        => vk::CompareOp::Equal,
-        GreaterEqual => vk::CompareOp::GreaterOrEqual,
-        Greater      => vk::CompareOp::Greater,
-        NotEqual     => vk::CompareOp::NotEqual,
-        Always       => vk::CompareOp::Always,
+        Never        => vk::CompareOp::NEVER,
+        Less         => vk::CompareOp::LESS,
+        LessEqual    => vk::CompareOp::LESS_OR_EQUAL,
+        Equal        => vk::CompareOp::EQUAL,
+        GreaterEqual => vk::CompareOp::GREATER_OR_EQUAL,
+        Greater      => vk::CompareOp::GREATER,
+        NotEqual     => vk::CompareOp::NOT_EQUAL,
+        Always       => vk::CompareOp::ALWAYS,
     }
 }
 
 pub fn map_stencil_op(op: pso::StencilOp) -> vk::StencilOp {
     use hal::pso::StencilOp::*;
     match op {
-        Keep           => vk::StencilOp::Keep,
-        Zero           => vk::StencilOp::Zero,
-        Replace        => vk::StencilOp::Replace,
-        IncrementClamp => vk::StencilOp::IncrementAndClamp,
-        IncrementWrap  => vk::StencilOp::IncrementAndWrap,
-        DecrementClamp => vk::StencilOp::DecrementAndClamp,
-        DecrementWrap  => vk::StencilOp::DecrementAndWrap,
-        Invert         => vk::StencilOp::Invert,
+        Keep           => vk::StencilOp::KEEP,
+        Zero           => vk::StencilOp::ZERO,
+        Replace        => vk::StencilOp::REPLACE,
+        IncrementClamp => vk::StencilOp::INCREMENT_AND_CLAMP,
+        IncrementWrap  => vk::StencilOp::INCREMENT_AND_WRAP,
+        DecrementClamp => vk::StencilOp::DECREMENT_AND_CLAMP,
+        DecrementWrap  => vk::StencilOp::DECREMENT_AND_WRAP,
+        Invert         => vk::StencilOp::INVERT,
     }
 }
 
@@ -317,25 +317,25 @@ pub fn map_stencil_side(side: &pso::StencilFace) -> vk::StencilOpState {
 pub fn map_blend_factor(factor: pso::Factor) -> vk::BlendFactor {
     use hal::pso::Factor::*;
     match factor {
-        Zero => vk::BlendFactor::Zero,
-        One => vk::BlendFactor::One,
-        SrcColor => vk::BlendFactor::SrcColor,
-        OneMinusSrcColor => vk::BlendFactor::OneMinusSrcColor,
-        DstColor => vk::BlendFactor::DstColor,
-        OneMinusDstColor => vk::BlendFactor::OneMinusDstColor,
-        SrcAlpha => vk::BlendFactor::SrcAlpha,
-        OneMinusSrcAlpha => vk::BlendFactor::OneMinusSrcAlpha,
-        DstAlpha => vk::BlendFactor::DstAlpha,
-        OneMinusDstAlpha => vk::BlendFactor::OneMinusDstAlpha,
-        ConstColor => vk::BlendFactor::ConstantColor,
-        OneMinusConstColor => vk::BlendFactor::OneMinusConstantColor,
-        ConstAlpha => vk::BlendFactor::ConstantAlpha,
-        OneMinusConstAlpha => vk::BlendFactor::OneMinusConstantAlpha,
-        SrcAlphaSaturate => vk::BlendFactor::SrcAlphaSaturate,
-        Src1Color => vk::BlendFactor::Src1Color,
-        OneMinusSrc1Color => vk::BlendFactor::OneMinusSrc1Color,
-        Src1Alpha => vk::BlendFactor::Src1Alpha,
-        OneMinusSrc1Alpha => vk::BlendFactor::OneMinusSrc1Alpha,
+        Zero => vk::BlendFactor::ZERO,
+        One => vk::BlendFactor::ONE,
+        SrcColor => vk::BlendFactor::SRC_COLOR,
+        OneMinusSrcColor => vk::BlendFactor::ONE_MINUS_SRC_COLOR,
+        DstColor => vk::BlendFactor::DST_COLOR,
+        OneMinusDstColor => vk::BlendFactor::ONE_MINUS_DST_COLOR,
+        SrcAlpha => vk::BlendFactor::SRC_ALPHA,
+        OneMinusSrcAlpha => vk::BlendFactor::ONE_MINUS_SRC_ALPHA,
+        DstAlpha => vk::BlendFactor::DST_ALPHA,
+        OneMinusDstAlpha => vk::BlendFactor::ONE_MINUS_DST_ALPHA,
+        ConstColor => vk::BlendFactor::CONSTANT_COLOR,
+        OneMinusConstColor => vk::BlendFactor::ONE_MINUS_CONSTANT_COLOR,
+        ConstAlpha => vk::BlendFactor::CONSTANT_ALPHA,
+        OneMinusConstAlpha => vk::BlendFactor::ONE_MINUS_CONSTANT_ALPHA,
+        SrcAlphaSaturate => vk::BlendFactor::SRC_ALPHA_SATURATE,
+        Src1Color => vk::BlendFactor::SRC1_COLOR,
+        OneMinusSrc1Color => vk::BlendFactor::ONE_MINUS_SRC1_COLOR,
+        Src1Alpha => vk::BlendFactor::SRC1_ALPHA,
+        OneMinusSrc1Alpha => vk::BlendFactor::ONE_MINUS_SRC1_ALPHA,
     }
 }
 
@@ -345,22 +345,22 @@ pub fn map_blend_op(
     use hal::pso::BlendOp::*;
     match operation {
         Add { src, dst } => (
-            vk::BlendOp::Add,
+            vk::BlendOp::ADD,
             map_blend_factor(src),
             map_blend_factor(dst),
         ),
         Sub { src, dst } => (
-            vk::BlendOp::Subtract,
+            vk::BlendOp::SUBTRACT,
             map_blend_factor(src),
             map_blend_factor(dst),
         ),
         RevSub { src, dst } => (
-            vk::BlendOp::ReverseSubtract,
+            vk::BlendOp::REVERSE_SUBTRACT,
             map_blend_factor(src),
             map_blend_factor(dst),
         ),
-        Min => (vk::BlendOp::Min, vk::BlendFactor::Zero, vk::BlendFactor::Zero),
-        Max => (vk::BlendOp::Max, vk::BlendFactor::Zero, vk::BlendFactor::Zero),
+        Min => (vk::BlendOp::MIN, vk::BlendFactor::ZERO, vk::BlendFactor::ZERO),
+        Max => (vk::BlendOp::MAX, vk::BlendFactor::ZERO, vk::BlendFactor::ZERO),
     }
 }
 
@@ -429,7 +429,7 @@ where
             let &(ref memory, ref range) = range.borrow();
             let (offset, size) = map_range_arg(range);
             vk::MappedMemoryRange {
-                s_type: vk::StructureType::MappedMemoryRange,
+                s_type: vk::StructureType::MAPPED_MEMORY_RANGE,
                 p_next: ptr::null(),
                 memory: memory.raw,
                 offset,
@@ -442,7 +442,7 @@ where
 /// Returns (offset, size) of the range.
 ///
 /// Unbound start indices will be mapped to 0.
-/// Unbound end indices will be mapped to VK_WHOLE_SIZE.
+/// Unbound end indices will be mapped to WHOLE_SIZE.
 pub fn map_range_arg<R>(range: &R) -> (u64, u64)
 where
     R: RangeArg<u64>,
@@ -450,7 +450,7 @@ where
     let offset = *range.start().unwrap_or(&0);
     let size = match range.end() {
         Some(end) => end - offset,
-        None => vk::VK_WHOLE_SIZE,
+        None => vk::WHOLE_SIZE,
     };
 
     (offset, size)
@@ -463,27 +463,27 @@ pub fn map_command_buffer_flags(flags: command::CommandBufferFlags) -> vk::Comma
 
 pub fn map_command_buffer_level(level: command::RawLevel) -> vk::CommandBufferLevel {
     match level {
-        command::RawLevel::Primary => vk::CommandBufferLevel::Primary,
-        command::RawLevel::Secondary => vk::CommandBufferLevel::Secondary,
+        command::RawLevel::Primary => vk::CommandBufferLevel::PRIMARY,
+        command::RawLevel::Secondary => vk::CommandBufferLevel::SECONDARY,
     }
 }
 
 pub fn map_view_kind(
     kind: image::ViewKind, ty: vk::ImageType, is_cube: bool
 ) -> Option<vk::ImageViewType> {
-    use vk::ImageType::*;
+    
     use hal::image::ViewKind::*;
 
     Some(match (ty, kind) {
-        (Type1d, D1) => vk::ImageViewType::Type1d,
-        (Type1d, D1Array) => vk::ImageViewType::Type1dArray,
-        (Type2d, D2) => vk::ImageViewType::Type2d,
-        (Type2d, D2Array) => vk::ImageViewType::Type2dArray,
-        (Type3d, D3) => vk::ImageViewType::Type3d,
-        (Type2d, Cube) if is_cube => vk::ImageViewType::Cube,
-        (Type2d, CubeArray) if is_cube => vk::ImageViewType::CubeArray,
-        (Type3d, Cube) if is_cube => vk::ImageViewType::Cube,
-        (Type3d, CubeArray) if is_cube => vk::ImageViewType::CubeArray,
+        (vk::ImageType::TYPE_1D, D1) => vk::ImageViewType::TYPE_1D,
+        (vk::ImageType::TYPE_1D, D1Array) => vk::ImageViewType::TYPE_1D_ARRAY,
+        (vk::ImageType::TYPE_2D, D2) => vk::ImageViewType::TYPE_2D,
+        (vk::ImageType::TYPE_2D, D2Array) => vk::ImageViewType::TYPE_2D_ARRAY,
+        (vk::ImageType::TYPE_3D, D3) => vk::ImageViewType::TYPE_3D,
+        (vk::ImageType::TYPE_2D, Cube) if is_cube => vk::ImageViewType::CUBE,
+        (vk::ImageType::TYPE_2D, CubeArray) if is_cube => vk::ImageViewType::CUBE_ARRAY,
+        (vk::ImageType::TYPE_3D, Cube) if is_cube => vk::ImageViewType::CUBE,
+        (vk::ImageType::TYPE_3D, CubeArray) if is_cube => vk::ImageViewType::CUBE_ARRAY,
         _ => return None
     })
 }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -61,7 +61,7 @@ impl Device {
 impl d::Device<B> for Device {
     fn allocate_memory(&self, mem_type: MemoryTypeId, size: u64) -> Result<n::Memory, d::OutOfMemory> {
         let info = vk::MemoryAllocateInfo {
-            s_type: vk::StructureType::MemoryAllocateInfo,
+            s_type: vk::StructureType::MEMORY_ALLOCATE_INFO,
             p_next: ptr::null(),
             allocation_size: size,
             memory_type_index: mem_type.0 as _,
@@ -79,14 +79,14 @@ impl d::Device<B> for Device {
     ) -> RawCommandPool {
         let mut flags = vk::CommandPoolCreateFlags::empty();
         if create_flags.contains(CommandPoolCreateFlags::TRANSIENT) {
-            flags |= vk::COMMAND_POOL_CREATE_TRANSIENT_BIT;
+            flags |= vk::CommandPoolCreateFlags::TRANSIENT;
         }
         if create_flags.contains(CommandPoolCreateFlags::RESET_INDIVIDUAL) {
-            flags |= vk::COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+            flags |= vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER;
         }
 
         let info = vk::CommandPoolCreateInfo {
-            s_type: vk::StructureType::CommandPoolCreateInfo,
+            s_type: vk::StructureType::COMMAND_POOL_CREATE_INFO,
             p_next: ptr::null(),
             flags,
             queue_family_index: family.0 as _,
@@ -123,7 +123,7 @@ impl d::Device<B> for Device {
     {
         let map_subpass_ref = |pass: pass::SubpassRef| {
             match pass {
-                pass::SubpassRef::External => vk::VK_SUBPASS_EXTERNAL,
+                pass::SubpassRef::External => vk::SUBPASS_EXTERNAL,
                 pass::SubpassRef::Pass(id) => id as u32,
             }
         };
@@ -132,8 +132,8 @@ impl d::Device<B> for Device {
             let attachment = attachment.borrow();
             vk::AttachmentDescription {
                 flags: vk::AttachmentDescriptionFlags::empty(), // TODO: may even alias!
-                format: attachment.format.map_or(vk::Format::Undefined, conv::map_format),
-                samples: vk::SAMPLE_COUNT_1_BIT, // TODO: multisampling
+                format: attachment.format.map_or(vk::Format::UNDEFINED, conv::map_format),
+                samples: vk::SampleCountFlags::TYPE_1, // TODO: multisampling
                 load_op: conv::map_attachment_load_op(attachment.ops.load),
                 store_op: conv::map_attachment_store_op(attachment.ops.store),
                 stencil_load_op: conv::map_attachment_load_op(attachment.stencil_ops.load),
@@ -174,7 +174,7 @@ impl d::Device<B> for Device {
 
             vk::SubpassDescription {
                 flags: vk::SubpassDescriptionFlags::empty(),
-                pipeline_bind_point: vk::PipelineBindPoint::Graphics,
+                pipeline_bind_point: vk::PipelineBindPoint::GRAPHICS,
                 input_attachment_count: input_attachments.len() as u32,
                 p_input_attachments: input_attachments.as_ptr(),
                 color_attachment_count: color_attachments.len() as u32,
@@ -204,7 +204,7 @@ impl d::Device<B> for Device {
         }).collect::<Vec<_>>();
 
         let info = vk::RenderPassCreateInfo {
-            s_type: vk::StructureType::RenderPassCreateInfo,
+            s_type: vk::StructureType::RENDER_PASS_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::RenderPassCreateFlags::empty(),
             attachment_count: attachments.len() as u32,
@@ -250,7 +250,7 @@ impl d::Device<B> for Device {
             }).collect::<Vec<_>>();
 
         let info = vk::PipelineLayoutCreateInfo {
-            s_type: vk::StructureType::PipelineLayoutCreateInfo,
+            s_type: vk::StructureType::PIPELINE_LAYOUT_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::PipelineLayoutCreateFlags::empty(),
             set_layout_count: set_layouts.len() as u32,
@@ -270,7 +270,7 @@ impl d::Device<B> for Device {
 
     fn create_pipeline_cache(&self) -> n::PipelineCache {
         let info = vk::PipelineCacheCreateInfo {
-            s_type: vk::StructureType::PipelineCacheCreateInfo,
+            s_type: vk::StructureType::PIPELINE_CACHE_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::PipelineCacheCreateFlags::empty(),
             initial_data_size: 0, //TODO
@@ -363,7 +363,7 @@ impl d::Device<B> for Device {
             let info = info_specializations.last().unwrap();
 
             vk::PipelineShaderStageCreateInfo {
-                s_type: vk::StructureType::PipelineShaderStageCreateInfo,
+                s_type: vk::StructureType::PIPELINE_SHADER_STAGE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags: vk::PipelineShaderStageCreateFlags::empty(),
                 stage,
@@ -378,23 +378,23 @@ impl d::Device<B> for Device {
             let mut stages = Vec::new();
             // Vertex stage
             if true { //vertex shader is required
-                stages.push(make_stage(vk::SHADER_STAGE_VERTEX_BIT, &desc.shaders.vertex));
+                stages.push(make_stage(vk::ShaderStageFlags::VERTEX, &desc.shaders.vertex));
             }
             // Pixel stage
             if let Some(ref entry) = desc.shaders.fragment {
-                stages.push(make_stage(vk::SHADER_STAGE_FRAGMENT_BIT, entry));
+                stages.push(make_stage(vk::ShaderStageFlags::FRAGMENT, entry));
             }
             // Geometry stage
             if let Some(ref entry) = desc.shaders.geometry {
-                stages.push(make_stage(vk::SHADER_STAGE_GEOMETRY_BIT, entry));
+                stages.push(make_stage(vk::ShaderStageFlags::GEOMETRY, entry));
             }
             // Domain stage
             if let Some(ref entry) = desc.shaders.domain {
-                stages.push(make_stage(vk::SHADER_STAGE_TESSELLATION_EVALUATION_BIT, entry));
+                stages.push(make_stage(vk::ShaderStageFlags::TESSELLATION_EVALUATION, entry));
             }
             // Hull stage
             if let Some(ref entry) = desc.shaders.hull {
-                stages.push(make_stage(vk::SHADER_STAGE_TESSELLATION_CONTROL_BIT, entry));
+                stages.push(make_stage(vk::ShaderStageFlags::TESSELLATION_CONTROL, entry));
             }
 
             let (polygon_mode, line_width) = conv::map_polygon_mode(desc.rasterizer.polygon_mode);
@@ -407,9 +407,9 @@ impl d::Device<B> for Device {
                         binding: vbuf.binding,
                         stride: vbuf.stride as u32,
                         input_rate: if vbuf.rate == 0 {
-                            vk::VertexInputRate::Vertex
+                            vk::VertexInputRate::VERTEX
                         } else {
-                            vk::VertexInputRate::Instance
+                            vk::VertexInputRate::INSTANCE
                         },
                     });
                 }
@@ -429,7 +429,7 @@ impl d::Device<B> for Device {
             let &(ref vertex_bindings, ref vertex_attributes) = info_vertex_descs.last().unwrap();
 
             info_vertex_input_states.push(vk::PipelineVertexInputStateCreateInfo {
-                s_type: vk::StructureType::PipelineVertexInputStateCreateInfo,
+                s_type: vk::StructureType::PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags: vk::PipelineVertexInputStateCreateFlags::empty(),
                 vertex_binding_description_count: vertex_bindings.len() as u32,
@@ -439,40 +439,40 @@ impl d::Device<B> for Device {
             });
 
             info_input_assembly_states.push(vk::PipelineInputAssemblyStateCreateInfo {
-                s_type: vk::StructureType::PipelineInputAssemblyStateCreateInfo,
+                s_type: vk::StructureType::PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags: vk::PipelineInputAssemblyStateCreateFlags::empty(),
                 topology: conv::map_topology(desc.input_assembler.primitive),
-                primitive_restart_enable: vk::VK_FALSE,
+                primitive_restart_enable: vk::FALSE,
             });
             let depth_bias = match desc.rasterizer.depth_bias {
                 Some(pso::State::Static(db)) => db,
                 Some(pso::State::Dynamic) => {
-                    dynamic_states.push(vk::DynamicState::DepthBias);
+                    dynamic_states.push(vk::DynamicState::DEPTH_BIAS);
                     pso::DepthBias::default()
                 },
                 None => pso::DepthBias::default(),
             };
 
             info_rasterization_states.push(vk::PipelineRasterizationStateCreateInfo {
-                s_type: vk::StructureType::PipelineRasterizationStateCreateInfo,
+                s_type: vk::StructureType::PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags: vk::PipelineRasterizationStateCreateFlags::empty(),
                 depth_clamp_enable: if desc.rasterizer.depth_clamping {
                     if self.raw.1.contains(Features::DEPTH_CLAMP) {
-                        vk::VK_TRUE
+                        vk::TRUE
                     } else {
                         warn!("Depth clamping was requested on a device with disabled feature");
-                        vk::VK_FALSE
+                        vk::FALSE
                     }
                 } else {
-                    vk::VK_FALSE
+                    vk::FALSE
                 },
-                rasterizer_discard_enable: if desc.shaders.fragment.is_none() { vk::VK_TRUE } else { vk::VK_FALSE },
+                rasterizer_discard_enable: if desc.shaders.fragment.is_none() { vk::TRUE } else { vk::FALSE },
                 polygon_mode,
                 cull_mode: conv::map_cull_face(desc.rasterizer.cull_face),
                 front_face: conv::map_front_face(desc.rasterizer.front_face),
-                depth_bias_enable: if desc.rasterizer.depth_bias.is_some() { vk::VK_TRUE } else { vk::VK_FALSE },
+                depth_bias_enable: if desc.rasterizer.depth_bias.is_some() { vk::TRUE } else { vk::FALSE },
                 depth_bias_constant_factor: depth_bias.const_factor,
                 depth_bias_clamp: depth_bias.clamp,
                 depth_bias_slope_factor: depth_bias.slope_factor,
@@ -482,7 +482,7 @@ impl d::Device<B> for Device {
             let is_tessellated = desc.shaders.hull.is_some() && desc.shaders.domain.is_some();
             if is_tessellated {
                 info_tessellation_states.push(vk::PipelineTessellationStateCreateInfo {
-                    s_type: vk::StructureType::PipelineTessellationStateCreateInfo,
+                    s_type: vk::StructureType::PIPELINE_TESSELLATION_STATE_CREATE_INFO,
                     p_next: ptr::null(),
                     flags: vk::PipelineTessellationStateCreateFlags::empty(),
                     patch_control_points: 1 // TODO: 0 < control_points <= VkPhysicalDeviceLimits::maxTessellationPatchSize
@@ -492,7 +492,7 @@ impl d::Device<B> for Device {
             let dynamic_state_base = dynamic_states.len();
 
             info_viewport_states.push(vk::PipelineViewportStateCreateInfo {
-                s_type: vk::StructureType::PipelineViewportStateCreateInfo,
+                s_type: vk::StructureType::PIPELINE_VIEWPORT_STATE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags: vk::PipelineViewportStateCreateFlags::empty(),
                 scissor_count: 1, // TODO
@@ -502,7 +502,7 @@ impl d::Device<B> for Device {
                         scissors.last().unwrap()
                     },
                     None => {
-                        dynamic_states.push(vk::DynamicState::Scissor);
+                        dynamic_states.push(vk::DynamicState::SCISSOR);
                         ptr::null()
                     },
                 },
@@ -513,7 +513,7 @@ impl d::Device<B> for Device {
                         viewports.last().unwrap()
                     },
                     None => {
-                        dynamic_states.push(vk::DynamicState::Viewport);
+                        dynamic_states.push(vk::DynamicState::VIEWPORT);
                         ptr::null()
                     },
                 },
@@ -528,7 +528,7 @@ impl d::Device<B> for Device {
                     sample_masks.push(sample_mask);
 
                     vk::PipelineMultisampleStateCreateInfo {
-                        s_type: vk::StructureType::PipelineMultisampleStateCreateInfo,
+                        s_type: vk::StructureType::PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
                         p_next: ptr::null(),
                         flags: vk::PipelineMultisampleStateCreateFlags::empty(),
                         rasterization_samples: vk::SampleCountFlags::from_flags_truncate(ms.rasterization_samples as _),
@@ -540,27 +540,27 @@ impl d::Device<B> for Device {
                     }
                 },
                 None => vk::PipelineMultisampleStateCreateInfo {
-                    s_type: vk::StructureType::PipelineMultisampleStateCreateInfo,
+                    s_type: vk::StructureType::PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
                     p_next: ptr::null(),
                     flags: vk::PipelineMultisampleStateCreateFlags::empty(),
-                    rasterization_samples: vk::SAMPLE_COUNT_1_BIT,
-                    sample_shading_enable: vk::VK_FALSE,
+                    rasterization_samples: vk::SampleCountFlags::TYPE_1,
+                    sample_shading_enable: vk::FALSE,
                     min_sample_shading: 0.0,
                     p_sample_mask: ptr::null(),
-                    alpha_to_coverage_enable: vk::VK_FALSE,
-                    alpha_to_one_enable: vk::VK_FALSE,
+                    alpha_to_coverage_enable: vk::FALSE,
+                    alpha_to_one_enable: vk::FALSE,
                 },
             };
             info_multisample_states.push(multisampling_state);
 
             let depth_stencil = desc.depth_stencil;
             let (depth_test_enable, depth_write_enable, depth_compare_op) = match depth_stencil.depth {
-                pso::DepthTest::On { fun, write } => (vk::VK_TRUE, write as _, conv::map_comparison(fun)),
-                pso::DepthTest::Off => (vk::VK_FALSE, vk::VK_FALSE, vk::CompareOp::Never),
+                pso::DepthTest::On { fun, write } => (vk::TRUE, write as _, conv::map_comparison(fun)),
+                pso::DepthTest::Off => (vk::FALSE, vk::FALSE, vk::CompareOp::NEVER),
             };
             let (stencil_test_enable, front, back) = match depth_stencil.stencil {
                 pso::StencilTest::On { ref front, ref back } => (
-                    vk::VK_TRUE,
+                    vk::TRUE,
                     conv::map_stencil_side(front),
                     conv::map_stencil_side(back),
                 ),
@@ -569,13 +569,13 @@ impl d::Device<B> for Device {
             let (min_depth_bounds, max_depth_bounds) = match desc.baked_states.depth_bounds {
                 Some(ref range) => (range.start, range.end),
                 None => {
-                    dynamic_states.push(vk::DynamicState::DepthBounds);
+                    dynamic_states.push(vk::DynamicState::DEPTH_BOUNDS);
                     (0.0, 1.0)
                 }
             };
 
             info_depth_stencil_states.push(vk::PipelineDepthStencilStateCreateInfo {
-                s_type: vk::StructureType::PipelineDepthStencilStateCreateInfo,
+                s_type: vk::StructureType::PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags: vk::PipelineDepthStencilStateCreateFlags::empty(),
                 depth_test_enable,
@@ -600,7 +600,7 @@ impl d::Device<B> for Device {
                             let (alpha_blend_op, src_alpha_blend_factor, dst_alpha_blend_factor) = conv::map_blend_op(alpha);
                             vk::PipelineColorBlendAttachmentState {
                                 color_write_mask,
-                                blend_enable: vk::VK_TRUE,
+                                blend_enable: vk::TRUE,
                                 src_color_blend_factor,
                                 dst_color_blend_factor,
                                 color_blend_op,
@@ -619,24 +619,24 @@ impl d::Device<B> for Device {
             color_attachments.push(blend_states);
 
             info_color_blend_states.push(vk::PipelineColorBlendStateCreateInfo {
-                s_type: vk::StructureType::PipelineColorBlendStateCreateInfo,
+                s_type: vk::StructureType::PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags: vk::PipelineColorBlendStateCreateFlags::empty(),
-                logic_op_enable: vk::VK_FALSE, // TODO
-                logic_op: vk::LogicOp::Clear,
+                logic_op_enable: vk::FALSE, // TODO
+                logic_op: vk::LogicOp::CLEAR,
                 attachment_count: color_attachments.last().unwrap().len() as _,
                 p_attachments: color_attachments.last().unwrap().as_ptr(), // TODO:
                 blend_constants: match desc.baked_states.blend_color {
                     Some(value) => value,
                     None => {
-                        dynamic_states.push(vk::DynamicState::BlendConstants);
+                        dynamic_states.push(vk::DynamicState::BLEND_CONSTANTS);
                         [0.0; 4]
                     },
                 },
             });
 
             info_dynamic_states.push(vk::PipelineDynamicStateCreateInfo {
-                s_type: vk::StructureType::PipelineDynamicStateCreateInfo,
+                s_type: vk::StructureType::PIPELINE_DYNAMIC_STATE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags: vk::PipelineDynamicStateCreateFlags::empty(),
                 dynamic_state_count: (dynamic_states.len() - dynamic_state_base) as _,
@@ -654,17 +654,17 @@ impl d::Device<B> for Device {
             let mut flags = vk::PipelineCreateFlags::empty();
             match desc.parent {
                 pso::BasePipeline::None => (),
-                _ => { flags |= vk::PIPELINE_CREATE_DERIVATIVE_BIT; }
+                _ => { flags |= vk::PipelineCreateFlags::DERIVATIVE; }
             }
             if desc.flags.contains(pso::PipelineCreationFlags::DISABLE_OPTIMIZATION) {
-                flags |= vk::PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
+                flags |= vk::PipelineCreateFlags::DISABLE_OPTIMIZATION;
             }
             if desc.flags.contains(pso::PipelineCreationFlags::ALLOW_DERIVATIVES) {
-                flags |= vk::PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT;
+                flags |= vk::PipelineCreateFlags::ALLOW_DERIVATIVES;
             }
 
             Ok(vk::GraphicsPipelineCreateInfo {
-                s_type: vk::StructureType::GraphicsPipelineCreateInfo,
+                s_type: vk::StructureType::GRAPHICS_PIPELINE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags,
                 stage_count: info_stages.last().unwrap().len() as _,
@@ -757,10 +757,10 @@ impl d::Device<B> for Device {
             let info = info_specializations.last().unwrap();
 
             let stage = vk::PipelineShaderStageCreateInfo {
-                s_type: vk::StructureType::PipelineShaderStageCreateInfo,
+                s_type: vk::StructureType::PIPELINE_SHADER_STAGE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags: vk::PipelineShaderStageCreateFlags::empty(),
-                stage: vk::SHADER_STAGE_COMPUTE_BIT,
+                stage: vk::ShaderStageFlags::COMPUTE,
                 module: desc.shader.module.raw,
                 p_name,
                 p_specialization_info: info,
@@ -775,17 +775,17 @@ impl d::Device<B> for Device {
             let mut flags = vk::PipelineCreateFlags::empty();
             match desc.parent {
                 pso::BasePipeline::None => (),
-                _ => { flags |= vk::PIPELINE_CREATE_DERIVATIVE_BIT; }
+                _ => { flags |= vk::PipelineCreateFlags::DERIVATIVE; }
             }
             if desc.flags.contains(pso::PipelineCreationFlags::DISABLE_OPTIMIZATION) {
-                flags |= vk::PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
+                flags |= vk::PipelineCreateFlags::DISABLE_OPTIMIZATION;
             }
             if desc.flags.contains(pso::PipelineCreationFlags::ALLOW_DERIVATIVES) {
-                flags |= vk::PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT;
+                flags |= vk::PipelineCreateFlags::ALLOW_DERIVATIVES;
             }
 
             Ok(vk::ComputePipelineCreateInfo {
-                s_type: vk::StructureType::ComputePipelineCreateInfo,
+                s_type: vk::StructureType::COMPUTE_PIPELINE_CREATE_INFO,
                 p_next: ptr::null(),
                 flags,
                 stage,
@@ -846,7 +846,7 @@ impl d::Device<B> for Device {
             .collect::<SmallVec<[_; 4]>>();
 
         let info = vk::FramebufferCreateInfo {
-            s_type: vk::StructureType::FramebufferCreateInfo,
+            s_type: vk::StructureType::FRAMEBUFFER_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::FramebufferCreateFlags::empty(),
             render_pass: renderpass.raw,
@@ -869,7 +869,7 @@ impl d::Device<B> for Device {
         assert_eq!(spirv_data.len() & 3, 0);
 
         let info = vk::ShaderModuleCreateInfo {
-            s_type: vk::StructureType::ShaderModuleCreateInfo,
+            s_type: vk::StructureType::SHADER_MODULE_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::ShaderModuleCreateFlags::empty(),
             code_size: spirv_data.len(),
@@ -893,18 +893,18 @@ impl d::Device<B> for Device {
         use hal::pso::Comparison;
 
         let (anisotropy_enable, max_anisotropy) = match sampler_info.anisotropic {
-            image::Anisotropic::Off => (vk::VK_FALSE, 1.0),
+            image::Anisotropic::Off => (vk::FALSE, 1.0),
             image::Anisotropic::On(aniso) => {
                 if self.raw.1.contains(Features::SAMPLER_ANISOTROPY) {
-                    (vk::VK_TRUE, aniso as f32)
+                    (vk::TRUE, aniso as f32)
                 } else {
                     warn!("Anisotropy({}) was requested on a device with disabled feature", aniso);
-                    (vk::VK_FALSE, 1.0)
+                    (vk::FALSE, 1.0)
                 }
             },
         };
         let info = vk::SamplerCreateInfo {
-            s_type: vk::StructureType::SamplerCreateInfo,
+            s_type: vk::StructureType::SAMPLER_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::SamplerCreateFlags::empty(),
             mag_filter: conv::map_filter(sampler_info.mag_filter),
@@ -916,7 +916,7 @@ impl d::Device<B> for Device {
             mip_lod_bias: sampler_info.lod_bias.into(),
             anisotropy_enable,
             max_anisotropy,
-            compare_enable: if sampler_info.comparison.is_some() { vk::VK_TRUE } else { vk::VK_FALSE },
+            compare_enable: if sampler_info.comparison.is_some() { vk::TRUE } else { vk::FALSE },
             compare_op: conv::map_comparison(sampler_info.comparison.unwrap_or(Comparison::Never)),
             min_lod: sampler_info.lod_range.start.into(),
             max_lod: sampler_info.lod_range.end.into(),
@@ -924,10 +924,10 @@ impl d::Device<B> for Device {
                 Some(bc) => bc,
                 None => {
                     error!("Unsupported border color {:x}", sampler_info.border.0);
-                    vk::BorderColor::FloatTransparentBlack
+                    vk::BorderColor::FLOAT_TRANSPARENT_BLACK
                 }
             },
-            unnormalized_coordinates: vk::VK_FALSE,
+            unnormalized_coordinates: vk::FALSE,
         };
 
         let sampler = unsafe {
@@ -941,12 +941,12 @@ impl d::Device<B> for Device {
     ///
     fn create_buffer(&self, size: u64, usage: buffer::Usage) -> Result<UnboundBuffer, buffer::CreationError> {
         let info = vk::BufferCreateInfo {
-            s_type: vk::StructureType::BufferCreateInfo,
+            s_type: vk::StructureType::BUFFER_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::BufferCreateFlags::empty(), // TODO:
             size,
             usage: conv::map_buffer_usage(usage),
-            sharing_mode: vk::SharingMode::Exclusive, // TODO:
+            sharing_mode: vk::SharingMode::EXCLUSIVE, // TODO:
             queue_family_index_count: 0,
             p_queue_family_indices: ptr::null(),
         };
@@ -986,11 +986,11 @@ impl d::Device<B> for Device {
     ) -> Result<n::BufferView, buffer::ViewCreationError> {
         let (offset, size) = conv::map_range_arg(&range);
         let info = vk::BufferViewCreateInfo {
-            s_type: vk::StructureType::BufferViewCreateInfo,
+            s_type: vk::StructureType::BUFFER_VIEW_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::BufferViewCreateFlags::empty(),
             buffer: buffer.raw,
-            format: format.map_or(vk::Format::Undefined, conv::map_format),
+            format: format.map_or(vk::Format::UNDEFINED, conv::map_format),
             offset,
             range: size,
         };
@@ -1016,13 +1016,13 @@ impl d::Device<B> for Device {
         let array_layers = kind.num_layers();
         let samples = kind.num_samples() as u32;
         let image_type = match kind {
-            image::Kind::D1(..) => vk::ImageType::Type1d,
-            image::Kind::D2(..) => vk::ImageType::Type2d,
-            image::Kind::D3(..) => vk::ImageType::Type3d,
+            image::Kind::D1(..) => vk::ImageType::TYPE_1D,
+            image::Kind::D2(..) => vk::ImageType::TYPE_2D,
+            image::Kind::D3(..) => vk::ImageType::TYPE_3D,
         };
 
         let info = vk::ImageCreateInfo {
-            s_type: vk::StructureType::ImageCreateInfo,
+            s_type: vk::StructureType::IMAGE_CREATE_INFO,
             p_next: ptr::null(),
             flags,
             image_type,
@@ -1033,10 +1033,10 @@ impl d::Device<B> for Device {
             samples: vk::SampleCountFlags::from_flags_truncate(samples),
             tiling: conv::map_tiling(tiling),
             usage: conv::map_image_usage(usage),
-            sharing_mode: vk::SharingMode::Exclusive, // TODO:
+            sharing_mode: vk::SharingMode::EXCLUSIVE, // TODO:
             queue_family_index_count: 0,
             p_queue_family_indices: ptr::null(),
-            initial_layout: vk::ImageLayout::Undefined,
+            initial_layout: vk::ImageLayout::UNDEFINED,
         };
 
         let raw = unsafe {
@@ -1088,9 +1088,9 @@ impl d::Device<B> for Device {
         swizzle: format::Swizzle,
         range: image::SubresourceRange,
     ) -> Result<n::ImageView, image::ViewError> {
-        let is_cube = image.flags.intersects(vk::IMAGE_CREATE_CUBE_COMPATIBLE_BIT);
+        let is_cube = image.flags.intersects(vk::ImageCreateFlags::CUBE_COMPATIBLE);
         let info = vk::ImageViewCreateInfo {
-            s_type: vk::StructureType::ImageViewCreateInfo,
+            s_type: vk::StructureType::IMAGE_VIEW_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::ImageViewCreateFlags::empty(),
             image: image.raw,
@@ -1122,13 +1122,13 @@ impl d::Device<B> for Device {
         let pools = descriptor_pools.into_iter().map(|pool| {
             let pool = pool.borrow();
             vk::DescriptorPoolSize {
-                typ: conv::map_descriptor_type(pool.ty),
+                ty: conv::map_descriptor_type(pool.ty),
                 descriptor_count: pool.count as u32,
             }
         }).collect::<Vec<_>>();
 
         let info = vk::DescriptorPoolCreateInfo {
-            s_type: vk::StructureType::DescriptorPoolCreateInfo,
+            s_type: vk::StructureType::DESCRIPTOR_POOL_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::DescriptorPoolCreateFlags::empty(), // disallow individual freeing
             max_sets: max_sets as u32,
@@ -1188,7 +1188,7 @@ impl d::Device<B> for Device {
         debug!("create_descriptor_set_layout {:?}", raw_bindings);
 
         let info = vk::DescriptorSetLayoutCreateInfo {
-            s_type: vk::StructureType::DescriptorSetLayoutCreateInfo,
+            s_type: vk::StructureType::DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::DescriptorSetLayoutCreateFlags::empty(),
             binding_count: raw_bindings.len() as _,
@@ -1222,7 +1222,7 @@ impl d::Device<B> for Device {
                 .find(|lb| lb.binding == sw.binding)
                 .expect("Descriptor set writes don't match the set layout!");
             let mut raw = vk::WriteDescriptorSet {
-                s_type: vk::StructureType::WriteDescriptorSet,
+                s_type: vk::StructureType::WRITE_DESCRIPTOR_SET,
                 p_next: ptr::null(),
                 dst_set: sw.set.raw,
                 dst_binding: sw.binding,
@@ -1241,7 +1241,7 @@ impl d::Device<B> for Device {
                         image_infos.push(vk::DescriptorImageInfo {
                             sampler: sampler.0,
                             image_view: vk::ImageView::null(),
-                            image_layout: vk::ImageLayout::General,
+                            image_layout: vk::ImageLayout::GENERAL,
                         });
                     }
                     pso::Descriptor::Image(view, layout) => {
@@ -1265,7 +1265,7 @@ impl d::Device<B> for Device {
                             offset,
                             range: match range.end {
                                 Some(end) => end - offset,
-                                None => vk::VK_WHOLE_SIZE,
+                                None => vk::WHOLE_SIZE,
                             },
                         });
                     }
@@ -1286,32 +1286,34 @@ impl d::Device<B> for Device {
         for raw in &mut raw_writes {
             use vk::DescriptorType as Dt;
             match raw.descriptor_type {
-                Dt::Sampler |
-                Dt::SampledImage |
-                Dt::StorageImage |
-                Dt::CombinedImageSampler |
-                Dt::InputAttachment => {
+                Dt::SAMPLER |
+                Dt::SAMPLED_IMAGE |
+                Dt::STORAGE_IMAGE |
+                Dt::COMBINED_IMAGE_SAMPLER |
+                Dt::INPUT_ATTACHMENT => {
                     raw.p_buffer_info = ptr::null();
                     raw.p_texel_buffer_view = ptr::null();
                     let base = raw.p_image_info as usize - raw.descriptor_count as usize;
                     raw.p_image_info = image_infos[base..].as_ptr();
                 }
-                Dt::UniformTexelBuffer |
-                Dt::StorageTexelBuffer => {
+                Dt::UNIFORM_TEXEL_BUFFER |
+                Dt::STORAGE_TEXEL_BUFFER => {
                     raw.p_buffer_info = ptr::null();
                     raw.p_image_info = ptr::null();
                     let base = raw.p_texel_buffer_view as usize - raw.descriptor_count as usize;
                     raw.p_texel_buffer_view = texel_buffer_views[base..].as_ptr();
                 }
-                Dt::UniformBuffer |
-                Dt::StorageBuffer |
-                Dt::StorageBufferDynamic |
-                Dt::UniformBufferDynamic => {
+                Dt::UNIFORM_BUFFER |
+                Dt::STORAGE_BUFFER |
+                Dt::STORAGE_BUFFER_DYNAMIC |
+                Dt::UNIFORM_BUFFER_DYNAMIC => {
                     raw.p_image_info = ptr::null();
                     raw.p_texel_buffer_view = ptr::null();
                     let base = raw.p_buffer_info as usize - raw.descriptor_count as usize;
                     raw.p_buffer_info = buffer_infos[base..].as_ptr();
                 }
+                // TODO: how should _ be handled?
+                _ => unimplemented!(),
             }
         }
 
@@ -1328,7 +1330,7 @@ impl d::Device<B> for Device {
         let copies = copies.into_iter().map(|copy| {
             let c = copy.borrow();
             vk::CopyDescriptorSet {
-                s_type: vk::StructureType::CopyDescriptorSet,
+                s_type: vk::StructureType::COPY_DESCRIPTOR_SET,
                 p_next: ptr::null(),
                 src_set: c.src_set.raw,
                 src_binding: c.src_binding as u32,
@@ -1396,7 +1398,7 @@ impl d::Device<B> for Device {
 
     fn create_semaphore(&self) -> n::Semaphore {
         let info = vk::SemaphoreCreateInfo {
-            s_type: vk::StructureType::SemaphoreCreateInfo,
+            s_type: vk::StructureType::SEMAPHORE_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::SemaphoreCreateFlags::empty(),
         };
@@ -1411,10 +1413,10 @@ impl d::Device<B> for Device {
 
     fn create_fence(&self, signaled: bool) -> n::Fence {
         let info = vk::FenceCreateInfo {
-            s_type: vk::StructureType::FenceCreateInfo,
+            s_type: vk::StructureType::FENCE_CREATE_INFO,
             p_next: ptr::null(),
             flags: if signaled {
-                vk::FENCE_CREATE_SIGNALED_BIT
+                vk::FenceCreateFlags::SIGNALED
             } else {
                 vk::FenceCreateFlags::empty()
             },
@@ -1453,8 +1455,8 @@ impl d::Device<B> for Device {
             self.raw.0.wait_for_fences(&fences, all, timeout_ns)
         };
         match result {
-            Ok(()) | Err(vk::Result::Success) => true,
-            Err(vk::Result::Timeout) => false,
+            Ok(()) | Err(vk::Result::SUCCESS) => true,
+            Err(vk::Result::TIMEOUT) => false,
             _ => panic!("Unexpected wait result {:?}", result),
         }
     }
@@ -1464,8 +1466,8 @@ impl d::Device<B> for Device {
             self.raw.0.get_fence_status(fence.0)
         };
         match result {
-            Ok(()) | Err(vk::Result::Success) => true,
-            Err(vk::Result::NotReady) => false,
+            Ok(()) | Err(vk::Result::SUCCESS) => true,
+            Err(vk::Result::NOT_READY) => false,
             _ => panic!("Unexpected get_fence_status result {:?}", result),
         }
     }
@@ -1477,15 +1479,15 @@ impl d::Device<B> for Device {
     fn create_query_pool(&self, ty: query::Type, query_count: query::Id) -> Result<n::QueryPool, query::Error> {
         let (query_type, pipeline_statistics) = match ty {
             query::Type::Occlusion =>
-                (vk::QueryType::Occlusion, vk::QueryPipelineStatisticFlags::empty()),
+                (vk::QueryType::OCCLUSION, vk::QueryPipelineStatisticFlags::empty()),
             query::Type::PipelineStatistics(statistics) =>
-                (vk::QueryType::PipelineStatistics, conv::map_pipeline_statistics(statistics)),
+                (vk::QueryType::PIPELINE_STATISTICS, conv::map_pipeline_statistics(statistics)),
             query::Type::Timestamp =>
-                (vk::QueryType::Timestamp, vk::QueryPipelineStatisticFlags::empty()),
+                (vk::QueryType::TIMESTAMP, vk::QueryPipelineStatisticFlags::empty()),
         };
 
         let info = vk::QueryPoolCreateInfo {
-            s_type: vk::StructureType::QueryPoolCreateInfo,
+            s_type: vk::StructureType::QUERY_POOL_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::QueryPoolCreateFlags::empty(),
             query_type,
@@ -1518,8 +1520,8 @@ impl d::Device<B> for Device {
         };
 
         match result {
-            vk::Result::Success => Ok(true),
-            vk::Result::NotReady => Ok(false),
+            vk::Result::SUCCESS => Ok(true),
+            vk::Result::NOT_READY => Ok(false),
             _ => {
                 error!("get_query_pool_results error {:?}", result);
                 Err(())
@@ -1545,24 +1547,24 @@ impl d::Device<B> for Device {
         surface.height = config.extent.height;
 
         let info = vk::SwapchainCreateInfoKHR {
-            s_type: vk::StructureType::SwapchainCreateInfoKhr,
+            s_type: vk::StructureType::SWAPCHAIN_CREATE_INFO_KHR,
             p_next: ptr::null(),
             flags: vk::SwapchainCreateFlagsKHR::empty(),
             surface: surface.raw.handle,
             min_image_count: config.image_count,
             image_format: conv::map_format(config.format),
-            image_color_space: vk::ColorSpaceKHR::SrgbNonlinear,
+            image_color_space: vk::ColorSpaceKHR::SRGB_NONLINEAR,
             image_extent: vk::Extent2D {
                 width: surface.width,
                 height: surface.height,
             },
             image_array_layers: 1,
             image_usage: conv::map_image_usage(config.image_usage),
-            image_sharing_mode: vk::SharingMode::Exclusive,
+            image_sharing_mode: vk::SharingMode::EXCLUSIVE,
             queue_family_index_count: 0,
             p_queue_family_indices: ptr::null(),
-            pre_transform: vk::SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-            composite_alpha: vk::COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+            pre_transform: vk::SurfaceTransformFlagsKHR::IDENTITY,
+            composite_alpha: vk::CompositeAlphaFlagsKHR::OPAQUE,
             present_mode: unsafe { mem::transmute(config.present_mode) },
             clipped: 1,
             old_swapchain,
@@ -1584,7 +1586,7 @@ impl d::Device<B> for Device {
             .map(|image| {
                 n::Image {
                     raw: image,
-                    ty: vk::ImageType::Type2d,
+                    ty: vk::ImageType::TYPE_2D,
                     flags: vk::ImageCreateFlags::empty(),
                     extent: vk::Extent3D {
                         width: surface.width,

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -117,7 +117,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         }
 
         let info = vk::DescriptorSetAllocateInfo {
-            s_type: vk::StructureType::DescriptorSetAllocateInfo,
+            s_type: vk::StructureType::DESCRIPTOR_SET_ALLOCATE_INFO,
             p_next: ptr::null(),
             descriptor_pool: self.raw,
             descriptor_set_count: raw_layouts.len() as u32,
@@ -133,10 +133,10 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
                 )
             })
             .map_err(|err| match err {
-                vk::Result::ErrorOutOfHostMemory => pso::AllocationError::OutOfHostMemory,
-                vk::Result::ErrorOutOfDeviceMemory => pso::AllocationError::OutOfDeviceMemory,
-                // TODO: Uncomment when ash updates to include VK_ERROR_OUT_OF_POOL_MEMORY(_KHR)
-                // vk::Result::ErrorOutOfPoolMemory => pso::AllocationError::OutOfPoolMemory,
+                vk::Result::ERROR_OUT_OF_HOST_MEMORY => pso::AllocationError::OutOfHostMemory,
+                vk::Result::ERROR_OUT_OF_DEVICE_MEMORY => pso::AllocationError::OutOfDeviceMemory,
+                // TODO: Uncomment when ash updates to include ERROR_OUT_OF_POOL_MEMORY(_KHR)
+                // vk::Result::ERROR_OUT_OF_POOL_MEMORY => pso::AllocationError::OutOfPoolMemory,
                 _ => pso::AllocationError::FragmentedPool,
             })
     }

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -27,7 +27,7 @@ impl pool::RawCommandPool<Backend> for RawCommandPool {
 
     fn allocate(&mut self, num: usize, level: command::RawLevel) -> Vec<CommandBuffer> {
         let info = vk::CommandBufferAllocateInfo {
-            s_type: vk::StructureType::CommandBufferAllocateInfo,
+            s_type: vk::StructureType::COMMAND_BUFFER_ALLOCATE_INFO,
             p_next: ptr::null(),
             command_pool: self.raw,
             level: conv::map_command_buffer_level(level),

--- a/src/backend/vulkan/src/result.rs
+++ b/src/backend/vulkan/src/result.rs
@@ -30,25 +30,25 @@ pub(crate) enum Error {
 
 impl From<vk::Result> for Error {
     fn from(result: vk::Result) -> Self {
-        use ash::vk::Result::*;
+        
         match result {
-            ErrorOutOfHostMemory => Error::OutOfHostMemory,
-            ErrorOutOfDeviceMemory => Error::OutOfDeviceMemory,
-            ErrorInitializationFailed => Error::InitializationFailed,
-            ErrorDeviceLost => Error::DeviceLost,
-            ErrorMemoryMapFailed => Error::MemoryMapFailed,
-            ErrorLayerNotPresent => Error::LayerNotPresent,
-            ErrorExtensionNotPresent => Error::ExtensionNotPresent,
-            ErrorFeatureNotPresent => Error::FeatureNotPresent,
-            ErrorIncompatibleDriver => Error::IncompatibleDriver,
-            ErrorTooManyObjects => Error::TooManyObjects,
-            ErrorFormatNotSupported => Error::FormatNotSupported,
-            ErrorFragmentedPool => Error::FragmentedPool,
-            ErrorSurfaceLostKhr => Error::SurfaceLostKhr,
-            ErrorNativeWindowInUseKhr => Error::NativeWindowInUseKhr,
-            ErrorOutOfDateKhr => Error::OutOfDateKhr,
-            ErrorIncompatibleDisplayKhr => Error::IncompatibleDisplayKhr,
-            ErrorValidationFailedExt => Error::ValidationFailedExt,
+            vk::Result::ERROR_OUT_OF_HOST_MEMORY => Error::OutOfHostMemory,
+            vk::Result::ERROR_OUT_OF_DEVICE_MEMORY => Error::OutOfDeviceMemory,
+            vk::Result::ERROR_INITIALIZATION_FAILED => Error::InitializationFailed,
+            vk::Result::ERROR_DEVICE_LOST => Error::DeviceLost,
+            vk::Result::ERROR_MEMORY_MAP_FAILED => Error::MemoryMapFailed,
+            vk::Result::ERROR_LAYER_NOT_PRESENT => Error::LayerNotPresent,
+            vk::Result::ERROR_EXTENSION_NOT_PRESENT => Error::ExtensionNotPresent,
+            vk::Result::ERROR_FEATURE_NOT_PRESENT => Error::FeatureNotPresent,
+            vk::Result::ERROR_INCOMPATIBLE_DRIVER => Error::IncompatibleDriver,
+            vk::Result::ERROR_TOO_MANY_OBJECTS => Error::TooManyObjects,
+            vk::Result::ERROR_FORMAT_NOT_SUPPORTED => Error::FormatNotSupported,
+            vk::Result::ERROR_FRAGMENTED_POOL => Error::FragmentedPool,
+            vk::Result::ERROR_SURFACE_LOST_KHR => Error::SurfaceLostKhr,
+            vk::Result::ERROR_NATIVE_WINDOW_IN_USE_KHR => Error::NativeWindowInUseKhr,
+            vk::Result::ERROR_OUT_OF_DATE_KHR => Error::OutOfDateKhr,
+            vk::Result::ERROR_INCOMPATIBLE_DISPLAY_KHR => Error::IncompatibleDisplayKhr,
+            vk::Result::ERROR_VALIDATION_FAILED_EXT => Error::ValidationFailedExt,
             _ => Error::Unknown,
         }
     }
@@ -58,7 +58,7 @@ impl From<vk::Result> for Error {
 //
 // Syntax:
 //    #HalError {
-//       #VulkanError => #HalErrorVariant,
+//       #Vulkanvk::Result::ERROR_ => #HalErrorVariant,
 //    }
 macro_rules! from_error {
     { $($name:ident { $($base_error:ident => $err:ident,)* },)* } => {

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -13,7 +13,7 @@ use hal::format::Format;
 use winit;
 
 use conv;
-use {VK_ENTRY, Backend, Instance, PhysicalDevice, QueueFamily, RawInstance};
+use {ENTRY, Backend, Instance, PhysicalDevice, QueueFamily, RawInstance};
 
 
 pub struct Surface {
@@ -44,12 +44,12 @@ impl Instance {
     pub fn create_surface_from_xlib(
         &self, dpy: *mut vk::Display, window: vk::Window
     ) -> Surface {
-        let entry = VK_ENTRY
+        let entry = ENTRY
             .as_ref()
             .expect("Unable to load Vulkan entry points");
 
-        if !self.extensions.contains(&vk::VK_KHR_XLIB_SURFACE_EXTENSION_NAME) {
-            panic!("Vulkan driver does not support VK_KHR_XLIB_SURFACE");
+        if !self.extensions.contains(&ext::XlibSurface::name().to_str().unwrap()) {
+            panic!("Vulkan driver does not support KHR_XLIB_SURFACE");
         }
 
         let surface = {
@@ -57,7 +57,7 @@ impl Instance {
                 .expect("XlibSurface::new() failed");
 
             let info = vk::XlibSurfaceCreateInfoKHR {
-                s_type: vk::StructureType::XlibSurfaceCreateInfoKhr,
+                s_type: vk::StructureType::XLIB_SURFACE_CREATE_INFO_KHR,
                 p_next: ptr::null(),
                 flags: vk::XlibSurfaceCreateFlagsKHR::empty(),
                 window,
@@ -86,12 +86,12 @@ impl Instance {
     pub fn create_surface_from_xcb(
         &self, connection: *mut vk::xcb_connection_t, window: vk::xcb_window_t
     ) -> Surface {
-        let entry = VK_ENTRY
+        let entry = ENTRY
             .as_ref()
             .expect("Unable to load Vulkan entry points");
 
-        if !self.extensions.contains(&vk::VK_KHR_XCB_SURFACE_EXTENSION_NAME) {
-            panic!("Vulkan driver does not support VK_KHR_XCB_SURFACE");
+        if !self.extensions.contains(&ext::XcbSurface::name().to_str().unwrap()) {
+            panic!("Vulkan driver does not support KHR_XCB_SURFACE");
         }
 
         let surface = {
@@ -99,7 +99,7 @@ impl Instance {
                 .expect("XcbSurface::new() failed");
 
             let info = vk::XcbSurfaceCreateInfoKHR {
-                s_type: vk::StructureType::XcbSurfaceCreateInfoKhr,
+                s_type: vk::StructureType::XCB_SURFACE_CREATE_INFO_KHR,
                 p_next: ptr::null(),
                 flags: vk::XcbSurfaceCreateFlagsKHR::empty(),
                 window,
@@ -131,12 +131,12 @@ impl Instance {
     pub fn create_surface_from_wayland(
         &self, display: *mut c_void, surface: *mut c_void, width: Size, height: Size
     ) -> Surface {
-        let entry = VK_ENTRY
+        let entry = ENTRY
             .as_ref()
             .expect("Unable to load Vulkan entry points");
 
-        if !self.extensions.contains(&vk::VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) {
-            panic!("Vulkan driver does not support VK_KHR_WAYLAND_SURFACE");
+        if !self.extensions.contains(&ext::WaylandSurface::name().to_str().unwrap()) {
+            panic!("Vulkan driver does not support KHR_WAYLAND_SURFACE");
         }
 
         let surface = {
@@ -144,7 +144,7 @@ impl Instance {
                 .expect("WaylandSurface failed");
 
             let info = vk::WaylandSurfaceCreateInfoKHR {
-                s_type: vk::StructureType::WaylandSurfaceCreateInfoKhr,
+                s_type: vk::StructureType::WAYLAND_SURFACE_CREATE_INFO_KHR,
                 p_next: ptr::null(),
                 flags: vk::WaylandSurfaceCreateFlagsKHR::empty(),
                 display: display as *mut _,
@@ -162,7 +162,7 @@ impl Instance {
     pub fn create_surface_android(
         &self, window: *const c_void, width: Size, height: Size
     ) -> Surface {
-        let entry = VK_ENTRY
+        let entry = ENTRY
             .as_ref()
             .expect("Unable to load Vulkan entry points");
 
@@ -171,7 +171,7 @@ impl Instance {
                 .expect("AndroidSurface failed");
 
             let info = vk::AndroidSurfaceCreateInfoKHR {
-                s_type: vk::StructureType::AndroidSurfaceCreateInfoKhr,
+                s_type: vk::StructureType::ANDROID_SURFACE_CREATE_INFO_KHR,
                 p_next: ptr::null(),
                 flags: vk::AndroidSurfaceCreateFlagsKHR::empty(),
                 window: window as *const _ as *mut _,
@@ -188,12 +188,12 @@ impl Instance {
     pub fn create_surface_from_hwnd(
         &self, hinstance: *mut c_void, hwnd: *mut c_void
     ) -> Surface {
-        let entry = VK_ENTRY
+        let entry = ENTRY
             .as_ref()
             .expect("Unable to load Vulkan entry points");
 
-        if !self.extensions.contains(&vk::VK_KHR_WIN32_SURFACE_EXTENSION_NAME) {
-            panic!("Vulkan driver does not support VK_KHR_WIN32_SURFACE");
+        if !self.extensions.contains(&ext::Win32Surface::name().to_str().unwrap()) {
+            panic!("Vulkan driver does not support KHR_WIN32_SURFACE");
         }
 
         let surface = {
@@ -202,7 +202,7 @@ impl Instance {
 
             unsafe {
                 let info = vk::Win32SurfaceCreateInfoKHR {
-                    s_type: vk::StructureType::Win32SurfaceCreateInfoKhr,
+                    s_type: vk::StructureType::WIN32_SURFACE_CREATE_INFO_KHR,
                     p_next: ptr::null(),
                     flags: vk::Win32SurfaceCreateFlagsKHR::empty(),
                     hinstance: hinstance as *mut _,
@@ -235,7 +235,7 @@ impl Instance {
         {
             use winit::os::unix::WindowExt;
 
-            if self.extensions.contains(&vk::VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME) {
+            if self.extensions.contains(&ext::WaylandSurface::name().to_str().unwrap()) {
                 if let Some(display) = window.get_wayland_display() {
                     let display: *mut c_void = display as *mut _;
                     let surface: *mut c_void = window.get_wayland_surface().unwrap() as *mut _;
@@ -243,7 +243,7 @@ impl Instance {
                     return self.create_surface_from_wayland(display, surface, px.width as _, px.height as _);
                 }
             }
-            if self.extensions.contains(&vk::VK_KHR_XLIB_SURFACE_EXTENSION_NAME) {
+            if self.extensions.contains(&ext::XlibSurface::name().to_str().unwrap()) {
                 if let Some(display) = window.get_xlib_display() {
                     let window = window.get_xlib_window().unwrap();
                     return self.create_surface_from_xlib(display as _, window);
@@ -273,7 +273,7 @@ impl Instance {
     fn create_surface_from_vk_surface_khr(
         &self, surface: vk::SurfaceKHR, width: Size, height: Size, samples: NumSamples
     ) -> Surface {
-        let entry = VK_ENTRY
+        let entry = ENTRY
             .as_ref()
             .expect("Unable to load Vulkan entry points");
 
@@ -347,9 +347,9 @@ impl hal::Surface<Backend> for Surface {
 
         let formats = match formats[0].format {
             // If pSurfaceFormats includes just one entry, whose value for format is
-            // VK_FORMAT_UNDEFINED, surface has no preferred format. In this case, the application
+            // FORMAT_UNDEFINED, surface has no preferred format. In this case, the application
             // can use any valid VkFormat value.
-            vk::Format::Undefined => None,
+            vk::Format::UNDEFINED => None,
             _ => {
                 Some(formats
                     .into_iter()
@@ -403,9 +403,9 @@ impl hal::Swapchain<Backend> for Swapchain {
 
         match index {
             Ok(i) => Ok(i),
-            Err(vk::Result::NotReady) => Err(hal::AcquireError::NotReady),
-            Err(vk::Result::SuboptimalKhr) | Err(vk::Result::ErrorOutOfDateKhr) => Err(hal::AcquireError::OutOfDate),
-            Err(vk::Result::ErrorSurfaceLostKhr) => Err(hal::AcquireError::SurfaceLost),
+            Err(vk::Result::NOT_READY) => Err(hal::AcquireError::NotReady),
+            Err(vk::Result::SUBOPTIMAL_KHR) | Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => Err(hal::AcquireError::OutOfDate),
+            Err(vk::Result::ERROR_SURFACE_LOST_KHR) => Err(hal::AcquireError::SurfaceLost),
             _ => panic!("Failed to acquire image."),
         }
     }


### PR DESCRIPTION
A new version of `ash` is going to be released soon, and it will contain breaking changes. This cost is offset by the following points:

0) changes only involve renaming

1) new features allow for removal of `mem::transmute` calls from many places

2) `VK_EXT_debug_utils` support

3) general extension/under-the-hood restructuring to stay up-to-date with Vulkan in an easier manner

This PR shows what changes would be involved (given the Vulkan backend's current state) if `gfx-hal` were to use the `generator` branch of `ash`.

Point for discussion (cc @grovesNL @kvark ) how soon can we pin `gfx-hal` master to use the `generator` master branch? I suppose the answer would partially depend on what regressions `generator` introduces (hopefully none!) -- @MaikKlein will be able to inform us about this. 
 
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
