### PR TITLE
export `gfx_backend_dx11::device::Device` as a public type.

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -89,6 +89,8 @@ mod internal;
 mod range_alloc;
 mod shader;
 
+pub use device::Device;
+
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
 pub(crate) struct ViewInfo {


### PR DESCRIPTION
in the dx11 backend, this type is reachable (it's returned by `open_with<_, gfx_hal::Graphics>`) but not nameable, which means we can't store it in a struct.

`Device` *is* publicly exported in the vulkan backend though, so this pr just unifies the dx11 api to be the same as the the vulkan one.