### PR TITLE
[mtl] fix DPI handling in surface extents

### DIFF
--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -107,7 +107,8 @@ impl SurfaceInner {
         let size = match self.view {
             Some(view) => unsafe {
                 let bounds: CGRect = msg_send![view.as_ptr(), bounds];
-                bounds.size
+                let backing_bounds: CGRect = msg_send![view.as_ptr(), convertRectToBacking: bounds];
+                backing_bounds.size
             },
             None => unsafe { msg_send![*self.render_layer.lock(), drawableSize] },
         };


### PR DESCRIPTION
On macOS with a Retina display, the surface `compatibility()` function was returning a non-DPI scaled value for `current_extent` (e.g. 640x360 when we were expecting 1280x720), which is not consistent with the behaviour on Windows, where a DPI-scaled value is returned.

My understanding is that the cause of this is that `NSView` `bounds` returns a value in "points" and you're meant to use `convertRectToBacking` to convert the value to pixels. Someone familiar with this backend, please review.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: mtl
- [x] `rustfmt` run on changed code
