### PR TITLE
Dummy surface creation for the empty backend

### DIFF
--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -12,3 +12,4 @@ name = "gfx_backend_empty"
 
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.1" }
+winit = { version = "0.18", optional = true }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -2,6 +2,8 @@
 //! outside of the graphics development environment.
 
 extern crate gfx_hal as hal;
+#[cfg(feature = "winit")]
+extern crate winit;
 
 use hal::range::RangeArg;
 use hal::{
@@ -862,6 +864,11 @@ impl Instance {
     /// Create instance.
     pub fn create(_name: &str, _version: u32) -> Self {
         Instance
+    }
+
+    #[cfg(feature = "winit")]
+    pub fn create_surface(&self, _: &winit::Window) -> Surface {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
Makes it more straightforward to use the empty backend in place of other ones in a complex project.
r? @grovesNL 