### PR TITLE
[mtl] support non-aligned copy_buffer offsets

### DIFF
--- a/src/backend/metal/shaders/fill.metal
+++ b/src/backend/metal/shaders/fill.metal
@@ -16,13 +16,18 @@ kernel void cs_fill_buffer(
     }
 }
 
+typedef struct {
+    uint size;
+    uint offsets;
+} CopyBufferRange;
+
 kernel void cs_copy_buffer(
     device uchar *dest [[ buffer(0) ]],
     device uchar *source [[ buffer(1) ]],
-    constant uint &size [[ buffer(2) ]],
+    constant CopyBufferRange &range [[ buffer(2) ]],
     uint index [[ thread_position_in_grid ]]
 ) {
-    if (index < size) {
-        dest[index] = source[index];
+    if (index < range.size) {
+        dest[(range.offsets>>16) + index] = source[(range.offsets & 0xFFFF) + index];
     }
 }


### PR DESCRIPTION
Fixes copy_buffer calls when either of buffer offsets is not aligned to 4 bytes (affects vkQuake)
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
