### PR TITLE
[vk] inherit composite alpha by default

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1691,7 +1691,7 @@ impl d::Device<B> for Device {
             queue_family_index_count: 0,
             p_queue_family_indices: ptr::null(),
             pre_transform: vk::SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-            composite_alpha: vk::COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+            composite_alpha: vk::COMPOSITE_ALPHA_INHERIT_BIT_KHR,
             present_mode: unsafe { mem::transmute(config.present_mode) },
             clipped: 1,
             old_swapchain,


### PR DESCRIPTION
Works around #2507 

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
