### PR TITLE
Fix dx11's bind_buffer_memory for DEVICE_LOCAL memory

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1052,7 +1052,7 @@ impl hal::Device<Backend> for Device {
                 let desc = d3d11::D3D11_BUFFER_DESC {
                     ByteWidth: buffer.requirements.size as _,
                     Usage: d3d11::D3D11_USAGE_DEFAULT,
-                    BindFlags: buffer.requirements.size as _,
+                    BindFlags: buffer.bind,
                     CPUAccessFlags: 0,
                     MiscFlags,
                     StructureByteStride: if buffer.internal.usage.contains(buffer::Usage::TRANSFER_SRC) { 4 } else { 0 },


### PR DESCRIPTION
Fixes #issue

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

The DEVICE_LOCAL branch was incorrectly using the size of the buffer for the BindFlags value. Changed it to actually use the BindFlags value that was created in create_buffer.