### PR TITLE
[mtl] fixes for metal-rs #73

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -24,7 +24,7 @@ bitflags = "1.0"
 log = { version = "0.4", features = ["release_max_level_error"] }
 winit = { version = "0.17", optional = true }
 dispatch = { version = "0.1", optional = true }
-metal = "0.12.1"
+metal = { version = "0.13.0", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -38,7 +38,7 @@ const WORD_ALIGNMENT: u64 = WORD_SIZE as _;
 /// Enable an optimization to have multi-layered render passed
 /// with clear operations set up to implement our `clear_image`
 /// Note: currently doesn't work, needs a repro case for Apple
-const CLEAR_IMAGE_ARRAY: bool = false;
+const CLEAR_IMAGE_ARRAY: bool = false && cfg!(target_os = "macos");
 /// Number of frames to average when reporting the performance counters.
 const COUNTERS_REPORT_WINDOW: usize = 0;
 

--- a/src/backend/metal/src/internal.rs
+++ b/src/backend/metal/src/internal.rs
@@ -483,7 +483,7 @@ impl ServicePipes {
             buffers.object_at(2).unwrap().set_mutability(metal::MTLMutability::Immutable);
         }*/
 
-        device.new_compute_pipeline_state(&pipeline).unwrap()
+        unsafe { device.new_compute_pipeline_state(&pipeline) }.unwrap()
     }
 
     fn create_fill_buffer(
@@ -501,6 +501,6 @@ impl ServicePipes {
             buffers.object_at(1).unwrap().set_mutability(metal::MTLMutability::Immutable);
         }*/
 
-        device.new_compute_pipeline_state(&pipeline).unwrap()
+        unsafe { device.new_compute_pipeline_state(&pipeline) }.unwrap()
     }
 }


### PR DESCRIPTION
This fixes gfx-backend-metal after [metal-rs/#73](https://github.com/gfx-rs/metal-rs/pull/73).

With this, I was able to rig up a tweaked version of quad that runs on iphone.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal ios/mac
- [ ] `rustfmt` run on changed code
