### PR TITLE
Consistent Instance::create in empty backend

### DIFF
--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -834,6 +834,14 @@ impl hal::Swapchain<Backend> for Swapchain {
 }
 
 pub struct Instance;
+
+impl Instance {
+    /// Create instance.
+    pub fn create(_name: &str, _version: u32) -> Self {
+        Instance
+    }
+}
+
 impl hal::Instance for Instance {
     type Backend = Backend;
     fn enumerate_adapters(&self) -> Vec<hal::Adapter<Backend>> {


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
