### PR TITLE
[dx12] relaxed vertex buffer binding

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -972,28 +972,37 @@ impl CommandBuffer {
         let vbs = &self.vertex_buffer_views;
         let mut last_end_slot = 0;
         loop {
-            match vbs_remap[last_end_slot..]
+            let start_offset = match vbs_remap[last_end_slot..]
                 .iter()
                 .position(|remap| remap.is_some())
             {
-                Some(start_offset) => {
-                    let start_slot = last_end_slot + start_offset;
-                    let buffers = vbs_remap[start_slot..]
-                        .iter()
-                        .take_while(|x| x.is_some())
-                        .filter_map(|x| *x)
-                        .map(|mapping| {
-                            let view = vbs[mapping.mapped_binding];
+                Some(offset) => offset,
+                None => break,
+            };
 
-                            d3d12::D3D12_VERTEX_BUFFER_VIEW {
-                                BufferLocation: view.BufferLocation + mapping.offset as u64,
-                                SizeInBytes: view.SizeInBytes - mapping.offset,
-                                StrideInBytes: mapping.stride,
-                            }
+            let start_slot = last_end_slot + start_offset;
+            let buffers = vbs_remap[start_slot..]
+                .iter()
+                .take_while(|x| x.is_some())
+                .filter_map(|mapping| {
+                    let mapping = mapping.unwrap();
+                    let view = vbs[mapping.mapped_binding];
+                    // Skip bindings that don't make sense. Since this function is called eagerly,
+                    // we expect it to be called with all the valid inputs prior to drawing.
+                    view.SizeInBytes
+                        .checked_sub(mapping.offset)
+                        .map(|size| d3d12::D3D12_VERTEX_BUFFER_VIEW {
+                            BufferLocation: view.BufferLocation + mapping.offset as u64,
+                            SizeInBytes: size,
+                            StrideInBytes: mapping.stride,
                         })
-                        .collect::<SmallVec<[_; MAX_VERTEX_BUFFERS]>>();
-                    let num_views = buffers.len();
+                })
+                .collect::<SmallVec<[_; MAX_VERTEX_BUFFERS]>>();
 
+                if buffers.is_empty() {
+                    last_end_slot = start_slot + 1;
+                } else {
+                    let num_views = buffers.len();
                     unsafe {
                         cmd_buffer.IASetVertexBuffers(
                             start_slot as _,
@@ -1003,8 +1012,6 @@ impl CommandBuffer {
                     }
                     last_end_slot = start_slot + num_views;
                 }
-                None => break,
-            }
         }
     }
 }
@@ -1706,9 +1713,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     {
         assert!(first_binding as usize <= MAX_VERTEX_BUFFERS);
 
-        for ((buffer, offset), view) in buffers
-            .into_iter()
-            .zip(self.vertex_buffer_views[first_binding as _..].iter_mut())
+        for (view, (buffer, offset)) in self
+            .vertex_buffer_views[first_binding as _ ..]
+            .iter_mut()
+            .zip(buffers)
         {
             let b = buffer.borrow().expect_bound();
             let base = (*b.resource).GetGPUVirtualAddress();

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1501,7 +1501,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             kind: src.kind,
             caps: src.view_caps,
             view_kind: image::ViewKind::D2Array, // TODO
-            format: src.descriptor.Format,
+            format: src.default_view_format.unwrap(),
             range: image::SubresourceRange {
                 aspects: format::Aspects::COLOR, // TODO
                 levels: 0..src.descriptor.MipLevels as _,
@@ -1547,10 +1547,11 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
             let key = match r.dst_subresource.aspects {
                 format::Aspects::COLOR => {
+                    let format = dst.default_view_format.unwrap();
                     // Create RTVs of the dst image for the miplevel of the current region
                     for i in 0..num_layers {
                         let mut desc = d3d12::D3D12_RENDER_TARGET_VIEW_DESC {
-                            Format: dst.descriptor.Format,
+                            Format: format,
                             ViewDimension: d3d12::D3D12_RTV_DIMENSION_TEXTURE2DARRAY,
                             u: mem::zeroed(),
                         };
@@ -1566,7 +1567,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         device.CreateRenderTargetView(dst.resource.as_mut_ptr(), &desc, view);
                     }
 
-                    (dst.descriptor.Format, filter)
+                    (format, filter)
                 }
                 _ => unimplemented!(),
             };

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -526,7 +526,7 @@ impl Device {
     ) -> r::DescriptorHeap {
         assert_ne!(capacity, 0);
 
-        let (heap, hr) = device.create_descriptor_heap(
+        let (heap, _hr) = device.create_descriptor_heap(
             capacity as _,
             heap_type,
             if shader_visible {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -76,31 +76,6 @@ pub(crate) enum CommandSignature {
     Dispatch,
 }
 
-#[derive(Debug)]
-pub struct UnboundBuffer {
-    requirements: memory::Requirements,
-    usage: buffer::Usage,
-}
-
-#[derive(Derivative)]
-#[derivative(Debug)]
-pub struct UnboundImage {
-    #[derivative(Debug = "ignore")]
-    desc: d3d12::D3D12_RESOURCE_DESC,
-    dsv_format: dxgiformat::DXGI_FORMAT,
-    requirements: memory::Requirements,
-    format: Format,
-    kind: image::Kind,
-    usage: image::Usage,
-    tiling: image::Tiling,
-    view_caps: image::ViewCapabilities,
-    //TODO: use hal::format::FormatDesc
-    bytes_per_block: u8,
-    // Dimension of a texel block (compressed formats).
-    block_dim: (u8, u8),
-    num_levels: image::Level,
-}
-
 /// Compile a single shader entry point from a HLSL text shader
 pub(crate) fn compile_shader(
     stage: pso::Stage,
@@ -2222,6 +2197,7 @@ impl d::Device<B> for Device {
             surface_type: image_unbound.format.base_format().0,
             kind: image_unbound.kind,
             usage: image_unbound.usage,
+            default_view_format: image_unbound.view_format,
             view_caps: image_unbound.view_caps,
             descriptor: image_unbound.desc,
             bytes_per_block: image_unbound.bytes_per_block,
@@ -3106,6 +3082,7 @@ impl d::Device<B> for Device {
                     surface_type,
                     kind,
                     usage: config.image_usage,
+                    default_view_format: Some(format),
                     view_caps: image::ViewCapabilities::empty(),
                     descriptor: d3d12::D3D12_RESOURCE_DESC {
                         Dimension: d3d12::D3D12_RESOURCE_DIMENSION_TEXTURE2D,

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -220,6 +220,7 @@ pub struct ImageBound {
     pub(crate) surface_type: format::SurfaceType,
     pub(crate) kind: image::Kind,
     pub(crate) usage: image::Usage,
+    pub(crate) default_view_format: Option<DXGI_FORMAT>,
     pub(crate) view_caps: image::ViewCapabilities,
     #[derivative(Debug = "ignore")]
     pub(crate) descriptor: d3d12::D3D12_RESOURCE_DESC,


### PR DESCRIPTION
Fixes #2614
Also contains a small but necessary follow-up to #2664
With these fixes, we only fail the fill_buffer tests, and that is easily explained by a giant TODO that now takes place inside :)

PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: dx12
- [ ] `rustfmt` run on changed code
