### PR TITLE
[vk] extend dual-source blending disable on Intel/windows

### DIFF
--- a/src/backend/vulkan/src/info.rs
+++ b/src/backend/vulkan/src/info.rs
@@ -1,4 +1,5 @@
 pub mod intel {
     pub const VENDOR: u32 = 0x8086;
     pub const DEVICE_KABY_LAKE_MASK: u32 = 0x5900;
+    pub const DEVICE_SKY_LAKE_MASK: u32 = 0x1900;
 }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -552,10 +552,12 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
     fn features(&self) -> Features {
         // see https://github.com/gfx-rs/gfx/issues/1930
-        let is_windows_intel_kaby = cfg!(windows)
+        let is_windows_intel_dual_src_bug = cfg!(windows)
             && self.properties.vendor_id == info::intel::VENDOR
-            && self.properties.device_id & info::intel::DEVICE_KABY_LAKE_MASK
-                == info::intel::DEVICE_KABY_LAKE_MASK;
+            && (self.properties.device_id & info::intel::DEVICE_KABY_LAKE_MASK
+                == info::intel::DEVICE_KABY_LAKE_MASK
+                || self.properties.device_id & info::intel::DEVICE_SKY_LAKE_MASK
+                    == info::intel::DEVICE_SKY_LAKE_MASK);
 
         let features = self.instance.0.get_physical_device_features(self.handle);
         let mut bits = Features::empty();
@@ -581,7 +583,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         if features.sample_rate_shading != 0 {
             bits |= Features::SAMPLE_RATE_SHADING;
         }
-        if features.dual_src_blend != 0 && !is_windows_intel_kaby {
+        if features.dual_src_blend != 0 && !is_windows_intel_dual_src_bug {
             bits |= Features::DUAL_SRC_BLENDING;
         }
         if features.logic_op != 0 {


### PR DESCRIPTION
This is a follow up on #1931 and fixes #1930.
cc @kvark 

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- [ ] `rustfmt` run on changed code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/2488)
<!-- Reviewable:end -->
