### PR TITLE
Add some docs to `gfx_hal::Instance`, and provide a make target for `cargo doc`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
 endif
 
 
-.PHONY: all check quad test reftests travis-sdl2
+.PHONY: all check quad test doc reftests travis-sdl2
 
 all: check test
 
@@ -59,6 +59,9 @@ check:
 
 test:
 	cargo test --all $(EXCLUDES)
+
+doc:
+	cargo doc --all $(EXCLUDES)
 
 reftests:
 	cd src/warden && cargo run --features "$(FEATURES_HAL) $(FEATURES_HAL2)" -- local #TODO: gl

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -839,6 +839,6 @@ pub struct Instance;
 impl hal::Instance for Instance {
     type Backend = Backend;
     fn enumerate_adapters(&self) -> Vec<hal::Adapter<Backend>> {
-        unimplemented!()
+        vec![]
     }
 }

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -126,7 +126,7 @@ pub struct AdapterInfo {
     /// PCI id of the adapter
     pub device: usize,
     /// Type of device
-    pub device_type: DeviceType, 
+    pub device_type: DeviceType,
 }
 
 /// The list of `Adapter` instances is obtained by calling `Instance::enumerate_adapters()`.
@@ -145,7 +145,7 @@ pub struct Adapter<B: Backend> {
 
 impl<B: Backend> Adapter<B> {
     /// Open the physical device with `count` queues from some active queue family. The family is
-    /// the first that both provides the capability `C`, supports at least `count' queues, and for
+    /// the first that both provides the capability `C`, supports at least `count` queues, and for
     /// which `selector` returns true.
     ///
     /// # Examples

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -337,7 +337,7 @@ pub enum IndexType {
 /// An instantiated backend.
 ///
 /// Any startup the backend needs to perform will be done when creating the type that implements
-/// this type.
+/// `Instance`.
 ///
 /// # Examples
 ///

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -334,7 +334,29 @@ pub enum IndexType {
     U32,
 }
 
-/// Basic backend instance trait.
+/// An instantiated backend.
+///
+/// Any startup the backend needs to perform will be done when creating the type that implements
+/// this type.
+///
+/// # Examples
+///
+/// ```rust
+/// # extern crate gfx_backend_empty;
+/// # extern crate gfx_hal;
+/// use gfx_backend_empty as backend;
+/// use gfx_hal as hal;
+///
+/// // Create a concrete instance of our backend (this is backend-dependent and may be more
+/// // complicated for some backends).
+/// let instance = backend::Instance;
+/// // We can get a list of the available adapters, which are either physical graphics
+/// // devices, or virtual adapters. Because we are using the dummy `empty` backend,
+/// // there will be nothing in this list.
+/// for (idx, adapter) in hal::Instance::enumerate_adapters(&instance).iter().enumerate() {
+///     println!("Adapter {}: {:?}", idx, adapter.info);
+/// }
+/// ```
 pub trait Instance: Any + Send + Sync {
     /// Associated backend type of this instance.
     type Backend: Backend;


### PR DESCRIPTION


Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends: n/a (doc-only)
- [ ] `rustfmt` run on changed code
