### PR TITLE
simplify quad resize logic

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -34,7 +34,7 @@ use hal::{Device, Instance, PhysicalDevice, Surface, Swapchain};
 use std::fs;
 use std::io::{Cursor, Read};
 
-#[cfg_attr(rustfmt, rustfmt_skip)]?
+#[cfg_attr(rustfmt, rustfmt_skip)]
 const DIMS: Extent2D = Extent2D { width: 1024,height: 768 };
 
 const ENTRY_NAME: &str = "main";
@@ -46,7 +46,7 @@ struct Vertex {
     a_Uv: [f32; 2],
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]?
+#[cfg_attr(rustfmt, rustfmt_skip)]
 const QUAD: [Vertex; 6] = [
     Vertex { a_Pos: [ -0.5, 0.33 ], a_Uv: [0.0, 1.0] },
     Vertex { a_Pos: [  0.5, 0.33 ], a_Uv: [1.0, 1.0] },

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -34,10 +34,8 @@ use hal::{Device, Instance, PhysicalDevice, Surface, Swapchain};
 use std::fs;
 use std::io::{Cursor, Read};
 
-const DIMS: Extent2D = Extent2D {
-    width: 1024,
-    height: 768,
-};
+#[cfg_attr(rustfmt, rustfmt_skip)]?
+const DIMS: Extent2D = Extent2D { width: 1024,height: 768 };
 
 const ENTRY_NAME: &str = "main";
 
@@ -48,31 +46,15 @@ struct Vertex {
     a_Uv: [f32; 2],
 }
 
+#[cfg_attr(rustfmt, rustfmt_skip)]?
 const QUAD: [Vertex; 6] = [
-    Vertex {
-        a_Pos: [-0.5, 0.33],
-        a_Uv: [0.0, 1.0],
-    },
-    Vertex {
-        a_Pos: [0.5, 0.33],
-        a_Uv: [1.0, 1.0],
-    },
-    Vertex {
-        a_Pos: [0.5, -0.33],
-        a_Uv: [1.0, 0.0],
-    },
-    Vertex {
-        a_Pos: [-0.5, 0.33],
-        a_Uv: [0.0, 1.0],
-    },
-    Vertex {
-        a_Pos: [0.5, -0.33],
-        a_Uv: [1.0, 0.0],
-    },
-    Vertex {
-        a_Pos: [-0.5, -0.33],
-        a_Uv: [0.0, 0.0],
-    },
+    Vertex { a_Pos: [ -0.5, 0.33 ], a_Uv: [0.0, 1.0] },
+    Vertex { a_Pos: [  0.5, 0.33 ], a_Uv: [1.0, 1.0] },
+    Vertex { a_Pos: [  0.5,-0.33 ], a_Uv: [1.0, 0.0] },
+
+    Vertex { a_Pos: [ -0.5, 0.33 ], a_Uv: [0.0, 1.0] },
+    Vertex { a_Pos: [  0.5,-0.33 ], a_Uv: [1.0, 0.0] },
+    Vertex { a_Pos: [ -0.5,-0.33 ], a_Uv: [0.0, 0.0] },
 ];
 
 const COLOR_RANGE: i::SubresourceRange = i::SubresourceRange {


### PR DESCRIPTION
Fixes #2326

First pass at simplifying logic, would like review here before tightening it up more.
Some logic is repeated, should it be pulled out into a function or left as is so that the logic is linear down the page?

Anything I am missing?

Have not run rustfmt yet, will make that a separate commit.


PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:vulkan, gl
- [ ] `rustfmt` run on changed code 
