### PR TITLE
[dx12] create image with typeless format

### DIFF
--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -14,6 +14,8 @@ use hal::pso::DescriptorSetLayoutBinding;
 use hal::{buffer, image, pso, Primitive};
 
 use native::descriptor::{Binding, DescriptorRange, DescriptorRangeType};
+
+
 pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
     use hal::format::Format::*;
 
@@ -100,6 +102,37 @@ pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
     };
 
     Some(format)
+}
+
+pub fn map_surface_type(st: SurfaceType) -> Option<DXGI_FORMAT> {
+    use hal::format::SurfaceType::*;
+
+    assert_eq!(1, unsafe {*(&1u32 as *const _ as *const u8)});
+    Some(match st {
+        R5_G6_B5 => DXGI_FORMAT_B5G6R5_UNORM,
+        A1_R5_G5_B5 => DXGI_FORMAT_B5G5R5A1_UNORM,
+        R8 => DXGI_FORMAT_R8_TYPELESS,
+        R8_G8 => DXGI_FORMAT_R8G8_TYPELESS,
+        R8_G8_B8_A8 => DXGI_FORMAT_R8G8B8A8_TYPELESS,
+        B8_G8_R8_A8 => DXGI_FORMAT_B8G8R8A8_TYPELESS,
+        A8_B8_G8_R8 => DXGI_FORMAT_R8G8B8A8_TYPELESS,
+        A2_B10_G10_R10 => DXGI_FORMAT_R10G10B10A2_TYPELESS,
+        R16 => DXGI_FORMAT_R16_TYPELESS,
+        R16_G16 => DXGI_FORMAT_R16G16_TYPELESS,
+        R16_G16_B16_A16 => DXGI_FORMAT_R16G16B16A16_TYPELESS,
+        R32 => DXGI_FORMAT_R32_TYPELESS,
+        R32_G32 => DXGI_FORMAT_R32G32_TYPELESS,
+        R32_G32_B32 => DXGI_FORMAT_R32G32B32_TYPELESS,
+        R32_G32_B32_A32 => DXGI_FORMAT_R32G32B32A32_TYPELESS,
+        B10_G11_R11 => DXGI_FORMAT_R11G11B10_FLOAT,
+        E5_B9_G9_R9 => DXGI_FORMAT_R9G9B9E5_SHAREDEXP,
+        D16 => DXGI_FORMAT_R16_TYPELESS,
+        X8D24 => DXGI_FORMAT_D24_UNORM_S8_UINT,
+        D32 => DXGI_FORMAT_R32_TYPELESS,
+        D24_S8 => DXGI_FORMAT_D24_UNORM_S8_UINT,
+        D32_S8 => DXGI_FORMAT_D32_FLOAT_S8X24_UINT,
+        _ => return None
+    })
 }
 
 pub fn map_format_dsv(surface: SurfaceType) -> Option<DXGI_FORMAT> {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2051,7 +2051,7 @@ impl d::Device<B> for Device {
                 kind.num_layers() as _
             },
             MipLevels: mip_levels as _,
-            Format: match conv::map_format(format) {
+            Format: match conv::map_surface_type(base_format.0) {
                 Some(format) => format,
                 None => return Err(image::CreationError::Format(format)),
             },
@@ -2079,7 +2079,8 @@ impl d::Device<B> for Device {
         };
 
         Ok(r::Image::Unbound(r::ImageUnbound {
-            dsv_format: conv::map_format_dsv(base_format.0).unwrap_or(desc.Format),
+            view_format: conv::map_format(format),
+            dsv_format: conv::map_format_dsv(base_format.0),
             desc,
             requirements: memory::Requirements {
                 size: alloc_info.SizeInBytes,
@@ -2225,9 +2226,11 @@ impl d::Device<B> for Device {
             bytes_per_block: image_unbound.bytes_per_block,
             block_dim: image_unbound.block_dim,
             clear_cv: if aspects.contains(Aspects::COLOR) && can_clear_color {
+                let format = image_unbound.view_format.unwrap();
                 (0..num_layers)
                     .map(|layer| {
                         self.view_image_as_render_target(ViewInfo {
+                            format,
                             range: image::SubresourceRange {
                                 aspects: Aspects::COLOR,
                                 levels: 0..1, //TODO?
@@ -2242,10 +2245,11 @@ impl d::Device<B> for Device {
                 Vec::new()
             },
             clear_dv: if aspects.contains(Aspects::DEPTH) && can_clear_depth {
+                let format = image_unbound.dsv_format.unwrap();
                 (0..num_layers)
                     .map(|layer| {
                         self.view_image_as_depth_stencil(ViewInfo {
-                            format: image_unbound.dsv_format,
+                            format,
                             range: image::SubresourceRange {
                                 aspects: Aspects::DEPTH,
                                 levels: 0..1, //TODO?
@@ -2260,10 +2264,11 @@ impl d::Device<B> for Device {
                 Vec::new()
             },
             clear_sv: if aspects.contains(Aspects::STENCIL) && can_clear_depth {
+                let format = image_unbound.dsv_format.unwrap();
                 (0..num_layers)
                     .map(|layer| {
                         self.view_image_as_depth_stencil(ViewInfo {
-                            format: image_unbound.dsv_format,
+                            format,
                             range: image::SubresourceRange {
                                 aspects: Aspects::STENCIL,
                                 levels: 0..1, //TODO?

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -260,7 +260,8 @@ impl ImageBound {
 pub struct ImageUnbound {
     #[derivative(Debug = "ignore")]
     pub(crate) desc: d3d12::D3D12_RESOURCE_DESC,
-    pub(crate) dsv_format: DXGI_FORMAT,
+    pub(crate) view_format: Option<DXGI_FORMAT>,
+    pub(crate) dsv_format: Option<DXGI_FORMAT>,
     pub(crate) requirements: memory::Requirements,
     pub(crate) format: format::Format,
     pub(crate) kind: image::Kind,


### PR DESCRIPTION
Fixes the simple case of creating a depth texture and trying to view it as R32Float
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: DX12
- [ ] `rustfmt` run on changed code

Edit: Closes https://github.com/gfx-rs/gfx/issues/2083 -msiglreith