### PR TITLE
[mtl] simple blit with scaling between the swapchains

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -573,6 +573,9 @@ fn main() {
             println!("{:?}", swap_config);
             let extent = swap_config.extent.to_extent();
 
+            let (new_swap_chain, new_backbuffer) =
+                device.create_swapchain(&mut surface, swap_config, Some(swap_chain));
+
             // Clean up the old framebuffers, images and swapchain
             for framebuffer in framebuffers {
                 device.destroy_framebuffer(framebuffer);
@@ -580,10 +583,7 @@ fn main() {
             for (_, rtv) in frame_images {
                 device.destroy_image_view(rtv);
             }
-            device.destroy_swapchain(swap_chain);
 
-            let (new_swap_chain, new_backbuffer) =
-                device.create_swapchain(&mut surface, swap_config, None);
             backbuffer = new_backbuffer;
             swap_chain = new_swap_chain;
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2491,10 +2491,7 @@ impl hal::Device<Backend> for Device {
         config: hal::SwapchainConfig,
         old_swapchain: Option<Swapchain>,
     ) -> (Swapchain, hal::Backbuffer<Backend>) {
-        if let Some(_swapchain) = old_swapchain {
-            //swapchain is dropped here
-        }
-        self.build_swapchain(surface, config)
+        self.build_swapchain(surface, config, old_swapchain)
     }
 
     fn destroy_swapchain(&self, _swapchain: Swapchain) {


### PR DESCRIPTION
Fixes #2414 

Also hang on resizing in general in some applications... like Dota2. Apparently, it's now resizing by re-creating the surface completely (previously, it only re-created the swapchain). In this case, we fail to track if the old swapchain is still presented, and the hack becomes inactive.

This new version of the hack is smarter: it's always active, and if the user provided the old swapchain, we'll even do a nice blit from the old frame to the new one, to address the flicker.
cc @mtak- 

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan, Metal
- [ ] `rustfmt` run on changed code
