### PR TITLE
Implementing missing gl backend functions

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -49,7 +49,7 @@ use std::{fs, iter};
 
 use hal::{
     buffer, command, format as f, image as i, memory as m, pass, pool, pso, window::Extent2D,
-    Adapter, Backend, DescriptorPool, Device, FrameSync, Instance, Limits, MemoryType,
+    Adapter, Backend, DescriptorPool, Device, Instance, Limits, MemoryType,
     PhysicalDevice, Primitive, QueueGroup, Surface, Swapchain, SwapchainConfig,
 };
 

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -33,7 +33,7 @@ use hal::queue::Submission;
 use hal::{
     buffer, command, format as f, image as i, memory as m, pass, pool, pso, window::Extent2D,
 };
-use hal::{DescriptorPool, FrameSync, Primitive, SwapchainConfig};
+use hal::{DescriptorPool, Primitive, SwapchainConfig};
 use hal::{Device, Instance, PhysicalDevice, Surface, Swapchain};
 
 use std::fs;

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -2426,7 +2426,7 @@ impl hal::Device<Backend> for Device {
         surface: &mut Surface,
         config: hal::SwapchainConfig,
         _old_swapchain: Option<Swapchain>,
-    ) -> Result<(Swapchain, hal::Backbuffer<Backend>), hal::window::CreationError> {
+    ) -> Result<(Swapchain, Vec<B::Image>), hal::window::CreationError> {
         // TODO: use IDXGIFactory2 for >=11.1
         // TODO: this function should be able to fail (Result)?
 
@@ -2567,7 +2567,7 @@ impl hal::Device<Backend> for Device {
             Swapchain {
                 dxgi_swapchain: swapchain,
             },
-            hal::Backbuffer::Images(images),
+            images,
         ))
     }
 

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -2426,7 +2426,7 @@ impl hal::Device<Backend> for Device {
         surface: &mut Surface,
         config: hal::SwapchainConfig,
         _old_swapchain: Option<Swapchain>,
-    ) -> Result<(Swapchain, Vec<B::Image>), hal::window::CreationError> {
+    ) -> Result<(Swapchain, Vec<Image>), hal::window::CreationError> {
         // TODO: use IDXGIFactory2 for >=11.1
         // TODO: this function should be able to fail (Result)?
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3008,7 +3008,7 @@ impl d::Device<B> for Device {
         surface: &mut w::Surface,
         config: hal::SwapchainConfig,
         old_swapchain: Option<w::Swapchain>,
-    ) -> Result<(w::Swapchain, hal::Backbuffer<B>), hal::window::CreationError> {
+    ) -> Result<(w::Swapchain, Vec<B::Image>), hal::window::CreationError> {
         if let Some(old_swapchain) = old_swapchain {
             self.destroy_swapchain(old_swapchain);
         }
@@ -3146,7 +3146,7 @@ impl d::Device<B> for Device {
             resources,
         };
 
-        Ok((swapchain, hal::Backbuffer::Images(images)))
+        Ok((swapchain, images))
     }
 
     unsafe fn destroy_swapchain(&self, swapchain: w::Swapchain) {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3008,7 +3008,7 @@ impl d::Device<B> for Device {
         surface: &mut w::Surface,
         config: hal::SwapchainConfig,
         old_swapchain: Option<w::Swapchain>,
-    ) -> Result<(w::Swapchain, Vec<B::Image>), hal::window::CreationError> {
+    ) -> Result<(w::Swapchain, Vec<r::Image>), hal::window::CreationError> {
         if let Some(old_swapchain) = old_swapchain {
             self.destroy_swapchain(old_swapchain);
         }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -455,7 +455,7 @@ impl hal::Device<Backend> for Device {
         _: &mut Surface,
         _: hal::SwapchainConfig,
         _: Option<Swapchain>,
-    ) -> Result<(Swapchain, hal::Backbuffer<Backend>), hal::window::CreationError> {
+    ) -> Result<(Swapchain, Vec<B::Image>), hal::window::CreationError> {
         unimplemented!()
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -455,7 +455,7 @@ impl hal::Device<Backend> for Device {
         _: &mut Surface,
         _: hal::SwapchainConfig,
         _: Option<Swapchain>,
-    ) -> Result<(Swapchain, Vec<B::Image>), hal::window::CreationError> {
+    ) -> Result<(Swapchain, Vec<()>), hal::window::CreationError> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -70,8 +70,8 @@ pub enum Command {
     BindIndexBuffer(gl::types::GLuint),
     //BindVertexBuffers(BufferSlice),
     BindUniform {
-        uniform: n::UniformDesc, 
-        buffer: BufferSlice
+        uniform: n::UniformDesc,
+        buffer: BufferSlice,
     },
     SetViewports {
         first_viewport: u32,
@@ -473,7 +473,7 @@ impl RawCommandBuffer {
 
                             return Some(cmd);
                         }
-                    } 
+                    }
 
                     // Clear depth-stencil target
                     let depth = if view_format.is_depth() {
@@ -1297,7 +1297,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         }
 
         let uniform = if offset == 0 {
-            // If offset is zero, we can just return the first item 
+            // If offset is zero, we can just return the first item
             // in our uniform list
             uniforms.get(0).unwrap()
         } else {
@@ -1318,12 +1318,10 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
             }
 
             needle.unwrap()
-        }.clone();
+        }
+        .clone();
 
-        self.push_cmd(Command::BindUniform {
-            uniform,
-            buffer,
-        });
+        self.push_cmd(Command::BindUniform { uniform, buffer });
     }
 
     unsafe fn push_compute_constants(

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -73,6 +73,13 @@ pub enum Command {
         uniform: n::UniformDesc,
         buffer: BufferSlice,
     },
+    BindRasterizer {
+        rasterizer: pso::Rasterizer,
+        is_embedded: bool,
+    },
+    BindDepth {
+        depth: pso::DepthTest,
+    },
     SetViewports {
         first_viewport: u32,
         viewport_ptr: BufferSlice,
@@ -919,6 +926,8 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
             ref attributes,
             ref vertex_buffers,
             ref uniforms,
+            rasterizer,
+            depth,
         } = *pipeline;
 
         if self.cache.primitive != Some(primitive) {
@@ -944,6 +953,14 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         self.cache.uniforms = uniforms.clone();
 
         self.update_blend_targets(blend_targets);
+
+        self.push_cmd(Command::BindRasterizer { 
+            rasterizer, 
+            is_embedded: false 
+        });
+        self.push_cmd(Command::BindDepth { 
+            depth,
+        });
     }
 
     unsafe fn bind_graphics_descriptor_sets<I, J>(

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1292,8 +1292,8 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         let buffer = self.add(constants);
 
         let uniforms = &self.cache.uniforms;
-        if uniforms.len() == 0 {
-            panic!("No uniforms bound when trying to bind push constant!");
+        if uniforms.is_empty() {
+            unimplemented!()
         }
 
         let uniform = if offset == 0 {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -603,11 +603,7 @@ impl d::Device<B> for Device {
                 let subpass = subpass.borrow();
                 let color_attachments = subpass.colors.iter().map(|&(index, _)| index).collect();
 
-                let depth_stencil = if subpass.depth_stencil.is_some() {
-                    Some(subpass.depth_stencil.unwrap().0)
-                } else {
-                    None
-                };
+                let depth_stencil = subpass.depth_stencil.map(|ds| ds.0);
 
                 n::SubpassDesc {
                     color_attachments,

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -101,7 +101,7 @@ fn create_fbo_internal(share: &Starc<Share>) -> Option<gl::types::GLuint> {
 /// GL device.
 #[derive(Debug)]
 pub struct Device {
-    share: Starc<Share>,
+    pub (crate) share: Starc<Share>,
 }
 
 impl Drop for Device {
@@ -846,6 +846,9 @@ impl d::Device<B> for Device {
             }
         }
 
+        state::bind_rasterizer(gl, &desc.rasterizer, false);
+        state::bind_depth(gl, &desc.depth_stencil.depth);
+
         Ok(n::GraphicsPipeline {
             program,
             primitive: conv::primitive_to_gl_primitive(desc.input_assembler.primitive),
@@ -1212,6 +1215,7 @@ impl d::Device<B> for Device {
         let (int_format, iformat, itype) = match format {
             Format::Rgba8Unorm => (gl::RGBA8, gl::RGBA, gl::UNSIGNED_BYTE),
             Format::Rgba8Srgb => (gl::SRGB8_ALPHA8, gl::RGBA, gl::UNSIGNED_BYTE),
+            Format::D32Sfloat => (gl::DEPTH32F_STENCIL8, gl::DEPTH_STENCIL, gl::FLOAT_32_UNSIGNED_INT_24_8_REV),
             _ => unimplemented!(),
         };
 
@@ -1631,7 +1635,7 @@ impl d::Device<B> for Device {
         surface: &mut Surface,
         config: c::SwapchainConfig,
         _old_swapchain: Option<Swapchain>,
-    ) -> Result<(Swapchain, c::Backbuffer<B>), c::window::CreationError> {
+    ) -> Result<(Swapchain, Vec<n::Image>), c::window::CreationError> {
         Ok(self.create_swapchain_impl(surface, config))
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -822,16 +822,18 @@ impl d::Device<B> for Device {
                 gl::ACTIVE_UNIFORM_MAX_LENGTH,
                 &mut uniform_max_size,
             );
+
+            let mut name = Vec::with_capacity(uniform_max_size as usize);
+            name.set_len(uniform_max_size as usize);
+
             for uniform in 0..count {
                 let mut length = 0;
                 let mut size = 0;
                 let mut utype = 0;
-                let mut name = Vec::with_capacity(uniform_max_size as usize);
-                name.set_len(uniform_max_size as usize - 1);
                 gl.GetActiveUniform(
                     program,
                     uniform as _,
-                    uniform_max_size - 1 as i32,
+                    uniform_max_size as i32,
                     &mut length,
                     &mut size,
                     &mut utype,

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -850,10 +850,7 @@ impl d::Device<B> for Device {
                     });
                 }
             }
-        }
-
-        state::bind_rasterizer(gl, &desc.rasterizer, false);
-        state::bind_depth(gl, &desc.depth_stencil.depth);
+        }        
 
         Ok(n::GraphicsPipeline {
             program,
@@ -878,6 +875,8 @@ impl d::Device<B> for Device {
                 })
                 .collect(),
             uniforms,
+            rasterizer: desc.rasterizer,
+            depth: desc.depth_stencil.depth,
         })
     }
 

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -1,7 +1,7 @@
 use crate::hal::{Features, Limits};
+use crate::{gl, Error, GlContainer};
 use std::collections::HashSet;
 use std::{ffi, fmt, mem, str};
-use crate::{gl, Error, GlContainer};
 
 /// A version number for a specific component of an OpenGL implementation
 #[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -306,6 +306,7 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
     use self::Requirement::*;
     let info = Info::get(gl);
     let max_texture_size = get_usize(gl, gl::MAX_TEXTURE_SIZE).unwrap_or(64) as u32;
+    let max_color_attachments = get_usize(gl, gl::MAX_COLOR_ATTACHMENTS).unwrap_or(8) as u8;
 
     let mut limits = Limits {
         max_image_1d_size: max_texture_size,
@@ -320,6 +321,7 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
         min_texel_buffer_offset_alignment: 1,   // TODO
         min_uniform_buffer_offset_alignment: 1, // TODO
         min_storage_buffer_offset_alignment: 1, // TODO
+        framebuffer_color_samples_count: max_color_attachments,
         ..Limits::default()
     };
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -378,10 +378,6 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
         gl.PixelStorei(gl::UNPACK_ALIGNMENT, 1);
 
-        if !self.0.info.version.is_embedded {
-            gl.Enable(gl::PROGRAM_POINT_SIZE);
-        }
-
         // create main VAO and bind it
         let mut vao = 0;
         if self.0.private_caps.vertex_array {

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -305,7 +305,7 @@ pub struct AttributeDesc {
 #[derive(Clone, Copy, Debug)]
 pub struct UniformDesc {
     pub(crate) location: gl::types::GLuint,
-    pub(crate) size: gl::types::GLint,
+    pub(crate) offset: u32,
     pub(crate) utype: gl::types::GLenum,
 }
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -136,6 +136,8 @@ pub struct GraphicsPipeline {
     pub(crate) attributes: Vec<AttributeDesc>,
     pub(crate) vertex_buffers: Vec<Option<pso::VertexBufferDesc>>,
     pub(crate) uniforms: Vec<UniformDesc>,
+    pub(crate) rasterizer: pso::Rasterizer,
+    pub(crate) depth: pso::DepthTest,
 }
 
 #[derive(Clone, Debug)]

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -272,8 +272,8 @@ pub struct SubpassDesc {
 impl SubpassDesc {
     /// Check if an attachment is used by this sub-pass.
     pub(crate) fn is_using(&self, at_id: pass::AttachmentId) -> bool {
-        self.color_attachments.iter().any(|id| *id == at_id) ||
-        (self.depth_stencil.is_some() && self.depth_stencil.unwrap() == at_id)
+        self.color_attachments.iter().any(|id| *id == at_id)
+            || (self.depth_stencil.is_some() && self.depth_stencil.unwrap() == at_id)
     }
 }
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -273,7 +273,7 @@ impl SubpassDesc {
     /// Check if an attachment is used by this sub-pass.
     pub(crate) fn is_using(&self, at_id: pass::AttachmentId) -> bool {
         self.color_attachments.iter().any(|id| *id == at_id)
-            || (self.depth_stencil.is_some() && self.depth_stencil.unwrap() == at_id)
+        || (self.depth_stencil.is_some() && self.depth_stencil.unwrap() == at_id)
     }
 }
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -274,8 +274,12 @@ pub struct SubpassDesc {
 impl SubpassDesc {
     /// Check if an attachment is used by this sub-pass.
     pub(crate) fn is_using(&self, at_id: pass::AttachmentId) -> bool {
-        self.color_attachments.iter().any(|id| *id == at_id)
-        || (self.depth_stencil.is_some() && self.depth_stencil.unwrap() == at_id)
+        let uses_ds = match self.depth_stencil {
+            Some(ds) => ds == at_id,
+            None => false,
+        };
+        let uses_color = self.color_attachments.iter().any(|id| *id == at_id);
+        uses_color || uses_ds
     }
 }
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -135,6 +135,7 @@ pub struct GraphicsPipeline {
     pub(crate) blend_targets: Vec<pso::ColorBlendDesc>,
     pub(crate) attributes: Vec<AttributeDesc>,
     pub(crate) vertex_buffers: Vec<Option<pso::VertexBufferDesc>>,
+    pub(crate) uniforms: Vec<UniformDesc>,
 }
 
 #[derive(Clone, Debug)]
@@ -265,12 +266,14 @@ pub struct RenderPass {
 #[derive(Clone, Debug)]
 pub struct SubpassDesc {
     pub(crate) color_attachments: Vec<usize>,
+    pub(crate) depth_stencil: Option<usize>,
 }
 
 impl SubpassDesc {
     /// Check if an attachment is used by this sub-pass.
     pub(crate) fn is_using(&self, at_id: pass::AttachmentId) -> bool {
-        self.color_attachments.iter().any(|id| *id == at_id)
+        self.color_attachments.iter().any(|id| *id == at_id) ||
+        (self.depth_stencil.is_some() && self.depth_stencil.unwrap() == at_id)
     }
 }
 
@@ -291,6 +294,13 @@ pub struct AttributeDesc {
     pub(crate) size: gl::types::GLint,
     pub(crate) format: gl::types::GLenum,
     pub(crate) vertex_attrib_fn: VertexAttribFunction,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct UniformDesc {
+    pub(crate) location: gl::types::GLuint,
+    pub(crate) size: gl::types::GLint,
+    pub(crate) utype: gl::types::GLenum,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -2,8 +2,8 @@
 
 use crate::hal::pso;
 use crate::hal::ColorSlot;
-use smallvec::SmallVec;
 use crate::{gl, GlContainer};
+use smallvec::SmallVec;
 
 pub(crate) fn bind_polygon_mode(
     gl: &GlContainer,

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -43,16 +43,10 @@
 //! }
 //! ```
 
-use hal::{
-    self,
-    format as f, image, memory
-    CompositeAlpha,
-};
+use crate::hal::window::Extent2D;
+use crate::hal::{self, format as f, image, memory, CompositeAlpha};
 
-use crate::{
-    native,
-    Backend as B, Device, PhysicalDevice, QueueFamily, Starc
-};
+use crate::{native, Backend as B, Device, PhysicalDevice, QueueFamily, Starc};
 
 use glutin::{self, ContextTrait};
 
@@ -201,7 +195,10 @@ impl Device {
                     let mut name = 0;
                     gl.GenTextures(1, &mut name);
                     match config.extent {
-                        Extent2D { width: w, height: h } => {
+                        Extent2D {
+                            width: w,
+                            height: h,
+                        } => {
                             gl.BindTexture(gl::TEXTURE_2D, name);
                             if self.share.private_caps.image_storage {
                                 gl.TexStorage2D(
@@ -242,7 +239,10 @@ impl Device {
                     let mut name = 0;
                     gl.GenRenderbuffers(1, &mut name);
                     match config.extent {
-                        Extent2D { width: w, height: h }  => {
+                        Extent2D {
+                            width: w,
+                            height: h,
+                        } => {
                             gl.BindRenderbuffer(gl::RENDERBUFFER, name);
                             gl.RenderbufferStorage(gl::RENDERBUFFER, int_format, w as _, h as _);
                         }

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -71,7 +71,9 @@ fn get_window_extent(window: &glutin::WindowedContext) -> image::Extent {
 #[derive(Debug)]
 pub struct Swapchain {
     // Underlying window, required for presentation
-    pub(crate) window: Starc<glutin::WindowedContext>,
+    pub(crate) window: Starc<glutin::GlWindow>,
+    // Extent because the window lies
+    pub(crate) extent: Extent2D,
 }
 
 impl hal::Swapchain<B> for Swapchain {
@@ -176,6 +178,7 @@ impl Device {
         config: hal::SwapchainConfig,
     ) -> (Swapchain, Vec<native::Image>) {
         let swapchain = Swapchain {
+            extent: config.extent,
             window: surface.window.clone(),
         };
 

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -65,7 +65,7 @@ fn get_window_extent(window: &glutin::WindowedContext) -> image::Extent {
 #[derive(Debug)]
 pub struct Swapchain {
     // Underlying window, required for presentation
-    pub(crate) window: Starc<glutin::GlWindow>,
+    pub(crate) window: Starc<glutin::WindowedContext>,
     // Extent because the window lies
     pub(crate) extent: Extent2D,
 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2664,7 +2664,7 @@ impl hal::Device<Backend> for Device {
         surface: &mut Surface,
         config: hal::SwapchainConfig,
         old_swapchain: Option<Swapchain>,
-    ) -> Result<(Swapchain, hal::Backbuffer<Backend>), window::CreationError> {
+    ) -> Result<(Swapchain, Vec<B::Image>), window::CreationError> {
         Ok(self.build_swapchain(surface, config, old_swapchain))
     }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use hal::{
-    buffer, error, format, image, mapping, memory, pass, pso, query, window,
+    buffer, error, format, image, mapping, memory, native, pass, pso, query, window,
     device::{
         AllocationError, BindError, DeviceLost, OomOrDeviceLost, OutOfMemory, ShaderError,
     },
@@ -2664,7 +2664,7 @@ impl hal::Device<Backend> for Device {
         surface: &mut Surface,
         config: hal::SwapchainConfig,
         old_swapchain: Option<Swapchain>,
-    ) -> Result<(Swapchain, Vec<B::Image>), window::CreationError> {
+    ) -> Result<(Swapchain, Vec<native::Image>), window::CreationError> {
         Ok(self.build_swapchain(surface, config, old_swapchain))
     }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use hal::{
-    buffer, error, format, image, mapping, memory, native, pass, pso, query, window,
+    buffer, error, format, image, mapping, memory, pass, pso, query, window,
     device::{
         AllocationError, BindError, DeviceLost, OomOrDeviceLost, OutOfMemory, ShaderError,
     },
@@ -2664,7 +2664,7 @@ impl hal::Device<Backend> for Device {
         surface: &mut Surface,
         config: hal::SwapchainConfig,
         old_swapchain: Option<Swapchain>,
-    ) -> Result<(Swapchain, Vec<native::Image>), window::CreationError> {
+    ) -> Result<(Swapchain, Vec<n::Image>), window::CreationError> {
         Ok(self.build_swapchain(surface, config, old_swapchain))
     }
 

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -7,8 +7,8 @@ use crate::{
 
 use hal::{
     format, image,
-    Backbuffer, SwapchainConfig, CompositeAlpha,
-    window::{Extent2D, PresentError, Suboptimal},
+    SwapchainConfig, CompositeAlpha,
+    window::Extent2D,
 };
 
 use core_graphics::base::CGFloat;
@@ -370,7 +370,7 @@ impl Device {
         surface: &mut Surface,
         config: SwapchainConfig,
         old_swapchain: Option<Swapchain>,
-    ) -> (Swapchain, Backbuffer<Backend>) {
+    ) -> (Swapchain, Vec<B::Image>) {
         info!("build_swapchain {:?}", config);
         if let Some(ref sc) = old_swapchain {
             sc.clear_drawables();
@@ -492,7 +492,7 @@ impl Device {
             acquire_mode: AcquireMode::Oldest,
         };
 
-        (swapchain, Backbuffer::Images(images))
+        (swapchain, images)
     }
 }
 

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -8,7 +8,7 @@ use crate::{
 use hal::{
     format, image,
     SwapchainConfig, CompositeAlpha,
-    window::Extent2D,
+    window::{Extent2D, Suboptimal},
 };
 
 use core_graphics::base::CGFloat;
@@ -370,7 +370,7 @@ impl Device {
         surface: &mut Surface,
         config: SwapchainConfig,
         old_swapchain: Option<Swapchain>,
-    ) -> (Swapchain, Vec<B::Image>) {
+    ) -> (Swapchain, Vec<native::Image>) {
         info!("build_swapchain {:?}", config);
         if let Some(ref sc) = old_swapchain {
             sc.clear_drawables();

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -10,7 +10,7 @@ use hal::pool::CommandPoolCreateFlags;
 use hal::pso::VertexInputRate;
 use hal::range::RangeArg;
 use hal::{buffer, device as d, format, image, mapping, pass, pso, query, queue};
-use hal::{Backbuffer, Features, MemoryTypeId, SwapchainConfig};
+use hal::{Features, MemoryTypeId, SwapchainConfig};
 
 use std::borrow::Borrow;
 use std::ffi::CString;
@@ -1876,7 +1876,7 @@ impl d::Device<B> for Device {
         surface: &mut w::Surface,
         config: SwapchainConfig,
         provided_old_swapchain: Option<w::Swapchain>,
-    ) -> Result<(w::Swapchain, Backbuffer<B>), hal::window::CreationError> {
+    ) -> Result<(w::Swapchain, Vec<B::Image>), hal::window::CreationError> {
         let functor = khr::Swapchain::new(&surface.raw.instance.0, &self.raw.0);
 
         let old_swapchain = match provided_old_swapchain {
@@ -1963,7 +1963,7 @@ impl d::Device<B> for Device {
             })
             .collect();
 
-        Ok((swapchain, Backbuffer::Images(images)))
+        Ok((swapchain, images))
     }
 
     unsafe fn destroy_swapchain(&self, swapchain: w::Swapchain) {

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1876,7 +1876,7 @@ impl d::Device<B> for Device {
         surface: &mut w::Surface,
         config: SwapchainConfig,
         provided_old_swapchain: Option<w::Swapchain>,
-    ) -> Result<(w::Swapchain, Vec<B::Image>), hal::window::CreationError> {
+    ) -> Result<(w::Swapchain, Vec<n::Image>), hal::window::CreationError> {
         let functor = khr::Swapchain::new(&surface.raw.instance.0, &self.raw.0);
 
         let old_swapchain = match provided_old_swapchain {

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -104,7 +104,9 @@ pub trait PhysicalDevice<B: Backend>: fmt::Debug + Any + Send + Sync {
     fn limits(&self) -> Limits;
 
     /// Check cache compatibility with the `Device`.
-    fn is_valid_cache(&self, _cache: &[u8]) -> bool { false }
+    fn is_valid_cache(&self, _cache: &[u8]) -> bool {
+        false
+    }
 }
 
 /// Supported physical device types
@@ -185,14 +187,9 @@ impl<B: Backend> Adapter<B> {
     {
         use crate::queue::QueueFamily;
 
-        let requested_family = self
-            .queue_families
-            .iter()
-            .find(|family| {
-                C::supported_by(family.queue_type())
-                    && selector(family)
-                    && count <= family.max_queues()
-            });
+        let requested_family = self.queue_families.iter().find(|family| {
+            C::supported_by(family.queue_type()) && selector(family) && count <= family.max_queues()
+        });
 
         let priorities = vec![1.0; count];
         let (id, families) = match requested_family {

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -11,7 +11,9 @@ use crate::image::{Filter, Layout, SubresourceRange};
 use crate::memory::{Barrier, Dependencies};
 use crate::range::RangeArg;
 use crate::{buffer, pass, pso, query};
-use crate::{Backend, DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount};
+use crate::{
+    Backend, DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount,
+};
 
 /// Unsafe variant of `ClearColor`.
 #[repr(C)]

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -25,7 +25,7 @@ use crate::pool::{CommandPool, CommandPoolCreateFlags};
 use crate::pso::DescriptorPoolCreateFlags;
 use crate::queue::{QueueFamilyId, QueueGroup};
 use crate::range::RangeArg;
-use crate::window::{self, Backbuffer, SwapchainConfig};
+use crate::window::{self, SwapchainConfig};
 
 /// Error occurred caused device to be lost.
 #[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
@@ -778,7 +778,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         surface: &mut B::Surface,
         config: SwapchainConfig,
         old_swapchain: Option<B::Swapchain>,
-    ) -> Result<(B::Swapchain, Backbuffer<B>), window::CreationError>;
+    ) -> Result<(B::Swapchain, Vec<B::Image>), window::CreationError>;
 
     ///
     unsafe fn destroy_swapchain(&self, swapchain: B::Swapchain);

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -266,10 +266,16 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     unsafe fn destroy_pipeline_layout(&self, layout: B::PipelineLayout);
 
     /// Create a pipeline cache object.
-    unsafe fn create_pipeline_cache(&self, data: Option<&[u8]>) -> Result<B::PipelineCache, OutOfMemory>;
+    unsafe fn create_pipeline_cache(
+        &self,
+        data: Option<&[u8]>,
+    ) -> Result<B::PipelineCache, OutOfMemory>;
 
     /// Retrieve data from pipeline cache object.
-    unsafe fn get_pipeline_cache_data(&self, cache: &B::PipelineCache) -> Result<Vec<u8>, OutOfMemory>;
+    unsafe fn get_pipeline_cache_data(
+        &self,
+        cache: &B::PipelineCache,
+    ) -> Result<Vec<u8>, OutOfMemory>;
 
     /// Merge a number of source pipeline caches into the target one.
     unsafe fn merge_pipeline_caches<I>(

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::queue::{
     Submission, Supports, Transfer,
 };
 pub use self::window::{
-    AcquireError, Backbuffer, CompositeAlpha, PresentMode, Surface, SurfaceCapabilities,
+    AcquireError, CompositeAlpha, FrameSync, PresentMode, Surface, SurfaceCapabilities,
     SwapImageIndex, Swapchain, SwapchainConfig,
 };
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::queue::{
     Submission, Supports, Transfer,
 };
 pub use self::window::{
-    AcquireError, CompositeAlpha, FrameSync, PresentMode, Surface, SurfaceCapabilities,
+    AcquireError, CompositeAlpha, PresentMode, Surface, SurfaceCapabilities,
     SwapImageIndex, Swapchain, SwapchainConfig,
 };
 

--- a/src/hal/src/mapping.rs
+++ b/src/hal/src/mapping.rs
@@ -2,8 +2,8 @@
 
 //! Memory mapping
 use crate::device;
-use std::ops::{self, Range};
 use crate::Backend;
+use std::ops::{self, Range};
 
 // TODO
 /// Error accessing a mapping.

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -1,9 +1,9 @@
 //! Types to describe the properties of memory allocated for gfx resources.
 
-use std::mem;
-use std::ops::Range;
 use crate::Backend;
 use crate::{buffer, image, queue};
+use std::mem;
+use std::ops::Range;
 
 /// A trait for plain-old-data types.
 ///

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -3,8 +3,8 @@
 use crate::format::Format;
 use crate::image;
 use crate::pso::PipelineStage;
-use std::ops::Range;
 use crate::Backend;
+use std::ops::Range;
 
 /// Specifies the operation which will be applied at the beginning of a subpass.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -198,7 +198,7 @@ pub struct DepthBias {
 }
 
 /// Rasterization state.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rasterizer {
     /// How to rasterize this primitive.

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -372,15 +372,6 @@ impl SwapchainConfig {
     // TODO: depth-only, stencil-only, swapchain size, present modes, etc.
 }
 
-/// Swapchain backbuffer type
-#[derive(Debug)]
-pub enum Backbuffer<B: Backend> {
-    /// Color image chain
-    Images(Vec<B::Image>),
-    /// A single opaque framebuffer
-    Framebuffer(B::Framebuffer),
-}
-
 /// Marker value returned if the swapchain no longer matches the surface properties exactly,
 /// but can still be used to present to the surface successfully.
 pub struct Suboptimal;


### PR DESCRIPTION
WIP for fixing some of the shortcomings of the GL backend. 
Currently the fixes would allow Lokathor's gfx-hal tutorials to be ran on OpenGL as well.

Fixes: 
- [x] Push constant translation to uniforms
- [x] Depth/Stencil

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan, gl
- [x] `rustfmt` run on changed code
