### PR TITLE
Add serde derives to QueueFamilyId

### DIFF
--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -34,6 +34,7 @@ pub trait QueueFamily: Debug + Any + Send + Sync {
 
 /// Identifier for a queue family of a physical device.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct QueueFamilyId(pub usize);
 
 /// Strong-typed group of queues of the same queue family.


### PR DESCRIPTION
Adds serde traits for trivially serializable `QueueFamilyId`.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan, dx12
- [x] `rustfmt` run on changed code
