### PR TITLE
Actually stop deriving Clone for backend's command buffers

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -23,7 +23,7 @@ use hal::{
     buffer, command, error, format, image, memory, pass, pso, query, Features, Limits, QueueType,
 };
 use hal::{
-    DrawCount, IndexCount, InstanceCount, SwapImageIndex, VertexCount, VertexOffset, WorkGroupCount,
+    DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount,
 };
 use hal::format::ChannelType;
 use hal::command::{ClearColor, ClearColorRaw};
@@ -89,7 +89,7 @@ mod internal;
 mod range_alloc;
 mod shader;
 
-#[derive(Clone, Derivative)]
+#[derive(Derivative)]
 #[derivative(Debug)]
 pub(crate) struct ViewInfo {
     #[derivative(Debug="ignore")]
@@ -825,7 +825,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
     }
 }
 
-#[derive(Derivative, Clone)]
+#[derive(Derivative)]
 #[derivative(Debug)]
 pub struct AttachmentClear {
     subpass_id: Option<pass::SubpassId>,
@@ -833,7 +833,7 @@ pub struct AttachmentClear {
     raw: command::AttachmentClear,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RenderPassCache {
     pub render_pass: RenderPass,
     pub framebuffer: Framebuffer,
@@ -892,7 +892,7 @@ bitflags! {
     }
 }
 
-#[derive(Derivative, Clone)]
+#[derive(Derivative)]
 #[derivative(Debug)]
 pub struct CommandBufferState {
     dirty_flag: DirtyStateFlag,
@@ -1159,7 +1159,7 @@ impl CommandBufferState {
     }
 }
 
-#[derive(Derivative, Clone)]
+#[derive(Derivative)]
 #[derivative(Debug)]
 pub struct CommandBuffer {
     // TODO: better way of sharing
@@ -2111,20 +2111,20 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 enum SyncRange {
     Whole,
     Partial(Range<u64>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MemoryFlush {
     host_memory: *mut u8,
     sync_range: SyncRange,
     buffer: *mut d3d11::ID3D11Buffer,
 }
 
-#[derive(Derivative, Clone)]
+#[derive(Derivative)]
 #[derivative(Debug)]
 pub struct MemoryInvalidate {
     #[derivative(Debug = "ignore")]
@@ -2424,7 +2424,7 @@ impl ::std::fmt::Debug for ShaderModule {
 unsafe impl Send for ShaderModule {}
 unsafe impl Sync for ShaderModule {}
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct SubpassDesc {
     pub color_attachments: Vec<pass::AttachmentRef>,
     pub depth_stencil_attachment: Option<pass::AttachmentRef>,
@@ -2443,13 +2443,13 @@ impl SubpassDesc {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct RenderPass {
     pub attachments: Vec<pass::Attachment>,
     pub subpasses: Vec<SubpassDesc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct Framebuffer {
     attachments: Vec<ImageView>,
     layers: image::Layer,
@@ -2464,7 +2464,7 @@ pub struct UnboundBuffer {
     requirements: memory::Requirements,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct InternalBuffer {
     raw: *mut d3d11::ID3D11Buffer,
     // TODO: need to sync between `raw` and `disjoint_cb`, same way as we do with
@@ -2577,8 +2577,8 @@ impl Image {
     }
 }
 
-#[derive(Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Derivative)]
+#[derivative(Clone, Debug)]
 pub struct ImageView {
     format: format::Format,
     #[derivative(Debug="ignore")]
@@ -2594,7 +2594,7 @@ pub struct ImageView {
 unsafe impl Send for ImageView {}
 unsafe impl Sync for ImageView {}
 
-#[derive(Derivative, Clone)]
+#[derive(Derivative)]
 #[derivative(Debug)]
 pub struct Sampler {
     #[derivative(Debug = "ignore")]
@@ -2620,7 +2620,7 @@ unsafe impl Sync for ComputePipeline {}
 ///
 /// [0]: https://msdn.microsoft.com/en-us/library/windows/desktop/ff476500(v=vs.85).aspx
 #[derive(Derivative)]
-#[derivative(Debug, Clone)]
+#[derivative(Clone, Debug)]
 pub struct GraphicsPipeline {
     #[derivative(Debug="ignore")]
     vs: ComPtr<d3d11::ID3D11VertexShader>,

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -60,7 +60,6 @@ struct AttachmentClear {
     stencil_value: Option<u32>,
 }
 
-#[derive(Clone)]
 pub struct RenderPassCache {
     render_pass: r::RenderPass,
     framebuffer: r::Framebuffer,
@@ -90,7 +89,6 @@ enum RootElement {
 }
 
 /// Virtual data storage for the current root signature memory.
-#[derive(Clone)]
 struct UserData {
     data: [RootElement; ROOT_SIGNATURE_SIZE],
     dirty_mask: u64,
@@ -141,7 +139,6 @@ impl UserData {
     }
 }
 
-#[derive(Clone)]
 struct PipelineCache {
     // Bound pipeline and root signature.
     // Changed on bind pipeline calls.
@@ -268,7 +265,6 @@ struct Copy {
     copy_extent: image::Extent,
 }
 
-#[derive(Clone)]
 pub struct CommandBuffer {
     raw: native::GraphicsCommandList,
     allocator: native::CommandAllocator,

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -22,7 +22,7 @@ pub enum ShaderModule {
 unsafe impl Send for ShaderModule {}
 unsafe impl Sync for ShaderModule {}
 
-#[derive(Debug, Hash, Clone)]
+#[derive(Clone, Debug, Hash)]
 pub struct BarrierDesc {
     pub(crate) attachment_id: pass::AttachmentId,
     pub(crate) states: Range<d3d12::D3D12_RESOURCE_STATES>,
@@ -52,7 +52,7 @@ impl BarrierDesc {
     }
 }
 
-#[derive(Debug, Hash, Clone)]
+#[derive(Clone, Debug, Hash)]
 pub struct SubpassDesc {
     pub(crate) color_attachments: Vec<pass::AttachmentRef>,
     pub(crate) depth_stencil_attachment: Option<pass::AttachmentRef>,
@@ -75,7 +75,7 @@ impl SubpassDesc {
     }
 }
 
-#[derive(Debug, Hash, Clone)]
+#[derive(Clone, Debug, Hash)]
 pub struct RenderPass {
     pub(crate) attachments: Vec<pass::Attachment>,
     pub(crate) subpasses: Vec<SubpassDesc>,

--- a/src/backend/dx12/src/root_constants.rs
+++ b/src/backend/dx12/src/root_constants.rs
@@ -10,7 +10,7 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::ops::Range;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct RootConstant {
     pub stages: pso::ShaderStageFlags,
     pub range: Range<u32>,

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -430,7 +430,6 @@ impl pool::RawCommandPool<Backend> for RawCommandPool {
 }
 
 /// Dummy command buffer, which ignores all the calls.
-#[derive(Clone)]
 pub struct RawCommandBuffer;
 impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     fn begin(&mut self, _: command::CommandBufferFlags, _: command::CommandBufferInheritanceInfo<Backend>) {

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -53,7 +53,7 @@ impl BufferSlice {
 }
 
 ///
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum Command {
     Dispatch(hal::WorkGroupCount),
     DispatchIndirect(gl::types::GLuint, buffer::Offset),
@@ -101,7 +101,7 @@ pub enum Command {
     SetPatchSize(gl::types::GLint),
     BindProgram(gl::types::GLuint),
     BindBlendSlot(ColorSlot, pso::ColorBlendDesc),
-    BindAttribute(n::AttributeDesc, gl::types::GLuint, gl::types::GLsizei, n::VertexAttribFunction),
+    BindAttribute(n::AttributeDesc, gl::types::GLuint, gl::types::GLsizei),
     //UnbindAttribute(n::AttributeDesc),
     CopyBufferToBuffer(n::RawBuffer, n::RawBuffer, command::BufferCopy),
     CopyBufferToTexture(n::RawBuffer, n::Texture, command::BufferImageCopy),
@@ -136,7 +136,6 @@ pub struct RenderPassCache {
 }
 
 // Cache current states of the command buffer
-#[derive(Clone)]
 struct Cache {
     // Active primitive topology, set by the current pipeline.
     primitive: Option<gl::types::GLenum>,
@@ -203,7 +202,6 @@ impl From<hal::Limits> for Limits {
 ///
 /// If you want to display your rendered results to a framebuffer created externally, see the
 /// `display_fb` field.
-#[derive(Clone)]
 pub struct RawCommandBuffer {
     pub(crate) memory: Arc<Mutex<BufferMemory>>,
     pub(crate) buf: BufferSlice,
@@ -381,7 +379,7 @@ impl RawCommandBuffer {
                         &self.id,
                         &mut self.memory,
                         &mut self.buf,
-                        Command::BindAttribute(*attribute, handle, desc.stride as _, attribute.vertex_attrib_fn)
+                        Command::BindAttribute(attribute.clone(), handle, desc.stride as _),
                     );
                 }
                 _ => error!("No vertex buffer description bound at {}", binding),

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -260,7 +260,7 @@ pub struct PipelineLayout {
 // No inter-queue synchronization required for GL.
 pub struct Semaphore;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Debug)]
 pub struct AttributeDesc {
     pub(crate) location: gl::types::GLuint,
     pub(crate) offset: u32,

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -475,16 +475,16 @@ impl CommandQueue {
             com::Command::BindBlendSlot(slot, ref blend) => {
                 state::bind_blend_slot(&self.share.context, slot, blend);
             }
-            com::Command::BindAttribute(ref attribute, handle, stride, function_type) => unsafe {
+            com::Command::BindAttribute(ref attribute, handle, stride) => unsafe {
                 use native::VertexAttribFunction::*;
 
-                let &native::AttributeDesc { location, size, format, offset, .. } = attribute;
+                let &native::AttributeDesc { location, size, format, offset, vertex_attrib_fn, .. } = attribute;
                 let offset = offset as *const gl::types::GLvoid;
                 let gl = &self.share.context;
 
                 gl.BindBuffer(gl::ARRAY_BUFFER, handle);
 
-                match function_type {
+                match vertex_attrib_fn {
                     Float => gl.VertexAttribPointer(location, size, format, gl::FALSE, stride, offset),
                     Integer => gl.VertexAttribIPointer(location, size, format, stride, offset),
                     Double => gl.VertexAttribLPointer(location, size, format, stride, offset),

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -167,7 +167,7 @@ impl ResourceData<PoolResourceIndex> {
 }
 
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct MultiStageData<T> {
     pub vs: T,
     pub ps: T,
@@ -182,7 +182,7 @@ pub struct DescriptorSetInfo {
     pub dynamic_buffers: Vec<MultiStageData<PoolResourceIndex>>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct PushConstantInfo {
     pub count: u32,
     pub buffer_index: ResourceIndex,
@@ -242,7 +242,7 @@ impl Default for RasterizerState {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct StencilState<T> {
     pub front_reference: T,
     pub back_reference: T,

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -50,6 +50,8 @@ impl<'a> Resources for &'a Ref {
     type ComputePipeline = &'a metal::ComputePipelineStateRef;
 }
 
+//TODO: Remove `Clone` from here, blocked by arguments of `quick_render` and
+// `quick_compute` which currently use `cloned()` iteration.
 #[derive(Clone, Debug)]
 pub enum RenderCommand<R: Resources> {
     SetViewport(hal::pso::Rect, Range<f32>),
@@ -112,7 +114,7 @@ pub enum RenderCommand<R: Resources> {
     },
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum BlitCommand {
     FillBuffer {
         dst: BufferPtr,

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -14,7 +14,7 @@ use hal::range::RangeArg;
 use {conv, native as n};
 use {Backend, RawDevice};
 
-#[derive(Clone)]
+
 pub struct CommandBuffer {
     pub raw: vk::CommandBuffer,
     pub device: Arc<RawDevice>,


### PR DESCRIPTION
Follow-up to #2514 that actually tries to lift the `Clone` bounds in the backends. This is going to be a long CI fight, I feel, but it's good that there is a ton of places where it was used.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
