### PR TITLE
Field init shorthand RFC 1682

### DIFF
--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -103,7 +103,7 @@ impl<'a, B: Backend, C, S: Shot, L: Level> CommandBuffer<'a, B, C, S, L> {
     /// Create a new typed command buffer from a raw command pool.
     pub unsafe fn new(raw: &'a mut B::CommandBuffer) -> Self {
         CommandBuffer {
-            raw: raw,
+            raw,
             _marker: PhantomData,
         }
     }


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
  - [x] metal
- [ ] `rustfmt` run on changed code