### PR TITLE
[mtl] support buffer-backed host-visible textures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,7 @@ else
 	endif
 	ifeq ($(UNAME_S),Darwin)
 		EXCLUDES+= --exclude gfx-backend-vulkan
-		ifeq ($(TARGET),$(filter $(TARGET),x86_64-apple-ios armv7-apple-ios))
-			EXCLUDES += --exclude gfx-backend-metal
-		else
-			FEATURES_HAL=metal
-		endif
+		FEATURES_HAL=metal
 	endif
 endif
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -193,9 +193,7 @@ impl Instance {
             msg_send![render_layer, setBounds: bounds];
 
             let window: *mut Object = msg_send![view, window];
-            if window.is_null() {
-                warn!("surface is not attached to a window");
-            } else {
+            if !window.is_null() {
                 let scale_factor: CGFloat = msg_send![window, backingScaleFactor];
                 msg_send![render_layer, setContentsScale: scale_factor];
             }

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -308,7 +308,7 @@ impl Device {
         let images = frames
             .iter()
             .map(|frame| native::Image {
-                raw: frame.texture.clone(),
+                like: native::ImageLike::Texture(frame.texture.clone()),
                 kind: image::Kind::D2(config.extent.width, config.extent.height, 1, 1),
                 format_desc,
                 shader_channel: Channel::Float,

--- a/src/hal/src/command/transfer.rs
+++ b/src/hal/src/command/transfer.rs
@@ -45,7 +45,7 @@ pub struct ImageCopy {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BufferImageCopy {
-    /// Buffer ofset in bytes.
+    /// Buffer offset in bytes.
     pub buffer_offset: buffer::Offset,
     /// Width of a buffer 'row' in texels.
     pub buffer_width: u32,


### PR DESCRIPTION
Fixes  #2095
Gets us to a point where the "cube" example from LunarG works out of the box (by just providing `VK_ICD_FILENAMES`).
Also re-enables "metal" backend by default on Darwin systems.

Edit: also fixes the copy_* operations on buffers to take the in-heap offset into account. This was a major issue that we somehow evaded.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
