### PR TITLE
Implement Drop for Device

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_dx11"
-version = "0.8.0"
+version = "0.8.1"
 description = "DirectX-11 backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -174,6 +174,12 @@ pub struct Device {
     max_resource_count: Option<usize>,
 }
 
+impl Drop for Device {
+    fn drop(&mut self) {
+        unsafe { (*self.context).Release(); }
+    }
+}
+
 static FEATURE_LEVELS: [d3dcommon::D3D_FEATURE_LEVEL; 3] = [
     d3dcommon::D3D_FEATURE_LEVEL_11_0,
     d3dcommon::D3D_FEATURE_LEVEL_10_1,


### PR DESCRIPTION
Device `context` field (`ID3D11DeviceContext`) have to call `.Release()` in `Drop` impl.