### PR TITLE
[mtl] improve literal readability

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2340,7 +2340,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             None => base_range.end,
         };
 
-        if (data & 0xFF) * 0x1010101 == data {
+        if (data & 0xFF) * 0x0101_0101 == data {
             let command = soft::BlitCommand::FillBuffer {
                 dst: AsNative::from(raw),
                 range: start..end,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1500,9 +1500,9 @@ impl hal::Device<Backend> for Device {
         }
         if [r, s, t].iter().any(|&am| am == image::WrapMode::Border) {
             descriptor.set_border_color(match info.border.0 {
-                0x00000000 => MTLSamplerBorderColor::TransparentBlack,
-                0x000000FF => MTLSamplerBorderColor::OpaqueBlack,
-                0xFFFFFFFF => MTLSamplerBorderColor::OpaqueWhite,
+                0x0000_0000 => MTLSamplerBorderColor::TransparentBlack,
+                0x0000_00FF => MTLSamplerBorderColor::OpaqueBlack,
+                0xFFFF_FFFF => MTLSamplerBorderColor::OpaqueWhite,
                 other => {
                     error!("Border color 0x{:X} is not supported", other);
                     MTLSamplerBorderColor::TransparentBlack


### PR DESCRIPTION
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [x] `rustfmt` run on changed code
