### PR TITLE
Updated Ash dependency from 0.24 to 0.26

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "1"
 log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
-ash = "0.24.4"
+ash = "0.26.2"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.18", optional = true }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -1,19 +1,18 @@
+use ash::version::DeviceV1_0;
+use ash::vk;
+use smallvec::SmallVec;
 use std::borrow::Borrow;
-use std::{mem, ptr};
 use std::ops::Range;
 use std::sync::Arc;
-use smallvec::SmallVec;
-use ash::vk;
-use ash::version::DeviceV1_0;
+use std::{mem, ptr};
 
-use hal::{buffer, command as com, memory, pso, query};
-use hal::{DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount};
 use hal::format::Aspects;
 use hal::image::{Filter, Layout, SubresourceRange};
 use hal::range::RangeArg;
+use hal::{buffer, command as com, memory, pso, query};
+use hal::{DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount};
 use {conv, native as n};
 use {Backend, RawDevice};
-
 
 pub struct CommandBuffer {
     pub raw: vk::CommandBuffer,
@@ -22,15 +21,12 @@ pub struct CommandBuffer {
 
 fn map_subpass_contents(contents: com::SubpassContents) -> vk::SubpassContents {
     match contents {
-        com::SubpassContents::Inline => vk::SubpassContents::Inline,
-        com::SubpassContents::SecondaryBuffers => vk::SubpassContents::SecondaryCommandBuffers,
+        com::SubpassContents::Inline => vk::SubpassContents::INLINE,
+        com::SubpassContents::SecondaryBuffers => vk::SubpassContents::SECONDARY_COMMAND_BUFFERS,
     }
 }
 
-fn map_buffer_image_regions<T>(
-    _image: &n::Image,
-    regions: T,
-) -> SmallVec<[vk::BufferImageCopy; 16]>
+fn map_buffer_image_regions<T>(_image: &n::Image, regions: T) -> SmallVec<[vk::BufferImageCopy; 16]>
 where
     T: IntoIterator,
     T::Item: Borrow<com::BufferImageCopy>,
@@ -67,7 +63,8 @@ impl CommandBuffer {
         J::Item: Borrow<com::DescriptorSetOffset>,
     {
         let sets: SmallVec<[_; 16]> = sets.into_iter().map(|set| set.borrow().raw).collect();
-        let dynamic_offsets: SmallVec<[_; 16]> = offsets.into_iter().map(|offset| *offset.borrow()).collect();
+        let dynamic_offsets: SmallVec<[_; 16]> =
+            offsets.into_iter().map(|offset| *offset.borrow()).collect();
 
         unsafe {
             self.device.0.cmd_bind_descriptor_sets(
@@ -83,28 +80,40 @@ impl CommandBuffer {
 }
 
 impl com::RawCommandBuffer<Backend> for CommandBuffer {
-    unsafe fn begin(&mut self, flags: com::CommandBufferFlags, info: com::CommandBufferInheritanceInfo<Backend>) {
+    unsafe fn begin(
+        &mut self,
+        flags: com::CommandBufferFlags,
+        info: com::CommandBufferInheritanceInfo<Backend>,
+    ) {
         let inheritance_info = vk::CommandBufferInheritanceInfo {
-            s_type: vk::StructureType::CommandBufferInheritanceInfo,
+            s_type: vk::StructureType::COMMAND_BUFFER_INHERITANCE_INFO,
             p_next: ptr::null(),
-            render_pass: info.subpass.map_or(vk::types::RenderPass::null(), |subpass| subpass.main_pass.raw),
+            render_pass: info
+                .subpass
+                .map_or(vk::RenderPass::null(), |subpass| subpass.main_pass.raw),
             subpass: info.subpass.map_or(0, |subpass| subpass.index as u32),
-            framebuffer: info.framebuffer.map_or(vk::types::Framebuffer::null(), |buffer| buffer.raw),
-            occlusion_query_enable: if info.occlusion_query_enable { vk::VK_TRUE } else { vk::VK_FALSE },
+            framebuffer: info
+                .framebuffer
+                .map_or(vk::Framebuffer::null(), |buffer| buffer.raw),
+            occlusion_query_enable: if info.occlusion_query_enable {
+                vk::TRUE
+            } else {
+                vk::FALSE
+            },
             query_flags: conv::map_query_control_flags(info.occlusion_query_flags),
             pipeline_statistics: conv::map_pipeline_statistics(info.pipeline_statistics),
         };
 
         let info = vk::CommandBufferBeginInfo {
-            s_type: vk::StructureType::CommandBufferBeginInfo,
+            s_type: vk::StructureType::COMMAND_BUFFER_BEGIN_INFO,
             p_next: ptr::null(),
             flags: conv::map_command_buffer_flags(flags),
             p_inheritance_info: &inheritance_info,
         };
 
-        assert_eq!(Ok(()),
-            unsafe { self.device.0.begin_command_buffer(self.raw, &info) }
-        );
+        assert_eq!(Ok(()), unsafe {
+            self.device.0.begin_command_buffer(self.raw, &info)
+        });
     }
 
     unsafe fn finish(&mut self) {
@@ -115,14 +124,14 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn reset(&mut self, release_resources: bool) {
         let flags = if release_resources {
-            vk::COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT
+            vk::CommandBufferResetFlags::RELEASE_RESOURCES
         } else {
             vk::CommandBufferResetFlags::empty()
         };
 
-        assert_eq!(Ok(()),
-            unsafe { self.device.0.reset_command_buffer(self.raw, flags) }
-        );
+        assert_eq!(Ok(()), unsafe {
+            self.device.0.reset_command_buffer(self.raw, flags)
+        });
     }
 
     unsafe fn begin_render_pass<T>(
@@ -138,17 +147,16 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     {
         let render_area = conv::map_rect(&render_area);
 
-        let clear_values: SmallVec<[vk::ClearValue; 16]> =
-            clear_values
-                .into_iter()
-                .map(|clear| unsafe {
-                    // Vulkan and HAL share same memory layout
-                    mem::transmute(*clear.borrow())
-                })
-                .collect();
+        let clear_values: SmallVec<[vk::ClearValue; 16]> = clear_values
+            .into_iter()
+            .map(|clear| unsafe {
+                // Vulkan and HAL share same memory layout
+                mem::transmute(*clear.borrow())
+            })
+            .collect();
 
         let info = vk::RenderPassBeginInfo {
-            s_type: vk::StructureType::RenderPassBeginInfo,
+            s_type: vk::StructureType::RENDER_PASS_BEGIN_INFO,
             p_next: ptr::null(),
             render_pass: render_pass.raw,
             framebuffer: frame_buffer.raw,
@@ -159,11 +167,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
         let contents = map_subpass_contents(first_subpass);
         unsafe {
-            self.device.0.cmd_begin_render_pass(
-                self.raw,
-                &info,
-                contents,
-            );
+            self.device
+                .0
+                .cmd_begin_render_pass(self.raw, &info, contents);
         }
     }
 
@@ -197,7 +203,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             match *barrier.borrow() {
                 memory::Barrier::AllBuffers(ref access) => {
                     global_bars.push(vk::MemoryBarrier {
-                        s_type: vk::StructureType::MemoryBarrier,
+                        s_type: vk::StructureType::MEMORY_BARRIER,
                         p_next: ptr::null(),
                         src_access_mask: conv::map_buffer_access(access.start),
                         dst_access_mask: conv::map_buffer_access(access.end),
@@ -205,19 +211,24 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 }
                 memory::Barrier::AllImages(ref access) => {
                     global_bars.push(vk::MemoryBarrier {
-                        s_type: vk::StructureType::MemoryBarrier,
+                        s_type: vk::StructureType::MEMORY_BARRIER,
                         p_next: ptr::null(),
                         src_access_mask: conv::map_image_access(access.start),
                         dst_access_mask: conv::map_image_access(access.end),
                     });
                 }
-                memory::Barrier::Buffer { ref states, target, ref range, ref families, } => {
+                memory::Barrier::Buffer {
+                    ref states,
+                    target,
+                    ref range,
+                    ref families,
+                } => {
                     let families = match families {
-                        Some(f) => f.start.0 as u32 .. f.end.0 as u32,
-                        None => vk::VK_QUEUE_FAMILY_IGNORED..vk::VK_QUEUE_FAMILY_IGNORED,
+                        Some(f) => f.start.0 as u32..f.end.0 as u32,
+                        None => vk::QUEUE_FAMILY_IGNORED..vk::QUEUE_FAMILY_IGNORED,
                     };
                     buffer_bars.push(vk::BufferMemoryBarrier {
-                        s_type: vk::StructureType::BufferMemoryBarrier,
+                        s_type: vk::StructureType::BUFFER_MEMORY_BARRIER,
                         p_next: ptr::null(),
                         src_access_mask: conv::map_buffer_access(states.start),
                         dst_access_mask: conv::map_buffer_access(states.end),
@@ -225,17 +236,24 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         dst_queue_family_index: families.end,
                         buffer: target.raw,
                         offset: range.start.unwrap_or(0),
-                        size: range.end.map_or(vk::VK_WHOLE_SIZE, |end| end - range.start.unwrap_or(0)),
+                        size: range
+                            .end
+                            .map_or(vk::WHOLE_SIZE, |end| end - range.start.unwrap_or(0)),
                     });
                 }
-                memory::Barrier::Image { ref states, target, ref range, ref families, } => {
+                memory::Barrier::Image {
+                    ref states,
+                    target,
+                    ref range,
+                    ref families,
+                } => {
                     let subresource_range = conv::map_subresource_range(range);
                     let families = match families {
-                        Some(f) => f.start.0 as u32 .. f.end.0 as u32,
-                        None => vk::VK_QUEUE_FAMILY_IGNORED..vk::VK_QUEUE_FAMILY_IGNORED,
+                        Some(f) => f.start.0 as u32..f.end.0 as u32,
+                        None => vk::QUEUE_FAMILY_IGNORED..vk::QUEUE_FAMILY_IGNORED,
                     };
                     image_bars.push(vk::ImageMemoryBarrier {
-                        s_type: vk::StructureType::ImageMemoryBarrier,
+                        s_type: vk::StructureType::IMAGE_MEMORY_BARRIER,
                         p_next: ptr::null(),
                         src_access_mask: conv::map_image_access(states.start.0),
                         dst_access_mask: conv::map_image_access(states.end.0),
@@ -263,39 +281,23 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    unsafe fn fill_buffer<R>(
-        &mut self,
-        buffer: &n::Buffer,
-        range: R,
-        data: u32,
-    ) where
+    unsafe fn fill_buffer<R>(&mut self, buffer: &n::Buffer, range: R, data: u32)
+    where
         R: RangeArg<buffer::Offset>,
     {
         let (offset, size) = conv::map_range_arg(&range);
         unsafe {
-            self.device.0.cmd_fill_buffer(
-                self.raw,
-                buffer.raw,
-                offset,
-                size,
-                data,
-            );
+            self.device
+                .0
+                .cmd_fill_buffer(self.raw, buffer.raw, offset, size, data);
         }
     }
 
-    unsafe fn update_buffer(
-        &mut self,
-        buffer: &n::Buffer,
-        offset: buffer::Offset,
-        data: &[u8],
-    ) {
+    unsafe fn update_buffer(&mut self, buffer: &n::Buffer, offset: buffer::Offset, data: &[u8]) {
         unsafe {
-            self.device.0.cmd_update_buffer(
-                self.raw,
-                buffer.raw,
-                offset,
-                data,
-            );
+            self.device
+                .0
+                .cmd_update_buffer(self.raw, buffer.raw, offset, data);
         }
     }
 
@@ -320,13 +322,13 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             if sub.aspects.contains(Aspects::COLOR) {
                 color_ranges.push(vk::ImageSubresourceRange {
                     aspect_mask: conv::map_image_aspects(Aspects::COLOR),
-                    .. vk_range
+                    ..vk_range
                 });
             }
             if !aspect_ds.is_empty() {
                 ds_ranges.push(vk::ImageSubresourceRange {
                     aspect_mask: conv::map_image_aspects(aspect_ds),
-                    .. vk_range
+                    ..vk_range
                 });
             }
         }
@@ -369,40 +371,45 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     {
         let clears: SmallVec<[vk::ClearAttachment; 16]> = clears
             .into_iter()
-            .map(|clear| {
-                match *clear.borrow() {
-                    com::AttachmentClear::Color { index, value } => {
-                        vk::ClearAttachment {
-                            aspect_mask: vk::IMAGE_ASPECT_COLOR_BIT,
-                            color_attachment: index as _,
-                            clear_value: vk::ClearValue { color: conv::map_clear_color(value) },
-                        }
-                    }
-                    com::AttachmentClear::DepthStencil { depth, stencil } => {
-                        vk::ClearAttachment {
-                            aspect_mask: if depth.is_some() { vk::IMAGE_ASPECT_DEPTH_BIT } else { vk::ImageAspectFlags::empty() } |
-                                if stencil.is_some() { vk::IMAGE_ASPECT_STENCIL_BIT } else { vk::ImageAspectFlags::empty() },
-                            color_attachment: 0,
-                            clear_value: vk::ClearValue {
-                                depth: vk::ClearDepthStencilValue {
-                                    depth: depth.unwrap_or_default(),
-                                    stencil: stencil.unwrap_or_default(),
-                                },
-                            },
-                        }
-                    }
-                }
+            .map(|clear| match *clear.borrow() {
+                com::AttachmentClear::Color { index, value } => vk::ClearAttachment {
+                    aspect_mask: vk::ImageAspectFlags::COLOR,
+                    color_attachment: index as _,
+                    clear_value: vk::ClearValue {
+                        color: conv::map_clear_color(value),
+                    },
+                },
+                com::AttachmentClear::DepthStencil { depth, stencil } => vk::ClearAttachment {
+                    aspect_mask: if depth.is_some() {
+                        vk::ImageAspectFlags::DEPTH
+                    } else {
+                        vk::ImageAspectFlags::empty()
+                    } | if stencil.is_some() {
+                        vk::ImageAspectFlags::STENCIL
+                    } else {
+                        vk::ImageAspectFlags::empty()
+                    },
+                    color_attachment: 0,
+                    clear_value: vk::ClearValue {
+                        depth_stencil: vk::ClearDepthStencilValue {
+                            depth: depth.unwrap_or_default(),
+                            stencil: stencil.unwrap_or_default(),
+                        },
+                    },
+                },
             })
             .collect();
 
         let rects: SmallVec<[vk::ClearRect; 16]> = rects
             .into_iter()
-            .map(|rect| {
-                conv::map_clear_rect(rect.borrow())
-            })
+            .map(|rect| conv::map_clear_rect(rect.borrow()))
             .collect();
 
-        unsafe { self.device.0.cmd_clear_attachments(self.raw, &clears, &rects) };
+        unsafe {
+            self.device
+                .0
+                .cmd_clear_attachments(self.raw, &clears, &rects)
+        };
     }
 
     unsafe fn resolve_image<T>(
@@ -452,7 +459,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         regions: T,
     ) where
         T: IntoIterator,
-        T::Item: Borrow<com::ImageBlit>
+        T::Item: Borrow<com::ImageBlit>,
     {
         let regions = regions
             .into_iter()
@@ -460,9 +467,15 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 let r = region.borrow();
                 vk::ImageBlit {
                     src_subresource: conv::map_subresource_layers(&r.src_subresource),
-                    src_offsets: [conv::map_offset(r.src_bounds.start), conv::map_offset(r.src_bounds.end)],
+                    src_offsets: [
+                        conv::map_offset(r.src_bounds.start),
+                        conv::map_offset(r.src_bounds.end),
+                    ],
                     dst_subresource: conv::map_subresource_layers(&r.dst_subresource),
-                    dst_offsets: [conv::map_offset(r.dst_bounds.start), conv::map_offset(r.dst_bounds.end)],
+                    dst_offsets: [
+                        conv::map_offset(r.dst_bounds.start),
+                        conv::map_offset(r.dst_bounds.end),
+                    ],
                 }
             })
             .collect::<SmallVec<[_; 4]>>();
@@ -496,18 +509,16 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<n::Buffer>,
     {
-        let (buffers, offsets): (SmallVec<[vk::Buffer; 16]>, SmallVec<[vk::DeviceSize; 16]>) = buffers
-            .into_iter()
-            .map(|(buffer, offset)| (buffer.borrow().raw, offset))
-            .unzip();
+        let (buffers, offsets): (SmallVec<[vk::Buffer; 16]>, SmallVec<[vk::DeviceSize; 16]>) =
+            buffers
+                .into_iter()
+                .map(|(buffer, offset)| (buffer.borrow().raw, offset))
+                .unzip();
 
         unsafe {
-            self.device.0.cmd_bind_vertex_buffers(
-                self.raw,
-                first_binding,
-                &buffers,
-                &offsets,
-            );
+            self.device
+                .0
+                .cmd_bind_vertex_buffers(self.raw, first_binding, &buffers, &offsets);
         }
     }
 
@@ -518,13 +529,13 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     {
         let viewports: SmallVec<[vk::Viewport; 16]> = viewports
             .into_iter()
-            .map(|viewport| {
-                conv::map_viewport(viewport.borrow())
-            })
+            .map(|viewport| conv::map_viewport(viewport.borrow()))
             .collect();
 
         unsafe {
-            self.device.0.cmd_set_viewport(self.raw, first_viewport, &viewports);
+            self.device
+                .0
+                .cmd_set_viewport(self.raw, first_viewport, &viewports);
         }
     }
 
@@ -535,34 +546,40 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     {
         let scissors: SmallVec<[vk::Rect2D; 16]> = scissors
             .into_iter()
-            .map(|scissor| {
-                conv::map_rect(scissor.borrow())
-            })
+            .map(|scissor| conv::map_rect(scissor.borrow()))
             .collect();
 
         unsafe {
-            self.device.0.cmd_set_scissor(self.raw, first_scissor, &scissors);
+            self.device
+                .0
+                .cmd_set_scissor(self.raw, first_scissor, &scissors);
         }
     }
 
     unsafe fn set_stencil_reference(&mut self, faces: pso::Face, value: pso::StencilValue) {
         unsafe {
             // Vulkan and HAL share same faces bit flags
-            self.device.0.cmd_set_stencil_reference(self.raw, mem::transmute(faces), value);
+            self.device
+                .0
+                .cmd_set_stencil_reference(self.raw, mem::transmute(faces), value);
         }
     }
 
     unsafe fn set_stencil_read_mask(&mut self, faces: pso::Face, value: pso::StencilValue) {
         unsafe {
             // Vulkan and HAL share same faces bit flags
-            self.device.0.cmd_set_stencil_compare_mask(self.raw, mem::transmute(faces), value);
+            self.device
+                .0
+                .cmd_set_stencil_compare_mask(self.raw, mem::transmute(faces), value);
         }
     }
 
     unsafe fn set_stencil_write_mask(&mut self, faces: pso::Face, value: pso::StencilValue) {
         unsafe {
             // Vulkan and HAL share same faces bit flags
-            self.device.0.cmd_set_stencil_write_mask(self.raw, mem::transmute(faces), value);
+            self.device
+                .0
+                .cmd_set_stencil_write_mask(self.raw, mem::transmute(faces), value);
         }
     }
 
@@ -574,7 +591,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn set_depth_bounds(&mut self, bounds: Range<f32>) {
         unsafe {
-            self.device.0.cmd_set_depth_bounds(self.raw, bounds.start, bounds.end);
+            self.device
+                .0
+                .cmd_set_depth_bounds(self.raw, bounds.start, bounds.end);
         }
     }
 
@@ -597,11 +616,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn bind_graphics_pipeline(&mut self, pipeline: &n::GraphicsPipeline) {
         unsafe {
-            self.device.0.cmd_bind_pipeline(
-                self.raw,
-                vk::PipelineBindPoint::Graphics,
-                pipeline.0,
-            )
+            self.device
+                .0
+                .cmd_bind_pipeline(self.raw, vk::PipelineBindPoint::GRAPHICS, pipeline.0)
         }
     }
 
@@ -618,7 +635,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         J::Item: Borrow<com::DescriptorSetOffset>,
     {
         self.bind_descriptor_sets(
-            vk::PipelineBindPoint::Graphics,
+            vk::PipelineBindPoint::GRAPHICS,
             layout,
             first_set,
             sets,
@@ -628,11 +645,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn bind_compute_pipeline(&mut self, pipeline: &n::ComputePipeline) {
         unsafe {
-            self.device.0.cmd_bind_pipeline(
-                self.raw,
-                vk::PipelineBindPoint::Compute,
-                pipeline.0,
-            )
+            self.device
+                .0
+                .cmd_bind_pipeline(self.raw, vk::PipelineBindPoint::COMPUTE, pipeline.0)
         }
     }
 
@@ -649,7 +664,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         J::Item: Borrow<com::DescriptorSetOffset>,
     {
         self.bind_descriptor_sets(
-            vk::PipelineBindPoint::Compute,
+            vk::PipelineBindPoint::COMPUTE,
             layout,
             first_set,
             sets,
@@ -659,22 +674,17 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn dispatch(&mut self, count: WorkGroupCount) {
         unsafe {
-            self.device.0.cmd_dispatch(
-                self.raw,
-                count[0],
-                count[1],
-                count[2],
-            )
+            self.device
+                .0
+                .cmd_dispatch(self.raw, count[0], count[1], count[2])
         }
     }
 
     unsafe fn dispatch_indirect(&mut self, buffer: &n::Buffer, offset: buffer::Offset) {
         unsafe {
-            self.device.0.cmd_dispatch_indirect(
-                self.raw,
-                buffer.raw,
-                offset,
-            )
+            self.device
+                .0
+                .cmd_dispatch_indirect(self.raw, buffer.raw, offset)
         }
     }
 
@@ -696,12 +706,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             .collect();
 
         unsafe {
-            self.device.0.cmd_copy_buffer(
-                self.raw,
-                src.raw,
-                dst.raw,
-                &regions,
-            )
+            self.device
+                .0
+                .cmd_copy_buffer(self.raw, src.raw, dst.raw, &regions)
         }
     }
 
@@ -826,13 +833,9 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         stride: u32,
     ) {
         unsafe {
-            self.device.0.cmd_draw_indirect(
-                self.raw,
-                buffer.raw,
-                offset,
-                draw_count,
-                stride,
-            )
+            self.device
+                .0
+                .cmd_draw_indirect(self.raw, buffer.raw, offset, draw_count, stride)
         }
     }
 
@@ -844,21 +847,13 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         stride: u32,
     ) {
         unsafe {
-            self.device.0.cmd_draw_indexed_indirect(
-                self.raw,
-                buffer.raw,
-                offset,
-                draw_count,
-                stride,
-            )
+            self.device
+                .0
+                .cmd_draw_indexed_indirect(self.raw, buffer.raw, offset, draw_count, stride)
         }
     }
 
-    unsafe fn begin_query(
-        &mut self,
-        query: query::Query<Backend>,
-        flags: query::ControlFlags,
-    ) {
+    unsafe fn begin_query(&mut self, query: query::Query<Backend>, flags: query::ControlFlags) {
         unsafe {
             self.device.0.cmd_begin_query(
                 self.raw,
@@ -869,24 +864,15 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    unsafe fn end_query(
-        &mut self,
-        query: query::Query<Backend>,
-    ) {
+    unsafe fn end_query(&mut self, query: query::Query<Backend>) {
         unsafe {
-            self.device.0.cmd_end_query(
-                self.raw,
-                query.pool.0,
-                query.id,
-            )
+            self.device
+                .0
+                .cmd_end_query(self.raw, query.pool.0, query.id)
         }
     }
 
-    unsafe fn reset_query_pool(
-        &mut self,
-        pool: &n::QueryPool,
-        queries: Range<query::Id>,
-    ) {
+    unsafe fn reset_query_pool(&mut self, pool: &n::QueryPool, queries: Range<query::Id>) {
         unsafe {
             self.device.0.cmd_reset_query_pool(
                 self.raw,
@@ -898,26 +884,30 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     unsafe fn copy_query_pool_results(
-        &mut self, pool: &n::QueryPool, queries: Range<query::Id>,
-        buffer: &n::Buffer, offset: buffer::Offset, stride: buffer::Offset,
+        &mut self,
+        pool: &n::QueryPool,
+        queries: Range<query::Id>,
+        buffer: &n::Buffer,
+        offset: buffer::Offset,
+        stride: buffer::Offset,
         flags: query::ResultFlags,
     ) {
         //TODO: use safer wrapper
         unsafe {
             self.device.0.fp_v1_0().cmd_copy_query_pool_results(
                 self.raw,
-                pool.0, queries.start, queries.end - queries.start,
-                buffer.raw, offset, stride,
+                pool.0,
+                queries.start,
+                queries.end - queries.start,
+                buffer.raw,
+                offset,
+                stride,
                 conv::map_query_result_flags(flags),
             )
         };
     }
 
-    unsafe fn write_timestamp(
-        &mut self,
-        stage: pso::PipelineStage,
-        query: query::Query<Backend>,
-    ) {
+    unsafe fn write_timestamp(&mut self, stage: pso::PipelineStage, query: query::Query<Backend>) {
         unsafe {
             self.device.0.cmd_write_timestamp(
                 self.raw,
@@ -938,7 +928,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             self.device.0.cmd_push_constants(
                 self.raw,
                 layout.raw,
-                vk::SHADER_STAGE_COMPUTE_BIT,
+                vk::ShaderStageFlags::COMPUTE,
                 offset * 4,
                 memory::cast_slice(constants),
             );
@@ -963,10 +953,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    unsafe fn execute_commands<'a, T, I>(
-        &mut self,
-        buffers: I,
-    ) where
+    unsafe fn execute_commands<'a, T, I>(&mut self, buffers: I)
+    where
         T: 'a + Borrow<CommandBuffer>,
         I: IntoIterator<Item = &'a T>,
     {
@@ -974,6 +962,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             .into_iter()
             .map(|b| b.borrow().raw)
             .collect::<Vec<_>>();
-        unsafe { self.device.0.cmd_execute_commands(self.raw, &command_buffers); }
+        unsafe {
+            self.device
+                .0
+                .cmd_execute_commands(self.raw, &command_buffers);
+        }
     }
 }

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -1,15 +1,14 @@
 use ash::vk;
 
-use hal::{buffer, command, format, image, pass, pso, query};
-use hal::{IndexType, Primitive, PresentMode};
 use hal::range::RangeArg;
+use hal::{buffer, command, format, image, pass, pso, query};
+use hal::{IndexType, PresentMode, Primitive};
 
 use native as n;
 
-use std::mem;
 use std::borrow::Borrow;
+use std::mem;
 use std::ptr;
-
 
 pub fn map_format(format: format::Format) -> vk::Format {
     // Safe due to equivalence of HAL format values and Vulkan format values
@@ -17,9 +16,7 @@ pub fn map_format(format: format::Format) -> vk::Format {
 }
 
 pub fn map_vk_format(format: vk::Format) -> Option<format::Format> {
-    if (format as usize) < format::NUM_FORMATS &&
-        format != vk::Format::Undefined
-    {
+    if (format.as_raw() as usize) < format::NUM_FORMATS && format != vk::Format::UNDEFINED {
         // Safe due to equivalence of HAL format values and Vulkan format values
         Some(unsafe { mem::transmute(format) })
     } else {
@@ -34,12 +31,12 @@ pub fn map_tiling(tiling: image::Tiling) -> vk::ImageTiling {
 pub fn map_component(component: format::Component) -> vk::ComponentSwizzle {
     use hal::format::Component::*;
     match component {
-        Zero => vk::ComponentSwizzle::Zero,
-        One  => vk::ComponentSwizzle::One,
-        R    => vk::ComponentSwizzle::R,
-        G    => vk::ComponentSwizzle::G,
-        B    => vk::ComponentSwizzle::B,
-        A    => vk::ComponentSwizzle::A,
+        Zero => vk::ComponentSwizzle::ZERO,
+        One => vk::ComponentSwizzle::ONE,
+        R => vk::ComponentSwizzle::R,
+        G => vk::ComponentSwizzle::G,
+        B => vk::ComponentSwizzle::B,
+        A => vk::ComponentSwizzle::A,
     }
 }
 
@@ -54,24 +51,24 @@ pub fn map_swizzle(swizzle: format::Swizzle) -> vk::ComponentMapping {
 
 pub fn map_index_type(index_type: IndexType) -> vk::IndexType {
     match index_type {
-        IndexType::U16 => vk::IndexType::Uint16,
-        IndexType::U32 => vk::IndexType::Uint32,
+        IndexType::U16 => vk::IndexType::UINT16,
+        IndexType::U32 => vk::IndexType::UINT32,
     }
 }
 
 pub fn map_image_layout(layout: image::Layout) -> vk::ImageLayout {
     use hal::image::Layout as Il;
     match layout {
-        Il::General => vk::ImageLayout::General,
-        Il::ColorAttachmentOptimal => vk::ImageLayout::ColorAttachmentOptimal,
-        Il::DepthStencilAttachmentOptimal => vk::ImageLayout::DepthStencilAttachmentOptimal,
-        Il::DepthStencilReadOnlyOptimal => vk::ImageLayout::DepthStencilReadOnlyOptimal,
-        Il::ShaderReadOnlyOptimal => vk::ImageLayout::ShaderReadOnlyOptimal,
-        Il::TransferSrcOptimal => vk::ImageLayout::TransferSrcOptimal,
-        Il::TransferDstOptimal => vk::ImageLayout::TransferDstOptimal,
-        Il::Undefined => vk::ImageLayout::Undefined,
-        Il::Preinitialized => vk::ImageLayout::Preinitialized,
-        Il::Present => vk::ImageLayout::PresentSrcKhr,
+        Il::General => vk::ImageLayout::GENERAL,
+        Il::ColorAttachmentOptimal => vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+        Il::DepthStencilAttachmentOptimal => vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        Il::DepthStencilReadOnlyOptimal => vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+        Il::ShaderReadOnlyOptimal => vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+        Il::TransferSrcOptimal => vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+        Il::TransferDstOptimal => vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+        Il::Undefined => vk::ImageLayout::UNDEFINED,
+        Il::Preinitialized => vk::ImageLayout::PREINITIALIZED,
+        Il::Present => vk::ImageLayout::PRESENT_SRC_KHR,
     }
 }
 
@@ -83,8 +80,8 @@ pub fn map_image_aspects(aspects: format::Aspects) -> vk::ImageAspectFlags {
 pub fn map_clear_color(value: command::ClearColor) -> vk::ClearColorValue {
     match value {
         command::ClearColor::Float(v) => vk::ClearColorValue { float32: v },
-        command::ClearColor::Int(v)   => vk::ClearColorValue { int32: v },
-        command::ClearColor::Uint(v)  => vk::ClearColorValue { uint32: v },
+        command::ClearColor::Int(v) => vk::ClearColorValue { int32: v },
+        command::ClearColor::Uint(v) => vk::ClearColorValue { uint32: v },
     }
 }
 
@@ -104,9 +101,7 @@ pub fn map_extent(offset: image::Extent) -> vk::Extent3D {
     }
 }
 
-pub fn map_subresource(
-    sub: &image::Subresource,
-) -> vk::ImageSubresource {
+pub fn map_subresource(sub: &image::Subresource) -> vk::ImageSubresource {
     vk::ImageSubresource {
         aspect_mask: map_image_aspects(sub.aspects),
         mip_level: sub.level as _,
@@ -114,9 +109,7 @@ pub fn map_subresource(
     }
 }
 
-pub fn map_subresource_layers(
-    sub: &image::SubresourceLayers,
-) -> vk::ImageSubresourceLayers {
+pub fn map_subresource_layers(sub: &image::SubresourceLayers) -> vk::ImageSubresourceLayers {
     vk::ImageSubresourceLayers {
         aspect_mask: map_image_aspects(sub.aspects),
         mip_level: sub.level as _,
@@ -125,9 +118,7 @@ pub fn map_subresource_layers(
     }
 }
 
-pub fn map_subresource_range(
-    range: &image::SubresourceRange,
-) -> vk::ImageSubresourceRange {
+pub fn map_subresource_range(range: &image::SubresourceRange) -> vk::ImageSubresourceRange {
     vk::ImageSubresourceRange {
         aspect_mask: map_image_aspects(range.aspects),
         base_mip_level: range.levels.start as _,
@@ -140,17 +131,17 @@ pub fn map_subresource_range(
 pub fn map_attachment_load_op(op: pass::AttachmentLoadOp) -> vk::AttachmentLoadOp {
     use hal::pass::AttachmentLoadOp as Alo;
     match op {
-        Alo::Load => vk::AttachmentLoadOp::Load,
-        Alo::Clear => vk::AttachmentLoadOp::Clear,
-        Alo::DontCare => vk::AttachmentLoadOp::DontCare,
+        Alo::Load => vk::AttachmentLoadOp::LOAD,
+        Alo::Clear => vk::AttachmentLoadOp::CLEAR,
+        Alo::DontCare => vk::AttachmentLoadOp::DONT_CARE,
     }
 }
 
 pub fn map_attachment_store_op(op: pass::AttachmentStoreOp) -> vk::AttachmentStoreOp {
     use hal::pass::AttachmentStoreOp as Aso;
     match op {
-        Aso::Store => vk::AttachmentStoreOp::Store,
-        Aso::DontCare => vk::AttachmentStoreOp::DontCare,
+        Aso::Store => vk::AttachmentStoreOp::STORE,
+        Aso::DontCare => vk::AttachmentStoreOp::DONT_CARE,
     }
 }
 
@@ -194,7 +185,6 @@ pub fn map_stage_flags(stages: pso::ShaderStageFlags) -> vk::ShaderStageFlags {
     unsafe { mem::transmute(stages) }
 }
 
-
 pub fn map_filter(filter: image::Filter) -> vk::Filter {
     // enums have to match exactly
     unsafe { mem::transmute(filter as u32) }
@@ -208,86 +198,86 @@ pub fn map_mip_filter(filter: image::Filter) -> vk::SamplerMipmapMode {
 pub fn map_wrap(wrap: image::WrapMode) -> vk::SamplerAddressMode {
     use hal::image::WrapMode as Wm;
     match wrap {
-        Wm::Tile   => vk::SamplerAddressMode::Repeat,
-        Wm::Mirror => vk::SamplerAddressMode::MirroredRepeat,
-        Wm::Clamp  => vk::SamplerAddressMode::ClampToEdge,
-        Wm::Border => vk::SamplerAddressMode::ClampToBorder,
+        Wm::Tile => vk::SamplerAddressMode::REPEAT,
+        Wm::Mirror => vk::SamplerAddressMode::MIRRORED_REPEAT,
+        Wm::Clamp => vk::SamplerAddressMode::CLAMP_TO_EDGE,
+        Wm::Border => vk::SamplerAddressMode::CLAMP_TO_BORDER,
     }
 }
 
 pub fn map_border_color(col: image::PackedColor) -> Option<vk::BorderColor> {
     match col.0 {
-        0x00000000 => Some(vk::BorderColor::FloatTransparentBlack),
-        0xFF000000 => Some(vk::BorderColor::FloatOpaqueBlack),
-        0xFFFFFFFF => Some(vk::BorderColor::FloatOpaqueWhite),
-        _ => None
+        0x00000000 => Some(vk::BorderColor::FLOAT_TRANSPARENT_BLACK),
+        0xFF000000 => Some(vk::BorderColor::FLOAT_OPAQUE_BLACK),
+        0xFFFFFFFF => Some(vk::BorderColor::FLOAT_OPAQUE_WHITE),
+        _ => None,
     }
 }
 
 pub fn map_topology(prim: Primitive) -> vk::PrimitiveTopology {
     match prim {
-        Primitive::PointList              => vk::PrimitiveTopology::PointList,
-        Primitive::LineList               => vk::PrimitiveTopology::LineList,
-        Primitive::LineListAdjacency      => vk::PrimitiveTopology::LineListWithAdjacency,
-        Primitive::LineStrip              => vk::PrimitiveTopology::LineStrip,
-        Primitive::LineStripAdjacency     => vk::PrimitiveTopology::LineStripWithAdjacency,
-        Primitive::TriangleList           => vk::PrimitiveTopology::TriangleList,
-        Primitive::TriangleListAdjacency  => vk::PrimitiveTopology::TriangleListWithAdjacency,
-        Primitive::TriangleStrip          => vk::PrimitiveTopology::TriangleStrip,
-        Primitive::TriangleStripAdjacency => vk::PrimitiveTopology::TriangleStripWithAdjacency,
-        Primitive::PatchList(_)           => vk::PrimitiveTopology::PatchList,
+        Primitive::PointList => vk::PrimitiveTopology::POINT_LIST,
+        Primitive::LineList => vk::PrimitiveTopology::LINE_LIST,
+        Primitive::LineListAdjacency => vk::PrimitiveTopology::LINE_LIST_WITH_ADJACENCY,
+        Primitive::LineStrip => vk::PrimitiveTopology::LINE_STRIP,
+        Primitive::LineStripAdjacency => vk::PrimitiveTopology::LINE_STRIP_WITH_ADJACENCY,
+        Primitive::TriangleList => vk::PrimitiveTopology::TRIANGLE_LIST,
+        Primitive::TriangleListAdjacency => vk::PrimitiveTopology::TRIANGLE_LIST_WITH_ADJACENCY,
+        Primitive::TriangleStrip => vk::PrimitiveTopology::TRIANGLE_STRIP,
+        Primitive::TriangleStripAdjacency => vk::PrimitiveTopology::TRIANGLE_STRIP_WITH_ADJACENCY,
+        Primitive::PatchList(_) => vk::PrimitiveTopology::PATCH_LIST,
     }
 }
 
 pub fn map_polygon_mode(rm: pso::PolygonMode) -> (vk::PolygonMode, f32) {
     match rm {
-        pso::PolygonMode::Point   => (vk::PolygonMode::Point, 1.0),
-        pso::PolygonMode::Line(w) => (vk::PolygonMode::Line, w),
-        pso::PolygonMode::Fill    => (vk::PolygonMode::Fill, 1.0),
+        pso::PolygonMode::Point => (vk::PolygonMode::POINT, 1.0),
+        pso::PolygonMode::Line(w) => (vk::PolygonMode::LINE, w),
+        pso::PolygonMode::Fill => (vk::PolygonMode::FILL, 1.0),
     }
 }
 
 pub fn map_cull_face(cf: pso::Face) -> vk::CullModeFlags {
     match cf {
-        pso::Face::NONE => vk::CULL_MODE_NONE,
-        pso::Face::FRONT => vk::CULL_MODE_FRONT_BIT,
-        pso::Face::BACK => vk::CULL_MODE_BACK_BIT,
-        _ => vk::CULL_MODE_FRONT_AND_BACK,
+        pso::Face::NONE => vk::CullModeFlags::NONE,
+        pso::Face::FRONT => vk::CullModeFlags::FRONT,
+        pso::Face::BACK => vk::CullModeFlags::BACK,
+        _ => vk::CullModeFlags::FRONT_AND_BACK,
     }
 }
 
 pub fn map_front_face(ff: pso::FrontFace) -> vk::FrontFace {
     match ff {
-        pso::FrontFace::Clockwise        => vk::FrontFace::Clockwise,
-        pso::FrontFace::CounterClockwise => vk::FrontFace::CounterClockwise,
+        pso::FrontFace::Clockwise => vk::FrontFace::CLOCKWISE,
+        pso::FrontFace::CounterClockwise => vk::FrontFace::COUNTER_CLOCKWISE,
     }
 }
 
 pub fn map_comparison(fun: pso::Comparison) -> vk::CompareOp {
     use hal::pso::Comparison::*;
     match fun {
-        Never        => vk::CompareOp::Never,
-        Less         => vk::CompareOp::Less,
-        LessEqual    => vk::CompareOp::LessOrEqual,
-        Equal        => vk::CompareOp::Equal,
-        GreaterEqual => vk::CompareOp::GreaterOrEqual,
-        Greater      => vk::CompareOp::Greater,
-        NotEqual     => vk::CompareOp::NotEqual,
-        Always       => vk::CompareOp::Always,
+        Never => vk::CompareOp::NEVER,
+        Less => vk::CompareOp::LESS,
+        LessEqual => vk::CompareOp::LESS_OR_EQUAL,
+        Equal => vk::CompareOp::EQUAL,
+        GreaterEqual => vk::CompareOp::GREATER_OR_EQUAL,
+        Greater => vk::CompareOp::GREATER,
+        NotEqual => vk::CompareOp::NOT_EQUAL,
+        Always => vk::CompareOp::ALWAYS,
     }
 }
 
 pub fn map_stencil_op(op: pso::StencilOp) -> vk::StencilOp {
     use hal::pso::StencilOp::*;
     match op {
-        Keep           => vk::StencilOp::Keep,
-        Zero           => vk::StencilOp::Zero,
-        Replace        => vk::StencilOp::Replace,
-        IncrementClamp => vk::StencilOp::IncrementAndClamp,
-        IncrementWrap  => vk::StencilOp::IncrementAndWrap,
-        DecrementClamp => vk::StencilOp::DecrementAndClamp,
-        DecrementWrap  => vk::StencilOp::DecrementAndWrap,
-        Invert         => vk::StencilOp::Invert,
+        Keep => vk::StencilOp::KEEP,
+        Zero => vk::StencilOp::ZERO,
+        Replace => vk::StencilOp::REPLACE,
+        IncrementClamp => vk::StencilOp::INCREMENT_AND_CLAMP,
+        IncrementWrap => vk::StencilOp::INCREMENT_AND_WRAP,
+        DecrementClamp => vk::StencilOp::DECREMENT_AND_CLAMP,
+        DecrementWrap => vk::StencilOp::DECREMENT_AND_WRAP,
+        Invert => vk::StencilOp::INVERT,
     }
 }
 
@@ -315,50 +305,56 @@ pub fn map_stencil_side(side: &pso::StencilFace) -> vk::StencilOpState {
 pub fn map_blend_factor(factor: pso::Factor) -> vk::BlendFactor {
     use hal::pso::Factor::*;
     match factor {
-        Zero => vk::BlendFactor::Zero,
-        One => vk::BlendFactor::One,
-        SrcColor => vk::BlendFactor::SrcColor,
-        OneMinusSrcColor => vk::BlendFactor::OneMinusSrcColor,
-        DstColor => vk::BlendFactor::DstColor,
-        OneMinusDstColor => vk::BlendFactor::OneMinusDstColor,
-        SrcAlpha => vk::BlendFactor::SrcAlpha,
-        OneMinusSrcAlpha => vk::BlendFactor::OneMinusSrcAlpha,
-        DstAlpha => vk::BlendFactor::DstAlpha,
-        OneMinusDstAlpha => vk::BlendFactor::OneMinusDstAlpha,
-        ConstColor => vk::BlendFactor::ConstantColor,
-        OneMinusConstColor => vk::BlendFactor::OneMinusConstantColor,
-        ConstAlpha => vk::BlendFactor::ConstantAlpha,
-        OneMinusConstAlpha => vk::BlendFactor::OneMinusConstantAlpha,
-        SrcAlphaSaturate => vk::BlendFactor::SrcAlphaSaturate,
-        Src1Color => vk::BlendFactor::Src1Color,
-        OneMinusSrc1Color => vk::BlendFactor::OneMinusSrc1Color,
-        Src1Alpha => vk::BlendFactor::Src1Alpha,
-        OneMinusSrc1Alpha => vk::BlendFactor::OneMinusSrc1Alpha,
+        Zero => vk::BlendFactor::ZERO,
+        One => vk::BlendFactor::ONE,
+        SrcColor => vk::BlendFactor::SRC_COLOR,
+        OneMinusSrcColor => vk::BlendFactor::ONE_MINUS_SRC_COLOR,
+        DstColor => vk::BlendFactor::DST_COLOR,
+        OneMinusDstColor => vk::BlendFactor::ONE_MINUS_DST_COLOR,
+        SrcAlpha => vk::BlendFactor::SRC_ALPHA,
+        OneMinusSrcAlpha => vk::BlendFactor::ONE_MINUS_SRC_ALPHA,
+        DstAlpha => vk::BlendFactor::DST_ALPHA,
+        OneMinusDstAlpha => vk::BlendFactor::ONE_MINUS_DST_ALPHA,
+        ConstColor => vk::BlendFactor::CONSTANT_COLOR,
+        OneMinusConstColor => vk::BlendFactor::ONE_MINUS_CONSTANT_COLOR,
+        ConstAlpha => vk::BlendFactor::CONSTANT_ALPHA,
+        OneMinusConstAlpha => vk::BlendFactor::ONE_MINUS_CONSTANT_ALPHA,
+        SrcAlphaSaturate => vk::BlendFactor::SRC_ALPHA_SATURATE,
+        Src1Color => vk::BlendFactor::SRC1_COLOR,
+        OneMinusSrc1Color => vk::BlendFactor::ONE_MINUS_SRC1_COLOR,
+        Src1Alpha => vk::BlendFactor::SRC1_ALPHA,
+        OneMinusSrc1Alpha => vk::BlendFactor::ONE_MINUS_SRC1_ALPHA,
     }
 }
 
-pub fn map_blend_op(
-    operation: pso::BlendOp
-) -> (vk::BlendOp, vk::BlendFactor, vk::BlendFactor) {
+pub fn map_blend_op(operation: pso::BlendOp) -> (vk::BlendOp, vk::BlendFactor, vk::BlendFactor) {
     use hal::pso::BlendOp::*;
     match operation {
         Add { src, dst } => (
-            vk::BlendOp::Add,
+            vk::BlendOp::ADD,
             map_blend_factor(src),
             map_blend_factor(dst),
         ),
         Sub { src, dst } => (
-            vk::BlendOp::Subtract,
+            vk::BlendOp::SUBTRACT,
             map_blend_factor(src),
             map_blend_factor(dst),
         ),
         RevSub { src, dst } => (
-            vk::BlendOp::ReverseSubtract,
+            vk::BlendOp::REVERSE_SUBTRACT,
             map_blend_factor(src),
             map_blend_factor(dst),
         ),
-        Min => (vk::BlendOp::Min, vk::BlendFactor::Zero, vk::BlendFactor::Zero),
-        Max => (vk::BlendOp::Max, vk::BlendFactor::Zero, vk::BlendFactor::Zero),
+        Min => (
+            vk::BlendOp::MIN,
+            vk::BlendFactor::ZERO,
+            vk::BlendFactor::ZERO,
+        ),
+        Max => (
+            vk::BlendOp::MAX,
+            vk::BlendFactor::ZERO,
+            vk::BlendFactor::ZERO,
+        ),
     }
 }
 
@@ -371,11 +367,11 @@ pub fn map_pipeline_statistics(
 
 pub fn map_query_control_flags(flags: query::ControlFlags) -> vk::QueryControlFlags {
     // Safe due to equivalence of HAL values and Vulkan values
-    vk::QueryControlFlags::from_flags_truncate(flags.bits())
+    vk::QueryControlFlags::from_raw(flags.bits() & vk::QueryControlFlags::all().as_raw())
 }
 
 pub fn map_query_result_flags(flags: query::ResultFlags) -> vk::QueryResultFlags {
-    vk::QueryResultFlags::from_flags_truncate(flags.bits())
+    vk::QueryResultFlags::from_raw(flags.bits() & vk::QueryResultFlags::all().as_raw())
 }
 
 pub fn map_image_features(features: vk::FormatFeatureFlags) -> format::ImageFeature {
@@ -394,13 +390,13 @@ where
     I::Item: Borrow<(&'a n::Memory, R)>,
     R: RangeArg<u64>,
 {
-     ranges
+    ranges
         .into_iter()
         .map(|range| {
             let &(ref memory, ref range) = range.borrow();
             let (offset, size) = map_range_arg(range);
             vk::MappedMemoryRange {
-                s_type: vk::StructureType::MappedMemoryRange,
+                s_type: vk::StructureType::MAPPED_MEMORY_RANGE,
                 p_next: ptr::null(),
                 memory: memory.raw,
                 offset,
@@ -421,7 +417,7 @@ where
     let offset = *range.start().unwrap_or(&0);
     let size = match range.end() {
         Some(end) => end - offset,
-        None => vk::VK_WHOLE_SIZE,
+        None => vk::WHOLE_SIZE,
     };
 
     (offset, size)
@@ -434,28 +430,30 @@ pub fn map_command_buffer_flags(flags: command::CommandBufferFlags) -> vk::Comma
 
 pub fn map_command_buffer_level(level: command::RawLevel) -> vk::CommandBufferLevel {
     match level {
-        command::RawLevel::Primary => vk::CommandBufferLevel::Primary,
-        command::RawLevel::Secondary => vk::CommandBufferLevel::Secondary,
+        command::RawLevel::Primary => vk::CommandBufferLevel::PRIMARY,
+        command::RawLevel::Secondary => vk::CommandBufferLevel::SECONDARY,
     }
 }
 
 pub fn map_view_kind(
-    kind: image::ViewKind, ty: vk::ImageType, is_cube: bool
+    kind: image::ViewKind,
+    ty: vk::ImageType,
+    is_cube: bool,
 ) -> Option<vk::ImageViewType> {
-    use vk::ImageType::*;
-    use hal::image::ViewKind::*;
+    use image::ViewKind::*;
+    use vk::ImageType;
 
     Some(match (ty, kind) {
-        (Type1d, D1) => vk::ImageViewType::Type1d,
-        (Type1d, D1Array) => vk::ImageViewType::Type1dArray,
-        (Type2d, D2) => vk::ImageViewType::Type2d,
-        (Type2d, D2Array) => vk::ImageViewType::Type2dArray,
-        (Type3d, D3) => vk::ImageViewType::Type3d,
-        (Type2d, Cube) if is_cube => vk::ImageViewType::Cube,
-        (Type2d, CubeArray) if is_cube => vk::ImageViewType::CubeArray,
-        (Type3d, Cube) if is_cube => vk::ImageViewType::Cube,
-        (Type3d, CubeArray) if is_cube => vk::ImageViewType::CubeArray,
-        _ => return None
+        (ImageType::TYPE_1D, D1) => vk::ImageViewType::TYPE_1D,
+        (ImageType::TYPE_1D, D1Array) => vk::ImageViewType::TYPE_1D_ARRAY,
+        (ImageType::TYPE_2D, D2) => vk::ImageViewType::TYPE_2D,
+        (ImageType::TYPE_2D, D2Array) => vk::ImageViewType::TYPE_2D_ARRAY,
+        (ImageType::TYPE_3D, D3) => vk::ImageViewType::TYPE_3D,
+        (ImageType::TYPE_2D, Cube) if is_cube => vk::ImageViewType::CUBE,
+        (ImageType::TYPE_2D, CubeArray) if is_cube => vk::ImageViewType::CUBE_ARRAY,
+        (ImageType::TYPE_3D, Cube) if is_cube => vk::ImageViewType::CUBE,
+        (ImageType::TYPE_3D, CubeArray) if is_cube => vk::ImageViewType::CUBE_ARRAY,
+        _ => return None,
     })
 }
 

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -1,14 +1,13 @@
+use ash::version::DeviceV1_0;
+use ash::vk;
+use smallvec::SmallVec;
 use std::ptr;
 use std::sync::Arc;
-use ash::vk;
-use ash::version::DeviceV1_0;
-use smallvec::SmallVec;
 
 use command::CommandBuffer;
 use conv;
-use hal::{pool, command};
+use hal::{command, pool};
 use {Backend, RawDevice};
-
 
 pub struct RawCommandPool {
     pub(crate) raw: vk::CommandPool,
@@ -18,16 +17,15 @@ pub struct RawCommandPool {
 impl pool::RawCommandPool<Backend> for RawCommandPool {
     unsafe fn reset(&mut self) {
         assert_eq!(Ok(()), unsafe {
-            self.device.0.reset_command_pool(
-                self.raw,
-                vk::CommandPoolResetFlags::empty(),
-            )
+            self.device
+                .0
+                .reset_command_pool(self.raw, vk::CommandPoolResetFlags::empty())
         });
     }
 
     fn allocate_vec(&mut self, num: usize, level: command::RawLevel) -> Vec<CommandBuffer> {
         let info = vk::CommandBufferAllocateInfo {
-            s_type: vk::StructureType::CommandBufferAllocateInfo,
+            s_type: vk::StructureType::COMMAND_BUFFER_ALLOCATE_INFO,
             p_next: ptr::null(),
             command_pool: self.raw,
             level: conv::map_command_buffer_level(level),
@@ -35,27 +33,24 @@ impl pool::RawCommandPool<Backend> for RawCommandPool {
         };
 
         let device = &self.device;
-        let cbufs_raw = unsafe {
-            device.0.allocate_command_buffers(&info)
-        }.expect("Error on command buffer allocation");
+        let cbufs_raw = unsafe { device.0.allocate_command_buffers(&info) }
+            .expect("Error on command buffer allocation");
 
         cbufs_raw
             .into_iter()
-            .map(|buffer| {
-                CommandBuffer {
-                    raw: buffer,
-                    device: device.clone(),
-                }
-            }).collect()
+            .map(|buffer| CommandBuffer {
+                raw: buffer,
+                device: device.clone(),
+            })
+            .collect()
     }
 
     unsafe fn free<I>(&mut self, cbufs: I)
-    where I: IntoIterator<Item = CommandBuffer>
+    where
+        I: IntoIterator<Item = CommandBuffer>,
     {
-        let buffers: SmallVec<[vk::CommandBuffer; 16]> = cbufs
-            .into_iter()
-            .map(|buffer| buffer.raw)
-            .collect();
+        let buffers: SmallVec<[vk::CommandBuffer; 16]> =
+            cbufs.into_iter().map(|buffer| buffer.raw).collect();
         self.device.0.free_command_buffers(self.raw, &buffers);
     }
 }

--- a/src/backend/vulkan/src/result.rs
+++ b/src/backend/vulkan/src/result.rs
@@ -1,4 +1,3 @@
-
 use ash::vk;
 
 use hal::error::{DeviceCreationError, HostExecutionError};
@@ -17,7 +16,7 @@ pub(crate) enum Error {
     IncompatibleDriver,
     TooManyObjects,
     FormatNotSupported,
-    FragmentedPool ,
+    FragmentedPool,
     SurfaceLostKhr,
     NativeWindowInUseKhr,
     OutOfDateKhr,
@@ -30,25 +29,24 @@ pub(crate) enum Error {
 
 impl From<vk::Result> for Error {
     fn from(result: vk::Result) -> Self {
-        use ash::vk::Result::*;
         match result {
-            ErrorOutOfHostMemory => Error::OutOfHostMemory,
-            ErrorOutOfDeviceMemory => Error::OutOfDeviceMemory,
-            ErrorInitializationFailed => Error::InitializationFailed,
-            ErrorDeviceLost => Error::DeviceLost,
-            ErrorMemoryMapFailed => Error::MemoryMapFailed,
-            ErrorLayerNotPresent => Error::LayerNotPresent,
-            ErrorExtensionNotPresent => Error::ExtensionNotPresent,
-            ErrorFeatureNotPresent => Error::FeatureNotPresent,
-            ErrorIncompatibleDriver => Error::IncompatibleDriver,
-            ErrorTooManyObjects => Error::TooManyObjects,
-            ErrorFormatNotSupported => Error::FormatNotSupported,
-            ErrorFragmentedPool => Error::FragmentedPool,
-            ErrorSurfaceLostKhr => Error::SurfaceLostKhr,
-            ErrorNativeWindowInUseKhr => Error::NativeWindowInUseKhr,
-            ErrorOutOfDateKhr => Error::OutOfDateKhr,
-            ErrorIncompatibleDisplayKhr => Error::IncompatibleDisplayKhr,
-            ErrorValidationFailedExt => Error::ValidationFailedExt,
+            ERROR_OUT_OF_HOST_MEMORY => Error::OutOfHostMemory,
+            ERROR_OUT_OF_DEVICE_MEMORY => Error::OutOfDeviceMemory,
+            ERROR_INITIALIZATION_FAILED => Error::InitializationFailed,
+            ERROR_DEVICE_LOST => Error::DeviceLost,
+            ERROR_MEMORY_MAP_FAILED => Error::MemoryMapFailed,
+            ERROR_LAYER_NOT_PRESENT => Error::LayerNotPresent,
+            ERROR_EXTENSION_NOT_PRESENT => Error::ExtensionNotPresent,
+            ERROR_FEATURE_NOT_PRESENT => Error::FeatureNotPresent,
+            ERROR_INCOMPATIBLE_DRIVER => Error::IncompatibleDriver,
+            ERROR_TOO_MANY_OBJECTS => Error::TooManyObjects,
+            ERROR_FORMAT_NOT_SUPPORTED => Error::FormatNotSupported,
+            ERROR_FRAGMENTED_POOL => Error::FragmentedPool,
+            ERROR_SURFACE_LOST_KHR => Error::SurfaceLostKhr,
+            ERROR_NATIVE_WINDOW_IN_USE_KHR => Error::NativeWindowInUseKhr,
+            ERROR_OUT_OF_DATE_KHR => Error::OutOfDateKhr,
+            ERROR_INCOMPATIBLE_DISPLAY_KHR => Error::IncompatibleDisplayKhr,
+            ERROR_VALIDATION_FAILED_EXT => Error::ValidationFailedExt,
             _ => Error::Unknown,
         }
     }


### PR DESCRIPTION
Fixes #2510. A lot of the changes were just renaming various constants that were moved around with no major changes. I went through the diff and checked to make sure everything was updated correctly, but it's possible there could have been a typo somewhere in the 500 or so changes. 

I tested the changes with warden and the examples and nothing appears to be wrong, but I can't be sure since it looks like warden is broken with 7 failing tests on the Vulkan backend. But this appears to be a separate issue from updating Ash since warden is also broken on at least the 0.1 release and maybe earlier.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
    - vulkan
- [x] `rustfmt` run on changed code
