### PR TITLE
Update glutin to 0.19 and winit to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_app"
-version = "0.7.0"
+version = "0.8.0"
 description = "GFX example application framework"
 homepage = "https://github.com/gfx-rs/gfx"
 keywords = ["graphics", "gamedev"]
@@ -42,7 +42,7 @@ optional = true
 
 [dependencies.gfx_window_vulkan]
 path = "src/window/vulkan"
-version = "0.7"
+version = "0.8"
 optional = true
 
 [dependencies.gfx_device_metal]
@@ -52,12 +52,12 @@ optional = true
 
 [dependencies.gfx_window_metal]
 path = "src/window/metal"
-version = "0.7"
+version = "0.8"
 optional = true
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.7" }
-gfx_window_dxgi = { path = "src/window/dxgi", version = "0.16" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.17" }
 
 [[example]]
 name = "blend"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ name = "gfx_app"
 [dependencies]
 log = "0.4"
 env_logger = "0.5"
-glutin = "0.18"
-winit = "0.17"
+glutin = "0.19"
+winit = "0.18"
 gfx_core = { path = "src/core", version = "0.8" }
 gfx = { path = "src/render", version = "0.17" }
 gfx_macros = { path = "src/macros", version = "0.2" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.15" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.26" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.27" }
 gfx_window_glfw = { path = "src/window/glfw", version = "0.16", optional = true }
 gfx_window_sdl = { path = "src/window/sdl", version = "0.8", optional = true }
 

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -30,7 +30,6 @@ extern crate cgmath;
 #[macro_use]
 extern crate gfx;
 extern crate gfx_window_glutin;
-extern crate glutin;
 extern crate gfx_app;
 extern crate rand;
 extern crate genmesh;

--- a/examples/gamma/main.rs
+++ b/examples/gamma/main.rs
@@ -23,7 +23,6 @@ use gfx::traits::{Factory, FactoryExt};
 use gfx::Device;
 use gfx::memory::Typed;
 use gfx::format::{Formatted, SurfaceTyped};
-use glutin::GlContext;
 
 pub type ColorFormat = gfx::format::Rgba8;
 pub type DepthFormat = gfx::format::DepthStencil;

--- a/examples/terrain/main.rs
+++ b/examples/terrain/main.rs
@@ -19,7 +19,6 @@ extern crate gfx_app;
 extern crate genmesh;
 extern crate noise;
 extern crate rand;
-extern crate winit;
 
 pub use gfx::format::{DepthStencil};
 pub use gfx_app::{ColorFormat, DepthFormat};

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -20,7 +20,7 @@ extern crate glutin;
 
 use gfx::traits::FactoryExt;
 use gfx::Device;
-use glutin::{GlContext, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
+use glutin::{Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 
 pub type ColorFormat = gfx::format::Rgba8;
 pub type DepthFormat = gfx::format::DepthStencil;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,6 @@ pub fn launch_gl3<A>(window: winit::WindowBuilder) where
 A: Sized + ApplicationBase<gfx_device_gl::Resources, gfx_device_gl::CommandBuffer>
 {
     use gfx::traits::Device;
-    use glutin::GlContext;
 
     env_logger::init();
     #[cfg(target_os = "emscripten")]

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.16.0"
+version = "0.17.0"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,7 +28,7 @@ name = "gfx_window_dxgi"
 
 [dependencies]
 log = "0.4"
-winapi = { version = "0.3" , features = ["d3d11", "dxgi"] }
+winapi = { version = "0.3", features = ["d3d11", "dxgi"] }
 winit = "0.18"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.7" }

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -29,6 +29,6 @@ name = "gfx_window_dxgi"
 [dependencies]
 log = "0.4"
 winapi = { version = "0.3" , features = ["d3d11", "dxgi"] }
-winit = "0.17"
+winit = "0.18"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.7" }

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.26.0"
+version = "0.27.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,7 +28,7 @@ documentation = "https://docs.rs/gfx_window_glutin"
 name = "gfx_window_glutin"
 
 [dependencies]
-glutin = "0.18"
+glutin = "0.19"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.15" }
 

--- a/src/window/glutin/src/headless.rs
+++ b/src/window/glutin/src/headless.rs
@@ -15,7 +15,7 @@
 use std::os::raw::c_void;
 
 use device_gl::{Device, Factory, Resources as Res, create as gl_create, create_main_targets_raw};
-use glutin::{GlContext, HeadlessContext};
+use glutin::{GlContext, Context};
 
 use core::format::{Format, DepthFormat, RenderFormat};
 use core::handle::{DepthStencilView, RawDepthStencilView, RawRenderTargetView, RenderTargetView};
@@ -38,19 +38,21 @@ use core::texture::Dimensions;
 /// use gfx_core::format::{DepthStencil, Rgba8};
 /// use gfx_core::texture::AaMode;
 /// use gfx_window_glutin::init_headless;
-/// use glutin::HeadlessRendererBuilder;
+/// use glutin::{Context, ContextBuilder, EventsLoop};
 ///
 /// # fn main() {
 /// let dim = (256, 256, 8, AaMode::Multi(4));
 ///
-/// let context = HeadlessRendererBuilder::new(dim.0 as u32, dim.1 as u32)
-///     .build()
+/// let events_loop = EventsLoop::new();
+/// let context_builder = ContextBuilder::new()
+///     .with_hardware_acceleration(Some(false));
+/// let context = Context::new(&events_loop, context_builder, false)
 ///     .expect("Failed to build headless context");
 ///
 /// let (mut device, _, _, _) = init_headless::<Rgba8, DepthStencil>(&context, dim);
 /// # }
 /// ```
-pub fn init_headless<Cf, Df>(context: &HeadlessContext, dim: Dimensions)
+pub fn init_headless<Cf, Df>(context: &Context, dim: Dimensions)
                              -> (Device, Factory,
                                  RenderTargetView<Res, Cf>, DepthStencilView<Res, Df>)
     where
@@ -66,7 +68,7 @@ pub fn init_headless<Cf, Df>(context: &HeadlessContext, dim: Dimensions)
 /// Raw version of [`init_headless`].
 ///
 /// [`init_headless`]: fn.init_headless.html
-pub fn init_headless_raw(context: &HeadlessContext, dim: Dimensions, color: Format, depth: Format)
+pub fn init_headless_raw(context: &Context, dim: Dimensions, color: Format, depth: Format)
                          -> (Device, Factory,
                              RawRenderTargetView<Res>, RawDepthStencilView<Res>)
 {
@@ -92,12 +94,14 @@ mod tests {
 
     #[test]
     fn test_headless() {
-        use glutin::{HeadlessRendererBuilder};
+        use glutin::{ContextBuilder, EventsLoop};
 
         let dim = (256, 256, 8, AaMode::Multi(4));
 
-        let context: HeadlessContext = HeadlessRendererBuilder::new(dim.0 as u32, dim.1 as u32)
-            .build()
+        let events_loop = EventsLoop::new();
+        let context_builder = ContextBuilder::new()
+            .with_hardware_acceleration(Some(false));
+        let context = Context::new(&events_loop, context_builder, false)
             .expect("Failed to build headless context");
 
         let (mut device, _, _, _) = init_headless::<Rgba8, DepthStencil>(&context, dim);

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_metal"
-version = "0.7.0"
+version = "0.8.0"
 description = "Metal window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -30,7 +30,7 @@ name = "gfx_window_metal"
 log = "0.4"
 cocoa = "0.9"
 objc = "0.2"
-winit = "0.17"
+winit = "0.18"
 metal-rs = "0.4"
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.3" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/gfx_window_vulkan"
 name = "gfx_window_vulkan"
 
 [dependencies]
-winit = "0.17"
+winit = "0.18"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 gfx_core = { path = "../../core", version = "0.8" }
 gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.2" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_window_vulkan"
-version = "0.7.0"
+version = "0.8.0"
 description = "Vulkan window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
Upgrading the `glutin` and `winit` dependencies.

**Q:** Will this automatically publish a new version or should I bump the version too?

---

Also, something to note in [`glutin v0.19`](https://github.com/tomaka/glutin/blob/master/CHANGELOG.md#version-0190-2018-11-09):

> **Breaking:** The entire API for headless contexts has been removed. Please instead use Context::new() when trying to make a context without a visible window. Also removed headless feature.

I've updated the headless tests to just use `Context::new()`.