### PR TITLE
Expose alpha composition mode

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1413,7 +1413,7 @@ struct SwapchainState<B: Backend> {
 
 impl<B: Backend> SwapchainState<B> {
     fn new(backend: &mut BackendState<B>, device: Rc<RefCell<DeviceState<B>>>) -> Self {
-        let (caps, formats, _present_modes) = backend
+        let (caps, formats, _present_modes, _composite_alphas) = backend
             .surface
             .compatibility(&device.borrow().physical_device);
         println!("formats: {:?}", formats);

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -360,7 +360,8 @@ fn main() {
             .expect("Can't wait for fence");
     }
 
-    let (caps, formats, _present_modes) = surface.compatibility(&mut adapter.physical_device);
+    let (caps, formats, _present_modes, _composite_alphas) =
+        surface.compatibility(&mut adapter.physical_device);
     println!("formats: {:?}", formats);
     let format = formats.map_or(f::Format::Rgba8Srgb, |formats| {
         formats
@@ -585,7 +586,7 @@ fn main() {
         if recreate_swapchain {
             device.wait_idle().unwrap();
 
-            let (caps, formats, _present_modes) =
+            let (caps, formats, _present_modes, _composite_alphas) =
                 surface.compatibility(&mut adapter.physical_device);
             // Verify that previous format still exists so we may resuse it.
             assert!(formats.iter().any(|fs| fs.contains(&format)));

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -675,6 +675,7 @@ impl hal::Surface<Backend> for Surface {
         hal::SurfaceCapabilities,
         Option<Vec<format::Format>>,
         Vec<hal::PresentMode>,
+        Vec<hal::CompositeAlpha>,
     ) {
         let extent = hal::window::Extent2D {
             width: self.width,
@@ -704,8 +705,11 @@ impl hal::Surface<Backend> for Surface {
         let present_modes = vec![
             hal::PresentMode::Fifo, //TODO
         ];
+        let composite_alphas = vec![
+            hal::CompositeAlpha::Inherit, //TODO
+        ];
 
-        (capabilities, Some(formats), present_modes)
+        (capabilities, Some(formats), present_modes, composite_alphas)
     }
 }
 

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -71,6 +71,7 @@ impl hal::Surface<Backend> for Surface {
         hal::SurfaceCapabilities,
         Option<Vec<f::Format>>,
         Vec<hal::PresentMode>,
+        Vec<hal::CompositeAlpha>,
     ) {
         let (width, height) = self.get_extent();
         let extent = hal::window::Extent2D { width, height };
@@ -98,8 +99,11 @@ impl hal::Surface<Backend> for Surface {
         let present_modes = vec![
             hal::PresentMode::Fifo, //TODO
         ];
+        let composite_alphas = vec![
+            hal::CompositeAlpha::Inherit, //TODO
+        ];
 
-        (capabilities, Some(formats), present_modes)
+        (capabilities, Some(formats), present_modes, composite_alphas)
     }
 }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -816,7 +816,7 @@ impl hal::Surface<Backend> for Surface {
 
     fn compatibility(
         &self, _: &PhysicalDevice,
-    ) -> (hal::SurfaceCapabilities, Option<Vec<format::Format>>, Vec<hal::PresentMode>) {
+    ) -> (hal::SurfaceCapabilities, Option<Vec<format::Format>>, Vec<hal::PresentMode>, Vec<hal::CompositeAlpha>) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -128,7 +128,7 @@ impl hal::Surface<B> for Surface {
 
     fn compatibility(
         &self, _: &PhysicalDevice
-    ) -> (hal::SurfaceCapabilities, Option<Vec<f::Format>>, Vec<hal::PresentMode>) {
+    ) -> (hal::SurfaceCapabilities, Option<Vec<f::Format>>, Vec<hal::PresentMode>, Vec<hal::CompositeAlpha>) {
         let ex = get_window_extent(&self.window);
         let extent = hal::window::Extent2D::from(ex);
 
@@ -142,9 +142,14 @@ impl hal::Surface<B> for Surface {
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
         };
-        let present_modes = vec![hal::PresentMode::Fifo]; //TODO
+        let present_modes = vec![
+            hal::PresentMode::Fifo, //TODO
+        ];
+        let composite_alphas = vec![
+            hal::CompositeAlpha::Inherit, //TODO
+        ];
 
-        (caps, Some(self.swapchain_formats()), present_modes)
+        (caps, Some(self.swapchain_formats()), present_modes, composite_alphas)
     }
 
     fn supports_queue_family(&self, _: &QueueFamily) -> bool { true }

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -247,7 +247,7 @@ impl SwapchainImage {
                     break
                 }
             }
-        }        
+        }
         count
     }
 }
@@ -261,7 +261,7 @@ impl hal::Surface<Backend> for Surface {
 
     fn compatibility(
         &self, device: &PhysicalDevice,
-    ) -> (hal::SurfaceCapabilities, Option<Vec<format::Format>>, Vec<hal::PresentMode>) {
+    ) -> (hal::SurfaceCapabilities, Option<Vec<format::Format>>, Vec<hal::PresentMode>, Vec<hal::CompositeAlpha>) {
         let current_extent = if self.main_thread_id == thread::current().id() {
             Some(self.inner.dimensions())
         } else {
@@ -293,8 +293,11 @@ impl hal::Surface<Backend> for Surface {
         } else {
             vec![hal::PresentMode::Fifo]
         };
+        let composite_alphas = vec![
+            hal::CompositeAlpha::Inherit, //TODO
+        ];
 
-        (caps, Some(formats), present_modes)
+        (caps, Some(formats), present_modes, composite_alphas)
     }
 
     fn supports_queue_family(&self, _queue_family: &QueueFamily) -> bool {

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1691,7 +1691,7 @@ impl d::Device<B> for Device {
             queue_family_index_count: 0,
             p_queue_family_indices: ptr::null(),
             pre_transform: vk::SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
-            composite_alpha: vk::COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
+            composite_alpha: vk::CompositeAlphaFlagsKHR::from_flags(1 << config.composite_alpha as u32).unwrap(),
             present_mode: unsafe { mem::transmute(config.present_mode) },
             clipped: 1,
             old_swapchain,

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -36,8 +36,8 @@ pub use self::queue::{
     Capability, Supports, General, Graphics, Compute, Transfer,
 };
 pub use self::window::{
-    AcquireError, Backbuffer, SwapImageIndex, FrameSync, PresentMode,
-    Surface, SurfaceCapabilities, Swapchain, SwapchainConfig,
+    AcquireError, Backbuffer, CompositeAlpha, SwapImageIndex, FrameSync,
+    PresentMode, Surface, SurfaceCapabilities, Swapchain, SwapchainConfig,
 };
 
 pub mod adapter;

--- a/src/hal/src/queue/capability.rs
+++ b/src/hal/src/queue/capability.rs
@@ -54,7 +54,6 @@ impl Capability for Transfer {
             QueueType::Compute |
             QueueType::Graphics |
             QueueType::Transfer => true,
-            _ => false,
         }
     }
 }

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -189,7 +189,7 @@ pub trait Surface<B: Backend>: Any + Send + Sync {
     fn compatibility(
         &self,
         physical_device: &B::PhysicalDevice,
-    ) -> (SurfaceCapabilities, Option<Vec<Format>>, Vec<PresentMode>);
+    ) -> (SurfaceCapabilities, Option<Vec<Format>>, Vec<PresentMode>, Vec<CompositeAlpha>);
 }
 
 /// Index of an image in the swapchain.
@@ -229,6 +229,20 @@ pub enum PresentMode {
     Relaxed = 3,
 }
 
+/// Specifies the composition of the swapchain with regards to alpha component.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum CompositeAlpha {
+    /// Ignore alpha and treat it as 1.0 at all times.
+    Opaque = 0,
+    /// Use the alpha, expect the color to already be multiplied by it.
+    PreMultiplied = 1,
+    /// Use the alpha, let the compositor multiply the color by it.
+    PostMultiplied = 2,
+    /// Default to native system settings.
+    Inherit = 3,
+}
+
 /// Contains all the data necessary to create a new `Swapchain`:
 /// color, depth, and number of images.
 ///
@@ -249,6 +263,8 @@ pub enum PresentMode {
 pub struct SwapchainConfig {
     /// Presentation mode.
     pub present_mode: PresentMode,
+    /// Alpha composition mode.
+    pub composite_alpha: CompositeAlpha,
     /// Format of the backbuffer images.
     pub format: Format,
     /// Requested image extent. Must be in
@@ -275,6 +291,7 @@ impl SwapchainConfig {
     pub fn new(width: u32, height: u32, format: Format, image_count: SwapImageIndex) -> Self {
         SwapchainConfig {
             present_mode: PresentMode::Fifo,
+            composite_alpha: CompositeAlpha::Inherit,
             format,
             extent: Extent2D { width, height },
             image_count,
@@ -304,6 +321,7 @@ impl SwapchainConfig {
 
         SwapchainConfig {
             present_mode: PresentMode::Fifo,
+            composite_alpha: CompositeAlpha::Inherit,
             format,
             extent: clamped_extent,
             image_count: caps.image_count.start,


### PR DESCRIPTION
Fixes #2507
PR checklist:
- [] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends: looks like `quad` fails to resize the swapchain for me with or without the PR :/. Possible that it has something to do with `winit`/WSI and not the gfx-rs code in particular.
- [ ] `rustfmt` run on changed code
