### PR TITLE
dx12: Destroy old swapchain on recreation

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -676,6 +676,8 @@ fn main() {
     }
 
     // cleanup!
+    device.wait_idle().unwrap();
+
     device.destroy_command_pool(command_pool.into_raw());
     device.destroy_descriptor_pool(desc_pool);
     device.destroy_descriptor_set_layout(set_layout);

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2968,8 +2968,12 @@ impl d::Device<B> for Device {
         &self,
         surface: &mut w::Surface,
         config: hal::SwapchainConfig,
-        _old_swapchain: Option<w::Swapchain>,
+        old_swapchain: Option<w::Swapchain>,
     ) -> (w::Swapchain, hal::Backbuffer<B>) {
+        if let Some(old_swapchain) = old_swapchain {
+            self.destroy_swapchain(old_swapchain);
+        }
+
         let mut swap_chain1 = native::WeakPtr::<dxgi1_2::IDXGISwapChain1>::null();
 
         let format = match config.format {


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/gfx/issues/2431
PR checklist:
- [x] tested quad with the following backends: dx12

Currently crashes on shutdown, not totally sure. Might be that the window handle is already invalid but the swapchain is still alive? Need to investigate further..