### PR TITLE
[gl] Device type inference enhanced

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -98,7 +98,12 @@ pub enum Command {
     SetPatchSize(gl::types::GLint),
     BindProgram(gl::types::GLuint),
     BindBlendSlot(ColorSlot, pso::ColorBlendDesc),
-    BindAttribute(n::AttributeDesc, gl::types::GLuint, gl::types::GLsizei, gl::types::GLuint),
+    BindAttribute(
+        n::AttributeDesc,
+        gl::types::GLuint,
+        gl::types::GLsizei,
+        gl::types::GLuint,
+    ),
     //UnbindAttribute(n::AttributeDesc),
     CopyBufferToBuffer(n::RawBuffer, n::RawBuffer, command::BufferCopy),
     CopyBufferToTexture(n::RawBuffer, n::Texture, command::BufferImageCopy),
@@ -381,7 +386,12 @@ impl RawCommandBuffer {
                         &self.id,
                         &mut self.memory,
                         &mut self.buf,
-                        Command::BindAttribute(attribute.clone(), handle, desc.stride as _, desc.rate as u32),
+                        Command::BindAttribute(
+                            attribute.clone(),
+                            handle,
+                            desc.stride as _,
+                            desc.rate as u32,
+                        ),
                     );
                 }
                 _ => error!("No vertex buffer description bound at {}", binding),
@@ -673,14 +683,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
                     | ChannelType::Srgb
                     | ChannelType::Uscaled
                     | ChannelType::Iscaled => {
-                        self.push_cmd(Command::ClearBufferColorF(0, unsafe { color.float32 }))
+                        self.push_cmd(Command::ClearBufferColorF(0, color.float32))
                     }
-                    ChannelType::Uint => {
-                        self.push_cmd(Command::ClearBufferColorU(0, unsafe { color.uint32 }))
-                    }
-                    ChannelType::Int => {
-                        self.push_cmd(Command::ClearBufferColorI(0, unsafe { color.int32 }))
-                    }
+                    ChannelType::Uint => self.push_cmd(Command::ClearBufferColorU(0, color.uint32)),
+                    ChannelType::Int => self.push_cmd(Command::ClearBufferColorI(0, color.int32)),
                 }
             }
             None => {
@@ -691,7 +697,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
                 };
 
                 self.push_cmd(Command::BindTexture(0, text));
-                self.push_cmd(Command::ClearTexture(unsafe { color.float32 }));
+                self.push_cmd(Command::ClearTexture(color.float32));
             }
         }
     }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -292,14 +292,14 @@ impl PhysicalDevice {
             "radeon(tm) r6 graphics",
             "radeon(tm) r7 graphics",
             "radeon r7 graphics",
-            "nforce", // All nvidia nforce are integrated
+            "nforce", // all nvidia nforce are integrated
             "tegra",  // all nvidia tegra are integrated
-            "shield",
+            "shield", // all nvidia shield are integrated
             "igp",
             "mali",
             "intel",
         ];
-        // todo Intel will release a discrete gpu soon, and we will need to update this logic when they do
+        // todo: Intel will release a discrete gpu soon, and we will need to update this logic when they do
         let inferred_device_type = if vendor_lower.contains("qualcomm")
             || vendor_lower.contains("intel")
             || strings_that_imply_integrated
@@ -372,25 +372,21 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             .contains(info::LegacyFeatures::SRGB_COLOR)
         {
             // TODO: Find way to emulate this on older Opengl versions.
-            unsafe {
-                gl.Enable(gl::FRAMEBUFFER_SRGB);
-            }
-        }
-        unsafe {
-            gl.PixelStorei(gl::UNPACK_ALIGNMENT, 1);
 
-            if !self.0.info.version.is_embedded {
-                gl.Enable(gl::PROGRAM_POINT_SIZE);
-            }
+            gl.Enable(gl::FRAMEBUFFER_SRGB);
+        }
+
+        gl.PixelStorei(gl::UNPACK_ALIGNMENT, 1);
+
+        if !self.0.info.version.is_embedded {
+            gl.Enable(gl::PROGRAM_POINT_SIZE);
         }
 
         // create main VAO and bind it
         let mut vao = 0;
         if self.0.private_caps.vertex_array {
-            unsafe {
-                gl.GenVertexArrays(1, &mut vao);
-                gl.BindVertexArray(vao);
-            }
+            gl.GenVertexArrays(1, &mut vao);
+            gl.BindVertexArray(vao);
         }
 
         if let Err(err) = self.0.check() {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -297,7 +297,7 @@ impl PhysicalDevice {
             "shield",
             "igp",
             "mali",
-            "intel", 
+            "intel",
         ];
         // todo Intel will release a discrete gpu soon, and we will need to update this logic when they do
         let inferred_device_type = if vendor_lower.contains("qualcomm")

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -554,7 +554,11 @@ impl CommandQueue {
                 }
 
                 if rate != 0 {
-                    if self.share.legacy_features.contains(LegacyFeatures::INSTANCED_ATTRIBUTE_BINDING) {
+                    if self
+                        .share
+                        .legacy_features
+                        .contains(LegacyFeatures::INSTANCED_ATTRIBUTE_BINDING)
+                    {
                         gl.VertexAttribDivisor(location, rate);
                     } else {
                         error!("Binding attribute with instanced input rate is not supported");


### PR DESCRIPTION
While researching how to support vendor id's I came across: http://vulkan.gpuinfo.org/
Which lists hardware and whether it is discrete or integrated.  By cross referencing with the opengl database I was able to expand on the logic for detecting integrated gpus.

Also it will set the vendor id based on the vendor string.

Supporting device id is not practical unless you want to pull in a huge database of strings and ids!

The last commit removes unnecessary unsafe blocks which cleans up the warning spam a lot.


PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends:
- [X] `rustfmt` run on changed code
