### PR TITLE
[dx12] clear attachments and SRV component swizzles

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -18,7 +18,7 @@ use winapi::Interface;
 
 use native::{self, descriptor};
 
-use device::ViewInfo;
+use device::{ViewInfo, IDENTITY_MAPPING};
 use root_constants::RootConstant;
 use smallvec::SmallVec;
 use {
@@ -1344,6 +1344,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             caps: image::ViewCapabilities::empty(),
                             view_kind: image::ViewKind::D2Array,
                             format: attachment.dxgi_format,
+                            component_mapping: IDENTITY_MAPPING,
                             range: image::SubresourceRange {
                                 aspects: Aspects::COLOR,
                                 levels: attachment.mip_levels.0..attachment.mip_levels.1,
@@ -1380,6 +1381,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             caps: image::ViewCapabilities::empty(),
                             view_kind: image::ViewKind::D2Array,
                             format: attachment.dxgi_format,
+                            component_mapping: IDENTITY_MAPPING,
                             range: image::SubresourceRange {
                                 aspects: if depth.is_some() {
                                     Aspects::DEPTH
@@ -1506,6 +1508,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             caps: src.view_caps,
             view_kind: image::ViewKind::D2Array, // TODO
             format: src.default_view_format.unwrap(),
+            component_mapping: IDENTITY_MAPPING,
             range: image::SubresourceRange {
                 aspects: format::Aspects::COLOR, // TODO
                 levels: 0..src.descriptor.MipLevels as _,

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1313,7 +1313,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         };
         let sub_pass = &pass_cache.render_pass.subpasses[self.cur_subpass];
 
-        let clear_rects: SmallVec<[pso::ClearRect; 16]> = rects
+        let clear_rects: SmallVec<[pso::ClearRect; 4]> = rects
             .into_iter()
             .map(|rect| rect.borrow().clone())
             .collect();
@@ -1335,6 +1335,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     );
 
                     for clear_rect in &clear_rects {
+                        assert!(attachment.layers.0 + clear_rect.layers.end <= attachment.layers.1);
                         let rect = [get_rect(&clear_rect.rect)];
 
                         let view_info = device::ViewInfo {
@@ -1346,7 +1347,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             range: image::SubresourceRange {
                                 aspects: Aspects::COLOR,
                                 levels: attachment.mip_levels.0..attachment.mip_levels.1,
-                                layers: clear_rect.layers.clone(),
+                                layers: attachment.layers.0 + clear_rect.layers.start ..
+                                    attachment.layers.0 + clear_rect.layers.end,
                             },
                         };
                         let rtv = rtv_pool.alloc_handle();
@@ -1369,6 +1371,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     );
 
                     for clear_rect in &clear_rects {
+                        assert!(attachment.layers.0 + clear_rect.layers.end <= attachment.layers.1);
                         let rect = [get_rect(&clear_rect.rect)];
 
                         let view_info = device::ViewInfo {
@@ -1388,7 +1391,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                     Aspects::empty()
                                 },
                                 levels: attachment.mip_levels.0..attachment.mip_levels.1,
-                                layers: clear_rect.layers.clone(),
+                                layers: attachment.layers.0 + clear_rect.layers.start ..
+                                    attachment.layers.0 + clear_rect.layers.end,
                             },
                         };
                         let dsv = dsv_pool.alloc_handle();

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -10,7 +10,7 @@ use winapi::shared::{dxgi, dxgi1_2, dxgi1_4, dxgiformat, dxgitype, winerror};
 use winapi::um::{d3d12, d3dcompiler, synchapi, winbase, winnt};
 use winapi::Interface;
 
-use hal::format::{Aspects, Format};
+use hal::format::Aspects;
 use hal::memory::Requirements;
 use hal::pool::CommandPoolCreateFlags;
 use hal::pso::VertexInputRate;

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -41,6 +41,8 @@ const MEM_TYPE_BUFFER_SHIFT: u64 = MEM_TYPE_SHIFT * MemoryGroup::BufferOnly as u
 const MEM_TYPE_IMAGE_SHIFT: u64 = MEM_TYPE_SHIFT * MemoryGroup::ImageOnly as u64;
 const MEM_TYPE_TARGET_SHIFT: u64 = MEM_TYPE_SHIFT * MemoryGroup::TargetOnly as u64;
 
+pub const IDENTITY_MAPPING: UINT = 0x1688; // D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING
+
 /// Emit error during shader module creation. Used if we don't expect an error
 /// but might panic due to an exception in SPIRV-Cross.
 fn gen_unexpected_error(err: SpirvErrorCode) -> d::ShaderError {
@@ -67,6 +69,7 @@ pub(crate) struct ViewInfo {
     pub(crate) caps: image::ViewCapabilities,
     pub(crate) view_kind: image::ViewKind,
     pub(crate) format: dxgiformat::DXGI_FORMAT,
+    pub(crate) component_mapping: UINT,
     pub(crate) range: image::SubresourceRange,
 }
 
@@ -722,7 +725,7 @@ impl Device {
         let mut desc = d3d12::D3D12_SHADER_RESOURCE_VIEW_DESC {
             Format: info.format,
             ViewDimension: 0,
-            Shader4ComponentMapping: 0x1688, // TODO: map swizzle
+            Shader4ComponentMapping: info.component_mapping,
             u: unsafe { mem::zeroed() },
         };
 
@@ -1942,7 +1945,7 @@ impl d::Device<B> for Device {
             let mut desc = d3d12::D3D12_SHADER_RESOURCE_VIEW_DESC {
                 Format: format,
                 ViewDimension: d3d12::D3D12_SRV_DIMENSION_BUFFER,
-                Shader4ComponentMapping: 0x1688, // TODO: verify
+                Shader4ComponentMapping: IDENTITY_MAPPING,
                 u: mem::zeroed(),
             };
 
@@ -2177,6 +2180,7 @@ impl d::Device<B> for Device {
                 image::Kind::D3(..) => image::ViewKind::D3,
             },
             format: image_unbound.desc.Format,
+            component_mapping: IDENTITY_MAPPING,
             range: image::SubresourceRange {
                 aspects: Aspects::empty(),
                 levels: 0..0,
@@ -2284,7 +2288,7 @@ impl d::Device<B> for Device {
         image: &r::Image,
         view_kind: image::ViewKind,
         format: format::Format,
-        _swizzle: format::Swizzle,
+        swizzle: format::Swizzle,
         range: image::SubresourceRange,
     ) -> Result<r::ImageView, image::ViewError> {
         let image = image.expect_bound();
@@ -2305,6 +2309,7 @@ impl d::Device<B> for Device {
                 view_kind
             },
             format: conv::map_format(format).ok_or(image::ViewError::BadFormat(format))?,
+            component_mapping: conv::map_swizzle(swizzle),
             range,
         };
 
@@ -3158,4 +3163,10 @@ impl d::Device<B> for Device {
         }
         Ok(())
     }
+}
+
+
+#[test]
+fn test_identity_mapping() {
+    assert_eq!(conv::map_swizzle(format::Swizzle::NO), IDENTITY_MAPPING);
 }


### PR DESCRIPTION
Fixes WebRender issue with clear rectangles on DX12. cc @zakorgy 
Note: the swizzles are only implemented for SRV. I don't know how to get them for other views.
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12
- [ ] `rustfmt` run on changed code
