### PR TITLE
Fix typo

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -588,7 +588,7 @@ fn main() {
 
             let (caps, formats, _present_modes, _composite_alphas) =
                 surface.compatibility(&mut adapter.physical_device);
-            // Verify that previous format still exists so we may resuse it.
+            // Verify that previous format still exists so we may reuse it.
             assert!(formats.iter().any(|fs| fs.contains(&format)));
 
             let swap_config = SwapchainConfig::from_caps(&caps, format, resize_dims);


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
  - [x] Metal
- [x] `rustfmt` run on changed code