### PR TITLE
[mtl] keep borrowed clear value longer

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2313,7 +2313,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             let pso; // has to live at least as long as all the commands
             let depth_stencil;
 
-            let (com_clear, target_index) = match *clear.borrow() {
+            let borrowed_clear = clear.borrow();
+            //Note: ^ has to live at least as long as the command
+            let (com_clear, target_index) = match *borrowed_clear {
                 com::AttachmentClear::Color { index, value } => {
                     let channel = self.state.target_formats.colors[index].1;
                     //Note: technically we should be able to derive the Channel from the


### PR DESCRIPTION
Intended to fix https://github.com/szeged/webrender/issues/216
Note: this is a little scary of an issue. Doesn't appear that we have any more of them, but we need to keep an eye on those cases.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
