### PR TITLE
Added panic for attempting to render an image descriptor set to a surface

### DIFF
--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1381,7 +1381,9 @@ impl d::Device<B> for Device {
                         n::ImageView::Texture(tex, _) | n::ImageView::TextureLayer(tex, _, _) => {
                             bindings.push(n::DescSetBindings::Texture(binding, *tex))
                         }
-                        n::ImageView::Surface(_) => unimplemented!(),
+                        n::ImageView::Surface(_) => panic!(
+                            "Texture was created with only render target usage which is invalid."
+                        ),
                     },
                     pso::Descriptor::Sampler(sampler) => match sampler {
                         n::FatSampler::Sampler(sampler) => {


### PR DESCRIPTION
Fixes #2376 by letting them know they are misusing the API.
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: gl
- [x] `rustfmt` run on changed code
