### PR TITLE
[0.1/dx12] array attachment clear fix and SRV component mapping

### DIFF
--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.1.2"
+version = "0.1.3"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1320,7 +1320,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         };
         let sub_pass = &pass_cache.render_pass.subpasses[self.cur_subpass];
 
-        let clear_rects: SmallVec<[pso::ClearRect; 16]> = rects
+        let clear_rects: SmallVec<[pso::ClearRect; 4]> = rects
             .into_iter()
             .map(|rect| rect.borrow().clone())
             .collect();
@@ -1342,6 +1342,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     );
 
                     for clear_rect in &clear_rects {
+                        assert!(attachment.layers.0 + clear_rect.layers.end <= attachment.layers.1);
                         let rect = [get_rect(&clear_rect.rect)];
 
                         let view_info = device::ViewInfo {
@@ -1353,7 +1354,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             range: image::SubresourceRange {
                                 aspects: Aspects::COLOR,
                                 levels: attachment.mip_levels.0..attachment.mip_levels.1,
-                                layers: clear_rect.layers.clone(),
+                                layers: attachment.layers.0 + clear_rect.layers.start ..
+                                    attachment.layers.0 + clear_rect.layers.end,
                             },
                         };
                         let rtv = rtv_pool.alloc_handle();
@@ -1378,6 +1380,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     );
 
                     for clear_rect in &clear_rects {
+                        assert!(attachment.layers.0 + clear_rect.layers.end <= attachment.layers.1);
                         let rect = [get_rect(&clear_rect.rect)];
 
                         let view_info = device::ViewInfo {
@@ -1397,7 +1400,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                                     Aspects::empty()
                                 },
                                 levels: attachment.mip_levels.0..attachment.mip_levels.1,
-                                layers: clear_rect.layers.clone(),
+                                layers: attachment.layers.0 + clear_rect.layers.start ..
+                                    attachment.layers.0 + clear_rect.layers.end,
                             },
                         };
                         let dsv = dsv_pool.alloc_handle();

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -18,7 +18,7 @@ use winapi::Interface;
 
 use native::{self, descriptor};
 
-use device::ViewInfo;
+use device::{ViewInfo, IDENTITY_MAPPING};
 use root_constants::RootConstant;
 use smallvec::SmallVec;
 use {
@@ -1351,6 +1351,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             caps: image::ViewCapabilities::empty(),
                             view_kind: image::ViewKind::D2Array,
                             format: attachment.dxgi_format,
+                            component_mapping: IDENTITY_MAPPING,
                             range: image::SubresourceRange {
                                 aspects: Aspects::COLOR,
                                 levels: attachment.mip_levels.0..attachment.mip_levels.1,
@@ -1389,6 +1390,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                             caps: image::ViewCapabilities::empty(),
                             view_kind: image::ViewKind::D2Array,
                             format: attachment.dxgi_format,
+                            component_mapping: IDENTITY_MAPPING,
                             range: image::SubresourceRange {
                                 aspects: if depth.is_some() {
                                     Aspects::DEPTH
@@ -1522,6 +1524,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 caps: src.view_caps,
                 view_kind: image::ViewKind::D2Array, // TODO
                 format:  src.default_view_format.unwrap(),
+                component_mapping: IDENTITY_MAPPING,
                 range: image::SubresourceRange {
                     aspects: format::Aspects::COLOR, // TODO
                     levels: 0..src.descriptor.MipLevels as _,

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -532,9 +532,6 @@ impl Device {
     ) -> Result<(), image::ViewError> {
         #![allow(non_snake_case)]
 
-        if info.component_mapping != IDENTITY_MAPPING {
-            warn!("Unsupported component_mapping for RTV: {:?}", info.component_mapping);
-        }
         let mut desc = d3d12::D3D12_RENDER_TARGET_VIEW_DESC {
             Format: info.format,
             ViewDimension: 0,
@@ -635,10 +632,6 @@ impl Device {
         info: ViewInfo,
     ) -> Result<(), image::ViewError> {
         #![allow(non_snake_case)]
-
-        if info.component_mapping != IDENTITY_MAPPING {
-            warn!("Unsupported component_mapping for DSV: {:?}", info.component_mapping);
-        }
 
         let mut desc = d3d12::D3D12_DEPTH_STENCIL_VIEW_DESC {
             Format: info.format,
@@ -861,9 +854,6 @@ impl Device {
         #![allow(non_snake_case)]
         assert_eq!(info.range.levels.start + 1, info.range.levels.end);
 
-        if info.component_mapping != IDENTITY_MAPPING {
-            warn!("Unsupported component_mapping for UAV: {:?}", info.component_mapping);
-        }
         let mut desc = d3d12::D3D12_UNORDERED_ACCESS_VIEW_DESC {
             Format: info.format,
             ViewDimension: 0,

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -10,7 +10,7 @@ use winapi::shared::{dxgi, dxgi1_2, dxgi1_4, dxgiformat, dxgitype, winerror};
 use winapi::um::{d3d12, d3dcompiler, synchapi, winbase, winnt};
 use winapi::Interface;
 
-use hal::format::{Aspects, Format};
+use hal::format::Aspects;
 use hal::memory::Requirements;
 use hal::pool::CommandPoolCreateFlags;
 use hal::queue::{QueueFamilyId, RawCommandQueue};


### PR DESCRIPTION
Sibling of #2696
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12
- [ ] `rustfmt` run on changed code
