### PR TITLE
dx12: Stricter allocator reset

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1084,6 +1084,7 @@ impl d::Device<B> for Device {
             device: self.raw,
             list_type,
             shared: self.shared.clone(),
+            create_flags,
         })
     }
 

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -17,6 +17,7 @@ pub struct RawCommandPool {
     pub(crate) device: native::Device,
     pub(crate) list_type: CmdListType,
     pub(crate) shared: Arc<Shared>,
+    pub(crate) create_flags: pool::CommandPoolCreateFlags,
 }
 
 impl RawCommandPool {
@@ -92,7 +93,7 @@ impl pool::RawCommandPool<Backend> for RawCommandPool {
         // TODO: Implement secondary buffers
         assert_eq!(level, command::RawLevel::Primary);
         let (command_list, command_allocator) = self.create_command_list();
-        CommandBuffer::new(command_list, command_allocator, self.shared.clone())
+        CommandBuffer::new(command_list, command_allocator, self.shared.clone(), self.create_flags)
     }
 
     unsafe fn free<I>(&mut self, cbufs: I)


### PR DESCRIPTION
Adjust reset behavior for associated allocator for individual command lists.

`quad` example runs fine (as expected).
wgpu examples will crash due to resetting the allocator while concurrent recording.