### PR TITLE
[0.1/dx11] buffer creation and synchronization fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### backend-dx11-0.1.1 (05-03-2019)
+  - fixed buffer bind flags
+  - synchronization of disjoint CB across copy operations
+  - depth texture views
+
 ### backend-dx12-0.1.2 (04-03-2019)
   - typeless formats for textures
   - fixed vertex buffer binding

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 default = []
 metal = ["gfx-backend-metal"]
 gl = ["gfx-backend-gl"]
+dx11 = ["gfx-backend-dx11"]
 dx12 = ["gfx-backend-dx12"]
 vulkan = ["gfx-backend-vulkan"]
 unstable = []
@@ -48,6 +49,11 @@ optional = true
 
 [target.'cfg(any(target_os = "macos", all(target_os = "ios", target_arch = "aarch64")))'.dependencies.gfx-backend-metal]
 path = "../src/backend/metal"
+version = "0.1"
+optional = true
+
+[target.'cfg(windows)'.dependencies.gfx-backend-dx11]
+path = "../src/backend/dx11"
 version = "0.1"
 optional = true
 

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(
     not(any(
         feature = "vulkan",
+        feature = "dx11",
         feature = "dx12",
         feature = "metal",
         feature = "gl"
@@ -8,10 +9,13 @@
     allow(dead_code, unused_extern_crates, unused_imports)
 )]
 
+#[cfg(feature = "dx11")]
+extern crate gfx_backend_dx11 as back;
 #[cfg(feature = "dx12")]
 extern crate gfx_backend_dx12 as back;
 #[cfg(not(any(
     feature = "vulkan",
+    feature = "dx11",
     feature = "dx12",
     feature = "metal",
     feature = "gl"
@@ -646,12 +650,12 @@ impl WindowState {
 struct BackendState<B: Backend> {
     surface: B::Surface,
     adapter: AdapterState<B>,
-    #[cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]
+    #[cfg(any(feature = "vulkan", feature = "dx11", feature = "dx12", feature = "metal"))]
     #[allow(dead_code)]
     window: winit::Window,
 }
 
-#[cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]
+#[cfg(any(feature = "vulkan", feature = "dx11", feature = "dx12", feature = "metal"))]
 fn create_backend(window_state: &mut WindowState) -> (BackendState<back::Backend>, back::Instance) {
     let window = window_state
         .wb
@@ -1654,6 +1658,7 @@ impl<B: Backend> Drop for FramebufferState<B> {
 
 #[cfg(any(
     feature = "vulkan",
+    feature = "dx11",
     feature = "dx12",
     feature = "metal",
     feature = "gl"
@@ -1672,6 +1677,7 @@ fn main() {
 
 #[cfg(not(any(
     feature = "vulkan",
+    feature = "dx11",
     feature = "dx12",
     feature = "metal",
     feature = "gl"

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -1,10 +1,12 @@
 #![cfg_attr(
-    not(any(feature = "vulkan", feature = "dx12", feature = "metal")),
+    not(any(feature = "vulkan", feature = "dx11", feature = "dx12", feature = "metal")),
     allow(dead_code, unused_extern_crates, unused_imports)
 )]
 
 extern crate env_logger;
 extern crate gfx_hal as hal;
+#[cfg(feature = "dx11")]
+extern crate gfx_backend_dx11 as back;
 #[cfg(feature = "dx12")]
 extern crate gfx_backend_dx12 as back;
 #[cfg(feature = "vulkan")]
@@ -24,7 +26,7 @@ extern crate glsl_to_spirv;
 use std::fs;
 use std::io::Read;
 
-#[cfg(any(feature = "vulkan", feature = "dx12", feature = "metal"))]
+#[cfg(any(feature = "vulkan", feature = "dx11", feature = "dx12", feature = "metal"))]
 fn main() {
     env_logger::init();
 
@@ -232,7 +234,7 @@ unsafe fn create_buffer<B: Backend>(
     (memory, buffer, requirements.size)
 }
 
-#[cfg(not(any(feature = "vulkan", feature = "dx12", feature = "metal")))]
+#[cfg(not(any(feature = "vulkan", feature = "dx11", feature = "dx12", feature = "metal")))]
 fn main() {
     println!("You need to enable one of the next-gen API feature (vulkan, dx12, metal) to run this example.");
 }

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(
     not(any(
         feature = "vulkan",
+        feature = "dx11",
         feature = "dx12",
         feature = "metal",
         feature = "gl"
@@ -9,6 +10,8 @@
 )]
 
 extern crate env_logger;
+#[cfg(feature = "dx11")]
+extern crate gfx_backend_dx11 as back;
 #[cfg(feature = "dx12")]
 extern crate gfx_backend_dx12 as back;
 #[cfg(feature = "gl")]
@@ -67,6 +70,7 @@ const COLOR_RANGE: i::SubresourceRange = i::SubresourceRange {
 
 #[cfg(any(
     feature = "vulkan",
+    feature = "dx11",
     feature = "dx12",
     feature = "metal",
     feature = "gl"
@@ -761,6 +765,7 @@ fn main() {
 
 #[cfg(not(any(
     feature = "vulkan",
+    feature = "dx11",
     feature = "dx12",
     feature = "metal",
     feature = "gl"

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.1.0"
+version = "0.1.1"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -25,7 +25,7 @@ derivative = "1"
 log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = "0.12.0"
-parking_lot = "0.6.3"
+parking_lot = "0.7"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.18", optional = true }
 wio = "0.2"

--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -758,4 +758,3 @@ pub fn map_filter(
     (reduction & D3D11_FILTER_REDUCTION_TYPE_MASK) << D3D11_FILTER_REDUCTION_TYPE_SHIFT |
     map_anisotropic(anisotropic)
 }
-

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -72,7 +72,7 @@ impl Device {
             memory_heap_flags: [
                 MemoryHeapFlags::DEVICE_LOCAL,
                 MemoryHeapFlags::HOST_COHERENT,
-                MemoryHeapFlags::HOST_NONCOHERENT,
+                MemoryHeapFlags::HOST_VISIBLE,
             ],
             internal: internal::Internal::new(&device),
         }
@@ -575,14 +575,31 @@ impl Device {
     }
 
     fn view_image_as_depth_stencil(&self, info: &ViewInfo) -> Result<ComPtr<d3d11::ID3D11DepthStencilView>, image::ViewError> {
+        #![allow(non_snake_case)]
+
+        let MipSlice = info.range.levels.start as _;
+        let FirstArraySlice = info.range.layers.start as _;
+        let ArraySize = (info.range.layers.end - info.range.layers.start) as _;
+        assert_eq!(info.range.levels.start + 1, info.range.levels.end);
+        assert!(info.range.layers.end <= info.kind.num_layers());
+
         let mut desc: d3d11::D3D11_DEPTH_STENCIL_VIEW_DESC = unsafe { mem::zeroed() };
         desc.Format = info.format;
 
         match info.view_kind {
             image::ViewKind::D2 => {
+                assert_eq!(info.range.layers, 0 .. 1);
                 desc.ViewDimension = d3d11::D3D11_DSV_DIMENSION_TEXTURE2D;
                 *unsafe{ desc.u.Texture2D_mut() } = d3d11::D3D11_TEX2D_DSV {
-                    MipSlice: 0,
+                    MipSlice,
+                }
+            },
+            image::ViewKind::D2Array => {
+                desc.ViewDimension = d3d11::D3D11_DSV_DIMENSION_TEXTURE2DARRAY;
+                *unsafe{ desc.u.Texture2DArray_mut() } = d3d11::D3D11_TEX2D_ARRAY_DSV {
+                    MipSlice,
+                    FirstArraySlice,
+                    ArraySize,
                 }
             },
             _ => unimplemented!()
@@ -1041,7 +1058,7 @@ impl hal::Device<Backend> for Device {
         };
 
         let initial_data = memory.host_visible.as_ref().map(|p| d3d11::D3D11_SUBRESOURCE_DATA {
-            pSysMem: unsafe { p.borrow().as_ptr().offset(offset as isize) as _ },
+            pSysMem: p.borrow().as_ptr().offset(offset as isize) as _ ,
             SysMemPitch: 0,
             SysMemSlicePitch: 0
         });
@@ -1052,32 +1069,30 @@ impl hal::Device<Backend> for Device {
                 let desc = d3d11::D3D11_BUFFER_DESC {
                     ByteWidth: buffer.requirements.size as _,
                     Usage: d3d11::D3D11_USAGE_DEFAULT,
-                    BindFlags: buffer.requirements.size as _,
+                    BindFlags: buffer.bind,
                     CPUAccessFlags: 0,
                     MiscFlags,
                     StructureByteStride: if buffer.internal.usage.contains(buffer::Usage::TRANSFER_SRC) { 4 } else { 0 },
                 };
 
                 let mut buffer: *mut d3d11::ID3D11Buffer = ptr::null_mut();
-                let hr = unsafe {
-                    self.raw.CreateBuffer(
-                        &desc,
-                        if let Some(data) = initial_data {
-                            &data
-                        } else {
-                            ptr::null_mut()
-                        },
-                        &mut buffer as *mut *mut _ as *mut *mut _
-                    )
-                };
+                let hr = self.raw.CreateBuffer(
+                    &desc,
+                    if let Some(data) = initial_data {
+                        &data
+                    } else {
+                        ptr::null_mut()
+                    },
+                    &mut buffer as *mut *mut _ as *mut *mut _
+                );
 
                 if !winerror::SUCCEEDED(hr) {
                     return Err(device::BindError::WrongMemory);
                 }
 
-                unsafe { ComPtr::from_raw(buffer) }
+                ComPtr::from_raw(buffer)
             },
-            MemoryHeapFlags::HOST_NONCOHERENT | MemoryHeapFlags::HOST_COHERENT => {
+            MemoryHeapFlags::HOST_VISIBLE | MemoryHeapFlags::HOST_COHERENT => {
                 let desc = d3d11::D3D11_BUFFER_DESC {
                     ByteWidth: buffer.requirements.size as _,
                     // TODO: dynamic?
@@ -1581,7 +1596,7 @@ impl hal::Device<Backend> for Device {
                         resource: resource,
                         kind: image.kind,
                         caps: image::ViewCapabilities::empty(),
-                        view_kind: image::ViewKind::D2,
+                        view_kind,
                         format: decomposed.dsv.unwrap(),
                         range: image::SubresourceRange {
                             aspects: format::Aspects::COLOR,
@@ -1621,23 +1636,28 @@ impl hal::Device<Backend> for Device {
         _swizzle: format::Swizzle,
         range: image::SubresourceRange,
     ) -> Result<ImageView, image::ViewError> {
+        let is_array = image.kind.num_layers() > 1;
+
         let info = ViewInfo {
             resource: image.internal.raw,
             kind: image.kind,
             caps: image.view_caps,
-            view_kind,
+            // D3D11 doesn't allow looking at a single slice of an array as a non-array
+            view_kind: if is_array && view_kind == image::ViewKind::D2 {
+                image::ViewKind::D2Array
+            } else if is_array && view_kind == image::ViewKind::D1 {
+                image::ViewKind::D1Array
+            } else {
+                view_kind
+            },
             format: conv::map_format(format)
                 .ok_or(image::ViewError::BadFormat(format))?,
-            range: range.clone(),
+            range,
         };
 
         let srv_info = ViewInfo {
-            resource: image.internal.raw,
-            kind: image.kind,
-            caps: image.view_caps,
-            view_kind,
             format: conv::viewable_format(info.format),
-            range,
+            .. info.clone()
         };
 
         Ok(ImageView {


### PR DESCRIPTION
Fixes dx11 to the point of being usable from wgpu-rs, enables it in the examples
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx11
- [ ] `rustfmt` run on changed code
