### PR TITLE
Allow access to extra types.

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -50,7 +50,7 @@ mod info;
 mod native;
 mod pool;
 mod result;
-mod window;
+pub mod window;
 
 const LAYERS: &'static [&'static str] = &[#[cfg(debug_assertions)]
 "VK_LAYER_LUNARG_standard_validation"];
@@ -292,7 +292,7 @@ impl hal::Instance for Instance {
                         ash::vk::PhysicalDeviceType::DiscreteGpu => DeviceType::DiscreteGpu,
                         ash::vk::PhysicalDeviceType::VirtualGpu => DeviceType::VirtualGpu,
                         ash::vk::PhysicalDeviceType::Cpu => DeviceType::Cpu,
-                    },                    
+                    },
                 };
                 let physical_device = PhysicalDevice {
                     instance: self.raw.clone(),

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -25,7 +25,7 @@ pub struct Surface {
     pub(crate) samples: NumSamples,
 }
 
-pub struct RawSurface {
+pub(crate) struct RawSurface {
     pub(crate) handle: vk::SurfaceKHR,
     functor: ext::Surface,
     pub(crate) instance: Arc<RawInstance>,


### PR DESCRIPTION
This is necessary for me to keep a handle on the backend surface (so
that I can get information about it, for example when its size changes).

Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- [x] `rustfmt` run on changed code
