### PR TITLE
[0.17/gl] don't use temporary manager for resource creation

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_gl"
-version = "0.15.3"
+version = "0.15.4"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -259,6 +259,8 @@ pub struct Device {
     info: Info,
     share: Rc<Share>,
     vao: ArrayBuffer,
+    /// Temporary handles to keep alive for the frame.
+    /// Note: this manager is not meant for resource creation or cleanup!
     frame_handles: handle::Manager<Resources>,
     max_resource_count: Option<usize>,
     reset: Vec<Command>,
@@ -901,7 +903,8 @@ impl Device {
         let fence = unsafe {
             gl.FenceSync(gl::SYNC_GPU_COMMANDS_COMPLETE, 0)
         };
-        self.frame_handles.make_fence(Fence(fence))
+
+        self.share.handles.borrow_mut().make_fence(Fence(fence))
     }
 
     // MappingKind::Persistent

--- a/src/backend/vulkan/src/factory.rs
+++ b/src/backend/vulkan/src/factory.rs
@@ -164,7 +164,7 @@ impl Factory {
             bind: Bind::RENDER_TARGET,
             usage: Usage::Data,
         };
-        let tex = self.frame_handles.make_texture(raw_tex, tex_desc);
+        let tex = self.share.handles.lock().unwrap().make_texture(raw_tex, tex_desc);
         let view_desc = t::RenderDesc {
             channel: format.1,
             level: 0,


### PR DESCRIPTION
Fixes a heavy memory leak per frame when using host-mapped resources.
What was happening is the fence being created on a temporary manger, which never cleans up the resources properly (just clears instead, since it assumes it's never the last one).
Ideally, we'd want to design the internal handle manager in such a way that it's not possible at the API level, but this isn't a priority right now.