### PR TITLE
[pre-ll] Add format::R8_G8_B8 for opengl

### DIFF
--- a/src/backend/dx11/src/data.rs
+++ b/src/backend/dx11/src/data.rs
@@ -39,7 +39,7 @@ pub fn map_format(format: Format, is_target: bool) -> Option<DXGI_FORMAT> {
     use core::format::SurfaceType::*;
     use core::format::ChannelType::*;
     Some(match format.0 {
-        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 => return None,
+        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 | R8_G8_B8 => return None,
         R8 => match format.1 {
             Int   => DXGI_FORMAT_R8_SINT,
             Uint  => DXGI_FORMAT_R8_UINT,
@@ -151,7 +151,7 @@ pub fn map_format(format: Format, is_target: bool) -> Option<DXGI_FORMAT> {
 pub fn map_surface(surface: SurfaceType) -> Option<DXGI_FORMAT> {
     use core::format::SurfaceType::*;
     Some(match surface {
-        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 => return None,
+        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 | R8_G8_B8 => return None,
         R16_G16_B16 => return None,
         R8              => DXGI_FORMAT_R8_TYPELESS,
         R8_G8           => DXGI_FORMAT_R8G8_TYPELESS,

--- a/src/backend/gl/src/tex.rs
+++ b/src/backend/gl/src/tex.rs
@@ -64,7 +64,7 @@ fn format_to_glpixel(format: NewFormat) -> GLenum {
     match format.0 {
         S::R8 | S::R16 | S::R32=> r,
         S::R4_G4 | S::R8_G8 | S::R16_G16 | S::R32_G32 => rg,
-        S::R16_G16_B16 | S::R32_G32_B32 | S::R5_G6_B5 | S::R11_G11_B10 => rgb,
+        S::R16_G16_B16 | S::R32_G32_B32 | S::R5_G6_B5 | S::R11_G11_B10 | S::R8_G8_B8 => rgb,
         S::R8_G8_B8_A8 | S::R16_G16_B16_A16 | S::R32_G32_B32_A32 |
         S::R4_G4_B4_A4 | S::R5_G5_B5_A1 | S::R10_G10_B10_A2 => rgba,
         S::D24_S8 => gl::DEPTH_STENCIL,
@@ -89,7 +89,7 @@ fn format_to_gltype(format: NewFormat) -> Result<GLenum, ()> {
         S::R4_G4_B4_A4 => gl::UNSIGNED_SHORT_4_4_4_4,
         S::R5_G5_B5_A1 => gl::UNSIGNED_SHORT_5_5_5_1,
         S::R5_G6_B5 => gl::UNSIGNED_SHORT_5_6_5,
-        S::B8_G8_R8_A8 | S::R8 | S::R8_G8 | S::R8_G8_B8_A8 => fm8,
+        S::B8_G8_R8_A8 | S::R8 | S::R8_G8 | S::R8_G8_B8_A8 | S::R8_G8_B8 => fm8,
         S::R10_G10_B10_A2 => gl::UNSIGNED_INT_10_10_10_2,
         S::R11_G11_B10 => return Err(()),
         S::R16 | S::R16_G16 | S::R16_G16_B16 | S::R16_G16_B16_A16 => fm16,
@@ -135,7 +135,14 @@ pub fn format_to_glfull(format: NewFormat) -> Result<GLenum, ()> {
             C::Unorm => gl::RG8,
             _ => return Err(()),
         },
-        //S::R8_G8_B8 |
+        S::R8_G8_B8 => match cty {
+            C::Int => gl::RGB8I,
+            C::Inorm => gl::RGB8_SNORM,
+            C::Uint => gl::RGB8UI,
+            C::Unorm => gl::RGB8,
+            C::Srgb => gl::SRGB8,
+            _ => return Err(()),
+        },
         S::R8_G8_B8_A8 => match cty {
             C::Int => gl::RGBA8I,
             C::Inorm => gl::RGBA8_SNORM,

--- a/src/backend/metal/src/map.rs
+++ b/src/backend/metal/src/map.rs
@@ -128,6 +128,15 @@ pub fn map_vertex_format(format: Format) -> Option<MTLVertexFormat> {
                 _ => return None,
             }
         }
+        R8_G8_B8 => {
+            match format.1 {
+                Int => MTLVertexFormat::Char3,
+                Uint => MTLVertexFormat::UChar3,
+                Inorm => MTLVertexFormat::Char3Normalized,
+                Unorm => MTLVertexFormat::UChar3Normalized,
+                _ => return None,
+            }
+        }
         R8_G8_B8_A8 => {
             match format.1 {
                 Int => MTLVertexFormat::Char4,
@@ -217,7 +226,7 @@ pub fn map_format(format: Format, is_target: bool) -> Option<MTLPixelFormat> {
     use metal::MTLPixelFormat::*;
 
     Some(match format.0 {
-        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 => return None,
+        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 | R8_G8_B8 => return None,
         R8 => match format.1 {
             Int   => R8Sint,
             Uint  => R8Uint,
@@ -339,7 +348,7 @@ pub fn map_channel_hint(hint: SurfaceType) -> Option<ChannelType> {
     use core::format::ChannelType::*;
 
     Some(match hint {
-        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 | R16_G16_B16 | R32_G32_B32 | D16 => {
+        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 | R16_G16_B16 | R32_G32_B32 | D16 | R8_G8_B8 => {
             return None
         }
         R8 | R8_G8 | R8_G8_B8_A8 | R10_G10_B10_A2 | R16 | R16_G16 | R16_G16_B16_A16 | R32 |

--- a/src/backend/vulkan/src/data.rs
+++ b/src/backend/vulkan/src/data.rs
@@ -159,6 +159,14 @@ pub fn map_format(surface: SurfaceType, chan: ChannelType) -> Option<vk::Format>
             Srgb  => vk::FORMAT_R8G8_SRGB,
             _ => return None,
         },
+        R8_G8_B8 => match chan {
+            Int   => vk::FORMAT_R8G8B8_SINT,
+            Uint  => vk::FORMAT_R8G8B8_UINT,
+            Inorm => vk::FORMAT_R8G8B8_SNORM,
+            Unorm => vk::FORMAT_R8G8B8_UNORM,
+            Srgb  => vk::FORMAT_R8G8B8_SRGB,
+            _ => return None,
+        },
         R8_G8_B8_A8 => match chan {
             Int   => vk::FORMAT_R8G8B8A8_SINT,
             Uint  => vk::FORMAT_R8G8B8A8_UINT,

--- a/src/core/src/format.rs
+++ b/src/core/src/format.rs
@@ -123,6 +123,8 @@ impl_formats! {
         [BufferSurface, TextureSurface, RenderSurface],
     R8_G8           : Vec2<Int, Uint, Inorm, Unorm> = [u8; 2] {0}
         [BufferSurface, TextureSurface, RenderSurface],
+    R8_G8_B8        : Vec3<Int, Uint, Inorm, Unorm, Srgb> = [u8; 3] {0}
+        [BufferSurface, TextureSurface, RenderSurface],
     R8_G8_B8_A8     : Vec4<Int, Uint, Inorm, Unorm, Srgb> = [u8; 4] {8}
         [BufferSurface, TextureSurface, RenderSurface],
     R10_G10_B10_A2  : Vec4<Uint, Unorm> = u32 {2}

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -79,6 +79,7 @@ fn sdl2_pixel_format_from_gfx(format: Format) -> Option<PixelFormatEnum> {
         R4_G4_B4_A4 => Some(SdlFmt::RGBA4444),
         R5_G5_B5_A1 => Some(SdlFmt::RGBA5551),
         R5_G6_B5 => Some(SdlFmt::RGB565),
+        R8_G8_B8 => Some(SdlFmt::RGB888),
         R8_G8_B8_A8 => Some(SdlFmt::RGBA8888),
         B8_G8_R8_A8 => Some(SdlFmt::BGRA8888),
         R10_G10_B10_A2 => {


### PR DESCRIPTION
This change adds `format::R8_G8_B8` support for opengl. This is useful to me as I have some large rgb pngs and this avoid me having to convert them to rgba before uploading to the gpu. It may help with vram usage in this case too, although maybe some drivers already optimise this.

PR checklist:
- [x] tested examples with the following backends: gl
