### PR TITLE
Fix typo in physical device Features struct

### DIFF
--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -197,9 +197,9 @@ bitflags! {
         ///
         const SPARSE_RESIDENCY_BUFFER = 0x000_2000_0000_0000;
         ///
-        const SHADER_RESIDENCY_IMAGE_2D = 0x000_4000_0000_0000;
+        const SPARSE_RESIDENCY_IMAGE_2D = 0x000_4000_0000_0000;
         ///
-        const SHADER_RESIDENSY_IMAGE_3D = 0x000_8000_0000_0000;
+        const SPARSE_RESIDENCY_IMAGE_3D = 0x000_8000_0000_0000;
         ///
         const SPARSE_RESIDENCY_2_SAMPLES = 0x001_0000_0000_0000;
         ///


### PR DESCRIPTION
As suggested in PR 2539, this fixes the Features struct to have the correct names. Going by https://www.khronos.org/registry/vulkan/specs/1.1-khr-extensions/html/vkspec.html#features-features the `SHADER_RESIDENCY_IMAGE_2D` and `SHADER_RECIDENSY_IMAGE_3D` should be changed to     `SPARSE_RESIDENCY_IMAGE_2D` and `SPARSE_RESIDENCY_IMAGE_3D`.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
