### PR TITLE
Remove Unbound resource variants

### DIFF
--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -198,7 +198,7 @@ fn create_buffer<B: Backend>(
     stride: u64,
     len: u64,
 ) -> (B::Memory, B::Buffer, u64) {
-    let buffer = device.create_buffer(stride * len, usage).unwrap();
+    let mut buffer = device.create_buffer(stride * len, usage).unwrap();
     let requirements = device.get_buffer_requirements(&buffer);
 
     let ty = memory_types
@@ -212,7 +212,7 @@ fn create_buffer<B: Backend>(
         .into();
 
     let memory = device.allocate_memory(ty, requirements.size).unwrap();
-    let buffer = device.bind_buffer_memory(&memory, 0, buffer).unwrap();
+    device.bind_buffer_memory(&memory, 0, &mut buffer).unwrap();
 
     (memory, buffer, requirements.size)
 }

--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -125,6 +125,16 @@ pub struct DecomposedDxgiFormat {
 }
 
 impl DecomposedDxgiFormat {
+    pub const UNKNOWN: DecomposedDxgiFormat = DecomposedDxgiFormat {
+        typeless: DXGI_FORMAT_UNKNOWN,
+        srv: None,
+        rtv: None,
+        uav: None,
+        dsv: None,
+        copy_uav: None,
+        copy_srv: None,
+    };
+
     // TODO: we probably want to pass in usage flags or similar to allow for our `typeless_format`
     //       field to only contain the input format (eg. depth only rather than typeless likely
     //       improves perf since the driver doesn't need to expose internals)

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -68,7 +68,7 @@ struct PartialClearInfo {
 const COPY_THREAD_GROUP_X: u32 = 8;
 const COPY_THREAD_GROUP_Y: u32 = 8;
 
-// Holds everything we need for fallback implementations of features that are not in DX. 
+// Holds everything we need for fallback implementations of features that are not in DX.
 //
 // TODO: maybe get rid of `Clone`? there's _a lot_ of refcounts here and it is used as a singleton
 //       anyway :s
@@ -137,7 +137,7 @@ pub struct Internal {
     // internal constant buffer that is used by internal shaders
     internal_buffer: ComPtr<d3d11::ID3D11Buffer>,
 
-    // public buffer that is used as intermediate storage for some operations (memory invalidation) 
+    // public buffer that is used as intermediate storage for some operations (memory invalidation)
     pub working_buffer: ComPtr<d3d11::ID3D11Buffer>,
     pub working_buffer_size: u64,
 }
@@ -595,12 +595,12 @@ impl Internal {
                 // TODO: layer subresources
                 unsafe {
                     context.CopySubresourceRegion(
-                        dst.internal.raw.as_raw() as _,
+                        dst.internal.raw,
                         src.calc_subresource(info.src_subresource.level as _, 0),
                         info.dst_offset.x as _,
                         info.dst_offset.y as _,
                         info.dst_offset.z as _,
-                        src.internal.raw.as_raw() as _,
+                        src.internal.raw,
                         dst.calc_subresource(info.dst_subresource.level as _, 0),
                         &d3d11::D3D11_BOX {
                             left:   info.src_offset.x as _,
@@ -716,7 +716,7 @@ impl Internal {
 
                 unsafe {
                     context.UpdateSubresource(
-                        dst.internal.raw.as_raw(),
+                        dst.internal.raw,
                         dst.calc_subresource(info.image_layers.level as _, info.image_layers.layers.start as _),
                         &d3d11::D3D11_BOX {
                             left:   info.image_offset.x as _,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1138,10 +1138,8 @@ impl hal::Backend for Backend {
     type RenderPass = resource::RenderPass;
     type Framebuffer = resource::Framebuffer;
 
-    type UnboundBuffer = device::UnboundBuffer;
     type Buffer = resource::Buffer;
     type BufferView = resource::BufferView;
-    type UnboundImage = device::UnboundImage;
     type Image = resource::Image;
     type ImageView = resource::ImageView;
     type Sampler = resource::Sampler;

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -32,10 +32,8 @@ impl hal::Backend for Backend {
     type RenderPass = ();
     type Framebuffer = ();
 
-    type UnboundBuffer = ();
     type Buffer = ();
     type BufferView = ();
-    type UnboundImage = ();
     type Image = ();
     type ImageView = ();
     type Sampler = ();
@@ -194,7 +192,7 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn bind_buffer_memory(&self, _: &(), _: u64, _: ()) -> Result<(), device::BindError> {
+    fn bind_buffer_memory(&self, _: &(), _: u64, _: &mut ()) -> Result<(), device::BindError> {
         unimplemented!()
     }
 
@@ -222,7 +220,7 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn bind_image_memory(&self, _: &(), _: u64, _: ()) -> Result<(), device::BindError> {
+    fn bind_image_memory(&self, _: &(), _: u64, _: &mut ()) -> Result<(), device::BindError> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -78,10 +78,8 @@ impl hal::Backend for Backend {
     type RenderPass = native::RenderPass;
     type Framebuffer = native::FrameBuffer;
 
-    type UnboundBuffer = device::UnboundBuffer;
     type Buffer = native::Buffer;
     type BufferView = native::BufferView;
-    type UnboundImage = device::UnboundImage;
     type Image = native::Image;
     type ImageView = native::ImageView;
     type Sampler = native::FatSampler;

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -2,7 +2,7 @@ use std::cell::Cell;
 use std::sync::{Arc, Mutex, RwLock};
 
 use hal::{format, image as i, pass, pso};
-use hal::memory::Properties;
+use hal::memory::{Properties, Requirements};
 use hal::backend::FastHashMap;
 
 use gl;
@@ -25,7 +25,7 @@ pub const DEFAULT_FRAMEBUFFER: FrameBuffer = 0;
 pub struct Buffer {
     pub(crate) raw: RawBuffer,
     pub(crate) target: gl::types::GLenum,
-    pub(crate) size: u64,
+    pub(crate) requirements: Requirements,
 }
 
 #[derive(Debug)]
@@ -123,11 +123,12 @@ pub struct ComputePipeline {
     pub(crate) program: Program,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Image {
     pub(crate) kind: ImageKind,
     // Required for clearing operations
     pub(crate) channel: format::ChannelType,
+    pub(crate) requirements: Requirements,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -318,10 +318,8 @@ impl hal::Backend for Backend {
     type RenderPass = native::RenderPass;
     type Framebuffer = native::Framebuffer;
 
-    type UnboundBuffer = native::UnboundBuffer;
     type Buffer = native::Buffer;
     type BufferView = native::BufferView;
-    type UnboundImage = native::UnboundImage;
     type Image = native::Image;
     type ImageView = native::ImageView;
     type Sampler = native::Sampler;

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -837,10 +837,8 @@ impl hal::Backend for Backend {
     type RenderPass = native::RenderPass;
     type Framebuffer = native::Framebuffer;
 
-    type UnboundBuffer = device::UnboundBuffer;
     type Buffer = native::Buffer;
     type BufferView = native::BufferView;
-    type UnboundImage = device::UnboundImage;
     type Image = native::Image;
     type ImageView = native::ImageView;
     type Sampler = native::Sampler;

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -376,22 +376,21 @@ pub trait Device<B: Backend>: Any + Send + Sync {
         &self,
         size: u64,
         usage: buffer::Usage,
-    ) -> Result<B::UnboundBuffer, buffer::CreationError>;
+    ) -> Result<B::Buffer, buffer::CreationError>;
 
-    /// Get memory requirements for the unbound buffer
-    fn get_buffer_requirements(&self, buf: &B::UnboundBuffer) -> Requirements;
+    /// Get memory requirements for the buffer
+    fn get_buffer_requirements(&self, buf: &B::Buffer) -> Requirements;
 
     /// Bind memory to a buffer.
     ///
-    /// The unbound buffer will be consumed because the binding is *immutable*.
     /// Be sure to check that there is enough memory available for the buffer.
     /// Use `get_buffer_requirements` to acquire the memory requirements.
     fn bind_buffer_memory(
         &self,
         memory: &B::Memory,
         offset: u64,
-        buf: B::UnboundBuffer,
-    ) -> Result<B::Buffer, BindError>;
+        buf: &mut B::Buffer,
+    ) -> Result<(), BindError>;
 
     /// Destroy a buffer.
     ///
@@ -419,10 +418,10 @@ pub trait Device<B: Backend>: Any + Send + Sync {
         tiling: image::Tiling,
         usage: image::Usage,
         view_caps: image::ViewCapabilities,
-    ) -> Result<B::UnboundImage, image::CreationError>;
+    ) -> Result<B::Image, image::CreationError>;
 
-    /// Get memory requirements for the unbound Image
-    fn get_image_requirements(&self, image: &B::UnboundImage) -> Requirements;
+    /// Get memory requirements for the Image
+    fn get_image_requirements(&self, image: &B::Image) -> Requirements;
 
     ///
     fn get_image_subresource_footprint(
@@ -436,8 +435,8 @@ pub trait Device<B: Backend>: Any + Send + Sync {
         &self,
         memory: &B::Memory,
         offset: u64,
-        image: B::UnboundImage,
-    ) -> Result<B::Image, BindError>;
+        image: &mut B::Image,
+    ) -> Result<(), BindError>;
 
     /// Destroy an image.
     ///

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -386,10 +386,8 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send
     type Memory:              fmt::Debug + Any + Send + Sync;
     type CommandPool:         pool::RawCommandPool<Self>;
 
-    type UnboundBuffer:       fmt::Debug + Any + Send + Sync;
     type Buffer:              fmt::Debug + Any + Send + Sync;
     type BufferView:          fmt::Debug + Any + Send + Sync;
-    type UnboundImage:        fmt::Debug + Any + Send + Sync;
     type Image:               fmt::Debug + Any + Send + Sync;
     type ImageView:           fmt::Debug + Any + Send + Sync;
     type Sampler:             fmt::Debug + Any + Send + Sync;


### PR DESCRIPTION
Remove unbound resources from backend and adjust creation and binding api
Fixes #2517 

#### Backends
- [x] Vulkan
- [x] empty
- [x] GL
- [x] Metal
- [x] dx11
- [x] dx12


#### PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
