### PR TITLE
Only discard rasterization if no fragment shader and the Depth/Stencil tests are both disabled (Vulkan backend)

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -543,10 +543,9 @@ impl d::Device<B> for Device {
                     } else {
                         vk::FALSE
                     },
-                    rasterizer_discard_enable: if desc.shaders.fragment.is_none() {
-                        vk::TRUE
-                    } else {
-                        vk::FALSE
+                    rasterizer_discard_enable: match (&desc.shaders.fragment, &desc.depth_stencil.depth, &desc.depth_stencil.stencil) {
+                        (None, pso::DepthTest::Off, pso::StencilTest::Off) => vk::TRUE,
+                                                                         _ => vk::FALSE,
                     },
                     polygon_mode,
                     cull_mode: conv::map_cull_face(desc.rasterizer.cull_face),


### PR DESCRIPTION
…ell as there being no pixel shader)

Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- [x] `rustfmt` run on changed code
