### PR TITLE
Add enumerate_adapters_by_gpu_preference

### DIFF
--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -26,5 +26,5 @@ d3d12 = "0.1"
 log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = "0.12.1"
-winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
+winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.18", optional = true }


### PR DESCRIPTION
Adds a method for enumerating the GPUs ordered by preference on Windows 10 v1803+ with the Direct3D 12 backend. Simply returns None on lower versions of the platform.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12 (quad, colour-uniform, compute)
- [x] `rustfmt` run on changed code
