### PR TITLE
Attachment clear order API changes

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1077,9 +1077,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             .iter()
             .enumerate()
             .map(|(i, attachment)| {
-                let cv = if attachment.ops.load == pass::AttachmentLoadOp::Clear
-                    || attachment.stencil_ops.load == pass::AttachmentLoadOp::Clear
-                {
+                let cv = if attachment.has_clears() {
                     Some(*clear_iter.next().unwrap().borrow())
                 } else {
                     None
@@ -1094,7 +1092,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         None
                     },
                     stencil_value: if attachment.stencil_ops.load == pass::AttachmentLoadOp::Clear {
-                        Some(unsafe { cv.unwrap().depth_stencil.stencil })
+                        Some(cv.unwrap().depth_stencil.stencil)
                     } else {
                         None
                     },

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -57,6 +57,7 @@ pub struct Sampler(pub vk::Sampler);
 #[derive(Debug, Hash)]
 pub struct RenderPass {
     pub raw: vk::RenderPass,
+    pub clear_attachments_mask: u64,
 }
 
 #[derive(Debug, Hash)]

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -290,7 +290,8 @@ pub trait RawCommandBuffer<B: Backend>: Any + Send + Sync {
     /// Begins recording commands for a render pass on the given framebuffer.
     /// `render_area` is the section of the framebuffer to render,
     /// `clear_values` is an iterator of `ClearValueRaw`'s to use to use for
-    /// `clear_*` commands, one for each attachment of the render pass.
+    /// `clear_*` commands, one for each attachment of the render pass
+    /// that has a clear operation.
     /// `first_subpass` specifies, for the first subpass, whether the
     /// rendering commands are provided inline or whether the render
     /// pass is composed of subpasses.

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -94,6 +94,14 @@ pub struct Attachment {
     pub layouts: Range<AttachmentLayout>,
 }
 
+impl Attachment {
+    /// Returns true if this attachment has some clear operations. This is useful
+    /// when starting a render pass, since there has to be a clear value provided.
+    pub fn has_clears(&self) -> bool {
+        self.ops.load == AttachmentLoadOp::Clear || self.stencil_ops.load == AttachmentLoadOp::Clear
+    }
+}
+
 /// Index of an attachment within a framebuffer/renderpass,
 pub type AttachmentId = usize;
 /// Reference to an attachment by index and expected image layout.


### PR DESCRIPTION
Fixes #2248
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds (after #2534)
- [ ] tested examples with the following backends: vulkan
- [ ] `rustfmt` run on changed code

Interestingly, DX11/12 backends were already treating the clear color iterator as specified for cleared attachments only (presumably because I implemented that and I was confused in the first place).

@msiglreith comments are welcome! I don't feel super strong either way, just want to make the semantics stronger.