### PR TITLE
Don't #[allow(type_alias_bounds)].

### DIFF
--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -90,8 +90,7 @@ unsafe impl<'a, B: Backend, C, L: Level> Submittable<'a, B, C, L> for &'a Submit
 }
 
 /// A convenience alias for not typing out the full signature of a secondary command buffer.
-#[allow(type_alias_bounds)]
-pub type SecondaryCommandBuffer<'a, B: Backend, C, S: Shot = OneShot> = CommandBuffer<'a, B, C, S, Secondary>;
+pub type SecondaryCommandBuffer<'a, B, C, S = OneShot> = CommandBuffer<'a, B, C, S, Secondary>;
 
 /// A strongly-typed command buffer that will only implement methods that are valid for the operations
 /// it supports.


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/54090 will fix false positives (not relevant here) and make it an error in the upcoming Rust 2018 edition, which means that if you want to migrate to Rust 2018, it shouldn't be ignored.

See also https://github.com/rust-lang/rust/issues/49441#issuecomment-421136550 for the decision and some background.