### PR TITLE
[0.1/dx12] back-port vertex buffer fixes

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1517,7 +1517,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 kind: src.kind,
                 caps: src.view_caps,
                 view_kind: image::ViewKind::D2Array, // TODO
-                format: src.descriptor.Format,
+                format:  src.default_view_format.unwrap(),
                 range: image::SubresourceRange {
                     aspects: format::Aspects::COLOR, // TODO
                     levels: 0..src.descriptor.MipLevels as _,
@@ -1565,10 +1565,11 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
             let key = match r.dst_subresource.aspects {
                 format::Aspects::COLOR => {
+                    let format = dst.default_view_format.unwrap();
                     // Create RTVs of the dst image for the miplevel of the current region
                     for i in 0..num_layers {
                         let mut desc = d3d12::D3D12_RENDER_TARGET_VIEW_DESC {
-                            Format: dst.descriptor.Format,
+                            Format: format,
                             ViewDimension: d3d12::D3D12_RTV_DIMENSION_TEXTURE2DARRAY,
                             u: unsafe { mem::zeroed() },
                         };
@@ -1586,7 +1587,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                         }
                     }
 
-                    (dst.descriptor.Format, filter)
+                    (format, filter)
                 }
                 _ => unimplemented!(),
             };

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -297,8 +297,11 @@ pub struct CommandBuffer {
     occlusion_query: Option<OcclusionQuery>,
     pipeline_stats_query: Option<UINT>,
 
-    // VertexBindings for the currently bound pipeline
+    // Cached vertex buffer views to bind.
+    // `Stride` values are not known at `bind_vertex_buffers` time because they are only stored
+    // inside the pipeline state.
     vertex_bindings_remap: [Option<r::VertexBinding>; MAX_VERTEX_BUFFERS],
+    vertex_buffer_views: [d3d12::D3D12_VERTEX_BUFFER_VIEW; MAX_VERTEX_BUFFERS],
 
     // Re-using allocation for the image-buffer copies.
     copies: Vec<Copy>,
@@ -353,6 +356,7 @@ impl CommandBuffer {
             occlusion_query: None,
             pipeline_stats_query: None,
             vertex_bindings_remap: [None; MAX_VERTEX_BUFFERS],
+            vertex_buffer_views: [NULL_VERTEX_BUFFER_VIEW; MAX_VERTEX_BUFFERS],
             copies: Vec::new(),
             viewport_cache: SmallVec::new(),
             scissor_cache: SmallVec::new(),
@@ -392,6 +396,7 @@ impl CommandBuffer {
         self.occlusion_query = None;
         self.pipeline_stats_query = None;
         self.vertex_bindings_remap = [None; MAX_VERTEX_BUFFERS];
+        self.vertex_buffer_views = [NULL_VERTEX_BUFFER_VIEW; MAX_VERTEX_BUFFERS];
         for heap in self.rtv_pools.drain(..) {
             unsafe {
                 heap.destroy();
@@ -968,6 +973,48 @@ impl CommandBuffer {
                         });
                     }
                 }
+            }
+        }
+    }
+
+    fn set_vertex_buffers(&mut self) {
+        let cmd_buffer = &mut self.raw;
+        let vbs_remap = &self.vertex_bindings_remap;
+        let vbs = &self.vertex_buffer_views;
+        let mut last_end_slot = 0;
+        loop {
+            match vbs_remap[last_end_slot..]
+                .iter()
+                .position(|remap| remap.is_some())
+            {
+                Some(start_offset) => {
+                    let start_slot = last_end_slot + start_offset;
+                    let buffers = vbs_remap[start_slot..]
+                        .iter()
+                        .take_while(|x| x.is_some())
+                        .filter_map(|x| *x)
+                        .map(|mapping| {
+                            let view = vbs[mapping.mapped_binding];
+
+                            d3d12::D3D12_VERTEX_BUFFER_VIEW {
+                                BufferLocation: view.BufferLocation + mapping.offset as u64,
+                                SizeInBytes: view.SizeInBytes - mapping.offset,
+                                StrideInBytes: mapping.stride,
+                            }
+                        })
+                        .collect::<SmallVec<[_; MAX_VERTEX_BUFFERS]>>();
+                    let num_views = buffers.len();
+
+                    unsafe {
+                        cmd_buffer.IASetVertexBuffers(
+                            start_slot as _,
+                            num_views as _,
+                            buffers.as_ptr(),
+                        );
+                    }
+                    last_end_slot = start_slot + num_views;
+                }
+                None => break,
             }
         }
     }
@@ -1682,66 +1729,23 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         );
     }
 
-    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, bind_buffers: I)
+    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
     where
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<r::Buffer>,
     {
         assert!(first_binding as usize <= MAX_VERTEX_BUFFERS);
-        assert!(
-            self.vertex_bindings_remap
-                .iter()
-                .find(|vb| vb.is_some())
-                .is_some(),
-            "A pipeline with vertex bindings must be bound before vertex_buffers can be bound"
-        );
-        let cmd_buffer = &self.raw;
-        let bind_buffers = bind_buffers
+
+        for ((buffer, offset), view) in buffers
             .into_iter()
-            .collect::<SmallVec<[_; MAX_VERTEX_BUFFERS]>>();
-
-        let vbs_remap = &self.vertex_bindings_remap;
-        let mut last_end_slot = 0;
-        loop {
-            match vbs_remap[last_end_slot..]
-                .iter()
-                .position(|remap| remap.is_some())
-            {
-                Some(start_offset) => {
-                    let start_slot = last_end_slot + start_offset;
-                    let buffers = vbs_remap[start_slot..]
-                        .iter()
-                        .take_while(|x| x.is_some())
-                        .filter_map(|x| *x)
-                        .map(|mapping| {
-
-                            let (buf, offset) = &bind_buffers[mapping.mapped_binding];
-                            let b = buf.borrow().expect_bound();
-                            let base = unsafe { (*b.resource).GetGPUVirtualAddress() };
-                            let buffer_location = base + offset;
-                            let size_in_bytes = (b.requirements.size - offset) as u32;
-
-                            d3d12::D3D12_VERTEX_BUFFER_VIEW {
-                                BufferLocation: buffer_location + mapping.offset as u64,
-                                SizeInBytes: size_in_bytes - mapping.offset,
-                                StrideInBytes: mapping.stride,
-                            }
-                        })
-                        .collect::<SmallVec<[_; MAX_VERTEX_BUFFERS]>>();
-                    let num_views = buffers.len();
-
-                    unsafe {
-                        cmd_buffer.IASetVertexBuffers(
-                            start_slot as _,
-                            num_views as _,
-                            buffers.as_ptr(),
-                        );
-                    }
-                    last_end_slot = start_slot + num_views;
-                }
-                None => break,
-            }
+            .zip(self.vertex_buffer_views[first_binding as _..].iter_mut())
+        {
+            let b = buffer.borrow().expect_bound();
+            let base = unsafe { (*b.resource).GetGPUVirtualAddress() };
+            view.BufferLocation = base + offset;
+            view.SizeInBytes = (b.requirements.size - offset) as u32;
         }
+        self.set_vertex_buffers();
     }
 
     unsafe fn set_viewports<T>(&mut self, first_viewport: u32, viewports: T)
@@ -1869,6 +1873,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         self.active_bindpoint = BindPoint::Graphics { internal: false };
         self.gr_pipeline.pipeline = Some((pipeline.raw, pipeline.signature));
         self.vertex_bindings_remap = pipeline.vertex_bindings;
+
+        self.set_vertex_buffers();
 
         if let Some(ref vp) = pipeline.baked_states.viewport {
             self.set_viewports(0, iter::once(vp));

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -297,11 +297,8 @@ pub struct CommandBuffer {
     occlusion_query: Option<OcclusionQuery>,
     pipeline_stats_query: Option<UINT>,
 
-    // Cached vertex buffer views to bind.
-    // `Stride` values are not known at `bind_vertex_buffers` time because they are only stored
-    // inside the pipeline state.
+    // VertexBindings for the currently bound pipeline
     vertex_bindings_remap: [Option<r::VertexBinding>; MAX_VERTEX_BUFFERS],
-    vertex_buffer_views: [d3d12::D3D12_VERTEX_BUFFER_VIEW; MAX_VERTEX_BUFFERS],
 
     // Re-using allocation for the image-buffer copies.
     copies: Vec<Copy>,
@@ -356,7 +353,6 @@ impl CommandBuffer {
             occlusion_query: None,
             pipeline_stats_query: None,
             vertex_bindings_remap: [None; MAX_VERTEX_BUFFERS],
-            vertex_buffer_views: [NULL_VERTEX_BUFFER_VIEW; MAX_VERTEX_BUFFERS],
             copies: Vec::new(),
             viewport_cache: SmallVec::new(),
             scissor_cache: SmallVec::new(),
@@ -396,7 +392,6 @@ impl CommandBuffer {
         self.occlusion_query = None;
         self.pipeline_stats_query = None;
         self.vertex_bindings_remap = [None; MAX_VERTEX_BUFFERS];
-        self.vertex_buffer_views = [NULL_VERTEX_BUFFER_VIEW; MAX_VERTEX_BUFFERS];
         for heap in self.rtv_pools.drain(..) {
             unsafe {
                 heap.destroy();
@@ -628,52 +623,6 @@ impl CommandBuffer {
 
         self.active_bindpoint = BindPoint::Graphics { internal: false };
         let cmd_buffer = &mut self.raw;
-
-        // Bind vertex buffers
-        // Use needs_bind array to determine which buffers still need to be bound
-        // and bind them one continuous group at a time.
-        {
-            let vbs_remap = &self.vertex_bindings_remap;
-            let vbs = &self.vertex_buffer_views;
-            let mut last_end_slot = 0;
-            loop {
-                match vbs_remap[last_end_slot..]
-                    .iter()
-                    .position(|remap| remap.is_some())
-                {
-                    Some(start_offset) => {
-                        let start_slot = last_end_slot + start_offset;
-                        let buffers = vbs_remap[start_slot..]
-                            .iter()
-                            .take_while(|x| x.is_some())
-                            .filter_map(|x| *x)
-                            .map(|mapping| {
-                                let view = vbs[mapping.mapped_binding];
-
-                                d3d12::D3D12_VERTEX_BUFFER_VIEW {
-                                    BufferLocation: view.BufferLocation + mapping.offset as u64,
-                                    SizeInBytes: view.SizeInBytes - mapping.offset,
-                                    StrideInBytes: mapping.stride,
-                                }
-                            })
-                            .collect::<SmallVec<[_; MAX_VERTEX_BUFFERS]>>();
-                        let num_views = buffers.len();
-
-                        unsafe {
-                            cmd_buffer.IASetVertexBuffers(
-                                start_slot as _,
-                                buffers.len() as _,
-                                buffers.as_ptr(),
-                            );
-                        }
-                        last_end_slot = start_slot + num_views;
-                    }
-                    None => break,
-                }
-            }
-        }
-        // Don't re-bind vertex buffers again.
-        self.vertex_bindings_remap = [None; MAX_VERTEX_BUFFERS];
 
         // Flush root signature data
         Self::flush_user_data(
@@ -1733,21 +1682,65 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         );
     }
 
-    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, bind_buffers: I)
     where
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<r::Buffer>,
     {
-        // Only cache the vertex buffer views as we don't know the stride (PSO).
         assert!(first_binding as usize <= MAX_VERTEX_BUFFERS);
-        for ((buffer, offset), view) in buffers
+        assert!(
+            self.vertex_bindings_remap
+                .iter()
+                .find(|vb| vb.is_some())
+                .is_some(),
+            "A pipeline with vertex bindings must be bound before vertex_buffers can be bound"
+        );
+        let cmd_buffer = &self.raw;
+        let bind_buffers = bind_buffers
             .into_iter()
-            .zip(self.vertex_buffer_views[first_binding as _..].iter_mut())
-        {
-            let b = buffer.borrow().expect_bound();
-            let base = unsafe { (*b.resource).GetGPUVirtualAddress() };
-            view.BufferLocation = base + offset;
-            view.SizeInBytes = (b.requirements.size - offset) as u32;
+            .collect::<SmallVec<[_; MAX_VERTEX_BUFFERS]>>();
+
+        let vbs_remap = &self.vertex_bindings_remap;
+        let mut last_end_slot = 0;
+        loop {
+            match vbs_remap[last_end_slot..]
+                .iter()
+                .position(|remap| remap.is_some())
+            {
+                Some(start_offset) => {
+                    let start_slot = last_end_slot + start_offset;
+                    let buffers = vbs_remap[start_slot..]
+                        .iter()
+                        .take_while(|x| x.is_some())
+                        .filter_map(|x| *x)
+                        .map(|mapping| {
+
+                            let (buf, offset) = &bind_buffers[mapping.mapped_binding];
+                            let b = buf.borrow().expect_bound();
+                            let base = unsafe { (*b.resource).GetGPUVirtualAddress() };
+                            let buffer_location = base + offset;
+                            let size_in_bytes = (b.requirements.size - offset) as u32;
+
+                            d3d12::D3D12_VERTEX_BUFFER_VIEW {
+                                BufferLocation: buffer_location + mapping.offset as u64,
+                                SizeInBytes: size_in_bytes - mapping.offset,
+                                StrideInBytes: mapping.stride,
+                            }
+                        })
+                        .collect::<SmallVec<[_; MAX_VERTEX_BUFFERS]>>();
+                    let num_views = buffers.len();
+
+                    unsafe {
+                        cmd_buffer.IASetVertexBuffers(
+                            start_slot as _,
+                            num_views as _,
+                            buffers.as_ptr(),
+                        );
+                    }
+                    last_end_slot = start_slot + num_views;
+                }
+                None => break,
+            }
         }
     }
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -544,6 +544,7 @@ impl Device {
 
         match info.view_kind {
             image::ViewKind::D1 => {
+                assert_eq!(info.range.layers, 0 .. 1);
                 desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE1D;
                 *unsafe { desc.u.Texture1D_mut() } = d3d12::D3D12_TEX1D_RTV { MipSlice }
             }
@@ -556,12 +557,14 @@ impl Device {
                 }
             }
             image::ViewKind::D2 if is_msaa => {
+                assert_eq!(info.range.layers, 0 .. 1);
                 desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2DMS;
                 *unsafe { desc.u.Texture2DMS_mut() } = d3d12::D3D12_TEX2DMS_RTV {
                     UnusedField_NothingToDefine: 0,
                 }
             }
             image::ViewKind::D2 => {
+                assert_eq!(info.range.layers, 0 .. 1);
                 desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE2D;
                 *unsafe { desc.u.Texture2D_mut() } = d3d12::D3D12_TEX2D_RTV {
                     MipSlice,
@@ -585,6 +588,7 @@ impl Device {
                 }
             }
             image::ViewKind::D3 => {
+                assert_eq!(info.range.layers, 0 .. 1);
                 desc.ViewDimension = d3d12::D3D12_RTV_DIMENSION_TEXTURE3D;
                 *unsafe { desc.u.Texture3D_mut() } = d3d12::D3D12_TEX3D_RTV {
                     MipSlice,
@@ -642,6 +646,7 @@ impl Device {
 
         match info.view_kind {
             image::ViewKind::D1 => {
+                assert_eq!(info.range.layers, 0 .. 1);
                 desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE1D;
                 *unsafe { desc.u.Texture1D_mut() } = d3d12::D3D12_TEX1D_DSV { MipSlice }
             }
@@ -654,12 +659,14 @@ impl Device {
                 }
             }
             image::ViewKind::D2 if is_msaa => {
+                assert_eq!(info.range.layers, 0 .. 1);
                 desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE2DMS;
                 *unsafe { desc.u.Texture2DMS_mut() } = d3d12::D3D12_TEX2DMS_DSV {
                     UnusedField_NothingToDefine: 0,
                 }
             }
             image::ViewKind::D2 => {
+                assert_eq!(info.range.layers, 0 .. 1);
                 desc.ViewDimension = d3d12::D3D12_DSV_DIMENSION_TEXTURE2D;
                 *unsafe { desc.u.Texture2D_mut() } = d3d12::D3D12_TEX2D_DSV { MipSlice }
             }
@@ -721,6 +728,7 @@ impl Device {
 
         match info.view_kind {
             image::ViewKind::D1 => {
+                assert_eq!(info.range.layers, 0..1);
                 desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE1D;
                 *unsafe { desc.u.Texture1D_mut() } = d3d12::D3D12_TEX1D_SRV {
                     MostDetailedMip,
@@ -739,12 +747,14 @@ impl Device {
                 }
             }
             image::ViewKind::D2 if is_msaa => {
+                assert_eq!(info.range.layers, 0..1);
                 desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE2DMS;
                 *unsafe { desc.u.Texture2DMS_mut() } = d3d12::D3D12_TEX2DMS_SRV {
                     UnusedField_NothingToDefine: 0,
                 }
             }
             image::ViewKind::D2 => {
+                assert_eq!(info.range.layers, 0..1);
                 desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE2D;
                 *unsafe { desc.u.Texture2D_mut() } = d3d12::D3D12_TEX2D_SRV {
                     MostDetailedMip,
@@ -772,6 +782,7 @@ impl Device {
                 }
             }
             image::ViewKind::D3 => {
+                assert_eq!(info.range.layers, 0..1);
                 desc.ViewDimension = d3d12::D3D12_SRV_DIMENSION_TEXTURE3D;
                 *unsafe { desc.u.Texture3D_mut() } = d3d12::D3D12_TEX3D_SRV {
                     MostDetailedMip,
@@ -858,6 +869,7 @@ impl Device {
 
         match info.view_kind {
             image::ViewKind::D1 => {
+                assert_eq!(info.range.layers, 0..1);
                 desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE1D;
                 *unsafe { desc.u.Texture1D_mut() } = d3d12::D3D12_TEX1D_UAV { MipSlice }
             }
@@ -870,6 +882,7 @@ impl Device {
                 }
             }
             image::ViewKind::D2 => {
+                assert_eq!(info.range.layers, 0..1);
                 desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE2D;
                 *unsafe { desc.u.Texture2D_mut() } = d3d12::D3D12_TEX2D_UAV {
                     MipSlice,
@@ -886,6 +899,7 @@ impl Device {
                 }
             }
             image::ViewKind::D3 => {
+                assert_eq!(info.range.layers, 0..1);
                 desc.ViewDimension = d3d12::D3D12_UAV_DIMENSION_TEXTURE3D;
                 *unsafe { desc.u.Texture3D_mut() } = d3d12::D3D12_TEX3D_UAV {
                     MipSlice,
@@ -2134,7 +2148,7 @@ impl d::Device<B> for Device {
         let mut resource = native::Resource::null();
         let num_layers = image_unbound.kind.num_layers();
 
-        assert_eq!(winerror::S_OK, unsafe {
+        assert_eq!(winerror::S_OK,
             self.raw.clone().CreatePlacedResource(
                 memory.heap.as_mut_ptr(),
                 offset,
@@ -2144,7 +2158,7 @@ impl d::Device<B> for Device {
                 &d3d12::ID3D12Resource::uuidof(),
                 resource.mut_void(),
             )
-        });
+        );
 
         let info = ViewInfo {
             resource,
@@ -2261,6 +2275,7 @@ impl d::Device<B> for Device {
         range: image::SubresourceRange,
     ) -> Result<r::ImageView, image::ViewError> {
         let image = image.expect_bound();
+        let is_array = image.kind.num_layers() > 1;
         let mip_levels = (range.levels.start, range.levels.end);
         let layers = (range.layers.start, range.layers.end);
 
@@ -2268,7 +2283,14 @@ impl d::Device<B> for Device {
             resource: image.resource,
             kind: image.kind,
             caps: image.view_caps,
-            view_kind,
+            // D3D12 doesn't allow looking at a single slice of an array as a non-array
+            view_kind: if is_array && view_kind == image::ViewKind::D2 {
+                image::ViewKind::D2Array
+            } else if is_array && view_kind == image::ViewKind::D1 {
+                image::ViewKind::D1Array
+            } else {
+                view_kind
+            },
             format: conv::map_format(format).ok_or(image::ViewError::BadFormat(format))?,
             range,
         };

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -517,7 +517,7 @@ impl Device {
     ) -> r::DescriptorHeap {
         assert_ne!(capacity, 0);
 
-        let (heap, hr) = device.create_descriptor_heap(
+        let (heap, _hr) = device.create_descriptor_heap(
             capacity as _,
             heap_type,
             if shader_visible {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -75,31 +75,6 @@ pub(crate) enum CommandSignature {
     Dispatch,
 }
 
-#[derive(Debug)]
-pub struct UnboundBuffer {
-    requirements: memory::Requirements,
-    usage: buffer::Usage,
-}
-
-#[derive(Derivative)]
-#[derivative(Debug)]
-pub struct UnboundImage {
-    #[derivative(Debug = "ignore")]
-    desc: d3d12::D3D12_RESOURCE_DESC,
-    dsv_format: dxgiformat::DXGI_FORMAT,
-    requirements: memory::Requirements,
-    format: Format,
-    kind: image::Kind,
-    usage: image::Usage,
-    tiling: image::Tiling,
-    view_caps: image::ViewCapabilities,
-    //TODO: use hal::format::FormatDesc
-    bytes_per_block: u8,
-    // Dimension of a texel block (compressed formats).
-    block_dim: (u8, u8),
-    num_levels: image::Level,
-}
-
 /// Compile a single shader entry point from a HLSL text shader
 pub(crate) fn compile_shader(
     stage: pso::Stage,
@@ -2215,6 +2190,7 @@ impl d::Device<B> for Device {
             surface_type: image_unbound.format.base_format().0,
             kind: image_unbound.kind,
             usage: image_unbound.usage,
+            default_view_format: image_unbound.view_format,
             view_caps: image_unbound.view_caps,
             descriptor: image_unbound.desc,
             bytes_per_block: image_unbound.bytes_per_block,
@@ -3125,6 +3101,7 @@ impl d::Device<B> for Device {
                     surface_type,
                     kind,
                     usage: config.image_usage,
+                    default_view_format: Some(format),
                     view_caps: image::ViewCapabilities::empty(),
                     descriptor: d3d12::D3D12_RESOURCE_DESC {
                         Dimension: d3d12::D3D12_RESOURCE_DIMENSION_TEXTURE2D,

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -220,6 +220,7 @@ pub struct ImageBound {
     pub(crate) surface_type: format::SurfaceType,
     pub(crate) kind: image::Kind,
     pub(crate) usage: image::Usage,
+    pub(crate) default_view_format: Option<DXGI_FORMAT>,
     pub(crate) view_caps: image::ViewCapabilities,
     #[derivative(Debug = "ignore")]
     pub(crate) descriptor: d3d12::D3D12_RESOURCE_DESC,


### PR DESCRIPTION
Back-ports #2590, #2672, and #2674  to hal-0.1
makes the wgpu-rs shadow example work
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
