### PR TITLE
[pre-ll] Update winit/glutin -> 0.19/0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ name = "gfx_app"
 
 [dependencies]
 log = "0.4"
-env_logger = "0.5"
-glutin = "0.19"
-winit = "0.18"
+env_logger = "0.6"
+glutin = "0.20"
+winit = "0.19"
 gfx_core = { path = "src/core", version = "0.9" }
 gfx = { path = "src/render", version = "0.18" }
 gfx_macros = { path = "src/macros", version = "0.2" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.16" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.29" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.30" }
 gfx_window_glfw = { path = "src/window/glfw", version = "0.17", optional = true }
 gfx_window_sdl = { path = "src/window/sdl", version = "0.9", optional = true }
 
@@ -57,7 +57,7 @@ optional = true
 
 [target.'cfg(windows)'.dependencies]
 gfx_device_dx11 = { path = "src/backend/dx11", version = "0.8" }
-gfx_window_dxgi = { path = "src/window/dxgi", version = "0.18" }
+gfx_window_dxgi = { path = "src/window/dxgi", version = "0.19" }
 
 [[example]]
 name = "blend"
@@ -124,9 +124,9 @@ name = "render_target"
 path = "examples/render_target/main.rs"
 
 [dev-dependencies]
-cgmath = "0.16"
+cgmath = "0.17"
 gfx_gl = "0.5"
 rand = "0.5"
 genmesh = "0.5"
 noise = "0.2" #TODO: update
-image = "0.20"
+image = "0.21"

--- a/examples/performance/main.rs
+++ b/examples/performance/main.rs
@@ -33,7 +33,7 @@ use std::ffi::CString;
 use std::time::{Duration, Instant};
 use gfx_device_gl::{Resources as R, CommandBuffer as CB};
 use gfx_core::Device;
-use glutin::GlContext;
+use glutin::ContextTrait;
 
 gfx_defines!{
     vertex Vertex {
@@ -94,7 +94,7 @@ trait Renderer: Drop {
 
 struct GFX {
     dimension: i16,
-    window: glutin::GlWindow,
+    window: glutin::WindowedContext,
     device:gfx_device_gl::Device,
     encoder: gfx::Encoder<R,CB>,
     data: pipe::Data<R>,
@@ -104,7 +104,7 @@ struct GFX {
 
 struct GL {
     dimension: i16,
-    window: glutin::GlWindow,
+    window: glutin::WindowedContext,
     gl:Gl,
     trans_uniform:GLint,
     vs:GLuint,
@@ -221,7 +221,7 @@ impl GL {
             }
         };
 
-        let window = glutin::GlWindow::new(builder, context, &events_loop).unwrap();
+        let window = glutin::WindowedContext::new_windowed(builder, context, &events_loop).unwrap();
         unsafe { window.make_current().unwrap() };
         let gl = Gl::load_with(|s| window.get_proc_address(s) as *const _);
 

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.18.0"
+version = "0.19.0"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,6 +29,6 @@ name = "gfx_window_dxgi"
 [dependencies]
 log = "0.4"
 winapi = { version = "0.3" , features = ["d3d11", "dxgi"] }
-winit = "0.18"
+winit = "0.19"
 gfx_core = { path = "../../core", version = "0.9" }
 gfx_device_dx11 = { path = "../../backend/dx11", version = "0.8" }

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.29.0"
+version = "0.30.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -28,7 +28,7 @@ documentation = "https://docs.rs/gfx_window_glutin"
 name = "gfx_window_glutin"
 
 [dependencies]
-glutin = "0.19"
+glutin = "0.20"
 gfx_core = { path = "../../core", version = "0.9" }
 gfx_device_gl = { path = "../../backend/gl", version = "0.16" }
 

--- a/src/window/glutin/README.md
+++ b/src/window/glutin/README.md
@@ -7,10 +7,10 @@ Glutin window backend for gfx-rs
 Make sure you have the following in your `Cargo.toml`:
 
 ```toml
-gfx_core = "0.8"
-gfx_device_gl = "0.15"
-gfx_window_glutin = "0.28.0"
-glutin = "0.19"
+gfx_core = "0.9"
+gfx_device_gl = "0.16"
+gfx_window_glutin = "0.30.0"
+glutin = "0.20"
 ```
 
 Then, initialize `gfx` as follows:

--- a/src/window/glutin/src/headless.rs
+++ b/src/window/glutin/src/headless.rs
@@ -15,7 +15,7 @@
 use std::os::raw::c_void;
 
 use device_gl::{Device, Factory, Resources as Res, create as gl_create, create_main_targets_raw};
-use glutin::{GlContext, Context};
+use glutin::{ContextTrait, Context};
 
 use core::format::{Format, DepthFormat, RenderFormat};
 use core::handle::{DepthStencilView, RawDepthStencilView, RawRenderTargetView, RenderTargetView};

--- a/src/window/glutin/src/headless.rs
+++ b/src/window/glutin/src/headless.rs
@@ -46,7 +46,7 @@ use core::texture::Dimensions;
 /// let events_loop = EventsLoop::new();
 /// let context_builder = ContextBuilder::new()
 ///     .with_hardware_acceleration(Some(false));
-/// let context = Context::new(&events_loop, context_builder, false)
+/// let context = Context::new_headless(&events_loop, context_builder, (256, 256).into())
 ///     .expect("Failed to build headless context");
 ///
 /// let (mut device, _, _, _) = init_headless::<Rgba8, DepthStencil>(&context, dim);
@@ -101,7 +101,7 @@ mod tests {
         let events_loop = EventsLoop::new();
         let context_builder = ContextBuilder::new()
             .with_hardware_acceleration(Some(false));
-        let context = Context::new(&events_loop, context_builder, false)
+        let context = Context::new_headless(&events_loop, context_builder, (256, 256).into())
             .expect("Failed to build headless context");
 
         let (mut device, _, _, _) = init_headless::<Rgba8, DepthStencil>(&context, dim);

--- a/src/window/metal/Cargo.toml
+++ b/src/window/metal/Cargo.toml
@@ -30,7 +30,7 @@ name = "gfx_window_metal"
 log = "0.4"
 cocoa = "0.9"
 objc = "0.2"
-winit = "0.18"
+winit = "0.19"
 metal-rs = "0.4"
 gfx_core = { path = "../../core", version = "0.9" }
 gfx_device_metal = { path = "../../backend/metal", version = "0.3" }

--- a/src/window/vulkan/Cargo.toml
+++ b/src/window/vulkan/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/gfx_window_vulkan"
 name = "gfx_window_vulkan"
 
 [dependencies]
-winit = "0.18"
+winit = "0.19"
 vk-sys = { git = "https://github.com/sectopod/vulkano", branch = "bind" }
 gfx_core = { path = "../../core", version = "0.9" }
 gfx_device_vulkan = { path = "../../backend/vulkan", version = "0.2" }


### PR DESCRIPTION
Bumped for release _(reflecting the v0.18 branch)_
* gfx_window_dxgi -> `0.19`
* gfx_window_glutin -> `0.30`

Also updated gfx_app `env_logger` and some dev-dependencies because why not?

PR checklist:
- [x] tested examples with the following backends: gl