### PR TITLE
Add tests building with emscripten target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sdl2; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated cmake || brew upgrade cmake; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then rustup target add asmjs-unknown-emscripten ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then rustup target add wasm32-unknown-emscripten ; fi
+  # The binary emsdk packages don't work as they are built to expect GLIBCXX_3.4.21 which isn't
+  # installed in the build environment. Instead, use a docker image with emsdk installed.
+  # See https://kripken.github.io/emscripten-site/docs/compiling/Travis.html
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then scripts/travis-emscripten-docker-setup.sh ; fi
 
 addons:
   apt:
@@ -68,3 +74,5 @@ script:
   - cargo test -p gfx_window_glutin $HEADLESS_FEATURE
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cargo test --all --features vulkan; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cargo test --all --features metal; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec -it emscripten cargo test --all --target=asmjs-unknown-emscripten ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker exec -it emscripten cargo test --all --target=wasm32-unknown-emscripten ; fi

--- a/scripts/travis-emscripten-docker-setup.sh
+++ b/scripts/travis-emscripten-docker-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ev
+
+# Start a container with the travis $HOME mounted at /root to get access to the rust installation,
+# and the $TRAVIS_BUILD_DIR mounted to /src, (which is the container's initial working directory)
+# so we can later run `cargo test ...` without changing directory.
+DOCKER_BASE_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+docker run -dit --name emscripten -e PATH=$DOCKER_BASE_PATH:/root/.cargo/bin -v $TRAVIS_BUILD_DIR:/src -v $HOME:/root trzeci/emscripten


### PR DESCRIPTION
Fixes #1695 

Adds tests on linux which run `cargo test --all` using `--target=asmjs-unknown-emscripten` and `--target=wasm32-unknown-emscripten`.

The default installation of emscripten (as per https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html) doesn't seem to work on travis. It fails with the error:
`/home/travis/emsdk/clang/e1.38.12_64bit/llc: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version 'GLIBCXX_3.4.20' not found (required by /home/travis/emsdk/clang/e1.38.12_64bit/llc)`. I've experienced this problem offline and the solution was to build clang from source, but this takes too long on travis so instead the test uses the docker image recommended on emscripten's website (https://kripken.github.io/emscripten-site/docs/compiling/Travis.html).

Note that the build is currently failing with the error `*** Error in '/emsdk_portable/llvm/clang/bin/llc': corrupted double-linked list: 0x0000000003148920 ***`. 

I've done some testing offline, attempting to build the triangle example. I've encountered the error above, and also the following:
 - `corrupted size vs. prev_size`
 - `double free or corruption (!prev)`

The error seems to be non deterministic. It also occasionally compiles without error and produces code which seems to work.

Tested on travis:
https://travis-ci.org/stevebob/gfx/jobs/429755777

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
