### PR TITLE
Bumped glutin version to 0.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ else
 	UNAME_S:=$(shell uname -s)
 	EXCLUDES+= --exclude gfx-backend-dx12
 	EXCLUDES+= --exclude gfx-backend-dx11
-	GLUTIN_HEADLESS_FEATURE="--features headless" #TODO?
 	ifeq ($(UNAME_S),Linux)
 		EXCLUDES+= --exclude gfx-backend-metal
 		FEATURES_HAL=vulkan

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,7 +28,7 @@ path = "compute/main.rs"
 env_logger = "0.5"
 image = "0.19"
 log = "0.4"
-winit = "0.17"
+winit = "0.18"
 glsl-to-spirv = "0.1.4"
 gfx-hal = { path = "../src/hal", version = "0.1" }
 gfx-backend-empty = { path = "../src/backend/empty", version = "0.1" }

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -26,5 +26,5 @@ smallvec = "0.6"
 spirv_cross = "0.11.2"
 parking_lot = "0.6.3"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
-winit = { version = "0.17", optional = true }
+winit = { version = "0.18", optional = true }
 wio = "0.2"

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -26,4 +26,4 @@ log = { version = "0.4", features = ["release_max_level_error"] }
 smallvec = "0.6"
 spirv_cross = "0.11.2"
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
-winit = { version = "0.17", optional = true }
+winit = { version = "0.18", optional = true }

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -23,5 +23,5 @@ log = { version = "0.4", features = ["release_max_level_error"] }
 gfx_gl = "0.5"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
-glutin = { version = "0.18", optional = true }
+glutin = { version = "0.19", optional = true }
 spirv_cross = "0.11.2"

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -32,11 +32,11 @@
 //!
 //! use gfx_hal::Instance;
 //! use gfx_backend_gl::Headless;
-//! use glutin::{HeadlessRendererBuilder};
+//! use glutin::{Context, ContextBuilder, EventsLoop};
 //!
 //! fn main() {
-//!     let context = HeadlessRendererBuilder::new(256, 256)
-//!         .build()
+//!     let events_loop = EventsLoop::new();
+//!     let context = Context::new(&events_loop, ContextBuilder::new(), false)
 //!         .expect("Failed to build headless context");
 //!     let headless = Headless(context);
 //!     let _adapters = headless.enumerate_adapters();
@@ -192,7 +192,7 @@ pub fn config_context(
         .with_srgb(color_base.1 == f::ChannelType::Srgb)
 }
 
-pub struct Headless(pub glutin::HeadlessContext);
+pub struct Headless(pub glutin::Context);
 
 unsafe impl Send for Headless {}
 unsafe impl Sync for Headless {}

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -22,7 +22,7 @@ name = "gfx_backend_metal"
 gfx-hal = { path = "../../hal", version = "0.1" }
 bitflags = "1.0"
 log = { version = "0.4", features = ["release_max_level_error"] }
-winit = { version = "0.17", optional = true }
+winit = { version = "0.18", optional = true }
 dispatch = { version = "0.1", optional = true }
 metal = { version = "0.13.0", features = ["private"] }
 foreign-types = "0.3"

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -26,7 +26,7 @@ shared_library = { version = "0.1.9", optional = true }
 ash = "0.24.4"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
-winit = { version = "0.17", optional = true }
+winit = { version = "0.18", optional = true }
 glsl-to-spirv = { version = "0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -248,8 +248,8 @@ fn main() {
         use gfx_backend_gl::glutin;
         println!("Warding GL headless:");
         let events_loop = glutin::EventsLoop::new();
-        let context = glutin::Context::new(&events_loop, glutin::ContextBuilder::new(), false)
-            .unwrap();
+        let context =
+            glutin::Context::new(&events_loop, glutin::ContextBuilder::new(), false).unwrap();
         let instance = gfx_backend_gl::Headless(context);
         num_failures += harness.run(instance, Disabilities::default());
     }

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -245,9 +245,10 @@ fn main() {
     }
     #[cfg(feature = "gl-headless")]
     {
+        use gfx_backend_gl::glutin;
         println!("Warding GL headless:");
-        let context = gfx_backend_gl::glutin::HeadlessRendererBuilder::new(1, 1)
-            .build()
+        let events_loop = glutin::EventsLoop::new();
+        let context = glutin::Context::new(&events_loop, glutin::ContextBuilder::new(), false)
             .unwrap();
         let instance = gfx_backend_gl::Headless(context);
         num_failures += harness.run(instance, Disabilities::default());


### PR DESCRIPTION
Transitively brings numerous fixes from newer winit version. https://github.com/tomaka/winit/blob/v0.18.0/CHANGELOG.md#version-0180-2018-11-07

PR checklist:
- [ ] `make` succeeds (on *nix): I don't have an environment with make available
- [ ] `make reftests` succeeds: I don't have an environment with make available
- [x] tested examples with the following backends: ran `cargo test --features gl-headless` in src/warden and `cargo test` in src/backend/gl
- [x] `rustfmt` run on changed code
