### PR TITLE
Add documentation to `gfx_app`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gfx_app"
 version = "0.9.0"
-description = "GFX example application framework"
+description = "Cross platform GFX example application framework"
 homepage = "https://github.com/gfx-rs/gfx"
 keywords = ["graphics", "gamedev"]
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,11 +57,7 @@
 //!     }
 //! }
 //! 
-//! fn main() {
-//!     use gfx_app::Application;
-//! 
-//!     App::launch_simple("Window title");
-//! }
+//! // Then just call `App::launch_simple("Window title");` from `main`.
 //! ```
 //! 
 //! Note: only `new` and `render` are required to be implemented, but implementing `on` (and `on_resize` or `on_resize_ext`) allows an app to handle events.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 
 //! Cross platform GFX example application framework.
 //! 
-//! Supports OpenGL 3.2, OpenGL ES 2.0, WebGL 2, DirectX 11, Vulkan, and Metal. Handles windowing via `winit`.
+//! Supports OpenGL 3.2, OpenGL ES 2.0, WebGL 2, and DirectX 11. Handles windowing via `winit`.
 //! 
 //! Note: The documentation will be available only for the backends corresponding to the platform you're compiling to.
 //! 

--- a/src/shade.rs
+++ b/src/shade.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Helpers for picking the correct shaders for the current backend.
 
 use std::error::Error;
 use std::fmt;
@@ -34,6 +35,7 @@ pub enum Backend {
     Vulkan,
 }
 
+/// Represents that a shader does not exist for a given backend.
 pub const EMPTY: &'static [u8] = &[];
 
 /// A type storing shader source for different graphics APIs and versions.


### PR DESCRIPTION
(Note: this is for `pre-ll`)

I understand that `gfx_app` is meant to be a framework for the `gfx` examples, but I've found it to be very useful in prototype or toy renderers. My original intention was to generalize it a little such that more kinds of projects could use it, but I figured I'd start by documenting the existing code (and potentially creating a new project that just does the cross platform window/backend initialization that `gfx_app` does).

Please let me know if this PR is useful and what improvements I can make on it, if so!

Cheers!