### PR TITLE
Fix crash on iPhone5s iOS 12.1

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -502,7 +502,7 @@ const FUNCTION_SPECIALIZATION_SUPPORT: &[MTLFeatureSet] = &[
 ];
 
 const DEPTH_CLIP_MODE: &[MTLFeatureSet] = &[
-    MTLFeatureSet::iOS_GPUFamily1_v4,
+    MTLFeatureSet::iOS_GPUFamily2_v1,
     MTLFeatureSet::tvOS_GPUFamily1_v3,
     MTLFeatureSet::macOS_GPUFamily1_v1,
 ];


### PR DESCRIPTION
 Crash log: -[MTLDebugRenderCommandEncoder setDepthClipMode:]:2621: failed assertion `-[MTLDebugRenderCommandEncoder setDepthClipMode:] is only supported on MTLFeatureSet_iOS_GPUFamily2_v1 and later'

Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
   - [x] Metal iPhone5s iOS 12.1
- [x] `rustfmt` run on changed code