### PR TITLE
[vk] Extend pipeline cache functionalities

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -904,7 +904,10 @@ impl hal::Device<Backend> for Device {
         })
     }
 
-    unsafe fn create_pipeline_cache(&self, _data: Option<&[u8]>) -> Result<(), device::OutOfMemory> {
+    unsafe fn create_pipeline_cache(
+        &self,
+        _data: Option<&[u8]>,
+    ) -> Result<(), device::OutOfMemory> {
         Ok(())
     }
 

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -904,8 +904,13 @@ impl hal::Device<Backend> for Device {
         })
     }
 
-    fn create_pipeline_cache(&self) -> Result<(), device::OutOfMemory> {
+    unsafe fn create_pipeline_cache(&self, _data: Option<&[u8]>) -> Result<(), device::OutOfMemory> {
         Ok(())
+    }
+
+    unsafe fn get_pipeline_cache_data(&self, cache: &()) -> Result<Vec<u8>, device::OutOfMemory> {
+        //empty
+        Ok(Vec::new())
     }
 
     unsafe fn destroy_pipeline_cache(&self, _: ()) {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1445,7 +1445,10 @@ impl d::Device<B> for Device {
         })
     }
 
-    unsafe fn create_pipeline_cache(&self, _data: Option<&[u8]>) -> Result<(), d::OutOfMemory> {
+    unsafe fn create_pipeline_cache(
+        &self,
+        _data: Option<&[u8]>
+    ) -> Result<(), d::OutOfMemory> {
         Ok(())
     }
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1445,8 +1445,13 @@ impl d::Device<B> for Device {
         })
     }
 
-    fn create_pipeline_cache(&self) -> Result<(), d::OutOfMemory> {
+    unsafe fn create_pipeline_cache(&self, _data: Option<&[u8]>) -> Result<(), d::OutOfMemory> {
         Ok(())
+    }
+
+    unsafe fn get_pipeline_cache_data(&self, cache: &()) -> Result<Vec<u8>, d::OutOfMemory> {
+        //empty
+        Ok(Vec::new())
     }
 
     unsafe fn destroy_pipeline_cache(&self, _: ()) {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -171,7 +171,11 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    fn create_pipeline_cache(&self) -> Result<(), device::OutOfMemory> {
+    unsafe fn create_pipeline_cache(&self, _data: Option<&[u8]>) -> Result<(), device::OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn get_pipeline_cache_data(&self, _cache: &()) -> Result<Vec<u8>, device::OutOfMemory> {
         unimplemented!()
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -171,7 +171,10 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    unsafe fn create_pipeline_cache(&self, _data: Option<&[u8]>) -> Result<(), device::OutOfMemory> {
+    unsafe fn create_pipeline_cache(
+        &self,
+        _data: Option<&[u8]>,
+    ) -> Result<(), device::OutOfMemory> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -658,7 +658,10 @@ impl d::Device<B> for Device {
         })
     }
 
-    unsafe fn create_pipeline_cache(&self, _data: Option<&[u8]>) -> Result<(), d::OutOfMemory> {
+    unsafe fn create_pipeline_cache(
+        &self,
+        _data: Option<&[u8]>
+    ) -> Result<(), d::OutOfMemory> {
         Ok(())
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -658,8 +658,13 @@ impl d::Device<B> for Device {
         })
     }
 
-    fn create_pipeline_cache(&self) -> Result<(), d::OutOfMemory> {
+    unsafe fn create_pipeline_cache(&self, _data: Option<&[u8]>) -> Result<(), d::OutOfMemory> {
         Ok(())
+    }
+
+    unsafe fn get_pipeline_cache_data(&self, cache: &()) -> Result<Vec<u8>, d::OutOfMemory> {
+        //empty
+        Ok(Vec::new())
     }
 
     unsafe fn destroy_pipeline_cache(&self, _: ()) {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1023,10 +1023,15 @@ impl hal::Device<Backend> for Device {
         })
     }
 
-    fn create_pipeline_cache(&self) -> Result<n::PipelineCache, OutOfMemory> {
+    unsafe fn create_pipeline_cache(&self, _data: Option<&[u8]>) -> Result<n::PipelineCache, OutOfMemory> {
         Ok(n::PipelineCache {
             modules: FastStorageMap::default(),
         })
+    }
+
+    unsafe fn get_pipeline_cache_data(&self, cache: &n::PipelineCache) -> Result<Vec<u8>, OutOfMemory> {
+        //empty
+        Ok(Vec::new())
     }
 
     unsafe fn destroy_pipeline_cache(&self, _cache: n::PipelineCache) {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -459,7 +459,7 @@ impl Device {
             _ => {
                 return Err(ShaderError::CompilationFailed(
                     "shader model not supported".into(),
-                ))
+                ));
             }
         };
         if msl_version > self.shared.private_caps.msl_version {
@@ -1023,13 +1023,19 @@ impl hal::Device<Backend> for Device {
         })
     }
 
-    unsafe fn create_pipeline_cache(&self, _data: Option<&[u8]>) -> Result<n::PipelineCache, OutOfMemory> {
+    unsafe fn create_pipeline_cache(
+        &self,
+        _data: Option<&[u8]>,
+    ) -> Result<n::PipelineCache, OutOfMemory> {
         Ok(n::PipelineCache {
             modules: FastStorageMap::default(),
         })
     }
 
-    unsafe fn get_pipeline_cache_data(&self, cache: &n::PipelineCache) -> Result<Vec<u8>, OutOfMemory> {
+    unsafe fn get_pipeline_cache_data(
+        &self,
+        cache: &n::PipelineCache,
+    ) -> Result<Vec<u8>, OutOfMemory> {
         //empty
         Ok(Vec::new())
     }
@@ -2055,7 +2061,7 @@ impl hal::Device<Backend> for Device {
             None => {
                 return Err(buffer::ViewCreationError::UnsupportedFormat {
                     format: format_maybe,
-                })
+                });
             }
         };
         let format_desc = format.surface_desc();

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -285,7 +285,7 @@ impl d::Device<B> for Device {
         &self,
         data: Option<&[u8]>,
     ) -> Result<n::PipelineCache, d::OutOfMemory> {
-        let (data_len, data) = if let Some(d) =  data {
+        let (data_len, data) = if let Some(d) = data {
             (d.len(), d.as_ptr())
         } else {
             (0_usize, ptr::null())
@@ -309,8 +309,11 @@ impl d::Device<B> for Device {
         }
     }
 
-    unsafe fn get_pipeline_cache_data(&self, cache: &n::PipelineCache) -> Result<Vec<u8>, d::OutOfMemory> {
-        let result = unsafe {self.raw.0.get_pipeline_cache_data(cache.raw) };
+    unsafe fn get_pipeline_cache_data(
+        &self,
+        cache: &n::PipelineCache,
+    ) -> Result<Vec<u8>, d::OutOfMemory> {
+        let result = unsafe { self.raw.0.get_pipeline_cache_data(cache.raw) };
 
         match result {
             Ok(data) => Ok(data),
@@ -1937,10 +1940,10 @@ impl d::Device<B> for Device {
         let swapchain_raw = match result {
             Ok(swapchain_raw) => swapchain_raw,
             Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY) => {
-                return Err(d::OutOfMemory::OutOfHostMemory.into())
+                return Err(d::OutOfMemory::OutOfHostMemory.into());
             }
             Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY) => {
-                return Err(d::OutOfMemory::OutOfDeviceMemory.into())
+                return Err(d::OutOfMemory::OutOfDeviceMemory.into());
             }
             Err(vk::Result::ERROR_DEVICE_LOST) => return Err(d::DeviceLost.into()),
             Err(vk::Result::ERROR_SURFACE_LOST_KHR) => return Err(d::SurfaceLost.into()),
@@ -1953,10 +1956,10 @@ impl d::Device<B> for Device {
         let backbuffer_images = match result {
             Ok(backbuffer_images) => backbuffer_images,
             Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY) => {
-                return Err(d::OutOfMemory::OutOfHostMemory.into())
+                return Err(d::OutOfMemory::OutOfHostMemory.into());
             }
             Err(vk::Result::ERROR_OUT_OF_DEVICE_MEMORY) => {
-                return Err(d::OutOfMemory::OutOfDeviceMemory.into())
+                return Err(d::OutOfMemory::OutOfDeviceMemory.into());
             }
             _ => unreachable!(),
         };

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -819,8 +819,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         if cache_info[2] != self.properties.vendor_id {
             warn!(
                 "Vendor ID mismatch. Device: {:?}, cache: {:?}.",
-                self.properties.vendor_id,
-                cache_info[2],
+                self.properties.vendor_id, cache_info[2],
             );
             return false;
         }
@@ -829,17 +828,16 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         if cache_info[3] != self.properties.device_id {
             warn!(
                 "Device ID mismatch. Device: {:?}, cache: {:?}.",
-                self.properties.device_id,
-                cache_info[3],
+                self.properties.device_id, cache_info[3],
             );
             return false;
         }
 
-        if self.properties.pipeline_cache_uuid != cache[16 .. 16 + vk::UUID_SIZE] {
+        if self.properties.pipeline_cache_uuid != cache[16..16 + vk::UUID_SIZE] {
             warn!(
                 "Pipeline cache UUID mismatch. Device: {:?}, cache: {:?}.",
                 self.properties.pipeline_cache_uuid,
-                &cache[16 .. 16 + vk::UUID_SIZE],
+                &cache[16..16 + vk::UUID_SIZE],
             );
             return false;
         }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -798,6 +798,53 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             max_sampler_anisotropy: limits.max_sampler_anisotropy,
         }
     }
+
+    fn is_valid_cache(&self, cache: &[u8]) -> bool {
+        assert!(cache.len() > 16 + vk::UUID_SIZE);
+        let cache_info: &[u32] = unsafe { slice::from_raw_parts(cache as *const _ as *const _, 4) };
+
+        // header length
+        if cache_info[0] <= 0 {
+            warn!("Bad header length {:?}", cache_info[0]);
+            return false;
+        }
+
+        // cache header version
+        if cache_info[1] != vk::PipelineCacheHeaderVersion::ONE.as_raw() as u32 {
+            warn!("Unsupported cache header version: {:?}", cache_info[1]);
+            return false;
+        }
+
+        // vendor id
+        if cache_info[2] != self.properties.vendor_id {
+            warn!(
+                "Vendor ID mismatch. Device: {:?}, cache: {:?}.",
+                self.properties.vendor_id,
+                cache_info[2],
+            );
+            return false;
+        }
+
+        // device id
+        if cache_info[3] != self.properties.device_id {
+            warn!(
+                "Device ID mismatch. Device: {:?}, cache: {:?}.",
+                self.properties.device_id,
+                cache_info[3],
+            );
+            return false;
+        }
+
+        if self.properties.pipeline_cache_uuid != cache[16 .. 16 + vk::UUID_SIZE] {
+            warn!(
+                "Pipeline cache UUID mismatch. Device: {:?}, cache: {:?}.",
+                self.properties.pipeline_cache_uuid,
+                &cache[16 .. 16 + vk::UUID_SIZE],
+            );
+            return false;
+        }
+        true
+    }
 }
 
 #[doc(hidden)]

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -148,8 +148,7 @@ impl Instance {
                 surface: surface as *mut _,
             };
 
-            unsafe { w_loader.create_wayland_surface(&info, None) }
-                .expect("WaylandSurface failed")
+            unsafe { w_loader.create_wayland_surface(&info, None) }.expect("WaylandSurface failed")
         };
 
         self.create_surface_from_vk_surface_khr(surface, width, height, 1)
@@ -175,8 +174,7 @@ impl Instance {
                 window: window as *const _ as *mut _,
             };
 
-            unsafe { loader.create_android_surface(&info, None) }
-                .expect("AndroidSurface failed")
+            unsafe { loader.create_android_surface(&info, None) }.expect("AndroidSurface failed")
         };
 
         self.create_surface_from_vk_surface_khr(surface, width, height, 1)
@@ -321,10 +319,7 @@ impl hal::Surface<Backend> for Surface {
         let caps = unsafe {
             self.raw
                 .functor
-                .get_physical_device_surface_capabilities(
-                    physical_device.handle,
-                    self.raw.handle,
-                )
+                .get_physical_device_surface_capabilities(physical_device.handle, self.raw.handle)
         }
         .expect("Unable to query surface capabilities");
 
@@ -388,10 +383,7 @@ impl hal::Surface<Backend> for Surface {
         let present_modes = unsafe {
             self.raw
                 .functor
-                .get_physical_device_surface_present_modes(
-                    physical_device.handle,
-                    self.raw.handle,
-                )
+                .get_physical_device_surface_present_modes(physical_device.handle, self.raw.handle)
         }
         .expect("Unable to query present modes");
         let present_modes = present_modes

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -101,6 +101,9 @@ pub trait PhysicalDevice<B: Backend>: Any + Send + Sync {
 
     /// Returns the resource limits of this `Device`.
     fn limits(&self) -> Limits;
+
+    /// Check cache compatibility with the `Device`.
+    fn is_valid_cache(&self, _cache: &[u8]) -> bool { false }
 }
 
 /// Supported physical device types

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -265,8 +265,10 @@ pub trait Device<B: Backend>: Any + Send + Sync {
     unsafe fn destroy_pipeline_layout(&self, layout: B::PipelineLayout);
 
     /// Create a pipeline cache object.
-    //TODO: allow loading from disk
-    fn create_pipeline_cache(&self) -> Result<B::PipelineCache, OutOfMemory>;
+    unsafe fn create_pipeline_cache(&self, data: Option<&[u8]>) -> Result<B::PipelineCache, OutOfMemory>;
+
+    /// Retrieve data from pipeline cache object.
+    unsafe fn get_pipeline_cache_data(&self, cache: &B::PipelineCache) -> Result<Vec<u8>, OutOfMemory>;
 
     /// Merge a number of source pipeline caches into the target one.
     unsafe fn merge_pipeline_caches<I>(


### PR DESCRIPTION
Depends on https://github.com/gfx-rs/gfx/pull/2565

Added the `get_pipeline_cache_data` function to query pipeline cache data from Device. Added the optional `data` member to `create_pipeline_cache` where we can supply the bytes of a loaded cache.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
  - Vulkan (Windows, Linux)
- [ ] `rustfmt` run on changed code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/2566)
<!-- Reviewable:end -->
