### PR TITLE
Improve frame synchronization in quad example

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -298,10 +298,8 @@ fn main() {
         ]);
     }
 
-    let mut frame_semaphore = device.create_semaphore().expect("Can't create semaphore");
-    let mut frame_fence = device.create_fence(false).expect("Can't create fence"); // TODO: remove
-
     // copy buffer to texture
+    let mut copy_fence = device.create_fence(false).expect("Could not create fence");
     unsafe {
         let mut cmd_buffer = command_pool.acquire_command_buffer::<command::OneShot>();
         cmd_buffer.begin();
@@ -357,11 +355,15 @@ fn main() {
 
         cmd_buffer.finish();
 
-        queue_group.queues[0].submit_nosemaphores(Some(&cmd_buffer), Some(&mut frame_fence));
+        queue_group.queues[0].submit_nosemaphores(Some(&cmd_buffer), Some(&mut copy_fence));
 
         device
-            .wait_for_fence(&frame_fence, !0)
+            .wait_for_fence(&copy_fence, !0)
             .expect("Can't wait for fence");
+    }
+
+    unsafe {
+        device.destroy_fence(copy_fence);
     }
 
     let (caps, formats, _present_modes) = surface.compatibility(&mut adapter.physical_device);
@@ -441,6 +443,63 @@ fn main() {
         }
         Backbuffer::Framebuffer(fbo) => (Vec::new(), vec![fbo]),
     };
+
+    // Define maximum number of frames we want to be able to be "in flight" (being computed
+    // simultaneously) at once
+    let frames_in_flight = 3;
+
+    // Number of image acquisition semaphores is based on the number of swapchain images, not frames in flight,
+    // plus one extra which we can guarantee is unused at any given time by swapping it out with the ones
+    // in the rest of the queue.
+    let mut image_acquire_semaphores = Vec::with_capacity(frame_images.len());
+    let mut free_acquire_semaphore = device
+        .create_semaphore()
+        .expect("Could not create semaphore");
+
+    // The number of the rest of the resources is based on the frames in flight.
+    let mut submission_complete_semaphores = Vec::with_capacity(frames_in_flight);
+    let mut submission_complete_fences = Vec::with_capacity(frames_in_flight);
+    // Note: We don't really need a different command pool per frame in such a simple demo like this,
+    // but in a more 'real' application, it's generally seen as optimal to have one command pool per
+    // thread per frame. There is a flag that lets a command pool reset individual command buffers
+    // which are created from it, but by default the whole pool (and therefore all buffers in it)
+    // must be reset at once. Furthermore, it is often the case that resetting a whole pool is actually
+    // faster and more efficient for the hardware than resetting individual command buffers, so it's
+    // usually best to just make a command pool for each set of buffers which need to be reset at the
+    // same time (each frame). In our case, each pool will only have one command buffer created from it,
+    // though.
+    let mut cmd_pools = Vec::with_capacity(frames_in_flight);
+    let mut cmd_buffers = Vec::with_capacity(frames_in_flight);
+
+    cmd_pools.push(command_pool);
+    for _ in 1..frames_in_flight {
+        unsafe {
+            cmd_pools.push(
+                device
+                    .create_command_pool_typed(&queue_group, pool::CommandPoolCreateFlags::empty())
+                    .expect("Can't create command pool"),
+            );
+        }
+    }
+
+    for i in 0..frames_in_flight {
+        image_acquire_semaphores.push(
+            device
+                .create_semaphore()
+                .expect("Could not create semaphore"),
+        );
+        submission_complete_semaphores.push(
+            device
+                .create_semaphore()
+                .expect("Could not create semaphore"),
+        );
+        submission_complete_fences.push(
+            device
+                .create_fence(true)
+                .expect("Could not create semaphore"),
+        );
+        cmd_buffers.push(cmd_pools[i].acquire_command_buffer::<command::MultiShot>());
+    }
 
     let pipeline_layout = unsafe {
         device.create_pipeline_layout(
@@ -564,6 +623,7 @@ fn main() {
         width: 0,
         height: 0,
     };
+    let mut frame: u64 = 0;
     while running {
         events_loop.poll_events(|event| {
             if let winit::Event::WindowEvent { event, .. } = event {
@@ -660,11 +720,11 @@ fn main() {
             recreate_swapchain = false;
         }
 
-        let frame: hal::SwapImageIndex = unsafe {
-            device.reset_fence(&frame_fence).unwrap();
-            command_pool.reset();
-            match swap_chain.acquire_image(!0, FrameSync::Semaphore(&mut frame_semaphore)) {
-                Ok(i) => i,
+        // Use guaranteed unused acquire semaphore to get the index of the next frame we will render to
+        // by using acquire_image
+        let swap_image = unsafe {
+            match swap_chain.acquire_image(!0, FrameSync::Semaphore(&free_acquire_semaphore)) {
+                Ok(i) => i as usize,
                 Err(_) => {
                     recreate_swapchain = true;
                     continue;
@@ -672,10 +732,36 @@ fn main() {
             }
         };
 
-        // Rendering
-        let mut cmd_buffer = command_pool.acquire_command_buffer::<command::OneShot>();
+        // Swap the acquire semaphore with the one previously associated with the image we are acquiring
+        core::mem::swap(
+            &mut free_acquire_semaphore,
+            &mut image_acquire_semaphores[swap_image],
+        );
+
+        // Compute index into our resource ring buffers based on the frame number
+        // and number of frames in flight. Pay close attention to where this index is needed
+        // versus when the swapchain image index we got from acquire_image is needed.
+        let frame_idx = frame as usize % frames_in_flight;
+
+        // Wait for the fence of the previous submission of this frame and reset it; ensures we are
+        // submitting only up to maximum number of frames_in_flight if we are submitting faster than
+        // the gpu can keep up with. This would also guarantee that any resources which need to be
+        // updated with a CPU->GPU data copy are not in use by the GPU, so we can perform those updates.
+        // In this case there are none to be done, however.
         unsafe {
-            cmd_buffer.begin();
+            device
+                .wait_for_fence(&submission_complete_fences[frame_idx], !0)
+                .expect("Failed to wait for fence");
+            device
+                .reset_fence(&submission_complete_fences[frame_idx])
+                .expect("Failed to reset fence");
+            cmd_pools[frame_idx].reset();
+        }
+
+        // Rendering
+        let cmd_buffer = &mut cmd_buffers[frame_idx];
+        unsafe {
+            cmd_buffer.begin(false);
 
             cmd_buffer.set_viewports(0, &[viewport.clone()]);
             cmd_buffer.set_scissors(0, &[viewport.rect]);
@@ -686,7 +772,7 @@ fn main() {
             {
                 let mut encoder = cmd_buffer.begin_render_pass_inline(
                     &render_pass,
-                    &framebuffers[frame as usize],
+                    &framebuffers[swap_image],
                     viewport.rect,
                     &[command::ClearValue::Color(command::ClearColor::Float([
                         0.8, 0.8, 0.8, 1.0,
@@ -698,27 +784,31 @@ fn main() {
             cmd_buffer.finish();
 
             let submission = Submission {
-                command_buffers: Some(&cmd_buffer),
-                wait_semaphores: Some((&frame_semaphore, PipelineStage::BOTTOM_OF_PIPE)),
-                signal_semaphores: &[],
+                command_buffers: Some(&*cmd_buffer),
+                wait_semaphores: Some((
+                    &image_acquire_semaphores[swap_image],
+                    PipelineStage::COLOR_ATTACHMENT_OUTPUT,
+                )),
+                signal_semaphores: Some(&submission_complete_semaphores[frame_idx]),
             };
-            queue_group.queues[0].submit(submission, Some(&mut frame_fence));
-
-            // TODO: replace with semaphore
-            device.wait_for_fence(&frame_fence, !0).unwrap();
-            command_pool.free(Some(cmd_buffer));
+            queue_group.queues[0].submit(submission, Some(&submission_complete_fences[frame_idx]));
 
             // present frame
-            if let Err(_) = swap_chain.present_nosemaphores(&mut queue_group.queues[0], frame) {
+            if let Err(_) = swap_chain.present(
+                &mut queue_group.queues[0],
+                swap_image as hal::SwapImageIndex,
+                Some(&submission_complete_semaphores[frame_idx]),
+            ) {
                 recreate_swapchain = true;
             }
         }
+        // Increment our frame
+        frame += 1;
     }
 
     // cleanup!
     device.wait_idle().unwrap();
     unsafe {
-        device.destroy_command_pool(command_pool.into_raw());
         device.destroy_descriptor_pool(desc_pool);
         device.destroy_descriptor_set_layout(set_layout);
 
@@ -727,8 +817,19 @@ fn main() {
         device.destroy_image(image_logo);
         device.destroy_image_view(image_srv);
         device.destroy_sampler(sampler);
-        device.destroy_fence(frame_fence);
-        device.destroy_semaphore(frame_semaphore);
+        device.destroy_semaphore(free_acquire_semaphore);
+        for p in cmd_pools {
+            device.destroy_command_pool(p.into_raw());
+        }
+        for s in image_acquire_semaphores {
+            device.destroy_semaphore(s);
+        }
+        for s in submission_complete_semaphores {
+            device.destroy_semaphore(s);
+        }
+        for f in submission_complete_fences {
+            device.destroy_fence(f);
+        }
         device.destroy_render_pass(render_pass);
         device.free_memory(buffer_memory);
         device.free_memory(image_memory);


### PR DESCRIPTION
Fixes TODOs in quad example and demonstrates a more proper method of frame synchronization

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan, DX12
- [x] `rustfmt` run on changed code
