### PR TITLE
[Vulkan] Add swapchain cleanup on recreation.

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1699,6 +1699,10 @@ impl d::Device<B> for Device {
 
         let result = unsafe { functor.create_swapchain_khr(&info, None) };
 
+        if old_swapchain != vk::SwapchainKHR::null() {
+            unsafe { functor.destroy_swapchain_khr(old_swapchain, None) }
+        }
+
         let swapchain_raw = match result {
             Ok(swapchain_raw) => swapchain_raw,
             Err(vk::Result::ErrorOutOfHostMemory) => return Err(d::OutOfMemory::OutOfHostMemory.into()),


### PR DESCRIPTION
Swapchain was not being destroyed when being passed back into device.create_swapchain which resulted in memory leaks and validation messages.

Fixes #2467 
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/2464)
<!-- Reviewable:end -->
