### PR TITLE
Use enum for vertex input rate

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -51,7 +51,7 @@ use hal::{
 
 use hal::format::{AsFormat, ChannelType, Rgba8Srgb as ColorFormat, Swizzle};
 use hal::pass::Subpass;
-use hal::pso::{PipelineStage, ShaderStageFlags};
+use hal::pso::{PipelineStage, ShaderStageFlags, VertexInputRate};
 use hal::queue::Submission;
 
 const ENTRY_NAME: &str = "main";
@@ -1381,7 +1381,7 @@ impl<B: Backend> PipelineState<B> {
                 pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
                     binding: 0,
                     stride: size_of::<Vertex>() as u32,
-                    rate: 0,
+                    rate: VertexInputRate::Vertex,
                 });
 
                 pipeline_desc.attributes.push(pso::AttributeDesc {

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -25,7 +25,7 @@ extern crate winit;
 
 use hal::format::{AsFormat, ChannelType, Rgba8Srgb as ColorFormat, Swizzle};
 use hal::pass::Subpass;
-use hal::pso::{PipelineStage, ShaderStageFlags};
+use hal::pso::{PipelineStage, ShaderStageFlags, VertexInputRate};
 use hal::queue::Submission;
 use hal::{
     buffer, command, format as f, image as i, memory as m, pass, pool, pso, window::Extent2D,
@@ -364,8 +364,7 @@ fn main() {
             .expect("Can't wait for fence");
     }
 
-    let (caps, formats, _present_modes) =
-        surface.compatibility(&mut adapter.physical_device);
+    let (caps, formats, _present_modes) = surface.compatibility(&mut adapter.physical_device);
     println!("formats: {:?}", formats);
     let format = formats.map_or(f::Format::Rgba8Srgb, |formats| {
         formats
@@ -514,7 +513,7 @@ fn main() {
             pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
                 binding: 0,
                 stride: std::mem::size_of::<Vertex>() as u32,
-                rate: 0,
+                rate: VertexInputRate::Vertex,
             });
 
             pipeline_desc.attributes.push(pso::AttributeDesc {

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1,4 +1,5 @@
 use hal;
+use hal::pso::VertexInputRate;
 use hal::queue::QueueFamilyId;
 use hal::range::RangeArg;
 use hal::{buffer, device, error, format, image, mapping, memory, pass, pool, pso, query};
@@ -184,9 +185,9 @@ impl Device {
                     }
                 };
 
-                let slot_class = match buffer_desc.rate {
-                    0 => d3d11::D3D11_INPUT_PER_VERTEX_DATA,
-                    _ => d3d11::D3D11_INPUT_PER_INSTANCE_DATA,
+                let (slot_class, step_rate) = match buffer_desc.rate {
+                    VertexInputRate::Vertex => (d3d11::D3D11_INPUT_PER_VERTEX_DATA, 0),
+                    VertexInputRate::Instance(divisor) => (d3d11::D3D11_INPUT_PER_INSTANCE_DATA, divisor)
                 };
                 let format = attrib.element.format;
 
@@ -204,7 +205,7 @@ impl Device {
                     InputSlot: attrib.binding as _,
                     AlignedByteOffset: attrib.element.offset,
                     InputSlotClass: slot_class,
-                    InstanceDataStepRate: buffer_desc.rate as _,
+                    InstanceDataStepRate: step_rate as _,
                 }))
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -390,7 +390,7 @@ impl RawCommandBuffer {
                             attribute.clone(),
                             handle,
                             desc.stride as _,
-                            desc.rate as u32,
+                            desc.rate.as_uint() as u32,
                         ),
                     );
                 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -21,6 +21,7 @@ use hal::device::{
 };
 use hal::memory::Properties;
 use hal::pool::CommandPoolCreateFlags;
+use hal::pso::VertexInputRate;
 use hal::queue::{QueueFamilyId, Queues};
 use hal::range::RangeArg;
 use hal::{self, buffer, error, format, image, mapping, memory, pass, pso, query, window};
@@ -1289,11 +1290,14 @@ impl hal::Device<Backend> for Device {
             }
             if vb.stride != 0 {
                 mtl_buffer_desc.set_stride(vb.stride as u64);
-                if vb.rate == 0 {
-                    mtl_buffer_desc.set_step_function(MTLVertexStepFunction::PerVertex);
-                } else {
-                    mtl_buffer_desc.set_step_function(MTLVertexStepFunction::PerInstance);
-                    mtl_buffer_desc.set_step_rate(vb.rate as u64);
+                match vb.rate {
+                    VertexInputRate::Vertex => {
+                        mtl_buffer_desc.set_step_function(MTLVertexStepFunction::PerVertex);
+                    }
+                    VertexInputRate::Instance(divisor) => {
+                        mtl_buffer_desc.set_step_function(MTLVertexStepFunction::PerInstance);
+                        mtl_buffer_desc.set_step_rate(divisor as u64);
+                    }
                 }
             } else {
                 mtl_buffer_desc.set_stride(256); // big enough to fit all the elements

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -7,6 +7,7 @@ use hal;
 use hal::error::HostExecutionError;
 use hal::memory::Requirements;
 use hal::pool::CommandPoolCreateFlags;
+use hal::pso::VertexInputRate;
 use hal::range::RangeArg;
 use hal::{buffer, device as d, format, image, mapping, pass, pso, query, queue};
 use hal::{Backbuffer, Features, MemoryTypeId, SwapchainConfig};
@@ -477,10 +478,12 @@ impl d::Device<B> for Device {
                         vertex_bindings.push(vk::VertexInputBindingDescription {
                             binding: vbuf.binding,
                             stride: vbuf.stride as u32,
-                            input_rate: if vbuf.rate == 0 {
-                                vk::VertexInputRate::VERTEX
-                            } else {
-                                vk::VertexInputRate::INSTANCE
+                            input_rate: match vbuf.rate {
+                                VertexInputRate::Vertex => vk::VertexInputRate::VERTEX,
+                                VertexInputRate::Instance(divisor) => {
+                                    debug_assert_eq!(divisor, 1, "Custom vertex rate divisors not supported in Vulkan backend without extension");
+                                    vk::VertexInputRate::INSTANCE
+                                },
                             },
                         });
                     }

--- a/src/hal/src/pso/input_assembler.rs
+++ b/src/hal/src/pso/input_assembler.rs
@@ -12,8 +12,28 @@ pub type BufferIndex = u32;
 pub type ElemOffset = u32;
 /// Offset between attribute values, in bytes
 pub type ElemStride = u32;
-/// The number of instances between each subsequent attribute value
+/// Number of instances between each advancement of the vertex buffer.
 pub type InstanceRate = u8;
+
+/// The rate at which to advance input data to shaders for the given buffer
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum VertexInputRate {
+    /// Advance the buffer after every vertex
+    Vertex,
+    /// Advance the buffer after every instance
+    Instance(InstanceRate),
+}
+
+impl VertexInputRate {
+    /// Get the numeric representation of the rate
+    pub fn as_uint(&self) -> u8 {
+        match *self {
+            VertexInputRate::Vertex => 0,
+            VertexInputRate::Instance(divisor) => divisor,
+        }
+    }
+}
 
 /// A struct element descriptor.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -34,8 +54,11 @@ pub struct VertexBufferDesc {
     /// Total container size, in bytes.
     /// Specifies the byte distance between two consecutive elements.
     pub stride: ElemStride,
-    /// Rate of the input for the given buffer
-    pub rate: InstanceRate,
+    /// The rate at which to advance data for the given buffer
+    ///
+    /// i.e. the rate at which data passed to shaders will get advanced by
+    /// `stride` bytes
+    pub rate: VertexInputRate,
 }
 
 /// PSO vertex attribute descriptor


### PR DESCRIPTION
Vulkan doesn't support input rates > 1 (instance rate). This PR changes the `VertexBufferDesc` rate to be an enum between `Vertex` and `Instance` to match Vulkan spec. Previously it was allowed to use a number > 1 and it would be properly passed through to the metal/dx12/dx11 backends, but there is no emulation for the Vulkan backend so it would create inconsistent behavior. 

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan, dx12, gl
- [x] `rustfmt` run on changed code
