### PR TITLE
[hal] remove unused lifetimes

### DIFF
--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -103,7 +103,7 @@ impl<B: Backend, C> CommandPool<B, C> {
 
 impl<B: Backend, C: Supports<Graphics>> CommandPool<B, C> {
     /// Allocates a new subpass command buffer from the pool.
-    pub fn acquire_subpass_command_buffer<'a, S: Shot>(&mut self) -> SubpassCommandBuffer<B, S> {
+    pub fn acquire_subpass_command_buffer<S: Shot>(&mut self) -> SubpassCommandBuffer<B, S> {
         let buffer = self.raw.allocate_one(RawLevel::Secondary);
         unsafe { SubpassCommandBuffer::new(buffer) }
     }


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
