### PR TITLE
Raw specialization data

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -43,7 +43,7 @@ use hal::{
 
 use hal::format::{AsFormat, ChannelType, Rgba8Srgb as ColorFormat, Swizzle};
 use hal::pass::Subpass;
-use hal::pso::{PipelineStage, ShaderStageFlags, Specialization};
+use hal::pso::{PipelineStage, ShaderStageFlags};
 use hal::queue::Submission;
 
 use std::fs;
@@ -1264,15 +1264,25 @@ impl<B: Backend> PipelineState<B> {
                     pso::EntryPoint::<B> {
                         entry: ENTRY_NAME,
                         module: &vs_module,
-                        specialization: &[Specialization {
-                            id: 0,
-                            value: pso::Constant::F32(0.8),
-                        }],
+                        specialization: pso::Specialization {
+                            constants: &[
+                                pso::SpecializationConstant {
+                                    id: 0,
+                                    range: 0 .. 4,
+                                },
+                            ],
+                            data: &[ // this is 0.8, trust me
+                                0xCD,
+                                0xCC,
+                                0x4C,
+                                0x3F,
+                            ],
+                        },
                     },
                     pso::EntryPoint::<B> {
                         entry: ENTRY_NAME,
                         module: &fs_module,
-                        specialization: &[],
+                        specialization: pso::Specialization::default(),
                     },
                 );
 

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -74,7 +74,11 @@ fn main() {
         );
 
         let pipeline_layout = device.create_pipeline_layout(Some(&set_layout), &[]);
-        let entry_point = pso::EntryPoint { entry: "main", module: &shader, specialization: &[] };
+        let entry_point = pso::EntryPoint {
+            entry: "main",
+            module: &shader,
+            specialization: pso::Specialization::default(),
+        };
         let pipeline = device
             .create_compute_pipeline(&pso::ComputePipelineDesc::new(entry_point, &pipeline_layout), None)
             .expect("Error creating compute pipeline!");

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -23,7 +23,7 @@ extern crate winit;
 
 use hal::format::{AsFormat, ChannelType, Rgba8Srgb as ColorFormat, Swizzle};
 use hal::pass::Subpass;
-use hal::pso::{PipelineStage, ShaderStageFlags, Specialization};
+use hal::pso::{PipelineStage, ShaderStageFlags};
 use hal::queue::Submission;
 use hal::{
     buffer, command, format as f, image as i, memory as m, pass, pool, pso, window::Extent2D,
@@ -446,15 +446,25 @@ fn main() {
                 pso::EntryPoint::<back::Backend> {
                     entry: ENTRY_NAME,
                     module: &vs_module,
-                    specialization: &[Specialization {
-                        id: 0,
-                        value: pso::Constant::F32(0.8),
-                    }],
+                    specialization: pso::Specialization {
+                        constants: &[
+                            pso::SpecializationConstant {
+                                id: 0,
+                                range: 0 .. 4,
+                            },
+                        ],
+                        data: &[ // this is 0.8, trust me
+                            0xCD,
+                            0xCC,
+                            0x4C,
+                            0x3F,
+                        ],
+                    },
                 },
                 pso::EntryPoint::<back::Backend> {
                     entry: ENTRY_NAME,
                     module: &fs_module,
-                    specialization: &[],
+                    specialization: pso::Specialization::default(),
                 },
             );
 

--- a/src/backend/dx11/src/shader.rs
+++ b/src/backend/dx11/src/shader.rs
@@ -43,24 +43,17 @@ pub(crate) fn compile_spirv_entrypoint(
         .map_err(gen_query_error)?;
 
     for spec_constant in spec_constants {
-        if let Some(constant) = source
-            .specialization
+        if let Some(constant) = source.specialization.constants
             .iter()
             .find(|c| c.id == spec_constant.constant_id)
         {
             // Override specialization constant values
-            unsafe {
-                let value = match constant.value {
-                    pso::Constant::Bool(v) => v as u64,
-                    pso::Constant::U32(v) => v as u64,
-                    pso::Constant::U64(v) => v,
-                    pso::Constant::I32(v) => *(&v as *const _ as *const u64),
-                    pso::Constant::I64(v) => *(&v as *const _ as *const u64),
-                    pso::Constant::F32(v) => *(&v as *const _ as *const u64),
-                    pso::Constant::F64(v) => *(&v as *const _ as *const u64),
-                };
-                ast.set_scalar_constant(spec_constant.id, value).map_err(gen_query_error)?;
-            }
+            let value = source.specialization
+                .data[constant.range.start as usize .. constant.range.end as usize]
+                .iter()
+                .fold(0u64, |u, &b| (u<<8) + b as u64);
+            ast.set_scalar_constant(spec_constant.id, value)
+                .map_err(gen_query_error)?;
         }
     }
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -493,26 +493,19 @@ impl Device {
                 let mut ast = Self::parse_spirv(raw_data)?;
                 let spec_constants = ast.get_specialization_constants().map_err(gen_query_error)?;
 
+                //TODO: move this out into `auxil`
                 for spec_constant in spec_constants {
-                    if let Some(constant) = source
-                        .specialization
+                    if let Some(constant) = source.specialization.constants
                         .iter()
                         .find(|c| c.id == spec_constant.constant_id)
                     {
                         // Override specialization constant values
-                        unsafe {
-                            let value = match constant.value {
-                                pso::Constant::Bool(v) => v as u64,
-                                pso::Constant::U32(v) => v as u64,
-                                pso::Constant::U64(v) => v,
-                                pso::Constant::I32(v) => *(&v as *const _ as *const u64),
-                                pso::Constant::I64(v) => *(&v as *const _ as *const u64),
-                                pso::Constant::F32(v) => *(&v as *const _ as *const u64),
-                                pso::Constant::F64(v) => *(&v as *const _ as *const u64),
-                            };
-                            ast.set_scalar_constant(spec_constant.id, value)
-                                .map_err(gen_query_error)?;
-                        }
+                        let value = source.specialization
+                            .data[constant.range.start as usize .. constant.range.end as usize]
+                            .iter()
+                            .fold(0u64, |u, &b| (u<<8) + b as u64);
+                        ast.set_scalar_constant(spec_constant.id, value)
+                            .map_err(gen_query_error)?;
                     }
                 }
 

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -364,33 +364,6 @@ pub fn map_blend_op(
     }
 }
 
-pub fn map_specialization_constants(
-    specialization: &[pso::Specialization],
-    data: &mut SmallVec<[u8; 64]>,
-) -> Result<SmallVec<[vk::SpecializationMapEntry; 16]>, io::Error> {
-    specialization
-        .iter()
-        .map(|constant| {
-            let offset = data.len();
-            match constant.value {
-                pso::Constant::Bool(v) => { data.write_u32::<NativeEndian>(v as u32) }
-                pso::Constant::U32(v)  => { data.write_u32::<NativeEndian>(v) }
-                pso::Constant::U64(v)  => { data.write_u64::<NativeEndian>(v) }
-                pso::Constant::I32(v)  => { data.write_i32::<NativeEndian>(v) }
-                pso::Constant::I64(v)  => { data.write_i64::<NativeEndian>(v) }
-                pso::Constant::F32(v)  => { data.write_f32::<NativeEndian>(v) }
-                pso::Constant::F64(v)  => { data.write_f64::<NativeEndian>(v) }
-            }?;
-
-            Ok(vk::SpecializationMapEntry {
-                constant_id: constant.id,
-                offset: offset as _,
-                size: (data.len() - offset) as _,
-            })
-        })
-        .collect::<Result<_, _>>()
-}
-
 pub fn map_pipeline_statistics(
     statistics: query::PipelineStatistic,
 ) -> vk::QueryPipelineStatisticFlags {

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -645,7 +645,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                                     module: reshaders
                                         .get(shader)
                                         .expect(&format!("Missing shader: {}", shader)),
-                                    specialization: &[],
+                                    specialization: pso::Specialization::default(),
                                 })
                             }
                         };
@@ -656,7 +656,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                                     module: reshaders
                                         .get(&shaders.vertex)
                                         .expect(&format!("Missing vertex shader: {}", shaders.vertex)),
-                                    specialization: &[],
+                                    specialization: pso::Specialization::default(),
                                 },
                                 hull: entry(&shaders.hull),
                                 domain: entry(&shaders.domain),
@@ -691,7 +691,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                                 module: resources.shaders
                                     .get(shader)
                                     .expect(&format!("Missing compute shader: {}", shader)),
-                                specialization: &[],
+                                specialization: pso::Specialization::default(),
                             },
                             layout: resources.pipeline_layouts
                                 .get(layout)


### PR DESCRIPTION
Fixes a large portion of CTS "dEQP-VK.pipeline.spec_constant" group. The compute sub-part has 83 successes and 38 failures. The graphics part seems to suffer from a descriptor allocation issue, which is unrelated.
Related to https://github.com/gfx-rs/gfx/issues/2059#issuecomment-416439423

- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
