### PR TITLE
Richer image view capabilities

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1070,7 +1070,7 @@ impl<B: Backend> ImageState<B> {
                 ColorFormat::SELF,
                 i::Tiling::Optimal,
                 i::Usage::TRANSFER_DST | i::Usage::SAMPLED,
-                i::StorageFlags::empty(),
+                i::ViewCapabilities::empty(),
             )
             .unwrap(); // TODO: usage
         let req = device.get_image_requirements(&unbound);

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -233,7 +233,7 @@ fn main() {
             ColorFormat::SELF,
             i::Tiling::Optimal,
             i::Usage::TRANSFER_DST | i::Usage::SAMPLED,
-            i::StorageFlags::empty(),
+            i::ViewCapabilities::empty(),
         )
         .unwrap(); // TODO: usage
     let image_req = device.get_image_requirements(&image_unbound);

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1237,7 +1237,7 @@ impl hal::Device<Backend> for Device {
         format: format::Format,
         tiling: image::Tiling,
         usage: image::Usage,
-        flags: image::StorageFlags,
+        view_caps: image::ViewCapabilities,
     ) -> Result<UnboundImage, image::CreationError> {
         use image::Usage;
         //
@@ -1279,7 +1279,7 @@ impl hal::Device<Backend> for Device {
             format,
             tiling,
             usage,
-            flags,
+            view_caps,
             bind,
             requirements: memory::Requirements {
                 size: size,
@@ -1398,7 +1398,7 @@ impl hal::Device<Backend> for Device {
                     Usage: usage,
                     BindFlags: bind,
                     CPUAccessFlags: cpu,
-                    MiscFlags: if image.flags.contains(image::StorageFlags::CUBE_VIEW) {
+                    MiscFlags: if image.view_caps.contains(image::ViewCapabilities::KIND_CUBE) {
                         d3d11::D3D11_RESOURCE_MISC_TEXTURECUBE
                     } else {
                         0
@@ -1475,7 +1475,7 @@ impl hal::Device<Backend> for Device {
                 let view = ViewInfo {
                     resource: resource.clone(),
                     kind: image.kind,
-                    flags: image::StorageFlags::empty(),
+                    caps: image::ViewCapabilities::empty(),
                     view_kind,
                     // TODO: we should be using `uav_format` rather than `copy_uav_format`, and share
                     //       the UAVs when the formats are identical
@@ -1498,7 +1498,7 @@ impl hal::Device<Backend> for Device {
             let mut view = ViewInfo {
                 resource: resource.clone(),
                 kind: image.kind,
-                flags: image::StorageFlags::empty(),
+                caps: image::ViewCapabilities::empty(),
                 view_kind,
                 format: decomposed.copy_srv.unwrap(),
                 range: image::SubresourceRange {
@@ -1537,7 +1537,7 @@ impl hal::Device<Backend> for Device {
                     let view = ViewInfo {
                         resource: resource.clone(),
                         kind: image.kind,
-                        flags: image::StorageFlags::empty(),
+                        caps: image::ViewCapabilities::empty(),
                         view_kind,
                         format: decomposed.rtv.unwrap(),
                         range: image::SubresourceRange {
@@ -1560,7 +1560,7 @@ impl hal::Device<Backend> for Device {
                     let view = ViewInfo {
                         resource: resource.clone(),
                         kind: image.kind,
-                        flags: image::StorageFlags::empty(),
+                        caps: image::ViewCapabilities::empty(),
                         view_kind: image::ViewKind::D2,
                         format: decomposed.dsv.unwrap(),
                         range: image::SubresourceRange {
@@ -1592,7 +1592,7 @@ impl hal::Device<Backend> for Device {
             usage: image.usage,
             format: image.format,
             decomposed_format: decomposed,
-            storage_flags: image.flags,
+            view_caps: image.view_caps,
             num_levels: image.kind.num_levels(),
             num_mips: image.mip_levels as _,
             internal,
@@ -1610,7 +1610,7 @@ impl hal::Device<Backend> for Device {
         let info = ViewInfo {
             resource: image.internal.raw.clone(),
             kind: image.kind,
-            flags: image.storage_flags,
+            caps: image.view_caps,
             view_kind,
             format: conv::map_format(format)
                 .ok_or(image::ViewError::BadFormat)?,
@@ -1620,7 +1620,7 @@ impl hal::Device<Backend> for Device {
         let srv_info = ViewInfo {
             resource: image.internal.raw.clone(),
             kind: image.kind,
-            flags: image.storage_flags,
+            caps: image.view_caps,
             view_kind,
             format: conv::viewable_format(info.format),
             range,
@@ -2258,7 +2258,7 @@ impl hal::Device<Backend> for Device {
         let mut view_info = ViewInfo {
             resource: resource.clone(),
             kind,
-            flags: image::StorageFlags::empty(),
+            caps: image::ViewCapabilities::empty(),
             view_kind: image::ViewKind::D2,
             format: decomposed.rtv.unwrap(),
             // TODO: can these ever differ for backbuffer?
@@ -2292,7 +2292,7 @@ impl hal::Device<Backend> for Device {
                 kind,
                 usage: config.image_usage,
                 format: config.format,
-                storage_flags: image::StorageFlags::empty(),
+                view_caps: image::ViewCapabilities::empty(),
                 // NOTE: not the actual format of the backbuffer(s)
                 decomposed_format: decomposed.clone(),
                 num_levels: 1,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -95,7 +95,7 @@ pub(crate) struct ViewInfo {
     #[derivative(Debug="ignore")]
     resource: ComPtr<d3d11::ID3D11Resource>,
     kind: image::Kind,
-    flags: image::StorageFlags,
+    caps: image::ViewCapabilities,
     view_kind: image::ViewKind,
     format: dxgiformat::DXGI_FORMAT,
     range: image::SubresourceRange,
@@ -538,7 +538,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         dimensions: u8,
         tiling: image::Tiling,
         usage: image::Usage,
-        storage_flags: image::StorageFlags,
+        view_caps: image::ViewCapabilities,
     ) -> Option<image::FormatProperties> {
         conv::map_format(format)?; //filter out unknown formats
 
@@ -604,7 +604,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                     _ => return None,
                 },
                 sample_count_mask: if dimensions == 2
-                    && !storage_flags.contains(image::StorageFlags::CUBE_VIEW)
+                    && !view_caps.contains(image::ViewCapabilities::KIND_CUBE)
                     && (usage.contains(image::Usage::COLOR_ATTACHMENT)
                         | usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT))
                 {
@@ -2491,7 +2491,7 @@ pub struct UnboundImage {
     format: format::Format,
     tiling: image::Tiling,
     usage: image::Usage,
-    flags: image::StorageFlags,
+    view_caps: image::ViewCapabilities,
     bind: d3d11::D3D11_BIND_FLAG,
     requirements: memory::Requirements,
 }
@@ -2502,7 +2502,7 @@ pub struct Image {
     kind: image::Kind,
     usage: image::Usage,
     format: format::Format,
-    storage_flags: image::StorageFlags,
+    view_caps: image::ViewCapabilities,
     decomposed_format: conv::DecomposedDxgiFormat,
     num_levels: image::Level,
     num_mips: image::Level,

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1261,7 +1261,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         let view_info = device::ViewInfo {
                             resource: attachment.resource,
                             kind: attachment.kind,
-                            flags: image::StorageFlags::empty(),
+                            caps: image::ViewCapabilities::empty(),
                             view_kind: image::ViewKind::D2Array,
                             format: attachment.dxgi_format,
                             range: image::SubresourceRange {
@@ -1302,7 +1302,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         let view_info = device::ViewInfo {
                             resource: attachment.resource,
                             kind: attachment.kind,
-                            flags: image::StorageFlags::empty(),
+                            caps: image::ViewCapabilities::empty(),
                             view_kind: image::ViewKind::D2Array,
                             format: attachment.dxgi_format,
                             range: image::SubresourceRange {
@@ -1423,7 +1423,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             &ViewInfo {
                 resource: src.resource,
                 kind: src.kind,
-                flags: src.storage_flags,
+                caps: src.view_caps,
                 view_kind: image::ViewKind::D2Array, // TODO
                 format: src.descriptor.Format,
                 range: image::SubresourceRange {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -330,7 +330,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         dimensions: u8,
         tiling: image::Tiling,
         usage: image::Usage,
-        storage_flags: image::StorageFlags,
+        view_caps: image::ViewCapabilities,
     ) -> Option<image::FormatProperties> {
         conv::map_format(format)?; //filter out unknown formats
 
@@ -396,7 +396,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                     _ => return None,
                 },
                 sample_count_mask: if dimensions == 2
-                    && !storage_flags.contains(image::StorageFlags::CUBE_VIEW)
+                    && !view_caps.contains(image::ViewCapabilities::KIND_CUBE)
                     && (usage.contains(image::Usage::COLOR_ATTACHMENT)
                         | usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT))
                 {

--- a/src/backend/dx12/src/native.rs
+++ b/src/backend/dx12/src/native.rs
@@ -191,7 +191,7 @@ pub struct Image {
     pub(crate) surface_type: format::SurfaceType,
     pub(crate) kind: image::Kind,
     pub(crate) usage: image::Usage,
-    pub(crate) storage_flags: image::StorageFlags,
+    pub(crate) view_caps: image::ViewCapabilities,
     #[derivative(Debug="ignore")]
     pub(crate) descriptor: d3d12::D3D12_RESOURCE_DESC,
     pub(crate) bytes_per_block: u8,

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -68,7 +68,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
     fn image_format_properties(
         &self, _: format::Format, _dim: u8, _: image:: Tiling,
-        _: image::Usage, _: image::StorageFlags,
+        _: image::Usage, _: image::ViewCapabilities,
     ) -> Option<image::FormatProperties> {
         unimplemented!()
     }
@@ -205,7 +205,7 @@ impl hal::Device<Backend> for Device {
         _: format::Format,
         _: image::Tiling,
         _: image::Usage,
-        _: image::StorageFlags,
+        _: image::ViewCapabilities,
     ) -> Result<(), image::CreationError> {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1042,7 +1042,7 @@ impl d::Device<B> for Device {
         format: Format,
         _tiling: i::Tiling,
         usage: i::Usage,
-        _flags: i::StorageFlags,
+        _view_caps: i::ViewCapabilities,
     ) -> Result<UnboundImage, i::CreationError> {
         let gl = &self.share.context;
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -300,7 +300,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         _dimensions: u8,
         _tiling: image::Tiling,
         _usage: image::Usage,
-        _storage_flags: image::StorageFlags,
+        _view_caps: image::ViewCapabilities,
     ) -> Option<image::FormatProperties> {
         None //TODO
     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2485,6 +2485,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
         let src_cubish = src.view_cube_as_2d();
         let dst_cubish = dst.view_cube_as_2d();
+        let dst_layers = dst.kind.num_layers();
 
         let vertices = &mut self.temp.blit_vertices;
         vertices.clear();
@@ -2666,7 +2667,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     },
                 ];
 
-                descriptor.set_render_target_array_length(ext.depth as _);
+                descriptor.set_render_target_array_length(dst_layers as _);
                 if aspects.contains(Aspects::COLOR) {
                     descriptor
                         .color_attachments()

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -37,7 +37,7 @@ const WORD_SIZE: usize = 4;
 const WORD_ALIGNMENT: u64 = WORD_SIZE as _;
 /// Enable an optimization to have multi-layered render passed
 /// with clear operations set up to implement our `clear_image`
-/// Note: currently doesn't work, needs a repro case for Apple
+/// Note: multi-target clears don't appear to work properly on Intel GPUs
 const CLEAR_IMAGE_ARRAY: bool = false && cfg!(target_os = "macos");
 /// Number of frames to average when reporting the performance counters.
 const COUNTERS_REPORT_WINDOW: usize = 0;
@@ -867,22 +867,22 @@ impl CommandSink {
     }
 
     /// Switch the active encoder to render by starting a render pass.
-    fn switch_render<'a>(
-        &'a mut self,
-        descriptor: &'a metal::RenderPassDescriptorRef,
-    ) -> PreRender<'a> {
+    fn switch_render(
+        &mut self,
+        descriptor: metal::RenderPassDescriptor,
+    ) -> PreRender {
         //assert!(AutoReleasePool::is_active());
         self.stop_encoding();
 
         match *self {
             CommandSink::Immediate { ref cmd_buffer, ref mut encoder_state, ref mut num_passes, .. } => {
                 *num_passes += 1;
-                let encoder = cmd_buffer.new_render_command_encoder(descriptor);
+                let encoder = cmd_buffer.new_render_command_encoder(&descriptor);
                 *encoder_state = EncoderState::Render(encoder.to_owned());
                 PreRender::Immediate(encoder)
             }
             CommandSink::Deferred { ref mut is_encoding, ref mut journal } => {
-                let pass = soft::Pass::Render(descriptor.to_owned());
+                let pass = soft::Pass::Render(descriptor);
                 *is_encoding = true;
                 journal.passes.push((pass, journal.render_commands.len() .. 0));
                 PreRender::Deferred(&mut journal.resources, &mut journal.render_commands)
@@ -890,7 +890,7 @@ impl CommandSink {
             #[cfg(feature = "dispatch")]
             CommandSink::Remote { ref mut pass, ref capacity, .. } => {
                 let mut list = Vec::with_capacity(capacity.render);
-                *pass = Some(EncodePass::Render(list, descriptor.to_owned()));
+                *pass = Some(EncodePass::Render(list, descriptor));
                 match *pass {
                     Some(EncodePass::Render(ref mut list, _)) => PreRender::Deferred(list),
                     _ => unreachable!()
@@ -902,7 +902,7 @@ impl CommandSink {
     fn quick_render<'a, I>(
         &mut self,
         label: &str,
-        descriptor: &'a metal::RenderPassDescriptorRef,
+        descriptor: metal::RenderPassDescriptor,
         commands: I,
     )
     where
@@ -2125,8 +2125,6 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             let raw = image.like.as_texture();
             for subresource_range in subresource_ranges {
                 let sub = subresource_range.borrow();
-                let descriptor = metal::RenderPassDescriptor::new();
-
                 let num_layers = (sub.layers.end - sub.layers.start) as u64;
                 let layers = if CLEAR_IMAGE_ARRAY {
                     0 .. 1
@@ -2153,66 +2151,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     raw
                 };
 
-                let color_attachment = if image.format_desc.aspects.contains(Aspects::COLOR) {
-                    let attachment = descriptor
-                        .color_attachments()
-                        .object_at(0)
-                        .unwrap();
-                    attachment.set_texture(Some(texture));
-                    attachment.set_store_action(metal::MTLStoreAction::Store);
-                    if sub.aspects.contains(Aspects::COLOR) {
-                        attachment.set_load_action(metal::MTLLoadAction::Clear);
-                        attachment.set_clear_color(clear_color.clone());
-                        Some(attachment)
-                    } else {
-                        attachment.set_load_action(metal::MTLLoadAction::Load);
-                        None
-                    }
-                } else {
-                    assert!(!sub.aspects.contains(Aspects::COLOR));
-                    None
-                };
-
-                let depth_attachment = if image.format_desc.aspects.contains(Aspects::DEPTH) {
-                    let attachment = descriptor
-                        .depth_attachment()
-                        .unwrap();
-                    attachment.set_texture(Some(texture));
-                    attachment.set_store_action(metal::MTLStoreAction::Store);
-                    if sub.aspects.contains(Aspects::DEPTH) {
-                        attachment.set_load_action(metal::MTLLoadAction::Clear);
-                        attachment.set_clear_depth(depth_stencil.depth as _);
-                        Some(attachment)
-                    } else {
-                        attachment.set_load_action(metal::MTLLoadAction::Load);
-                        None
-                    }
-                } else {
-                    assert!(!sub.aspects.contains(Aspects::DEPTH));
-                    None
-                };
-
-                let stencil_attachment = if image.format_desc.aspects.contains(Aspects::STENCIL) {
-                    let attachment = descriptor
-                        .stencil_attachment()
-                        .unwrap();
-                    attachment.set_texture(Some(texture));
-                    attachment.set_store_action(metal::MTLStoreAction::Store);
-                    if sub.aspects.contains(Aspects::STENCIL) {
-                        attachment.set_load_action(metal::MTLLoadAction::Clear);
-                        attachment.set_clear_stencil(depth_stencil.stencil);
-                        Some(attachment)
-                    } else {
-                        attachment.set_load_action(metal::MTLLoadAction::Load);
-                        None
-                    }
-                } else {
-                    assert!(!sub.aspects.contains(Aspects::STENCIL));
-                    None
-                };
-
                 for layer in layers {
                     for level in sub.levels.clone() {
+                        let descriptor = metal::RenderPassDescriptor::new().to_owned();
                         if base_extent.depth > 1 {
                             assert_eq!(sub.layers.end, 1);
                             let depth = base_extent.at_level(level).depth as u64;
@@ -2221,24 +2162,66 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             descriptor.set_render_target_array_length(num_layers);
                         };
 
-                        if let Some(attachment) = color_attachment {
+                        if image.format_desc.aspects.contains(Aspects::COLOR) {
+                            let attachment = descriptor
+                                .color_attachments()
+                                .object_at(0)
+                                .unwrap();
+                            attachment.set_texture(Some(texture));
                             attachment.set_level(level as _);
                             if !CLEAR_IMAGE_ARRAY {
                                 attachment.set_slice(layer as _);
                             }
-                        }
-                        if let Some(attachment) = depth_attachment {
+                            attachment.set_store_action(metal::MTLStoreAction::Store);
+                            if sub.aspects.contains(Aspects::COLOR) {
+                                attachment.set_load_action(metal::MTLLoadAction::Clear);
+                                attachment.set_clear_color(clear_color.clone());
+                            } else {
+                                attachment.set_load_action(metal::MTLLoadAction::Load);
+                            }
+                        } else {
+                            assert!(!sub.aspects.contains(Aspects::COLOR));
+                        };
+
+                        if image.format_desc.aspects.contains(Aspects::DEPTH) {
+                            let attachment = descriptor
+                                .depth_attachment()
+                                .unwrap();
+                            attachment.set_texture(Some(texture));
                             attachment.set_level(level as _);
                             if !CLEAR_IMAGE_ARRAY {
                                 attachment.set_slice(layer as _);
                             }
-                        }
-                        if let Some(attachment) = stencil_attachment {
+                            attachment.set_store_action(metal::MTLStoreAction::Store);
+                            if sub.aspects.contains(Aspects::DEPTH) {
+                                attachment.set_load_action(metal::MTLLoadAction::Clear);
+                                attachment.set_clear_depth(depth_stencil.depth as _);
+                            } else {
+                                attachment.set_load_action(metal::MTLLoadAction::Load);
+                            }
+                        } else {
+                            assert!(!sub.aspects.contains(Aspects::DEPTH));
+                        };
+
+                        if image.format_desc.aspects.contains(Aspects::STENCIL) {
+                            let attachment = descriptor
+                                .stencil_attachment()
+                                .unwrap();
+                            attachment.set_texture(Some(texture));
                             attachment.set_level(level as _);
                             if !CLEAR_IMAGE_ARRAY {
                                 attachment.set_slice(layer as _);
                             }
-                        }
+                            attachment.set_store_action(metal::MTLStoreAction::Store);
+                            if sub.aspects.contains(Aspects::STENCIL) {
+                                attachment.set_load_action(metal::MTLLoadAction::Clear);
+                                attachment.set_clear_stencil(depth_stencil.stencil);
+                            } else {
+                                attachment.set_load_action(metal::MTLLoadAction::Load);
+                            }
+                        } else {
+                            assert!(!sub.aspects.contains(Aspects::STENCIL));
+                        };
 
                         sink.as_mut()
                             .unwrap()
@@ -2607,32 +2590,38 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         };
 
         autoreleasepool(|| {
-            let descriptor = metal::RenderPassDescriptor::new();
             let dst_new = match dst_cubish {
                 Some(ref tex) => tex.as_ref(),
                 None => dst.like.as_texture(),
             };
-            if src.format_desc.aspects.contains(Aspects::COLOR) {
-                descriptor
-                    .color_attachments()
-                    .object_at(0)
-                    .unwrap()
-                    .set_texture(Some(dst_new));
-            }
-            if src.format_desc.aspects.contains(Aspects::DEPTH) {
-                descriptor
-                    .depth_attachment()
-                    .unwrap()
-                    .set_texture(Some(dst_new));
-            }
-            if src.format_desc.aspects.contains(Aspects::STENCIL) {
-                descriptor
-                    .stencil_attachment()
-                    .unwrap()
-                    .set_texture(Some(dst_new));
-            }
 
             for ((aspects, level), list) in vertices.drain() {
+                let descriptor = metal::RenderPassDescriptor::new().to_owned();
+                descriptor.set_render_target_array_length(dst_layers as _);
+
+                if aspects.contains(Aspects::COLOR) {
+                    let att = descriptor
+                        .color_attachments()
+                        .object_at(0)
+                        .unwrap();
+                    att.set_texture(Some(dst_new));
+                    att.set_level(level as _);
+                }
+                if aspects.contains(Aspects::DEPTH) {
+                    let att = descriptor
+                        .depth_attachment()
+                        .unwrap();
+                    att.set_texture(Some(dst_new));
+                    att.set_level(level as _);
+                }
+                if aspects.contains(Aspects::STENCIL) {
+                    let att = descriptor
+                        .stencil_attachment()
+                        .unwrap();
+                    att.set_texture(Some(dst_new));
+                    att.set_level(level as _);
+                }
+
                 let ext = dst.kind.extent().at_level(level);
                 //Note: flipping Y coordinate of the destination here
                 let rect = pso::Rect {
@@ -2667,27 +2656,6 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     },
                 ];
 
-                descriptor.set_render_target_array_length(dst_layers as _);
-                if aspects.contains(Aspects::COLOR) {
-                    descriptor
-                        .color_attachments()
-                        .object_at(0)
-                        .unwrap()
-                        .set_level(level as _);
-                }
-                if aspects.contains(Aspects::DEPTH) {
-                    descriptor
-                        .depth_attachment()
-                        .unwrap()
-                        .set_level(level as _);
-                }
-                if aspects.contains(Aspects::STENCIL) {
-                    descriptor
-                        .stencil_attachment()
-                        .unwrap()
-                        .set_level(level as _);
-                }
-
                 let commands = prelude
                     .iter()
                     .chain(&com_ds)
@@ -2697,7 +2665,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 sink
                     .as_mut()
                     .unwrap()
-                    .quick_render("blit_image", &descriptor, commands);
+                    .quick_render("blit_image", descriptor, commands);
             }
         });
 
@@ -3004,7 +2972,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.inner
             .borrow_mut()
             .sink()
-            .switch_render(&sin.descriptor)
+            .switch_render(sin.descriptor)
             .issue_many(init_commands);
     }
 

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -10,7 +10,7 @@ impl PrivateCapabilities {
         use metal::MTLPixelFormat::*;
         use hal::format::Format as f;
         Some(match format {
-            f::B5g6r5Unorm    if self.format_b5 => B5G6R5Unorm,
+            f::R5g6b5Unorm    if self.format_b5 => B5G6R5Unorm,
             f::R5g5b5a1Unorm  if self.format_b5 => A1BGR5Unorm,
             f::A1r5g5b5Unorm  if self.format_b5 => BGR5A1Unorm,
             f::Rgba4Unorm     if self.format_b5 => ABGR4Unorm,
@@ -149,6 +149,7 @@ impl PrivateCapabilities {
             (Rgba8Unorm, Swizzle(B, G, R, A)) => Some(Pf::BGRA8Unorm),
             (Bgra8Unorm, Swizzle(B, G, R, A)) => Some(Pf::RGBA8Unorm),
             (Bgra8Srgb, Swizzle(B, G, R, A)) => Some(Pf::RGBA8Unorm_sRGB),
+            (B5g6r5Unorm, Swizzle(B, G, R, A)) if self.format_b5 => Some(Pf::B5G6R5Unorm),
             _ => {
                 let bits = format.base_format().0.describe_bits();
                 if swizzle != Swizzle::NO && !(bits.alpha == 0 && swizzle == Swizzle(R, G, B, One)) {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -543,6 +543,10 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             // MTLRenderPassDescriptor texture must not be MTLTextureType1D
             return None;
         }
+        if dimensions == 3 && view_caps.contains(image::ViewCapabilities::KIND_2D_ARRAY) {
+            // Can't create 2D/2DArray views of 3D textures
+            return None;
+        }
         //TODO: actually query this data
         let max_dimension = 4096u32;
         let max_extent = image::Extent {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -525,13 +525,13 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
     fn image_format_properties(
         &self, format: format::Format, dimensions: u8, tiling: image::Tiling,
-        usage: image::Usage, storage_flags: image::StorageFlags,
+        usage: image::Usage, view_caps: image::ViewCapabilities,
     ) -> Option<image::FormatProperties> {
         if let image::Tiling::Linear = tiling {
             let format_desc = format.surface_desc();
             let host_usage = image::Usage::TRANSFER_SRC | image::Usage::TRANSFER_DST;
             if dimensions != 2 ||
-                !storage_flags.is_empty() ||
+                !view_caps.is_empty() ||
                 !host_usage.contains(usage) ||
                 format_desc.aspects != format::Aspects::COLOR ||
                 format_desc.is_compressed()
@@ -2068,12 +2068,12 @@ impl hal::Device<Backend> for Device {
         format: format::Format,
         tiling: image::Tiling,
         usage: image::Usage,
-        flags: image::StorageFlags,
+        flags: image::ViewCapabilities,
     ) -> Result<n::UnboundImage, image::CreationError> {
         debug!("create_image {:?} with {} mips of {:?} {:?} and usage {:?}",
             kind, mip_levels, format, tiling, usage);
 
-        let is_cube = flags.contains(image::StorageFlags::CUBE_VIEW);
+        let is_cube = flags.contains(image::ViewCapabilities::KIND_CUBE);
         let mtl_format = self.private_caps
             .map_format(format)
             .ok_or(image::CreationError::Format(format))?;

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -1,6 +1,4 @@
 use ash::vk;
-use byteorder::{NativeEndian, WriteBytesExt};
-use smallvec::SmallVec;
 
 use hal::{buffer, command, format, image, pass, pso, query};
 use hal::{IndexType, Primitive, PresentMode};
@@ -8,7 +6,7 @@ use hal::range::RangeArg;
 
 use native as n;
 
-use std::{io, mem};
+use std::mem;
 use std::borrow::Borrow;
 use std::ptr;
 
@@ -493,9 +491,9 @@ pub fn map_viewport(vp: &pso::Viewport) -> vk::Viewport {
     }
 }
 
-pub fn map_image_flags(flags: image::StorageFlags) -> vk::ImageCreateFlags {
+pub fn map_view_capabilities(caps: image::ViewCapabilities) -> vk::ImageCreateFlags {
     // the flag values have to match Vulkan
-    unsafe { mem::transmute(flags) }
+    unsafe { mem::transmute(caps) }
 }
 
 pub fn map_vk_present_mode(mode: vk::PresentModeKHR) -> PresentMode {

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1015,9 +1015,9 @@ impl d::Device<B> for Device {
         format: format::Format,
         tiling: image::Tiling,
         usage: image::Usage,
-        storage_flags: image::StorageFlags,
+        view_caps: image::ViewCapabilities,
     ) -> Result<UnboundImage, image::CreationError> {
-        let flags = conv::map_image_flags(storage_flags);
+        let flags = conv::map_view_capabilities(view_caps);
         let extent = conv::map_extent(kind.extent());
         let array_layers = kind.num_layers();
         let samples = kind.num_samples() as u32;

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -457,7 +457,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         dimensions: u8,
         tiling: image::Tiling,
         usage: image::Usage,
-        storage_flags: image::StorageFlags,
+        view_caps: image::ViewCapabilities,
     ) -> Option<image::FormatProperties> {
         match self.instance.0.get_physical_device_image_format_properties(
             self.handle,
@@ -470,7 +470,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             },
             conv::map_tiling(tiling),
             conv::map_image_usage(usage),
-            conv::map_image_flags(storage_flags),
+            conv::map_view_capabilities(view_caps),
         ) {
             Ok(props) => Some(image::FormatProperties {
                 max_extent: image::Extent {

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -85,7 +85,7 @@ pub trait PhysicalDevice<B: Backend>: Any + Send + Sync {
         dimensions: u8,
         tiling: image::Tiling,
         usage: image::Usage,
-        storage_flags: image::StorageFlags,
+        view_caps: image::ViewCapabilities,
     ) -> Option<image::FormatProperties>;
 
     /// Fetch details for the memory regions provided by the device.

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -355,7 +355,7 @@ pub trait Device<B: Backend>: Any + Send + Sync {
     /// Create a new image object
     fn create_image(
         &self, kind: image::Kind, mip_levels: image::Level, format: format::Format,
-        tiling: image::Tiling, usage: image::Usage, storage_flags: image::StorageFlags,
+        tiling: image::Tiling, usage: image::Usage, view_caps: image::ViewCapabilities,
     ) -> Result<B::UnboundImage, image::CreationError>;
 
     /// Get memory requirements for the unbound Image

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -382,11 +382,15 @@ pub enum ViewKind {
 }
 
 bitflags!(
-    /// Image storage flags
+    /// Capabilities to create views into an image.
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct StorageFlags: u32 {
-        /// Support creation of `Cube` and `CubeArray` views.
-        const CUBE_VIEW = 0b0010000;
+    pub struct ViewCapabilities: u32 {
+        /// Support creation of views with different formats.
+        const MUTABLE_FORMAT = 0x00000008;
+        /// Support creation of `Cube` and `CubeArray` kinds of views.
+        const KIND_CUBE      = 0x00000010;
+        /// Support creation of `D2Array` kind of view.
+        const KIND_ARRAY_2D  = 0x00000020;
     }
 );
 

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -390,7 +390,7 @@ bitflags!(
         /// Support creation of `Cube` and `CubeArray` kinds of views.
         const KIND_CUBE      = 0x00000010;
         /// Support creation of `D2Array` kind of view.
-        const KIND_ARRAY_2D  = 0x00000020;
+        const KIND_2D_ARRAY  = 0x00000020;
     }
 );
 

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -305,7 +305,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                     raw::Resource::Image { kind, num_levels, format, usage, ref data } => {
                         // allocate memory
                         let unbound = device.create_image(
-                            kind, num_levels, format, i::Tiling::Optimal, usage, i::StorageFlags::empty()
+                            kind, num_levels, format, i::Tiling::Optimal, usage, i::ViewCapabilities::empty()
                             ).unwrap();
                         let requirements = device.get_image_requirements(&unbound);
                         let memory_type = memory_types


### PR DESCRIPTION
WIP steps towards #2396, exploiting CI to get it error-less.
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
