### PR TITLE
Support device specific feature requests

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -463,8 +463,13 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     unsafe fn open(
         &self,
         families: &[(&QueueFamily, &[hal::QueuePriority])],
+        requested_features: hal::Features,
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
         let (device, cxt) = {
+            if !self.features().contains(requested_features) {
+                return Err(error::DeviceCreationError::MissingFeature);
+            }
+
             let feature_level = get_feature_level(self.adapter.as_raw());
             let mut returned_level = d3dcommon::D3D_FEATURE_LEVEL_9_1;
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -198,12 +198,17 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     unsafe fn open(
         &self,
         families: &[(&QueueFamily, &[hal::QueuePriority])],
+        requested_features: hal::Features,
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
         let lock = self.is_open.try_lock();
         let mut open_guard = match lock {
             Ok(inner) => inner,
             Err(_) => return Err(error::DeviceCreationError::TooManyObjects),
         };
+
+        if !self.features().contains(requested_features) {
+            return Err(error::DeviceCreationError::MissingFeature);
+        }
 
         let (device_raw, hr_device) =
             native::Device::create(self.adapter, native::FeatureLevel::L11_0);

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -55,7 +55,7 @@ impl hal::Backend for Backend {
 pub struct PhysicalDevice;
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     unsafe fn open(
-        &self, _: &[(&QueueFamily, &[hal::QueuePriority])]
+        &self, _: &[(&QueueFamily, &[hal::QueuePriority])], _: hal::Features,
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
         unimplemented!()
     }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -298,6 +298,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     unsafe fn open(
         &self,
         families: &[(&QueueFamily, &[hal::QueuePriority])],
+        requested_features: hal::Features,
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
         // Can't have multiple logical devices at the same time
         // as they would share the same context.
@@ -306,6 +307,11 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         }
         self.0.open.set(true);
 
+        // TODO: Check for support in the LeagcyFeatures struct too
+        if !self.features().contains(requested_features) {
+            return Err(error::DeviceCreationError::MissingFeature);
+        }
+        
         // initialize permanent states
         let gl = &self.0.context;
         if self

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -475,8 +475,14 @@ impl PhysicalDevice {
 
 impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     unsafe fn open(
-        &self, families: &[(&QueueFamily, &[hal::QueuePriority])],
+        &self, families: &[(&QueueFamily, &[hal::QueuePriority])], requested_features: hal::Features,
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
+        // TODO: Query supported features by feature set rather than hard coding in the supported
+        // features. https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
+        if !self.features().contains(requested_features) {
+            return Err(error::DeviceCreationError::MissingFeature);
+        }
+        
         // TODO: Handle opening a physical device multiple times
         assert_eq!(families.len(), 1);
         assert_eq!(families[0].1.len(), 1);

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -2,7 +2,7 @@ use ash::vk;
 
 use hal::range::RangeArg;
 use hal::{buffer, command, format, image, pass, pso, query};
-use hal::{IndexType, PresentMode, Primitive};
+use hal::{IndexType, PresentMode, Primitive, Features};
 
 use native as n;
 use std::borrow::Borrow;
@@ -365,6 +365,68 @@ pub fn map_image_features(features: vk::FormatFeatureFlags) -> format::ImageFeat
 
 pub fn map_buffer_features(features: vk::FormatFeatureFlags) -> format::BufferFeature {
     format::BufferFeature::from_bits_truncate(features.as_raw())
+}
+
+pub fn map_device_features(features: Features) -> vk::PhysicalDeviceFeatures {
+    // vk::PhysicalDeviceFeatures is a struct composed of Bool32's while
+    // Features is a bitfield so we need to map everything manually
+    vk::PhysicalDeviceFeatures::builder()
+        .robust_buffer_access(features.contains(Features::ROBUST_BUFFER_ACCESS))
+        .full_draw_index_uint32(features.contains(Features::FULL_DRAW_INDEX_U32))
+        .image_cube_array(features.contains(Features::IMAGE_CUBE_ARRAY))
+        .independent_blend(features.contains(Features::INDEPENDENT_BLENDING))
+        .geometry_shader(features.contains(Features::GEOMETRY_SHADER))
+        .tessellation_shader(features.contains(Features::TESSELLATION_SHADER))
+        .sample_rate_shading(features.contains(Features::SAMPLE_RATE_SHADING))
+        .dual_src_blend(features.contains(Features::DUAL_SRC_BLENDING))
+        .logic_op(features.contains(Features::LOGIC_OP))
+        .multi_draw_indirect(features.contains(Features::MULTI_DRAW_INDIRECT))
+        .draw_indirect_first_instance(features.contains(Features::DRAW_INDIRECT_FIRST_INSTANCE))
+        .depth_clamp(features.contains(Features::DEPTH_CLAMP))
+        .depth_bias_clamp(features.contains(Features::DEPTH_BIAS_CLAMP))
+        .fill_mode_non_solid(features.contains(Features::NON_FILL_POLYGON_MODE))
+        .depth_bounds(features.contains(Features::DEPTH_BOUNDS))
+        .wide_lines(features.contains(Features::LINE_WIDTH))
+        .large_points(features.contains(Features::POINT_SIZE))
+        .alpha_to_one(features.contains(Features::ALPHA_TO_ONE))
+        .multi_viewport(features.contains(Features::MULTI_VIEWPORTS))
+        .sampler_anisotropy(features.contains(Features::SAMPLER_ANISOTROPY))
+        .texture_compression_etc2(features.contains(Features::FORMAT_ETC2))
+        .texture_compression_astc_ldr(features.contains(Features::FORMAT_ASTC_LDR))
+        .texture_compression_bc(features.contains(Features::FORMAT_BC))
+        .occlusion_query_precise(features.contains(Features::PRECISE_OCCLUSION_QUERY))
+        .pipeline_statistics_query(features.contains(Features::PIPELINE_STATISTICS_QUERY))
+        .vertex_pipeline_stores_and_atomics(features.contains(Features::VERTEX_STORES_AND_ATOMICS))
+        .fragment_stores_and_atomics(features.contains(Features::FRAGMENT_STORES_AND_ATOMICS))
+        .shader_tessellation_and_geometry_point_size(features.contains(Features::SHADER_TESSELLATION_AND_GEOMETRY_POINT_SIZE))
+        .shader_image_gather_extended(features.contains(Features::SHADER_IMAGE_GATHER_EXTENDED))
+        .shader_storage_image_extended_formats(features.contains(Features::SHADER_STORAGE_IMAGE_EXTENDED_FORMATS))
+        .shader_storage_image_multisample(features.contains(Features::SHADER_STORAGE_IMAGE_MULTISAMPLE))
+        .shader_storage_image_read_without_format(features.contains(Features::SHADER_STORAGE_IMAGE_READ_WITHOUT_FORMAT))
+        .shader_storage_image_write_without_format(features.contains(Features::SHADER_STORAGE_IMAGE_WRITE_WITHOUT_FORMAT))
+        .shader_uniform_buffer_array_dynamic_indexing(features.contains(Features::SHADER_UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING))
+        .shader_sampled_image_array_dynamic_indexing(features.contains(Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING))
+        .shader_storage_buffer_array_dynamic_indexing(features.contains(Features::SHADER_STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING))
+        .shader_storage_image_array_dynamic_indexing(features.contains(Features::SHADER_STORAGE_IMAGE_ARRAY_DYNAMIC_INDEXING))
+        .shader_clip_distance(features.contains(Features::SHADER_CLIP_DISTANCE))
+        .shader_cull_distance(features.contains(Features::SHADER_CULL_DISTANCE))
+        .shader_float64(features.contains(Features::SHADER_FLOAT64))
+        .shader_int64(features.contains(Features::SHADER_INT64))
+        .shader_int16(features.contains(Features::SHADER_INT16))
+        .shader_resource_residency(features.contains(Features::SHADER_RESOURCE_RESIDENCY))
+        .shader_resource_min_lod(features.contains(Features::SHADER_RESOURCE_MIN_LOD))
+        .sparse_binding(features.contains(Features::SPARSE_BINDING))
+        .sparse_residency_buffer(features.contains(Features::SPARSE_RESIDENCY_BUFFER))
+        .sparse_residency_image2_d(features.contains(Features::SPARSE_RESIDENCY_IMAGE_2D))
+        .sparse_residency_image3_d(features.contains(Features::SPARSE_RESIDENCY_IMAGE_3D))
+        .sparse_residency2_samples(features.contains(Features::SPARSE_RESIDENCY_2_SAMPLES))
+        .sparse_residency4_samples(features.contains(Features::SPARSE_RESIDENCY_4_SAMPLES))
+        .sparse_residency8_samples(features.contains(Features::SPARSE_RESIDENCY_8_SAMPLES))
+        .sparse_residency16_samples(features.contains(Features::SPARSE_RESIDENCY_16_SAMPLES))
+        .sparse_residency_aliased(features.contains(Features::SPARSE_RESIDENCY_ALIASED))
+        .variable_multisample_rate(features.contains(Features::VARIABLE_MULTISAMPLE_RATE))
+        .inherited_queries(features.contains(Features::INHERITED_QUERIES))
+        .build()
 }
 
 pub fn map_memory_ranges<'a, I, R>(ranges: I) -> Vec<vk::MappedMemoryRange>


### PR DESCRIPTION
Fixes #1928 by adding an optional parameter containing device features to enable. Currently only actually does anything on the Vulkan back-end since both Metal and DirectX use feature sets rather than fine grained features. If a device does not support all the requested features, than `DeviceCreationError::MissingFeature` is returned. I wasn't too sure what to do with `open_with`, but since it's just a convenience method, I thought it was alright to just not request any additional features. But I'm not sure if we want to expose it or not. Otherwise people can just use `PhysicalDevice::open` instead of `Adapter::open_with`

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
    - Vulkan on Linux
    - Vulkan, DX12, DX11, OpenGL on Windows
- [ ] `rustfmt` run on changed code
