### PR TITLE
[vk] remove unnecessary unsafe blocks

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -34,7 +34,7 @@ impl d::Device<B> for Device {
             memory_type_index: mem_type.0 as _,
         };
 
-        let result = unsafe { self.raw.0.allocate_memory(&info, None) };
+        let result = self.raw.0.allocate_memory(&info, None);
 
         match result {
             Ok(memory) => Ok(n::Memory { raw: memory }),
@@ -69,7 +69,7 @@ impl d::Device<B> for Device {
             queue_family_index: family.0 as _,
         };
 
-        let result = unsafe { self.raw.0.create_command_pool(&info, None) };
+        let result = self.raw.0.create_command_pool(&info, None);
 
         match result {
             Ok(pool) => Ok(RawCommandPool {
@@ -83,7 +83,7 @@ impl d::Device<B> for Device {
     }
 
     unsafe fn destroy_command_pool(&self, pool: RawCommandPool) {
-        unsafe { self.raw.0.destroy_command_pool(pool.raw, None) };
+        self.raw.0.destroy_command_pool(pool.raw, None);
     }
 
     unsafe fn create_render_pass<'a, IA, IS, ID>(
@@ -218,7 +218,7 @@ impl d::Device<B> for Device {
             p_dependencies: dependencies.as_ptr(),
         };
 
-        let result = unsafe { self.raw.0.create_render_pass(&info, None) };
+        let result = self.raw.0.create_render_pass(&info, None);
 
         match result {
             Ok(renderpass) => Ok(n::RenderPass {
@@ -271,7 +271,7 @@ impl d::Device<B> for Device {
             p_push_constant_ranges: push_constant_ranges.as_ptr(),
         };
 
-        let result = unsafe { self.raw.0.create_pipeline_layout(&info, None) };
+        let result = self.raw.0.create_pipeline_layout(&info, None);
 
         match result {
             Ok(raw) => Ok(n::PipelineLayout { raw }),
@@ -299,7 +299,7 @@ impl d::Device<B> for Device {
             p_initial_data: data as _,
         };
 
-        let result = unsafe { self.raw.0.create_pipeline_cache(&info, None) };
+        let result = self.raw.0.create_pipeline_cache(&info, None);
 
         match result {
             Ok(raw) => Ok(n::PipelineCache { raw }),
@@ -313,7 +313,7 @@ impl d::Device<B> for Device {
         &self,
         cache: &n::PipelineCache,
     ) -> Result<Vec<u8>, d::OutOfMemory> {
-        let result = unsafe { self.raw.0.get_pipeline_cache_data(cache.raw) };
+        let result = self.raw.0.get_pipeline_cache_data(cache.raw);
 
         match result {
             Ok(data) => Ok(data),
@@ -324,7 +324,7 @@ impl d::Device<B> for Device {
     }
 
     unsafe fn destroy_pipeline_cache(&self, cache: n::PipelineCache) {
-        unsafe { self.raw.0.destroy_pipeline_cache(cache.raw, None) };
+        self.raw.0.destroy_pipeline_cache(cache.raw, None);
     }
 
     unsafe fn merge_pipeline_caches<I>(
@@ -340,14 +340,12 @@ impl d::Device<B> for Device {
             .into_iter()
             .map(|s| s.borrow().raw)
             .collect::<Vec<_>>();
-        let result = unsafe {
-            self.raw.0.fp_v1_0().merge_pipeline_caches(
-                self.raw.0.handle(),
-                target.raw,
-                caches.len() as u32,
-                caches.as_ptr(),
-            )
-        };
+        let result = self.raw.0.fp_v1_0().merge_pipeline_caches(
+            self.raw.0.handle(),
+            target.raw,
+            caches.len() as u32,
+            caches.as_ptr(),
+        );
 
         match result {
             vk::Result::SUCCESS => Ok(()),
@@ -655,7 +653,7 @@ impl d::Device<B> for Device {
                         conv::map_stencil_side(front),
                         conv::map_stencil_side(back),
                     ),
-                    pso::StencilTest::Off => unsafe { mem::zeroed() },
+                    pso::StencilTest::Off => mem::zeroed(),
                 };
                 let (min_depth_bounds, max_depth_bounds) = match desc.baked_states.depth_bounds {
                     Some(ref range) => (range.start, range.end),
@@ -712,7 +710,7 @@ impl d::Device<B> for Device {
                             }
                             pso::BlendState::Off => vk::PipelineColorBlendAttachmentState {
                                 color_write_mask,
-                                ..unsafe { mem::zeroed() }
+                                ..mem::zeroed()
                             },
                         }
                     })
@@ -741,9 +739,7 @@ impl d::Device<B> for Device {
                     p_next: ptr::null(),
                     flags: vk::PipelineDynamicStateCreateFlags::empty(),
                     dynamic_state_count: (dynamic_states.len() - dynamic_state_base) as _,
-                    p_dynamic_states: unsafe {
-                        dynamic_states.as_ptr().offset(dynamic_state_base as _)
-                    },
+                    p_dynamic_states: dynamic_states.as_ptr().offset(dynamic_state_base as _),
                 });
 
                 let (base_handle, base_index) = match desc.parent {
@@ -807,16 +803,14 @@ impl d::Device<B> for Device {
         let result = if valid_infos.is_empty() {
             Ok(Vec::new())
         } else {
-            unsafe {
-                self.raw.0.create_graphics_pipelines(
-                    match cache {
-                        Some(cache) => cache.raw,
-                        None => vk::PipelineCache::null(),
-                    },
-                    &valid_infos,
-                    None,
-                )
-            }
+            self.raw.0.create_graphics_pipelines(
+                match cache {
+                    Some(cache) => cache.raw,
+                    None => vk::PipelineCache::null(),
+                },
+                &valid_infos,
+                None,
+            )
         };
 
         let (pipelines, error) = match result {
@@ -948,16 +942,14 @@ impl d::Device<B> for Device {
         let result = if valid_infos.is_empty() {
             Ok(Vec::new())
         } else {
-            unsafe {
-                self.raw.0.create_compute_pipelines(
-                    match cache {
-                        Some(cache) => cache.raw,
-                        None => vk::PipelineCache::null(),
-                    },
-                    &valid_infos,
-                    None,
-                )
-            }
+            self.raw.0.create_compute_pipelines(
+                match cache {
+                    Some(cache) => cache.raw,
+                    None => vk::PipelineCache::null(),
+                },
+                &valid_infos,
+                None,
+            )
         };
 
         let (pipelines, error) = match result {
@@ -1016,7 +1008,7 @@ impl d::Device<B> for Device {
             layers: extent.depth,
         };
 
-        let result = unsafe { self.raw.0.create_framebuffer(&info, None) };
+        let result = self.raw.0.create_framebuffer(&info, None);
 
         match result {
             Ok(raw) => Ok(n::Framebuffer { raw }),
@@ -1041,7 +1033,7 @@ impl d::Device<B> for Device {
             p_code: spirv_data as *const _ as *const u32,
         };
 
-        let module = unsafe { self.raw.0.create_shader_module(&info, None) };
+        let module = self.raw.0.create_shader_module(&info, None);
 
         match module {
             Ok(raw) => Ok(n::ShaderModule { raw }),
@@ -1108,7 +1100,7 @@ impl d::Device<B> for Device {
             unnormalized_coordinates: vk::FALSE,
         };
 
-        let result = unsafe { self.raw.0.create_sampler(&info, None) };
+        let result = self.raw.0.create_sampler(&info, None);
 
         match result {
             Ok(sampler) => Ok(n::Sampler(sampler)),
@@ -1140,7 +1132,7 @@ impl d::Device<B> for Device {
             p_queue_family_indices: ptr::null(),
         };
 
-        let result = unsafe { self.raw.0.create_buffer(&info, None) };
+        let result = self.raw.0.create_buffer(&info, None);
 
         match result {
             Ok(raw) => Ok(n::Buffer { raw }),
@@ -1170,11 +1162,10 @@ impl d::Device<B> for Device {
         offset: u64,
         buffer: &mut n::Buffer,
     ) -> Result<(), d::BindError> {
-        let result = unsafe {
-            self.raw
-                .0
-                .bind_buffer_memory(buffer.raw, memory.raw, offset)
-        };
+        let result = self
+            .raw
+            .0
+            .bind_buffer_memory(buffer.raw, memory.raw, offset);
 
         match result {
             Ok(()) => Ok(()),
@@ -1205,7 +1196,7 @@ impl d::Device<B> for Device {
             range: size,
         };
 
-        let result = unsafe { self.raw.0.create_buffer_view(&info, None) };
+        let result = self.raw.0.create_buffer_view(&info, None);
 
         match result {
             Ok(raw) => Ok(n::BufferView { raw }),
@@ -1256,7 +1247,7 @@ impl d::Device<B> for Device {
             initial_layout: vk::ImageLayout::UNDEFINED,
         };
 
-        let result = unsafe { self.raw.0.create_image(&info, None) };
+        let result = self.raw.0.create_image(&info, None);
 
         match result {
             Ok(raw) => Ok(n::Image {
@@ -1309,7 +1300,7 @@ impl d::Device<B> for Device {
     ) -> Result<(), d::BindError> {
         // TODO: error handling
         // TODO: check required type
-        let result = unsafe { self.raw.0.bind_image_memory(image.raw, memory.raw, offset) };
+        let result = self.raw.0.bind_image_memory(image.raw, memory.raw, offset);
 
         match result {
             Ok(()) => Ok(()),
@@ -1348,7 +1339,7 @@ impl d::Device<B> for Device {
             subresource_range: conv::map_subresource_range(&range),
         };
 
-        let result = unsafe { self.raw.0.create_image_view(&info, None) };
+        let result = self.raw.0.create_image_view(&info, None);
 
         match result {
             Ok(view) => Ok(n::ImageView {
@@ -1395,7 +1386,7 @@ impl d::Device<B> for Device {
             p_pool_sizes: pools.as_ptr(),
         };
 
-        let result = unsafe { self.raw.0.create_descriptor_pool(&info, None) };
+        let result = self.raw.0.create_descriptor_pool(&info, None);
 
         match result {
             Ok(pool) => Ok(n::DescriptorPool {
@@ -1464,7 +1455,7 @@ impl d::Device<B> for Device {
             p_bindings: raw_bindings.as_ptr(),
         };
 
-        let result = unsafe { self.raw.0.create_descriptor_set_layout(&info, None) };
+        let result = self.raw.0.create_descriptor_set_layout(&info, None);
 
         match result {
             Ok(layout) => Ok(n::DescriptorSetLayout {
@@ -1619,9 +1610,7 @@ impl d::Device<B> for Device {
             })
             .collect::<Vec<_>>();
 
-        unsafe {
-            self.raw.0.update_descriptor_sets(&[], &copies);
-        }
+        self.raw.0.update_descriptor_sets(&[], &copies);
     }
 
     unsafe fn map_memory<R>(&self, memory: &n::Memory, range: R) -> Result<*mut u8, mapping::Error>
@@ -1629,11 +1618,10 @@ impl d::Device<B> for Device {
         R: RangeArg<u64>,
     {
         let (offset, size) = conv::map_range_arg(&range);
-        let result = unsafe {
-            self.raw
-                .0
-                .map_memory(memory.raw, offset, size, vk::MemoryMapFlags::empty())
-        };
+        let result = self
+            .raw
+            .0
+            .map_memory(memory.raw, offset, size, vk::MemoryMapFlags::empty());
 
         match result {
             Ok(ptr) => Ok(ptr as *mut _),
@@ -1649,7 +1637,7 @@ impl d::Device<B> for Device {
     }
 
     unsafe fn unmap_memory(&self, memory: &n::Memory) {
-        unsafe { self.raw.0.unmap_memory(memory.raw) }
+        self.raw.0.unmap_memory(memory.raw)
     }
 
     unsafe fn flush_mapped_memory_ranges<'a, I, R>(&self, ranges: I) -> Result<(), d::OutOfMemory>
@@ -1659,7 +1647,7 @@ impl d::Device<B> for Device {
         R: RangeArg<u64>,
     {
         let ranges = conv::map_memory_ranges(ranges);
-        let result = unsafe { self.raw.0.flush_mapped_memory_ranges(&ranges) };
+        let result = self.raw.0.flush_mapped_memory_ranges(&ranges);
 
         match result {
             Ok(()) => Ok(()),
@@ -1683,7 +1671,7 @@ impl d::Device<B> for Device {
         R: RangeArg<u64>,
     {
         let ranges = conv::map_memory_ranges(ranges);
-        let result = unsafe { self.raw.0.invalidate_mapped_memory_ranges(&ranges) };
+        let result = self.raw.0.invalidate_mapped_memory_ranges(&ranges);
 
         match result {
             Ok(()) => Ok(()),
@@ -1752,7 +1740,7 @@ impl d::Device<B> for Device {
             .into_iter()
             .map(|fence| fence.borrow().0)
             .collect::<Vec<_>>();
-        let result = unsafe { self.raw.0.reset_fences(&fences) };
+        let result = self.raw.0.reset_fences(&fences);
 
         match result {
             Ok(()) => Ok(()),
@@ -1784,7 +1772,7 @@ impl d::Device<B> for Device {
             d::WaitFor::Any => false,
             d::WaitFor::All => true,
         };
-        let result = unsafe { self.raw.0.wait_for_fences(&fences, all, timeout_ns) };
+        let result = self.raw.0.wait_for_fences(&fences, all, timeout_ns);
         match result {
             Ok(()) => Ok(true),
             Err(vk::Result::TIMEOUT) => Ok(false),
@@ -1800,7 +1788,7 @@ impl d::Device<B> for Device {
     }
 
     unsafe fn get_fence_status(&self, fence: &n::Fence) -> Result<bool, d::DeviceLost> {
-        let result = unsafe { self.raw.0.get_fence_status(fence.0) };
+        let result = self.raw.0.get_fence_status(fence.0);
         match result {
             Ok(()) => Ok(true),
             Err(vk::Result::NOT_READY) => Ok(false),
@@ -1810,9 +1798,7 @@ impl d::Device<B> for Device {
     }
 
     unsafe fn free_memory(&self, memory: n::Memory) {
-        unsafe {
-            self.raw.0.free_memory(memory.raw, None);
-        }
+        self.raw.0.free_memory(memory.raw, None);
     }
 
     unsafe fn create_query_pool(
@@ -1844,7 +1830,7 @@ impl d::Device<B> for Device {
             pipeline_statistics,
         };
 
-        let result = unsafe { self.raw.0.create_query_pool(&info, None) };
+        let result = self.raw.0.create_query_pool(&info, None);
 
         match result {
             Ok(pool) => Ok(n::QueryPool(pool)),
@@ -1866,18 +1852,16 @@ impl d::Device<B> for Device {
         stride: buffer::Offset,
         flags: query::ResultFlags,
     ) -> Result<bool, d::OomOrDeviceLost> {
-        let result = unsafe {
-            self.raw.0.fp_v1_0().get_query_pool_results(
-                self.raw.0.handle(),
-                pool.0,
-                queries.start,
-                queries.end - queries.start,
-                data.len(),
-                data.as_mut_ptr() as *mut _,
-                stride,
-                conv::map_query_result_flags(flags),
-            )
-        };
+        let result = self.raw.0.fp_v1_0().get_query_pool_results(
+            self.raw.0.handle(),
+            pool.0,
+            queries.start,
+            queries.end - queries.start,
+            data.len(),
+            data.as_mut_ptr() as *mut _,
+            stride,
+            conv::map_query_result_flags(flags),
+        );
 
         match result {
             vk::Result::SUCCESS => Ok(true),
@@ -1926,15 +1910,15 @@ impl d::Device<B> for Device {
             composite_alpha: vk::CompositeAlphaFlagsKHR::from_raw(
                 1 << config.composite_alpha as u32,
             ),
-            present_mode: unsafe { mem::transmute(config.present_mode) },
+            present_mode: mem::transmute(config.present_mode),
             clipped: 1,
             old_swapchain,
         };
 
-        let result = unsafe { functor.create_swapchain(&info, None) };
+        let result = functor.create_swapchain(&info, None);
 
         if old_swapchain != vk::SwapchainKHR::null() {
-            unsafe { functor.destroy_swapchain(old_swapchain, None) }
+            functor.destroy_swapchain(old_swapchain, None)
         }
 
         let swapchain_raw = match result {
@@ -1987,105 +1971,71 @@ impl d::Device<B> for Device {
     }
 
     unsafe fn destroy_swapchain(&self, swapchain: w::Swapchain) {
-        unsafe {
-            swapchain.functor.destroy_swapchain(swapchain.raw, None);
-        }
+        swapchain.functor.destroy_swapchain(swapchain.raw, None);
     }
 
     unsafe fn destroy_query_pool(&self, pool: n::QueryPool) {
-        unsafe {
-            self.raw.0.destroy_query_pool(pool.0, None);
-        }
+        self.raw.0.destroy_query_pool(pool.0, None);
     }
 
     unsafe fn destroy_shader_module(&self, module: n::ShaderModule) {
-        unsafe {
-            self.raw.0.destroy_shader_module(module.raw, None);
-        }
+        self.raw.0.destroy_shader_module(module.raw, None);
     }
 
     unsafe fn destroy_render_pass(&self, rp: n::RenderPass) {
-        unsafe {
-            self.raw.0.destroy_render_pass(rp.raw, None);
-        }
+        self.raw.0.destroy_render_pass(rp.raw, None);
     }
 
     unsafe fn destroy_pipeline_layout(&self, pl: n::PipelineLayout) {
-        unsafe {
-            self.raw.0.destroy_pipeline_layout(pl.raw, None);
-        }
+        self.raw.0.destroy_pipeline_layout(pl.raw, None);
     }
 
     unsafe fn destroy_graphics_pipeline(&self, pipeline: n::GraphicsPipeline) {
-        unsafe {
-            self.raw.0.destroy_pipeline(pipeline.0, None);
-        }
+        self.raw.0.destroy_pipeline(pipeline.0, None);
     }
 
     unsafe fn destroy_compute_pipeline(&self, pipeline: n::ComputePipeline) {
-        unsafe {
-            self.raw.0.destroy_pipeline(pipeline.0, None);
-        }
+        self.raw.0.destroy_pipeline(pipeline.0, None);
     }
 
     unsafe fn destroy_framebuffer(&self, fb: n::Framebuffer) {
-        unsafe {
-            self.raw.0.destroy_framebuffer(fb.raw, None);
-        }
+        self.raw.0.destroy_framebuffer(fb.raw, None);
     }
 
     unsafe fn destroy_buffer(&self, buffer: n::Buffer) {
-        unsafe {
-            self.raw.0.destroy_buffer(buffer.raw, None);
-        }
+        self.raw.0.destroy_buffer(buffer.raw, None);
     }
 
     unsafe fn destroy_buffer_view(&self, view: n::BufferView) {
-        unsafe {
-            self.raw.0.destroy_buffer_view(view.raw, None);
-        }
+        self.raw.0.destroy_buffer_view(view.raw, None);
     }
 
     unsafe fn destroy_image(&self, image: n::Image) {
-        unsafe {
-            self.raw.0.destroy_image(image.raw, None);
-        }
+        self.raw.0.destroy_image(image.raw, None);
     }
 
     unsafe fn destroy_image_view(&self, view: n::ImageView) {
-        unsafe {
-            self.raw.0.destroy_image_view(view.view, None);
-        }
+        self.raw.0.destroy_image_view(view.view, None);
     }
 
     unsafe fn destroy_sampler(&self, sampler: n::Sampler) {
-        unsafe {
-            self.raw.0.destroy_sampler(sampler.0, None);
-        }
+        self.raw.0.destroy_sampler(sampler.0, None);
     }
 
     unsafe fn destroy_descriptor_pool(&self, pool: n::DescriptorPool) {
-        unsafe {
-            self.raw.0.destroy_descriptor_pool(pool.raw, None);
-        }
+        self.raw.0.destroy_descriptor_pool(pool.raw, None);
     }
 
     unsafe fn destroy_descriptor_set_layout(&self, layout: n::DescriptorSetLayout) {
-        unsafe {
-            self.raw.0.destroy_descriptor_set_layout(layout.raw, None);
-        }
+        self.raw.0.destroy_descriptor_set_layout(layout.raw, None);
     }
 
     unsafe fn destroy_fence(&self, fence: n::Fence) {
-        unsafe {
-            self.raw.0.destroy_fence(fence.0, None);
-        }
+        self.raw.0.destroy_fence(fence.0, None);
     }
 
     unsafe fn destroy_semaphore(&self, semaphore: n::Semaphore) {
-        unsafe {
-            self.raw.0.destroy_semaphore(semaphore.0, None);
-        }
+        self.raw.0.destroy_semaphore(semaphore.0, None);
     }
 
     fn wait_idle(&self) -> Result<(), HostExecutionError> {

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -127,7 +127,9 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
             p_set_layouts: raw_layouts.as_ptr(),
         };
 
-        unsafe { self.device.0.allocate_descriptor_sets(&info) }
+        self.device
+            .0
+            .allocate_descriptor_sets(&info)
             .map(|sets| {
                 output.extend(
                     sets.into_iter()
@@ -150,19 +152,18 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         self.set_free_vec.clear();
         self.set_free_vec
             .extend(descriptor_sets.into_iter().map(|d| d.raw));
-        unsafe {
-            self.device
-                .0
-                .free_descriptor_sets(self.raw, &self.set_free_vec);
-        }
+        self.device
+            .0
+            .free_descriptor_sets(self.raw, &self.set_free_vec);
     }
 
     unsafe fn reset(&mut self) {
-        assert_eq!(Ok(()), unsafe {
+        assert_eq!(
+            Ok(()),
             self.device
                 .0
                 .reset_descriptor_pool(self.raw, vk::DescriptorPoolResetFlags::empty())
-        });
+        );
     }
 }
 

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -16,11 +16,12 @@ pub struct RawCommandPool {
 
 impl pool::RawCommandPool<Backend> for RawCommandPool {
     unsafe fn reset(&mut self) {
-        assert_eq!(Ok(()), unsafe {
+        assert_eq!(
+            Ok(()),
             self.device
                 .0
                 .reset_command_pool(self.raw, vk::CommandPoolResetFlags::empty())
-        });
+        );
     }
 
     fn allocate_vec(&mut self, num: usize, level: command::RawLevel) -> Vec<CommandBuffer> {

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -429,11 +429,10 @@ impl hal::Swapchain<Backend> for Swapchain {
             hal::FrameSync::Fence(fence) => (vk::Semaphore::null(), fence.0),
         };
 
-        let index = unsafe {
-            // will block if no image is available
-            self.functor
-                .acquire_next_image(self.raw, timeout_ns, semaphore, fence)
-        };
+        // will block if no image is available
+        let index = self
+            .functor
+            .acquire_next_image(self.raw, timeout_ns, semaphore, fence);
 
         match index {
             Ok((i, suboptimal)) => {


### PR DESCRIPTION
Fixes #2585 
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vk
- [x] `rustfmt` run on changed code

cc @msiglreith 