### PR TITLE
Fix default `CompositeAlpha` mode

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1438,7 +1438,7 @@ struct SwapchainState<B: Backend> {
 
 impl<B: Backend> SwapchainState<B> {
     unsafe fn new(backend: &mut BackendState<B>, device: Rc<RefCell<DeviceState<B>>>) -> Self {
-        let (caps, formats, _present_modes, _composite_alphas) = backend
+        let (caps, formats, _present_modes) = backend
             .surface
             .compatibility(&device.borrow().physical_device);
         println!("formats: {:?}", formats);

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -364,7 +364,7 @@ fn main() {
             .expect("Can't wait for fence");
     }
 
-    let (caps, formats, _present_modes, _composite_alphas) =
+    let (caps, formats, _present_modes) =
         surface.compatibility(&mut adapter.physical_device);
     println!("formats: {:?}", formats);
     let format = formats.map_or(f::Format::Rgba8Srgb, |formats| {
@@ -598,7 +598,7 @@ fn main() {
         if recreate_swapchain {
             device.wait_idle().unwrap();
 
-            let (caps, formats, _present_modes, _composite_alphas) =
+            let (caps, formats, _present_modes) =
                 surface.compatibility(&mut adapter.physical_device);
             // Verify that previous format still exists so we may reuse it.
             assert!(formats.iter().any(|fs| fs.contains(&format)));

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -23,7 +23,8 @@ use hal::format::ChannelType;
 use hal::queue::{QueueFamilyId, Queues};
 use hal::range::RangeArg;
 use hal::{
-    buffer, command, error, format, image, memory, pass, pso, query, Features, Limits, QueueType,
+    buffer, command, error, format, image, memory, pass, pso, query, CompositeAlpha, Features,
+    Limits, QueueType,
 };
 use hal::{DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount};
 
@@ -680,7 +681,6 @@ impl hal::Surface<Backend> for Surface {
         hal::SurfaceCapabilities,
         Option<Vec<format::Format>>,
         Vec<hal::PresentMode>,
-        Vec<hal::CompositeAlpha>,
     ) {
         let extent = hal::window::Extent2D {
             width: self.width,
@@ -696,6 +696,7 @@ impl hal::Surface<Backend> for Surface {
             extents: extent..extent,
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
+            composite_alpha: CompositeAlpha::INHERIT, //TODO
         };
 
         let formats = vec![
@@ -710,11 +711,8 @@ impl hal::Surface<Backend> for Surface {
         let present_modes = vec![
             hal::PresentMode::Fifo, //TODO
         ];
-        let composite_alphas = vec![
-            hal::CompositeAlpha::Inherit, //TODO
-        ];
 
-        (capabilities, Some(formats), present_modes, composite_alphas)
+        (capabilities, Some(formats), present_modes)
     }
 }
 

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -696,7 +696,7 @@ impl hal::Surface<Backend> for Surface {
             extents: extent..extent,
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
-            composite_alpha: CompositeAlpha::INHERIT, //TODO
+            composite_alpha: CompositeAlpha::OPAQUE, //TODO
         };
 
         let formats = vec![

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -81,7 +81,7 @@ impl hal::Surface<Backend> for Surface {
             extents: extent..extent,
             max_image_layers: 1,
             usage: i::Usage::COLOR_ATTACHMENT | i::Usage::TRANSFER_SRC | i::Usage::TRANSFER_DST,
-            composite_alpha: CompositeAlpha::INHERIT, //TODO
+            composite_alpha: CompositeAlpha::OPAQUE, //TODO
         };
 
         // Sticking to FLIP swap effects for the moment.

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -8,7 +8,7 @@ use winapi::shared::dxgi1_4;
 use winapi::shared::windef::{HWND, RECT};
 use winapi::um::winuser::GetClientRect;
 
-use hal::{self, format as f, image as i};
+use hal::{self, format as f, image as i, CompositeAlpha};
 use {native, resource as r, Backend, Instance, PhysicalDevice, QueueFamily};
 
 use std::os::raw::c_void;
@@ -71,7 +71,6 @@ impl hal::Surface<Backend> for Surface {
         hal::SurfaceCapabilities,
         Option<Vec<f::Format>>,
         Vec<hal::PresentMode>,
-        Vec<hal::CompositeAlpha>,
     ) {
         let (width, height) = self.get_extent();
         let extent = hal::window::Extent2D { width, height };
@@ -82,6 +81,7 @@ impl hal::Surface<Backend> for Surface {
             extents: extent..extent,
             max_image_layers: 1,
             usage: i::Usage::COLOR_ATTACHMENT | i::Usage::TRANSFER_SRC | i::Usage::TRANSFER_DST,
+            composite_alpha: CompositeAlpha::INHERIT, //TODO
         };
 
         // Sticking to FLIP swap effects for the moment.
@@ -99,11 +99,8 @@ impl hal::Surface<Backend> for Surface {
         let present_modes = vec![
             hal::PresentMode::Fifo, //TODO
         ];
-        let composite_alphas = vec![
-            hal::CompositeAlpha::Inherit, //TODO
-        ];
 
-        (capabilities, Some(formats), present_modes, composite_alphas)
+        (capabilities, Some(formats), present_modes)
     }
 }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -836,7 +836,6 @@ impl hal::Surface<Backend> for Surface {
         hal::SurfaceCapabilities,
         Option<Vec<format::Format>>,
         Vec<hal::PresentMode>,
-        Vec<hal::CompositeAlpha>,
     ) {
         unimplemented!()
     }

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -145,7 +145,7 @@ impl hal::Surface<B> for Surface {
             },
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
-            composite_alpha: CompositeAlpha::INHERIT, //TODO
+            composite_alpha: CompositeAlpha::OPAQUE, //TODO
         };
         let present_modes = vec![
             hal::PresentMode::Fifo, //TODO

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -43,7 +43,7 @@
 //! }
 //! ```
 
-use hal::{self, format as f, image};
+use hal::{self, format as f, image, CompositeAlpha};
 
 use {Backend as B, Device, PhysicalDevice, QueueFamily, Starc};
 
@@ -128,7 +128,6 @@ impl hal::Surface<B> for Surface {
         hal::SurfaceCapabilities,
         Option<Vec<f::Format>>,
         Vec<hal::PresentMode>,
-        Vec<hal::CompositeAlpha>,
     ) {
         let ex = get_window_extent(&self.window);
         let extent = hal::window::Extent2D::from(ex);
@@ -146,20 +145,13 @@ impl hal::Surface<B> for Surface {
             },
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
+            composite_alpha: CompositeAlpha::INHERIT, //TODO
         };
         let present_modes = vec![
             hal::PresentMode::Fifo, //TODO
         ];
-        let composite_alphas = vec![
-            hal::CompositeAlpha::Inherit, //TODO
-        ];
 
-        (
-            caps,
-            Some(self.swapchain_formats()),
-            present_modes,
-            composite_alphas,
-        )
+        (caps, Some(self.swapchain_formats()), present_modes)
     }
 
     fn supports_queue_family(&self, _: &QueueFamily) -> bool {

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -9,7 +9,7 @@ use std::thread;
 
 use hal::window::Extent2D;
 use hal::{self, format, image};
-use hal::{Backbuffer, SwapchainConfig};
+use hal::{Backbuffer, SwapchainConfig, CompositeAlpha};
 
 use core_graphics::geometry::{CGRect, CGSize};
 use foreign_types::{ForeignType, ForeignTypeRef};
@@ -264,7 +264,6 @@ impl hal::Surface<Backend> for Surface {
         hal::SurfaceCapabilities,
         Option<Vec<format::Format>>,
         Vec<hal::PresentMode>,
-        Vec<hal::CompositeAlpha>,
     ) {
         let current_extent = if self.main_thread_id == thread::current().id() {
             Some(self.inner.dimensions())
@@ -302,6 +301,7 @@ impl hal::Surface<Backend> for Surface {
                 | image::Usage::SAMPLED
                 | image::Usage::TRANSFER_SRC
                 | image::Usage::TRANSFER_DST,
+            composite_alpha: CompositeAlpha::INHERIT, //TODO
         };
 
         let formats = vec![
@@ -318,11 +318,8 @@ impl hal::Surface<Backend> for Surface {
         } else {
             vec![hal::PresentMode::Fifo]
         };
-        let composite_alphas = vec![
-            hal::CompositeAlpha::Inherit, //TODO
-        ];
 
-        (caps, Some(formats), present_modes, composite_alphas)
+        (caps, Some(formats), present_modes)
     }
 
     fn supports_queue_family(&self, _queue_family: &QueueFamily) -> bool {

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -301,7 +301,7 @@ impl hal::Surface<Backend> for Surface {
                 | image::Usage::SAMPLED
                 | image::Usage::TRANSFER_SRC
                 | image::Usage::TRANSFER_DST,
-            composite_alpha: CompositeAlpha::INHERIT, //TODO
+            composite_alpha: CompositeAlpha::OPAQUE, //TODO
         };
 
         let formats = vec![

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -2,7 +2,7 @@ use ash::vk;
 
 use hal::range::RangeArg;
 use hal::{buffer, command, format, image, pass, pso, query};
-use hal::{Features, IndexType, PresentMode, Primitive};
+use hal::{CompositeAlpha, Features, IndexType, PresentMode, Primitive};
 
 use native as n;
 use std::borrow::Borrow;
@@ -556,6 +556,18 @@ pub fn map_view_capabilities(caps: image::ViewCapabilities) -> vk::ImageCreateFl
     vk::ImageCreateFlags::from_raw(caps.bits())
 }
 
+pub fn map_present_mode(mode: PresentMode) -> vk::PresentModeKHR {
+    vk::PresentModeKHR::from_raw(mode as i32)
+}
+
 pub fn map_vk_present_mode(mode: vk::PresentModeKHR) -> PresentMode {
     unsafe { mem::transmute(mode) }
+}
+
+pub fn map_composite_alpha(composite_alpha: CompositeAlpha) -> vk::CompositeAlphaFlagsKHR {
+    vk::CompositeAlphaFlagsKHR::from_raw(composite_alpha.bits())
+}
+
+pub fn map_vk_composite_alpha(composite_alpha: vk::CompositeAlphaFlagsKHR) -> CompositeAlpha {
+    CompositeAlpha::from_bits_truncate(composite_alpha.as_raw())
 }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1907,10 +1907,8 @@ impl d::Device<B> for Device {
             queue_family_index_count: 0,
             p_queue_family_indices: ptr::null(),
             pre_transform: vk::SurfaceTransformFlagsKHR::IDENTITY,
-            composite_alpha: vk::CompositeAlphaFlagsKHR::from_raw(
-                1 << config.composite_alpha as u32,
-            ),
-            present_mode: mem::transmute(config.present_mode),
+            composite_alpha: conv::map_composite_alpha(config.composite_alpha),
+            present_mode: conv::map_present_mode(config.present_mode),
             clipped: 1,
             old_swapchain,
         };

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -311,10 +311,7 @@ impl hal::Surface<Backend> for Surface {
         hal::SurfaceCapabilities,
         Option<Vec<Format>>,
         Vec<hal::PresentMode>,
-        Vec<hal::CompositeAlpha>,
     ) {
-        use std::mem;
-
         // Capabilities
         let caps = unsafe {
             self.raw
@@ -357,6 +354,7 @@ impl hal::Surface<Backend> for Surface {
             extents: min_extent..max_extent,
             max_image_layers: caps.max_image_array_layers as _,
             usage: conv::map_vk_image_usage(caps.supported_usage_flags),
+            composite_alpha: conv::map_vk_composite_alpha(caps.supported_composite_alpha),
         };
 
         // Swapchain formats
@@ -391,15 +389,7 @@ impl hal::Surface<Backend> for Surface {
             .map(conv::map_vk_present_mode)
             .collect();
 
-        let composite_alphas = (0u32..10u32)
-            .filter(|i| {
-                let flag = vk::CompositeAlphaFlagsKHR::from_raw(1u32 << i);
-                caps.supported_composite_alpha.intersects(flag)
-            })
-            .map(|i| unsafe { mem::transmute(i) })
-            .collect();
-
-        (capabilities, formats, present_modes, composite_alphas)
+        (capabilities, formats, present_modes)
     }
 
     fn supports_queue_family(&self, queue_family: &QueueFamily) -> bool {

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -312,7 +312,7 @@ impl SwapchainConfig {
     pub fn new(width: u32, height: u32, format: Format, image_count: SwapImageIndex) -> Self {
         SwapchainConfig {
             present_mode: PresentMode::Fifo,
-            composite_alpha: CompositeAlpha::INHERIT,
+            composite_alpha: CompositeAlpha::OPAQUE,
             format,
             extent: Extent2D { width, height },
             image_count,
@@ -340,9 +340,17 @@ impl SwapchainConfig {
             }
         };
 
+        let composite_alpha = if caps.composite_alpha.contains(CompositeAlpha::INHERIT) {
+            CompositeAlpha::INHERIT
+        } else if caps.composite_alpha.contains(CompositeAlpha::OPAQUE) {
+            CompositeAlpha::OPAQUE
+        } else {
+            unreachable!("neither INHERIT or OPAQUE CompositeAlpha modes are supported")
+        };
+
         SwapchainConfig {
             present_mode: PresentMode::Fifo,
-            composite_alpha: CompositeAlpha::INHERIT,
+            composite_alpha,
             format,
             extent: clamped_extent,
             image_count: caps.image_count.start,

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -164,6 +164,9 @@ pub struct SurfaceCapabilities {
 
     /// Supported image usage flags.
     pub usage: image::Usage,
+
+    /// A bitmask of supported alpha composition modes.
+    pub composite_alpha: CompositeAlpha,
 }
 
 /// A `Surface` abstracts the surface of a native window, which will be presented
@@ -191,12 +194,7 @@ pub trait Surface<B: Backend>: Any + Send + Sync {
     fn compatibility(
         &self,
         physical_device: &B::PhysicalDevice,
-    ) -> (
-        SurfaceCapabilities,
-        Option<Vec<Format>>,
-        Vec<PresentMode>,
-        Vec<CompositeAlpha>,
-    );
+    ) -> (SurfaceCapabilities, Option<Vec<Format>>, Vec<PresentMode>);
 }
 
 /// Index of an image in the swapchain.
@@ -236,19 +234,35 @@ pub enum PresentMode {
     Relaxed = 3,
 }
 
-/// Specifies the composition of the swapchain with regards to alpha component.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
-pub enum CompositeAlpha {
-    /// Ignore alpha and treat it as 1.0 at all times.
-    Opaque = 0,
-    /// Use the alpha, expect the color to already be multiplied by it.
-    PreMultiplied = 1,
-    /// Use the alpha, let the compositor multiply the color by it.
-    PostMultiplied = 2,
-    /// Default to native system settings.
-    Inherit = 3,
-}
+bitflags!(
+    /// Specifies how the alpha channel of the images should be handled during
+    /// compositing.
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct CompositeAlpha: u32 {
+        /// The alpha channel, if it exists, of the images is ignored in the
+        /// compositing process. Instead, the image is treated as if it has a
+        /// constant alpha of 1.0.
+        const OPAQUE = 0x1;
+        /// The alpha channel, if it exists, of the images is respected in the
+        /// compositing process. The non-alpha channels of the image are
+        /// expected to already be multiplied by the alpha channel by the
+        /// application.
+        const PREMULTIPLIED = 0x2;
+        /// The alpha channel, if it exists, of the images is respected in the
+        /// compositing process. The non-alpha channels of the image are not
+        /// expected to already be multiplied by the alpha channel by the
+        /// application; instead, the compositor will multiply the non-alpha
+        /// channels of the image by the alpha channel during compositing.
+        const POSTMULTIPLIED = 0x4;
+        /// The way in which the presentation engine treats the alpha channel in
+        /// the images is unknown to gfx-hal. Instead, the application is
+        /// responsible for setting the composite alpha blending mode using
+        /// native window system commands. If the application does not set the
+        /// blending mode using native window system commands, then a
+        /// platform-specific default will be used.
+        const INHERIT = 0x8;
+    }
+);
 
 /// Contains all the data necessary to create a new `Swapchain`:
 /// color, depth, and number of images.
@@ -298,7 +312,7 @@ impl SwapchainConfig {
     pub fn new(width: u32, height: u32, format: Format, image_count: SwapImageIndex) -> Self {
         SwapchainConfig {
             present_mode: PresentMode::Fifo,
-            composite_alpha: CompositeAlpha::Inherit,
+            composite_alpha: CompositeAlpha::INHERIT,
             format,
             extent: Extent2D { width, height },
             image_count,
@@ -328,7 +342,7 @@ impl SwapchainConfig {
 
         SwapchainConfig {
             present_mode: PresentMode::Fifo,
-            composite_alpha: CompositeAlpha::Inherit,
+            composite_alpha: CompositeAlpha::INHERIT,
             format,
             extent: clamped_extent,
             image_count: caps.image_count.start,


### PR DESCRIPTION
Fixes #2583 
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vk, mtl, dx12, gl
- [x] `rustfmt` run on changed code
