### PR TITLE
[vk] Pass blend constant value by reference

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "1"
 log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
-ash = "0.27.0"
+ash = "0.28.0"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.18", optional = true }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -552,7 +552,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     }
 
     unsafe fn set_blend_constants(&mut self, color: pso::ColorValue) {
-        self.device.0.cmd_set_blend_constants(self.raw, color);
+        self.device.0.cmd_set_blend_constants(self.raw, &color);
     }
 
     unsafe fn set_depth_bounds(&mut self, bounds: Range<f32>) {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -224,21 +224,21 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         (
             "queue info",
             display_debug_utils_label_ext(
-                callback_data.p_queue_labels,
+                callback_data.p_queue_labels as *mut _,
                 callback_data.queue_label_count as usize,
             ),
         ),
         (
             "cmd buf info",
             display_debug_utils_label_ext(
-                callback_data.p_cmd_buf_labels,
+                callback_data.p_cmd_buf_labels as *mut _,
                 callback_data.cmd_buf_label_count as usize,
             ),
         ),
         (
             "object info",
             display_debug_utils_object_name_info_ext(
-                callback_data.p_objects,
+                callback_data.p_objects as *mut _,
                 callback_data.object_count as usize,
             ),
         ),


### PR DESCRIPTION
The related conversation is here: https://github.com/MaikKlein/ash/pull/191
Also updates ash version
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: GL, Vulkan, Metal, DX12, DX11
- [ ] `rustfmt` run on changed code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/2693)
<!-- Reviewable:end -->
