### PR TITLE
Removed "max_level_*" features from log dependencies

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -21,7 +21,7 @@ name = "gfx_backend_dx11"
 bitflags = "1"
 derivative = "1"
 gfx-hal = { path = "../../hal", version = "0.1" }
-log = { version = "0.4", features = ["release_max_level_error"] }
+log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = "0.11.2"
 parking_lot = "0.6.3"

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -22,7 +22,7 @@ bitflags = "1"
 derivative = "1"
 d3d12 = { git = "https://github.com/gfx-rs/d3d12-rs.git", rev = "ee01154" }
 gfx-hal = { path = "../../hal", version = "0.1" }
-log = { version = "0.4", features = ["release_max_level_error"] }
+log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = "0.11.2"
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -19,7 +19,7 @@ default = ["glutin"]
 
 [dependencies]
 bitflags = "1"
-log = { version = "0.4", features = ["release_max_level_error"] }
+log = { version = "0.4" }
 gfx_gl = "0.5"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -21,7 +21,7 @@ name = "gfx_backend_metal"
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.1" }
 bitflags = "1.0"
-log = { version = "0.4", features = ["release_max_level_error"] }
+log = { version = "0.4" }
 winit = { version = "0.18", optional = true }
 dispatch = { version = "0.1", optional = true }
 metal = { version = "0.13.0", features = ["private"] }

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -20,7 +20,7 @@ name = "gfx_backend_vulkan"
 
 [dependencies]
 byteorder = "1"
-log = { version = "0.4", features = ["release_max_level_error"] }
+log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
 ash = "0.24.4"


### PR DESCRIPTION
Fixes discussion from #2237.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: gl, vulkan
- [x] `rustfmt` run on changed code
