### PR TITLE
Fix reftest issue introduced in #2611

### DIFF
--- a/reftests/scenes/vertex-offset.ron
+++ b/reftests/scenes/vertex-offset.ron
@@ -72,7 +72,7 @@
                 VertexBufferDesc(
                     binding: 0,
                     stride: 16,
-                    rate: 0,
+                    rate: Vertex,
                 ),
             ],
             attributes: [
@@ -119,7 +119,7 @@
                 VertexBufferDesc(
                     binding: 0,
                     stride: 16,
-                    rate: 0,
+                    rate: Vertex,
                 ),
             ],
             attributes: [


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [x] `rustfmt` run on changed code
