### PR TITLE
[mtl] expose line fill, fix MSAA views

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -3,7 +3,7 @@ use gfx_hal as hal;
 use crate::internal::{BlitVertex, ClearKey, ClearVertex};
 use crate::{conversions as conv, native, soft, window};
 use crate::{
-    validate_line_width, AsNative, Backend, BufferPtr, OnlineRecording, PrivateDisabilities,
+    AsNative, Backend, BufferPtr, OnlineRecording, PrivateDisabilities,
     ResourceIndex, SamplerPtr, Shared, TexturePtr,
 };
 
@@ -1389,6 +1389,7 @@ where
         Cmd::SetRasterizerState(ref rs) => {
             encoder.set_front_facing_winding(rs.front_winding);
             encoder.set_cull_mode(rs.cull_mode);
+            encoder.set_triangle_fill_mode(rs.fill_mode);
             if let Some(depth_clip) = rs.depth_clip {
                 encoder.set_depth_clip_mode(depth_clip);
             }
@@ -3102,7 +3103,10 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     unsafe fn set_line_width(&mut self, width: f32) {
-        validate_line_width(width);
+        // Note from the Vulkan spec:
+        // > If the wide lines feature is not enabled, lineWidth must be 1.0
+        // Simply assert and no-op because Metal never exposes `Features::LINE_WIDTH`
+        assert_eq!(width, 1.0);
     }
 
     unsafe fn set_depth_bias(&mut self, depth_bias: pso::DepthBias) {

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -1176,6 +1176,22 @@ pub fn map_winding(face: pso::FrontFace) -> MTLWinding {
     }
 }
 
+pub fn map_polygon_mode(mode: pso::PolygonMode) -> MTLTriangleFillMode {
+    match mode {
+        pso::PolygonMode::Point => {
+            warn!("Unable to fill with points");
+            MTLTriangleFillMode::Lines
+        }
+        pso::PolygonMode::Line(width) => {
+            if width != 1.0 {
+                warn!("Unsupported line width: {:?}", width);
+            }
+            MTLTriangleFillMode::Lines
+        }
+        pso::PolygonMode::Fill => MTLTriangleFillMode::Fill,
+    }
+}
+
 pub fn map_cull_face(face: pso::Face) -> Option<MTLCullMode> {
     match face {
         pso::Face::NONE => Some(MTLCullMode::None),

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -503,6 +503,8 @@ struct PrivateCapabilities {
     os_version: (u32, u32),
     msl_version: metal::MTLLanguageVersion,
     exposed_queues: usize,
+    // if TRUE, we'll report `NON_FILL_POLYGON_MODE` feature without the points support
+    expose_line_mode: bool,
     resource_heaps: bool,
     argument_buffers: bool,
     shared_textures: bool,
@@ -624,6 +626,7 @@ impl PrivateCapabilities {
                 MTLLanguageVersion::V1_0
             },
             exposed_queues: 1,
+            expose_line_mode: true,
             resource_heaps: Self::supports_any(&device, RESOURCE_HEAP_SUPPORT),
             argument_buffers: Self::supports_any(&device, ARGUMENT_BUFFER_SUPPORT) && false, //TODO
             shared_textures: !os_is_mac,
@@ -806,13 +809,6 @@ impl PrivateCapabilities {
 #[derive(Clone, Copy, Debug)]
 struct PrivateDisabilities {
     broken_viewport_near_depth: bool,
-}
-
-fn validate_line_width(width: f32) {
-    // Note from the Vulkan spec:
-    // > If the wide lines feature is not enabled, lineWidth must be 1.0
-    // Simply assert and no-op because Metal never exposes `Features::LINE_WIDTH`
-    assert_eq!(width, 1.0);
 }
 
 trait AsNative {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -222,6 +222,7 @@ impl fmt::Debug for PipelineCache {
 pub struct RasterizerState {
     //TODO: more states
     pub front_winding: metal::MTLWinding,
+    pub fill_mode: metal::MTLTriangleFillMode,
     pub cull_mode: metal::MTLCullMode,
     pub depth_clip: Option<metal::MTLDepthClipMode>,
 }
@@ -230,6 +231,7 @@ impl Default for RasterizerState {
     fn default() -> Self {
         RasterizerState {
             front_winding: metal::MTLWinding::Clockwise,
+            fill_mode: metal::MTLTriangleFillMode::Fill,
             cull_mode: metal::MTLCullMode::None,
             depth_clip: None,
         }


### PR DESCRIPTION
Fixes vkQuake2 running on gfx-portability.
Changes are relatively harmless.
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
