### PR TITLE
[mtl] return an error on Swapchain::present if drawable not found

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1786,12 +1786,12 @@ impl RawCommandQueue<Backend> for CommandQueue {
 
             for (swapchain, index) in swapchains {
                 debug!("presenting frame {}", index);
-                if let Ok(drawable) = swapchain.borrow().take_drawable(index) {
-                    command_buffer.present_drawable(&drawable);
-                }
+                let drawable = swapchain.borrow().take_drawable(index)?;
+                command_buffer.present_drawable(&drawable);
             }
             command_buffer.commit();
-        });
+            Ok(())
+        })?;
 
         if let Some(ref mut counters) = self.perf_counters {
             counters.frame += 1;


### PR DESCRIPTION
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal (ios/mac)
- [ ] `rustfmt` run on changed code
