### PR TITLE
Add `DescriptorPoolCreateFlags`

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -188,6 +188,7 @@ impl<B: Backend> RendererState<B> {
                         count: 1,
                     },
                 ],
+                pso::DescriptorPoolCreateFlags::empty(),
             )
             .ok();
 
@@ -200,6 +201,7 @@ impl<B: Backend> RendererState<B> {
                     ty: pso::DescriptorType::UniformBuffer,
                     count: 1,
                 }],
+                pso::DescriptorPoolCreateFlags::empty(),
             )
             .ok();
 

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -96,6 +96,7 @@ fn main() {
                     ty: pso::DescriptorType::StorageBuffer,
                     count: 1,
                 }],
+                pso::DescriptorPoolCreateFlags::empty(),
             )
         }
         .expect("Can't create descriptor pool");

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -161,6 +161,7 @@ fn main() {
                     count: 1,
                 },
             ],
+            pso::DescriptorPoolCreateFlags::empty(),
         )
     }
     .expect("Can't create descriptor pool");

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1868,6 +1868,7 @@ impl hal::Device<Backend> for Device {
         &self,
         _max_sets: usize,
         ranges: I,
+        _flags: pso::DescriptorPoolCreateFlags,
     ) -> Result<DescriptorPool, device::OutOfMemory>
     where
         I: IntoIterator,

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2384,6 +2384,7 @@ impl d::Device<B> for Device {
         &self,
         max_sets: usize,
         descriptor_pools: I,
+        _flags: pso::DescriptorPoolCreateFlags,
     ) -> Result<r::DescriptorPool, d::OutOfMemory>
     where
         I: IntoIterator,

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -290,6 +290,7 @@ impl hal::Device<Backend> for Device {
         &self,
         _: usize,
         _: I,
+        _: pso::DescriptorPoolCreateFlags,
     ) -> Result<DescriptorPool, device::OutOfMemory>
     where
         I: IntoIterator,

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1309,6 +1309,7 @@ impl d::Device<B> for Device {
         &self,
         _: usize,
         _: I,
+        _: pso::DescriptorPoolCreateFlags,
     ) -> Result<n::DescriptorPool, d::OutOfMemory>
     where
         I: IntoIterator,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1625,6 +1625,7 @@ impl hal::Device<Backend> for Device {
         &self,
         _max_sets: usize,
         descriptor_ranges: I,
+        _flags: pso::DescriptorPoolCreateFlags,
     ) -> Result<n::DescriptorPool, OutOfMemory>
     where
         I: IntoIterator,

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -571,3 +571,9 @@ pub fn map_composite_alpha(composite_alpha: CompositeAlpha) -> vk::CompositeAlph
 pub fn map_vk_composite_alpha(composite_alpha: vk::CompositeAlphaFlagsKHR) -> CompositeAlpha {
     CompositeAlpha::from_bits_truncate(composite_alpha.as_raw())
 }
+
+pub fn map_descriptor_pool_create_flags(
+    flags: pso::DescriptorPoolCreateFlags,
+) -> vk::DescriptorPoolCreateFlags {
+    vk::DescriptorPoolCreateFlags::from_raw(flags.bits())
+}

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1363,6 +1363,7 @@ impl d::Device<B> for Device {
         &self,
         max_sets: usize,
         descriptor_pools: T,
+        flags: pso::DescriptorPoolCreateFlags,
     ) -> Result<n::DescriptorPool, d::OutOfMemory>
     where
         T: IntoIterator,
@@ -1382,7 +1383,7 @@ impl d::Device<B> for Device {
         let info = vk::DescriptorPoolCreateInfo {
             s_type: vk::StructureType::DESCRIPTOR_POOL_CREATE_INFO,
             p_next: ptr::null(),
-            flags: vk::DescriptorPoolCreateFlags::empty(), // disallow individual freeing
+            flags: conv::map_descriptor_pool_create_flags(flags),
             max_sets: max_sets as u32,
             pool_size_count: pools.len() as u32,
             p_pool_sizes: pools.as_ptr(),

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -22,6 +22,7 @@ use crate::{Backend, MemoryTypeId};
 use crate::error::HostExecutionError;
 use crate::memory::Requirements;
 use crate::pool::{CommandPool, CommandPoolCreateFlags};
+use crate::pso::DescriptorPoolCreateFlags;
 use crate::queue::{QueueFamilyId, QueueGroup};
 use crate::range::RangeArg;
 use crate::window::{self, Backbuffer, SwapchainConfig};
@@ -483,6 +484,7 @@ pub trait Device<B: Backend>: Any + Send + Sync {
         &self,
         max_sets: usize,
         descriptor_ranges: I,
+        flags: DescriptorPoolCreateFlags,
     ) -> Result<B::DescriptorPool, OutOfMemory>
     where
         I: IntoIterator,

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -243,3 +243,12 @@ pub struct DescriptorSetCopy<'a, B: Backend> {
     pub dst_array_offset: DescriptorArrayIndex,
     pub count: usize,
 }
+
+bitflags! {
+    /// Descriptor pool creation flags.
+    pub struct DescriptorPoolCreateFlags: u32 {
+        /// Specifies that descriptor sets are allowed to be freed from the pool
+        /// individually.
+        const FREE_DESCRIPTOR_SET = 0x1;
+    }
+}

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -602,8 +602,14 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                 } => {
                     assert!(!ranges.is_empty());
                     assert!(capacity > 0);
-                    let pool = unsafe { device.create_descriptor_pool(capacity, ranges) }
-                        .expect("Descriptor pool creation failure!");
+                    let pool = unsafe {
+                        device.create_descriptor_pool(
+                            capacity,
+                            ranges,
+                            pso::DescriptorPoolCreateFlags::empty(),
+                        )
+                    }
+                    .expect("Descriptor pool creation failure!");
                     resources.desc_pools.insert(name.clone(), pool);
                 }
                 _ => {}


### PR DESCRIPTION
Allows specifying `DescriptorPoolCreateFlags::FREE_DESCRIPTOR_SET` on descriptor pool creation to allow individual descriptor sets to be freed with `DescriptorPool::free_sets` without triggering a validation error on the Vulkan backend.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: gl dx12 vulkan metal
- [x] `rustfmt` run on changed code
