### PR TITLE
removing create_shader_module_from_glsl from vulkan backend

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -43,7 +43,6 @@ optional = true
 [dependencies.gfx-backend-vulkan]
 path = "../src/backend/vulkan"
 version = "0.1"
-#features = ["glsl-to-spirv"]
 optional = true
 
 [target.'cfg(any(target_os = "macos", all(target_os = "ios", target_arch = "aarch64")))'.dependencies.gfx-backend-metal]

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -27,7 +27,6 @@ ash = "0.24.4"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.18", optional = true }
-glsl-to-spirv = { version = "0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -21,38 +21,6 @@ use {Backend as B, Device};
 use {conv, native as n, result, window as w};
 use pool::RawCommandPool;
 
-
-impl Device {
-    #[cfg(feature = "glsl-to-spirv")]
-    pub fn create_shader_module_from_glsl(
-        &self,
-        code: &str,
-        stage: pso::Stage,
-    ) -> Result<n::ShaderModule, d::ShaderError> {
-        use self::d::Device;
-        use std::io::Read;
-        use glsl_to_spirv::{compile, ShaderType};
-
-        let ty = match stage {
-            pso::Stage::Vertex => ShaderType::Vertex,
-            pso::Stage::Fragment => ShaderType::Fragment,
-            pso::Stage::Geometry => ShaderType::Geometry,
-            pso::Stage::Hull => ShaderType::TessellationControl,
-            pso::Stage::Domain => ShaderType::TessellationEvaluation,
-            pso::Stage::Compute => ShaderType::Compute,
-        };
-
-        match compile(code, ty) {
-            Ok(mut file) => {
-                let mut data = Vec::new();
-                file.read_to_end(&mut data).unwrap();
-                self.create_shader_module(&data)
-            },
-            Err(string) => Err(d::ShaderError::CompilationFailed(string)),
-        }
-    }
-}
-
 impl d::Device<B> for Device {
     unsafe fn allocate_memory(&self, mem_type: MemoryTypeId, size: u64) -> Result<n::Memory, d::AllocationError> {
         let info = vk::MemoryAllocateInfo {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -19,9 +19,6 @@ extern crate x11;
 #[cfg(all(unix, not(target_os = "android")))]
 extern crate xcb;
 
-#[cfg(feature = "glsl-to-spirv")]
-extern crate glsl_to_spirv;
-
 use ash::extensions as ext;
 use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0, V1_0};
 use ash::vk;


### PR DESCRIPTION
Code was currently unused iin the project and was specific to the Vulkan backend. Compilation from GLSL->SpirV should be done outside of gfx-hal

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan,DX12
- [x] `rustfmt` run on changed code