### PR TITLE
[hal] more succinctly expressed by calling .find(p) instead.

### DIFF
--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -187,12 +187,11 @@ impl<B: Backend> Adapter<B> {
         let requested_family = self
             .queue_families
             .iter()
-            .filter(|family| {
+            .find(|family| {
                 C::supported_by(family.queue_type())
-                    && selector(&family)
+                    && selector(family)
                     && count <= family.max_queues()
-            })
-            .next();
+            });
 
         let priorities = vec![1.0; count];
         let (id, families) = match requested_family {


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
