### PR TITLE
[dx12] fix image view format

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2339,7 +2339,7 @@ impl d::Device<B> for Device {
             } else {
                 None
             },
-            dxgi_format: image.descriptor.Format,
+            dxgi_format: image.default_view_format.unwrap(),
             num_levels: image.descriptor.MipLevels as image::Level,
             mip_levels,
             layers,


### PR DESCRIPTION
Follow up for #2664. Without this I get an error, when calling `clear_attachments`, because the [format](https://github.com/gfx-rs/gfx/blob/master/src/backend/dx12/src/command.rs#L1345) is typeless:  
```
D3D12 ERROR: ID3D12Device::CreateRenderTargetView: The Format (0x3c, R8_TYPELESS) is invalid,
when creating a View; it is not a fully qualified Format castable from the Format of the 
Resource (0x3c, R8_TYPELESS). [ STATE_CREATION ERROR #38: CREATERENDERTARGETVIEW_INVALIDFORMAT]	
```
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: DX12
- [ ] `rustfmt` run on changed code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/2692)
<!-- Reviewable:end -->
