### PR TITLE
[mtl] pre-release the drawables of the old swapchain

### DIFF
--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -171,6 +171,12 @@ impl Drop for Swapchain {
 }
 
 impl Swapchain {
+    fn clear_drawables(&self) {
+        for frame in self.frames.iter() {
+            frame.inner.lock().drawable = None;
+        }
+    }
+
     /// Returns the drawable for the specified swapchain image index,
     /// marks the index as free for future use.
     pub(crate) fn take_drawable(&self, index: hal::SwapImageIndex) -> Result<metal::Drawable, ()> {
@@ -305,6 +311,9 @@ impl Device {
         old_swapchain: Option<Swapchain>,
     ) -> (Swapchain, Backbuffer<Backend>) {
         info!("build_swapchain {:?}", config);
+        if let Some(ref sc) = old_swapchain {
+            sc.clear_drawables();
+        }
 
         let caps = &self.private_caps;
         let mtl_format = caps


### PR DESCRIPTION
Fixes #2441
cc @overdrivenpotato

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
