### PR TITLE
[hal-0.1] back-port fixes in dx12 and empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
       osx_image: xcode9
       rust: nightly
 
+    # Windows 64bit
+    - os: windows
+      rust: stable
+
 branches:
   except:
     - staging.tmp
@@ -56,6 +60,7 @@ before_install:
   # see https://docs.travis-ci.com/user/trusty-ci-environment/
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && make travis-sdl2 && export CXX=g++-5; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update && brew install sdl2; fi
+  - if [[ $TRAVIS_OS_NAME == "windows" ]]; then choco install make; fi
   - rustup self update
   - rustup target add $TARGET; true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: rust
 cache:
-  cargo: true
   directories:
-   - $HOME/deps
+   - $HOME/.cargo
+before-cache:
+  - rm -rf $HOME/.cargo/registry
 
 matrix:
   include:

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
   "continuous-integration/travis-ci/push",
-  "continuous-integration/appveyor/branch"
+# "continuous-integration/appveyor/branch"
 ]
 
 timeout_sec = 18000 # 5 hours

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.1.0"
+version = "0.1.1"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2867,16 +2867,18 @@ impl d::Device<B> for Device {
         }
     }
 
-    unsafe fn get_fence_status(&self, _fence: &r::Fence) -> Result<bool, d::DeviceLost> {
-        unimplemented!()
+    unsafe fn get_fence_status(&self, fence: &r::Fence) -> Result<bool, d::DeviceLost> {
+        match fence.raw.GetCompletedValue() {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(d::DeviceLost),
+        }
     }
 
     unsafe fn free_memory(&self, memory: r::Memory) {
-        unsafe {
-            memory.heap.destroy();
-            if let Some(buffer) = memory.resource {
-                buffer.destroy();
-            }
+        memory.heap.destroy();
+        if let Some(buffer) = memory.resource {
+            buffer.destroy();
         }
     }
 

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-empty"
-version = "0.1.0"
+version = "0.1.1"
 description = "Empty backend for gfx-rs"
 license = "MIT OR Apache-2.0"
 authors = ["The Gfx-rs Developers"]

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -12,3 +12,4 @@ name = "gfx_backend_empty"
 
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.1" }
+winit = { version = "0.18", optional = true }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -2,6 +2,8 @@
 //! outside of the graphics development environment.
 
 extern crate gfx_hal as hal;
+#[cfg(feature = "winit")]
+extern crate winit;
 
 use std::borrow::Borrow;
 use std::ops::Range;
@@ -839,6 +841,11 @@ impl Instance {
     /// Create instance.
     pub fn create(_name: &str, _version: u32) -> Self {
         Instance
+    }
+
+    #[cfg(feature = "winit")]
+    pub fn create_surface(&self, _: &winit::Window) -> Surface {
+        unimplemented!()
     }
 }
 

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -221,12 +221,12 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                         })
                         .unwrap()
                         .into();
-                    let memory = unsafe {
+                    let gpu_memory = unsafe {
                         device.allocate_memory(memory_type, requirements.size)
                     }.unwrap();
 
                     unsafe {
-                        device.bind_buffer_memory(&memory, 0, &mut buffer)
+                        device.bind_buffer_memory(&gpu_memory, 0, &mut buffer)
                         .unwrap();
                     }
 
@@ -260,7 +260,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                         }.unwrap();
 
                         unsafe {
-                        device.bind_buffer_memory(&memory, 0, &mut upload_buffer)
+                            device.bind_buffer_memory(&upload_memory, 0, &mut upload_buffer)
                         }.unwrap();
                         // write the data
                         unsafe {
@@ -311,7 +311,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
 
                     resources.buffers.insert(name.clone(), Buffer {
                         handle: buffer,
-                        _memory: memory,
+                        _memory: gpu_memory,
                         size,
                         stable_state,
                     });
@@ -335,11 +335,11 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                         })
                         .unwrap()
                         .into();
-                    let memory = unsafe {
+                    let gpu_memory = unsafe {
                         device.allocate_memory(memory_type, requirements.size)
                     }.unwrap();
                     unsafe {
-                        device.bind_image_memory(&memory, 0, &mut image)
+                        device.bind_image_memory(&gpu_memory, 0, &mut image)
                     }.unwrap();
 
                     // process initial data for the image
@@ -473,7 +473,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
 
                     resources.images.insert(name.clone(), Image {
                         handle: image,
-                        _memory: memory,
+                        _memory: gpu_memory,
                         kind,
                         format,
                         range: COLOR_RANGE.clone(),


### PR DESCRIPTION
Backports a few essential changes in dx12 and empty backends.
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
