### PR TITLE
Fix acquire semaphore initialization in quad example

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -487,12 +487,15 @@ fn main() {
         }
     }
 
-    for i in 0..frames_in_flight {
+    for _ in 0..frame_images.len() {
         image_acquire_semaphores.push(
             device
                 .create_semaphore()
                 .expect("Could not create semaphore"),
         );
+    }
+
+    for i in 0..frames_in_flight {
         submission_complete_semaphores.push(
             device
                 .create_semaphore()


### PR DESCRIPTION
Fixes a small error in the quad example that would cause problems for when `frames_in_flight` < `frame_images.len()`. Aligns the code with what the comments say.