### PR TITLE
[mtl] obey push constant ranges

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1106,6 +1106,16 @@ impl hal::Device<Backend> for Device {
         let mut shader_compiler_options_point = shader_compiler_options.clone();
         shader_compiler_options_point.enable_point_size_builtin = true;
 
+        const LIMIT_MASK: u32 = 3;
+        // round up the limits alignment to 4, so that it matches MTL compiler logic
+        //TODO: figure out what and how exactly does the alignment. Clearly, it's not
+        // straightforward, given that value of 2 stays non-aligned.
+        for limit in &mut pc_limits {
+            if *limit > LIMIT_MASK {
+                *limit = (*limit + LIMIT_MASK) & !LIMIT_MASK;
+            }
+        }
+
         n::PipelineLayout {
             shader_compiler_options,
             shader_compiler_options_point,

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -182,13 +182,20 @@ pub struct DescriptorSetInfo {
     pub dynamic_buffers: Vec<MultiStageData<PoolResourceIndex>>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PushConstantInfo {
+    pub count: u32,
+    pub buffer_index: ResourceIndex,
+}
+
 #[derive(Debug)]
 pub struct PipelineLayout {
     pub(crate) shader_compiler_options: msl::CompilerOptions,
     pub(crate) shader_compiler_options_point: msl::CompilerOptions,
     pub(crate) infos: Vec<DescriptorSetInfo>,
     pub(crate) total: MultiStageResourceCounters,
-    pub(crate) push_constant_buffer_index: MultiStageData<Option<ResourceIndex>>,
+    pub(crate) push_constants: MultiStageData<Option<PushConstantInfo>>,
+    pub(crate) total_push_constants: u32,
 }
 
 impl PipelineLayout {
@@ -255,8 +262,8 @@ pub struct GraphicsPipeline {
     pub(crate) raw: metal::RenderPipelineState,
     pub(crate) primitive_type: metal::MTLPrimitiveType,
     pub(crate) attribute_buffer_index: ResourceIndex,
-    pub(crate) vs_pc_buffer_index: Option<ResourceIndex>,
-    pub(crate) ps_pc_buffer_index: Option<ResourceIndex>,
+    pub(crate) vs_pc_info: Option<PushConstantInfo>,
+    pub(crate) ps_pc_info: Option<PushConstantInfo>,
     pub(crate) rasterizer_state: Option<RasterizerState>,
     pub(crate) depth_bias: pso::State<pso::DepthBias>,
     pub(crate) depth_stencil_desc: pso::DepthStencilDesc,
@@ -278,7 +285,7 @@ pub struct ComputePipeline {
     pub(crate) cs_lib: metal::Library,
     pub(crate) raw: metal::ComputePipelineState,
     pub(crate) work_group_size: metal::MTLSize,
-    pub(crate) pc_buffer_index: Option<ResourceIndex>,
+    pub(crate) pc_info: Option<PushConstantInfo>,
 }
 
 unsafe impl Send for ComputePipeline {}


### PR DESCRIPTION
Fixes a validation error happening in vkQuake because we always bind the whole push constant array. This PR makes us only bind the relevant slice (which should also reduce the data passed to GPU), and avoid doing so if we know in advance that more data has to come in.

Tested on vkQuake and the relevant CTS section.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
