### PR TITLE
Allow to use swapchain image as trasnfer destination

### DIFF
--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -80,7 +80,7 @@ impl hal::Surface<Backend> for Surface {
             current_extent: Some(extent),
             extents: extent..extent,
             max_image_layers: 1,
-            usage: i::Usage::COLOR_ATTACHMENT | i::Usage::TRANSFER_SRC,
+            usage: i::Usage::COLOR_ATTACHMENT | i::Usage::TRANSFER_SRC | i::Usage::TRANSFER_DST,
         };
 
         // Sticking to FLIP swap effects for the moment.


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/2490)
<!-- Reviewable:end -->
