### PR TITLE
dx12: support individual command buffer reset

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1044,7 +1044,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    fn reset(&mut self, _release_resources: bool) {
+    fn reset(&mut self, release_resources: bool) {
+        if release_resources {
+            unsafe { self.allocator.Reset(); }
+        }
         self.reset();
     }
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1052,15 +1052,9 @@ impl d::Device<B> for Device {
         _create_flags: CommandPoolCreateFlags,
     ) -> RawCommandPool {
         let list_type = QUEUE_FAMILIES[family.0].native_type();
-        let (command_allocator, hr) = self.raw.create_command_allocator(list_type);
-
-        // TODO: error handling
-        if !winerror::SUCCEEDED(hr) {
-            error!("error on command allocator creation: {:x}", hr);
-        }
 
         RawCommandPool {
-            raw: command_allocator,
+            allocators: Vec::new(),
             device: self.raw,
             list_type,
             shared: self.shared.clone(),
@@ -1068,9 +1062,7 @@ impl d::Device<B> for Device {
     }
 
     fn destroy_command_pool(&self, pool: RawCommandPool) {
-        unsafe {
-            pool.raw.destroy();
-        }
+        pool.destroy();
     }
 
     fn create_render_pass<'a, IA, IS, ID>(

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -21,7 +21,7 @@ use native::command_list::IndirectArgument;
 use native::descriptor;
 use native::pso::{CachedPSO, PipelineStateFlags, PipelineStateSubobject, Subobject};
 
-use pool::RawCommandPool;
+use pool::{CommandPoolAllocator, RawCommandPool};
 use range_alloc::RangeAllocator;
 use root_constants::RootConstant;
 use {
@@ -1049,12 +1049,26 @@ impl d::Device<B> for Device {
     fn create_command_pool(
         &self,
         family: QueueFamilyId,
-        _create_flags: CommandPoolCreateFlags,
+        create_flags: CommandPoolCreateFlags,
     ) -> RawCommandPool {
         let list_type = QUEUE_FAMILIES[family.0].native_type();
 
+        let allocator = if create_flags.contains(CommandPoolCreateFlags::RESET_INDIVIDUAL) {
+            // Allocators are created per individual ID3D12GraphicsCommandList
+            CommandPoolAllocator::Individual(Vec::new())
+        } else {
+            let (command_allocator, hr) = self.raw.create_command_allocator(list_type);
+
+            // TODO: error handling
+            if !winerror::SUCCEEDED(hr) {
+                error!("error on command allocator creation: {:x}", hr);
+            }
+
+            CommandPoolAllocator::Shared(command_allocator)
+        };
+
         RawCommandPool {
-            allocators: Vec::new(),
+            allocator,
             device: self.raw,
             list_type,
             shared: self.shared.clone(),

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -8,20 +8,25 @@ use native::command_list::CmdListType;
 use {native, Backend, Shared};
 
 pub struct RawCommandPool {
-    pub(crate) raw: native::CommandAllocator,
+    pub(crate) allocators: Vec<native::CommandAllocator>,
     pub(crate) device: native::Device,
     pub(crate) list_type: CmdListType,
     pub(crate) shared: Arc<Shared>,
 }
 
 impl RawCommandPool {
-    fn create_command_list(&mut self) -> native::GraphicsCommandList {
+    fn create_command_list(&mut self) -> (native::GraphicsCommandList, native::CommandAllocator) {
+        let (command_allocator, hr) = self.device.create_command_allocator(self.list_type);
+
         // TODO: error handling
+        if !SUCCEEDED(hr) {
+            error!("error on command allocator creation: {:x}", hr);
+        }
 
         // allocate command lists
         let (command_list, hr) = self.device.create_graphics_command_list(
             self.list_type,
-            self.raw,
+            command_allocator,
             native::PipelineState::null(),
             0,
         );
@@ -34,7 +39,15 @@ impl RawCommandPool {
         // But only one command list can be recording for each allocator
         let _hr = command_list.close();
 
-        command_list
+        self.allocators.push(command_allocator);
+
+        (command_list, command_allocator)
+    }
+
+    pub(crate) fn destroy(self) {
+        for allocator in self.allocators {
+            unsafe { allocator.destroy(); }
+        }
     }
 }
 
@@ -43,14 +56,21 @@ unsafe impl Sync for RawCommandPool {}
 
 impl pool::RawCommandPool<Backend> for RawCommandPool {
     fn reset(&mut self) {
-        self.raw.reset();
+        self.allocators.iter_mut().for_each(|allocator| {
+            unsafe {
+                allocator.Reset();
+            }
+        })
     }
 
     fn allocate(&mut self, num: usize, level: command::RawLevel) -> Vec<CommandBuffer> {
         // TODO: Implement secondary buffers
         assert_eq!(level, command::RawLevel::Primary);
         (0..num)
-            .map(|_| CommandBuffer::new(self.create_command_list(), self.raw, self.shared.clone()))
+            .map(|_| {
+                let (command_list, command_allocator) = self.create_command_list();
+                CommandBuffer::new(command_list, command_allocator, self.shared.clone())
+            })
             .collect()
     }
 


### PR DESCRIPTION
dx12::RawCommandPool now holds a collection of ID3D12CommandAllocator,
introducing a new one each time a new command buffer is allocated.

dx12::RawCommandPool::reset() now performs a reset() on each allocator in
the collection, mimicking the prior single-allocator behaviour.

dx12::CommandBuffer::reset() now handles the `release_resources` flag by
reseting its allocator.

Fixes #2140 

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds*
- [x] tested examples with the following backends: **dx12**
- [ ] `rustfmt` run on changed code*

*make reftests fails here:

```
Warding DX12:
        Scene 'basic':
thread 'main' panicked at 'assertion failed: `(left != right)`
  left: `0`,
 right: `0`', src\warden\src\gpu.rs:1152:9
```

I haven't looked too closely into this, but it also fails with the patch reverted. Other than this, there are 15 passing reftests.

---

*rustfmt --check requests many changes (not limited to things inserted in this patch), but I believe the style of the code added in this patch is consistent with the rest of the file.

---

TODO: add a test (I'm not sure how easy it will be to simulate an EOM reliably to verify that it doesn't happen with the patch applied, though).
