### PR TITLE
Fix deprecated anonymous functions parameters

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -431,7 +431,7 @@ fn validate_line_width(width: f32) {
 
 trait AsNative {
     type Native;
-    fn from(&Self::Native) -> Self;
+    fn from(native: &Self::Native) -> Self;
     fn as_native(&self) -> &Self::Native;
 }
 


### PR DESCRIPTION
Anonymous functions parameters are deprecated (RFC 1685)

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
