### PR TITLE
Fix for panic when creating an empty vertex buffer dx11

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_dx11"
-version = "0.7.0"
+version = "0.7.1"
 description = "DirectX-11 backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
Fixes #2370 
PR checklist:
- [ ] tested examples with the following backends: dx11
