### PR TITLE
Replace unimplemented! debug implementation with placeholder

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -858,8 +858,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 #[doc(hidden)]
 pub struct RawDevice(pub ash::Device, Features);
 impl fmt::Debug for RawDevice {
-    fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
-        unimplemented!()
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "RawDevice") // TODO: Real Debug impl
     }
 }
 impl Drop for RawDevice {


### PR DESCRIPTION
Mirror of #2669 for master instead of 0.1

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
