### PR TITLE
[mtl] build internal shaders with debug info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,18 @@ matrix:
     - env: MACOSX_DEPLOYMENT_TARGET=10.9
       os: osx
       rust: stable
-      osx_image: xcode9
+      osx_image: xcode10
       compiler: clang
     - env: MACOSX_DEPLOYMENT_TARGET=10.9
       os: osx
       rust: nightly
-      osx_image: xcode9
+      osx_image: xcode10
       compiler: clang
 
     # iPhoneOS 64bit
     - env: TARGET=aarch64-apple-ios
       os: osx
-      osx_image: xcode9
+      osx_image: xcode10
       rust: nightly
 
 branches:

--- a/src/backend/metal/build.rs
+++ b/src/backend/metal/build.rs
@@ -17,6 +17,10 @@ fn main() {
         panic!("unsupported target {}", target)
     };
     let arch = &target[..target.chars().position(|c| c == '-').unwrap()];
+    let is_debug = match env::var("PROFILE") {
+        Ok(profile) => profile == "debug",
+        Err(_) => false,
+    };
 
     let sdk_name = match (os, arch) {
         ("ios", "aarch64") => "iphoneos",
@@ -59,6 +63,7 @@ fn main() {
             .arg(shader_path.as_os_str())
             .arg("-o")
             .arg(out_path.as_os_str())
+            .args(if is_debug { &["-g", "-MO"][..] } else { &[] })
             .status()
             .expect("failed to execute metal compiler");
 


### PR DESCRIPTION
Helps investigating #2364
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
