### PR TITLE
Improve secondary and subpass command buffers

### DIFF
--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -28,7 +28,8 @@ mod transfer;
 pub use self::graphics::*;
 pub use self::raw::{
     ClearColorRaw, ClearDepthStencilRaw, ClearValueRaw, CommandBufferFlags,
-    CommandBufferInheritanceInfo, DescriptorSetOffset, Level as RawLevel, RawCommandBuffer,
+    CommandBufferInheritanceInfo, DescriptorSetOffset, IntoRawCommandBuffer, Level as RawLevel,
+    RawCommandBuffer,
 };
 pub use self::render_pass::*;
 pub use self::transfer::*;
@@ -89,6 +90,12 @@ where
 impl<B: Backend, C, K: Capability + Supports<C>, S, L: Level> Submittable<B, K, L>
     for CommandBuffer<B, C, S, L>
 {
+}
+
+impl<B: Backend, C, S, L> IntoRawCommandBuffer<B, C> for CommandBuffer<B, C, S, L> {
+    fn into_raw(self) -> B::CommandBuffer {
+        self.raw
+    }
 }
 
 impl<B: Backend, C> CommandBuffer<B, C, OneShot, Primary> {

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -526,3 +526,9 @@ pub trait RawCommandBuffer<B: Backend>: Any + Send + Sync {
         T: 'a + Borrow<B::CommandBuffer>,
         I: IntoIterator<Item = &'a T>;
 }
+
+/// A trait for types that can be converted into raw command buffer.
+pub trait IntoRawCommandBuffer<B: Backend, C> {
+    /// Converts into raw command buffer.
+    fn into_raw(self) -> B::CommandBuffer;
+}

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -4,8 +4,8 @@ use std::ops::{Deref, DerefMut, Range};
 
 use super::{
     AttachmentClear, ClearValue, ClearValueRaw, CommandBuffer, CommandBufferFlags,
-    CommandBufferInheritanceInfo, DescriptorSetOffset, MultiShot, OneShot, Primary,
-    RawCommandBuffer, Secondary, Shot, Submittable,
+    CommandBufferInheritanceInfo, DescriptorSetOffset, IntoRawCommandBuffer, MultiShot, OneShot,
+    Primary, RawCommandBuffer, Secondary, Shot, Submittable,
 };
 use queue::{Capability, Graphics, Supports};
 use {buffer, pass, pso, query};
@@ -453,4 +453,14 @@ where
     C: Capability + Supports<Graphics>,
     S: Shot,
 {
+}
+
+impl<B, S> IntoRawCommandBuffer<B, Graphics> for SubpassCommandBuffer<B, S>
+where
+    B: Backend,
+    S: Shot,
+{
+    fn into_raw(self) -> B::CommandBuffer {
+        self.0.cmb
+    }
 }

--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -1,6 +1,9 @@
 //! Command pools
 
-use command::{CommandBuffer, RawLevel, SecondaryCommandBuffer, Shot, SubpassCommandBuffer};
+use command::{
+    CommandBuffer, IntoRawCommandBuffer, RawLevel, SecondaryCommandBuffer, Shot,
+    SubpassCommandBuffer,
+};
 use queue::capability::{Graphics, Supports};
 use Backend;
 
@@ -83,11 +86,13 @@ impl<B: Backend, C> CommandPool<B, C> {
     }
 
     /// Free the given iterator of command buffers from the pool.
-    pub unsafe fn free<S: Shot, I>(&mut self, cmd_buffers: I)
+    pub unsafe fn free<I>(&mut self, cmd_buffers: I)
     where
-        I: IntoIterator<Item = CommandBuffer<B, C, S>>,
+        I: IntoIterator,
+        I::Item: IntoRawCommandBuffer<B, C>,
     {
-        self.raw.free(cmd_buffers.into_iter().map(|cmb| cmb.raw))
+        self.raw
+            .free(cmd_buffers.into_iter().map(|cmb| cmb.into_raw()))
     }
 
     /// Downgrade a typed command pool to untyped one.


### PR DESCRIPTION
This PR:
- implements `Submittable` for `SubpassCommandBuffer`, thus allowing it to be recorded into primary command buffers. 
- Modifies `CommandPool::free` to allow freeing also secondary and subpass command buffers.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: quad (vulkan, gl)
- [x] `rustfmt` run on changed code
