### PR TITLE
More detailed limits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 members = [
-	"src/auxil/range-alloc",
+    "src/auxil/range-alloc",
     "src/backend/dx11",
     "src/backend/dx12",
     "src/backend/empty",

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -908,7 +908,7 @@ impl<B: Backend> BufferState<B> {
     ) -> (Self, Dimensions<u32>, u32, usize) {
         let (width, height) = img.dimensions();
 
-        let row_alignment_mask = adapter.limits.min_buffer_copy_pitch_alignment as u32 - 1;
+        let row_alignment_mask = adapter.limits.optimal_buffer_copy_pitch_alignment as u32 - 1;
         let stride = 4usize;
 
         let row_pitch = (width * stride as u32 + row_alignment_mask) & !row_alignment_mask;

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -217,7 +217,7 @@ fn main() {
         .to_rgba();
     let (width, height) = img.dimensions();
     let kind = i::Kind::D2(width as i::Size, height as i::Size, 1, 1);
-    let row_alignment_mask = limits.min_buffer_copy_pitch_alignment as u32 - 1;
+    let row_alignment_mask = limits.optimal_buffer_copy_pitch_alignment as u32 - 1;
     let image_stride = 4usize;
     let row_pitch = (width * image_stride as u32 + row_alignment_mask) & !row_alignment_mask;
     let upload_size = (height * row_pitch) as u64;

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -338,24 +338,28 @@ impl hal::Instance for Instance {
             };
 
             let limits = hal::Limits {
-                max_texture_size: d3d11::D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION as _,
+                max_image_1d_size: d3d11::D3D11_REQ_TEXTURE1D_U_DIMENSION as _,
+                max_image_2d_size: d3d11::D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION as _,
+                max_image_3d_size: d3d11::D3D11_REQ_TEXTURE3D_U_V_OR_W_DIMENSION as _,
+                max_image_cube_size: d3d11::D3D11_REQ_TEXTURECUBE_DIMENSION as _,
+                max_image_array_layers: d3d11::D3D11_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION as _,
                 max_texel_elements: d3d11::D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION as _, //TODO
                 max_patch_size: 0,                                                    // TODO
                 max_viewports: d3d11::D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE as _,
-                max_compute_group_count: [
+                max_compute_work_group_count: [
                     d3d11::D3D11_CS_THREAD_GROUP_MAX_X,
                     d3d11::D3D11_CS_THREAD_GROUP_MAX_Y,
                     d3d11::D3D11_CS_THREAD_GROUP_MAX_Z,
                 ],
-                max_compute_group_size: [d3d11::D3D11_CS_THREAD_GROUP_MAX_THREADS_PER_GROUP, 1, 1], // TODO
+                max_compute_work_group_size: [d3d11::D3D11_CS_THREAD_GROUP_MAX_THREADS_PER_GROUP, 1, 1], // TODO
                 max_vertex_input_attribute_offset: 255, // TODO
                 max_vertex_input_attributes: d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as _,
                 max_vertex_input_binding_stride:
                     d3d11::D3D11_REQ_MULTI_ELEMENT_STRUCTURE_SIZE_IN_BYTES as _,
                 max_vertex_input_bindings: d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as _, // TODO: verify same as attributes
                 max_vertex_output_components: d3d11::D3D11_VS_OUTPUT_REGISTER_COUNT as _, // TODO
-                min_buffer_copy_offset_alignment: 1,                                      // TODO
-                min_buffer_copy_pitch_alignment: 1,                                       // TODO
+                optimal_buffer_copy_offset_alignment: 1,                                      // TODO
+                optimal_buffer_copy_pitch_alignment: 1,                                       // TODO
                 min_texel_buffer_offset_alignment: 1,                                     // TODO
                 min_uniform_buffer_offset_alignment: 16, // TODO: verify
                 min_storage_buffer_offset_alignment: 1,  // TODO
@@ -366,6 +370,7 @@ impl hal::Instance for Instance {
                 non_coherent_atom_size: 1,               // TODO
                 max_sampler_anisotropy: 16.,
                 min_vertex_input_binding_stride_alignment: 1,
+                .. hal::Limits::default() //TODO
             };
 
             let features = get_features(device.clone(), feature_level);
@@ -1711,7 +1716,7 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: pso::BufferIndex, buffers: I)
     where
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<Buffer>,

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1707,7 +1707,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         );
     }
 
-    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: pso::BufferIndex, buffers: I)
     where
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<r::Buffer>,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -180,8 +180,8 @@ static QUEUE_FAMILIES: [QueueFamily; 4] = [
 
 pub struct PhysicalDevice {
     adapter: native::WeakPtr<dxgi1_2::IDXGIAdapter2>,
-    features: hal::Features,
-    limits: hal::Limits,
+    features: Features,
+    limits: Limits,
     format_properties: Arc<FormatProperties>,
     private_caps: Capabilities,
     heap_properties: &'static [HeapProperties; NUM_HEAP_PROPERTIES],
@@ -198,7 +198,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     unsafe fn open(
         &self,
         families: &[(&QueueFamily, &[hal::QueuePriority])],
-        requested_features: hal::Features,
+        requested_features: Features,
     ) -> Result<hal::Gpu<Backend>, error::DeviceCreationError> {
         let lock = self.is_open.try_lock();
         let mut open_guard = match lock {
@@ -1036,16 +1036,20 @@ impl hal::Instance for Instance {
                     Features::INSTANCE_RATE |
                     Features::SAMPLER_MIP_LOD_BIAS,
                 limits: Limits { // TODO
-                    max_texture_size: 0,
+                    max_image_1d_size: d3d12::D3D12_REQ_TEXTURE1D_U_DIMENSION as _,
+                    max_image_2d_size: d3d12::D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION as _,
+                    max_image_3d_size: d3d12::D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION as _,
+                    max_image_cube_size: d3d12::D3D12_REQ_TEXTURECUBE_DIMENSION as _,
+                    max_image_array_layers: d3d12::D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION as _,
                     max_texel_elements: 0,
                     max_patch_size: 0,
                     max_viewports: 0,
-                    max_compute_group_count: [
+                    max_compute_work_group_count: [
                         d3d12::D3D12_CS_THREAD_GROUP_MAX_X,
                         d3d12::D3D12_CS_THREAD_GROUP_MAX_Y,
                         d3d12::D3D12_CS_THREAD_GROUP_MAX_Z,
                     ],
-                    max_compute_group_size: [
+                    max_compute_work_group_size: [
                         d3d12::D3D12_CS_THREAD_GROUP_MAX_THREADS_PER_GROUP,
                         1, //TODO
                         1, //TODO
@@ -1055,8 +1059,8 @@ impl hal::Instance for Instance {
                     max_vertex_input_attribute_offset: 255, // TODO
                     max_vertex_input_binding_stride: d3d12::D3D12_REQ_MULTI_ELEMENT_STRUCTURE_SIZE_IN_BYTES as _,
                     max_vertex_output_components: 16, // TODO
-                    min_buffer_copy_offset_alignment: d3d12::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as _,
-                    min_buffer_copy_pitch_alignment: d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as _,
+                    optimal_buffer_copy_offset_alignment: d3d12::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as _,
+                    optimal_buffer_copy_pitch_alignment: d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as _,
                     min_texel_buffer_offset_alignment: 1, // TODO
                     min_uniform_buffer_offset_alignment: 256, // Required alignment for CBVs
                     min_storage_buffer_offset_alignment: 1, // TODO
@@ -1069,6 +1073,7 @@ impl hal::Instance for Instance {
                     non_coherent_atom_size: 1, //TODO: confirm
                     max_sampler_anisotropy: 16.,
                     min_vertex_input_binding_stride_alignment: 1,
+                    .. Limits::default() //TODO
                 },
                 format_properties: Arc::new(FormatProperties::new(device)),
                 private_caps: Capabilities {

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -751,7 +751,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         self.push_cmd(Command::BindIndexBuffer(ibv.buffer.raw));
     }
 
-    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: pso::BufferIndex, buffers: I)
     where
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<n::Buffer>,

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -123,7 +123,7 @@ impl Device {
     ) -> Result<n::ShaderModule, d::ShaderError> {
         let gl = &self.share.context;
 
-        let can_compute = self.share.limits.max_compute_group_count[0] != 0;
+        let can_compute = self.share.limits.max_compute_work_group_count[0] != 0;
         let can_tessellate = self.share.limits.max_patch_size != 0;
         let target = match stage {
             pso::Stage::Vertex => gl::VERTEX_SHADER,

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -305,13 +305,18 @@ impl Info {
 pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Limits, PrivateCaps) {
     use self::Requirement::*;
     let info = Info::get(gl);
+    let max_texture_size = get_usize(gl, gl::MAX_TEXTURE_SIZE).unwrap_or(64) as u32;
 
     let mut limits = Limits {
-        max_texture_size: get_usize(gl, gl::MAX_TEXTURE_SIZE).unwrap_or(64),
+        max_image_1d_size: max_texture_size,
+        max_image_2d_size: max_texture_size,
+        max_image_3d_size: max_texture_size,
+        max_image_cube_size: max_texture_size,
+        max_image_array_layers: get_usize(gl, gl::MAX_ARRAY_TEXTURE_LAYERS).unwrap_or(1) as u16,
         max_texel_elements: get_usize(gl, gl::MAX_TEXTURE_BUFFER_SIZE).unwrap_or(0),
         max_viewports: 1,
-        min_buffer_copy_offset_alignment: 1,
-        min_buffer_copy_pitch_alignment: 1,
+        optimal_buffer_copy_offset_alignment: 1,
+        optimal_buffer_copy_pitch_alignment: 1,
         min_texel_buffer_offset_alignment: 1,   // TODO
         min_uniform_buffer_offset_alignment: 1, // TODO
         min_storage_buffer_offset_alignment: 1, // TODO
@@ -335,9 +340,9 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
     {
         let mut values = [0 as gl::types::GLint; 2];
         for (i, (count, size)) in limits
-            .max_compute_group_count
+            .max_compute_work_group_count
             .iter_mut()
-            .zip(limits.max_compute_group_size.iter_mut())
+            .zip(limits.max_compute_work_group_size.iter_mut())
             .enumerate()
         {
             unsafe {

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -794,7 +794,7 @@ impl Journal {
         // Each upper level points to the lower one with index
         // sub-ranges. In order to merge two journals, we need
         // to fix those indices of the one that goes on top.
-        // This is referred here as "rebasing". 
+        // This is referred here as "rebasing".
         for mut com in other.render_commands.iter().cloned() {
             self.resources.rebase_render(&mut com);
             self.render_commands.push(com);
@@ -3019,7 +3019,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         });
     }
 
-    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: pso::BufferIndex, buffers: I)
     where
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<native::Buffer>,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -391,25 +391,28 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn limits(&self) -> hal::Limits {
+        let pc = &self.shared.private_caps;
         hal::Limits {
-            max_texture_size: self.shared.private_caps.max_texture_size as usize,
-            max_texel_elements: (self.shared.private_caps.max_texture_size
-                * self.shared.private_caps.max_texture_size)
-                as usize,
+            max_image_1d_size: pc.max_texture_size as _,
+            max_image_2d_size: pc.max_texture_size as _,
+            max_image_3d_size: pc.max_texture_3d_size as _,
+            max_image_cube_size: pc.max_texture_size as _,
+            max_image_array_layers: pc.max_texture_layers as _,
+            max_texel_elements: (pc.max_texture_size * pc.max_texture_size) as usize,
             max_patch_size: 0, // No tessellation
 
             // Note: The maximum number of supported viewports and scissor rectangles varies by device.
             // TODO: read from Metal Feature Sets.
             max_viewports: 1,
 
-            min_buffer_copy_offset_alignment: self.shared.private_caps.buffer_alignment,
-            min_buffer_copy_pitch_alignment: 4,
-            min_texel_buffer_offset_alignment: self.shared.private_caps.buffer_alignment,
-            min_uniform_buffer_offset_alignment: self.shared.private_caps.buffer_alignment,
-            min_storage_buffer_offset_alignment: self.shared.private_caps.buffer_alignment,
+            optimal_buffer_copy_offset_alignment: pc.buffer_alignment,
+            optimal_buffer_copy_pitch_alignment: 4,
+            min_texel_buffer_offset_alignment: pc.buffer_alignment,
+            min_uniform_buffer_offset_alignment: pc.buffer_alignment,
+            min_storage_buffer_offset_alignment: pc.buffer_alignment,
 
-            max_compute_group_count: [16; 3], // TODO
-            max_compute_group_size: [64; 3],  // TODO
+            max_compute_work_group_count: [16; 3], // TODO
+            max_compute_work_group_size: [64; 3],  // TODO
 
             max_vertex_input_attributes: 31,
             max_vertex_input_bindings: 31,
@@ -427,6 +430,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             non_coherent_atom_size: 4,
             max_sampler_anisotropy: 16.,
             min_vertex_input_binding_stride_alignment: STRIDE_GRANULARITY as u64,
+            .. hal::Limits::default() //TODO
         }
     }
 }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -484,7 +484,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         );
     }
 
-    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: pso::BufferIndex, buffers: I)
     where
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<n::Buffer>,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -774,16 +774,19 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         let max_group_size = limits.max_compute_work_group_size;
 
         Limits {
-            max_texture_size: limits.max_image_dimension3_d as _,
+            max_image_1d_size: limits.max_image_dimension1_d as _,
+            max_image_2d_size: limits.max_image_dimension2_d as _,
+            max_image_3d_size: limits.max_image_dimension3_d as _,
+            max_image_cube_size: limits.max_image_dimension_cube as _,
             max_texel_elements: limits.max_texel_buffer_elements as _,
             max_patch_size: limits.max_tessellation_patch_size as PatchSize,
             max_viewports: limits.max_viewports as _,
-            max_compute_group_count: [
+            max_compute_work_group_count: [
                 max_group_count[0] as _,
                 max_group_count[1] as _,
                 max_group_count[2] as _,
             ],
-            max_compute_group_size: [
+            max_compute_work_group_size: [
                 max_group_size[0] as _,
                 max_group_size[1] as _,
                 max_group_size[2] as _,
@@ -793,8 +796,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             max_vertex_input_attribute_offset: limits.max_vertex_input_attribute_offset as _,
             max_vertex_input_binding_stride: limits.max_vertex_input_binding_stride as _,
             max_vertex_output_components: limits.max_vertex_output_components as _,
-            min_buffer_copy_offset_alignment: limits.optimal_buffer_copy_offset_alignment as _,
-            min_buffer_copy_pitch_alignment: limits.optimal_buffer_copy_row_pitch_alignment as _,
+            optimal_buffer_copy_offset_alignment: limits.optimal_buffer_copy_offset_alignment as _,
+            optimal_buffer_copy_pitch_alignment: limits.optimal_buffer_copy_row_pitch_alignment as _,
             min_texel_buffer_offset_alignment: limits.min_texel_buffer_offset_alignment as _,
             min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment as _,
             min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment as _,
@@ -806,6 +809,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             non_coherent_atom_size: limits.non_coherent_atom_size as _,
             max_sampler_anisotropy: limits.max_sampler_anisotropy,
             min_vertex_input_binding_stride_alignment: 1,
+            .. Limits::default() //TODO: please halp
         }
     }
 

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -191,7 +191,7 @@ impl<B: Backend, C: Supports<Graphics>, S: Shot, L: Level> CommandBuffer<B, C, S
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.
-    pub unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    pub unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: pso::BufferIndex, buffers: I)
     where
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<B::Buffer>,

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -221,7 +221,7 @@ pub trait RawCommandBuffer<B: Backend>: Any + Send + Sync {
     /// The `buffers` iterator should yield the `Buffer` to bind, as well as an
     /// offset, in bytes, into that buffer where the vertex data that should be bound
     /// starts.
-    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: pso::BufferIndex, buffers: I)
     where
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<B::Buffer>;
@@ -381,7 +381,7 @@ pub trait RawCommandBuffer<B: Backend>: Any + Send + Sync {
     /// - A compute pipeline must be bound using `bind_compute_pipeline`.
     /// - Only queues with compute capability support this function.
     /// - This function must be called outside of a render pass.
-    /// - `count` must be less than or equal to `Limits::max_compute_group_count`
+    /// - `count` must be less than or equal to `Limits::max_compute_work_group_count`
     ///
     /// TODO:
     unsafe fn dispatch(&mut self, count: WorkGroupCount);

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -99,7 +99,7 @@ impl<B: Backend, C: BorrowMut<B::CommandBuffer>> RenderSubpassCommon<B, C> {
     }
 
     ///
-    pub unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: u32, buffers: I)
+    pub unsafe fn bind_vertex_buffers<I, T>(&mut self, first_binding: pso::BufferIndex, buffers: I)
     where
         I: IntoIterator<Item = (T, buffer::Offset)>,
         T: Borrow<B::Buffer>,

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -228,18 +228,62 @@ bitflags! {
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Limits {
-    /// Maximum supported texture size.
-    pub max_texture_size: usize,
+    /// Maximum supported image 1D size.
+    pub max_image_1d_size: image::Size,
+    /// Maximum supported image 2D size.
+    pub max_image_2d_size: image::Size,
+    /// Maximum supported image 3D size.
+    pub max_image_3d_size: image::Size,
+    /// Maximum supported image cube size.
+    pub max_image_cube_size: image::Size,
+    /// Maximum supporter image array size.
+    pub max_image_array_layers: image::Layer,
     /// Maximum number of elements for the BufferView to see.
     pub max_texel_elements: usize,
-    /// Maximum number of vertices for each patch.
-    pub max_patch_size: PatchSize,
-    /// Maximum number of viewports.
-    pub max_viewports: usize,
     ///
-    pub max_compute_group_count: WorkGroupCount,
+    pub max_uniform_buffer_range: buffer::Offset,
     ///
-    pub max_compute_group_size: [u32; 3],
+    pub max_storage_buffer_range: buffer::Offset,
+    ///
+    pub max_push_constants_size: usize,
+    ///
+    pub max_memory_allocation_count: usize,
+    ///
+    pub max_sampler_allocation_count: usize,
+    ///
+    pub max_bound_descriptor_sets: pso::DescriptorSetIndex,
+
+    ///
+    pub max_per_stage_descriptor_samplers: usize,
+    ///
+    pub max_per_stage_descriptor_uniform_buffers: usize,
+    ///
+    pub max_per_stage_descriptor_storage_buffers: usize,
+    ///
+    pub max_per_stage_descriptor_sampled_images: usize,
+    ///
+    pub max_per_stage_descriptor_storage_images: usize,
+    ///
+    pub max_per_stage_descriptor_input_attachments: usize,
+    ///
+    pub max_per_stage_resources: usize,
+
+    ///
+    pub max_descriptor_set_samplers: usize,
+    ///
+    pub max_descriptor_set_uniform_buffers: usize,
+    ///
+    pub max_descriptor_set_uniform_buffers_dynamic: usize,
+    ///
+    pub max_descriptor_set_storage_buffers: usize,
+    ///
+    pub max_descriptor_set_storage_buffers_dynamic: usize,
+    ///
+    pub max_descriptor_set_sampled_images: usize,
+    ///
+    pub max_descriptor_set_storage_images: usize,
+    ///
+    pub max_descriptor_set_input_attachments: usize,
 
     /// Maximum number of vertex input attributes that can be specified for a graphics pipeline.
     pub max_vertex_input_attributes: usize,
@@ -252,11 +296,55 @@ pub struct Limits {
     /// Maximum number of components of output variables which can be output by a vertex shader.
     pub max_vertex_output_components: usize,
 
-    /// The alignment of the start of the buffer used as a GPU copy source, in bytes, non-zero.
-    pub min_buffer_copy_offset_alignment: buffer::Offset,
-    /// The alignment of the row pitch of the texture data stored in a buffer that is
-    /// used in a GPU copy operation, in bytes, non-zero.
-    pub min_buffer_copy_pitch_alignment: buffer::Offset,
+    /// Maximum number of vertices for each patch.
+    pub max_patch_size: PatchSize,
+    ///
+    pub max_geometry_shader_invocations: usize,
+    ///
+    pub max_geometry_input_components: usize,
+    ///
+    pub max_geometry_output_components: usize,
+    ///
+    pub max_geometry_output_vertices: usize,
+    ///
+    pub max_geometry_total_output_components: usize,
+    ///
+    pub max_fragment_input_components: usize,
+    ///
+    pub max_fragment_output_attachments: usize,
+    ///
+    pub max_fragment_dual_source_attachments: usize,
+    ///
+    pub max_fragment_combined_output_resources: usize,
+
+    ///
+    pub max_compute_shared_memory_size: usize,
+    ///
+    pub max_compute_work_group_count: WorkGroupCount,
+    ///
+    pub max_compute_work_group_invocations: usize,
+    ///
+    pub max_compute_work_group_size: [u32; 3],
+
+    ///
+    pub max_draw_indexed_index_value: IndexCount,
+    ///
+    pub max_draw_indirect_count: InstanceCount,
+
+    ///
+    pub max_sampler_lod_bias: f32,
+    /// Maximum degree of sampler anisotropy.
+    pub max_sampler_anisotropy: f32,
+
+    /// Maximum number of viewports.
+    pub max_viewports: usize,
+    ///
+    pub max_viewport_dimensions: [image::Size; 2],
+    ///
+    pub max_framebuffer_extent: image::Extent,
+
+    ///
+    pub min_memory_map_alignment: usize,
     /// The alignment of the start of buffer used as a texel buffer, in bytes, non-zero.
     pub min_texel_buffer_offset_alignment: buffer::Offset,
     /// The alignment of the start of buffer used for uniform buffer updates, in bytes, non-zero.
@@ -271,10 +359,15 @@ pub struct Limits {
     pub framebuffer_stencil_samples_count: image::NumSamples,
     /// Maximum number of color attachments that can be used by a subpass in a render pass.
     pub max_color_attachments: usize,
+    ///
+    pub standard_sample_locations: bool,
+    /// The alignment of the start of the buffer used as a GPU copy source, in bytes, non-zero.
+    pub optimal_buffer_copy_offset_alignment: buffer::Offset,
+    /// The alignment of the row pitch of the texture data stored in a buffer that is
+    /// used in a GPU copy operation, in bytes, non-zero.
+    pub optimal_buffer_copy_pitch_alignment: buffer::Offset,
     /// Size and alignment in bytes that bounds concurrent access to host-mapped device memory.
     pub non_coherent_atom_size: usize,
-    /// Maximum degree of sampler anisotropy.
-    pub max_sampler_anisotropy: f32,
 
     /// The alignment of the vertex buffer stride.
     pub min_vertex_input_binding_stride_alignment: buffer::Offset,

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -136,19 +136,19 @@ impl Harness {
                     );
                     results.skip += 1;
                 }
-                let mut max_compute_groups = [0; 3];
+                let mut max_compute_work_groups = [0; 3];
                 for job_name in &test.jobs {
                     if let warden::raw::Job::Compute { dispatch, .. } = tg.scene.jobs[job_name] {
-                        for (max, count) in max_compute_groups.iter_mut().zip(dispatch.iter()) {
+                        for (max, count) in max_compute_work_groups.iter_mut().zip(dispatch.iter()) {
                             *max = (*max).max(*count);
                         }
                     }
                 }
-                if max_compute_groups[0] > limits.max_compute_group_size[0]
-                    || max_compute_groups[1] > limits.max_compute_group_size[1]
-                    || max_compute_groups[2] > limits.max_compute_group_size[2]
+                if max_compute_work_groups[0] > limits.max_compute_work_group_size[0]
+                    || max_compute_work_groups[1] > limits.max_compute_work_group_size[1]
+                    || max_compute_work_groups[2] > limits.max_compute_work_group_size[2]
                 {
-                    println!("\tskipped (compute {:?})", max_compute_groups);
+                    println!("\tskipped (compute {:?})", max_compute_work_groups);
                     results.skip += 1;
                     continue;
                 }

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -244,7 +244,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                         access
                     } else {
                         // calculate required sizes
-                        let upload_size = align(size as _, limits.min_buffer_copy_pitch_alignment);
+                        let upload_size = align(size as _, limits.optimal_buffer_copy_pitch_alignment);
                         // create upload buffer
                         let mut upload_buffer =
                             unsafe { device.create_buffer(upload_size, b::Usage::TRANSFER_SRC) }
@@ -400,7 +400,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
                         let d = extent.depth;
 
                         let width_bytes = (format_desc.bits as u64 * w) / (8 * block_width as u64);
-                        let row_pitch = align(width_bytes, limits.min_buffer_copy_pitch_alignment);
+                        let row_pitch = align(width_bytes, limits.optimal_buffer_copy_pitch_alignment);
                         let upload_size =
                             (row_pitch as u64 * h as u64 * d as u64) / block_height as u64;
                         // create upload buffer
@@ -1280,7 +1280,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
             .expect(&format!("Unable to find buffer to fetch: {}", name));
         let limits = &self.limits;
 
-        let down_size = align(buffer.size as u64, limits.min_buffer_copy_pitch_alignment);
+        let down_size = align(buffer.size as u64, limits.optimal_buffer_copy_pitch_alignment);
 
         let mut down_buffer =
             unsafe { self.device.create_buffer(down_size, b::Usage::TRANSFER_DST) }.unwrap();
@@ -1386,7 +1386,7 @@ impl<B: hal::Backend> Scene<B, hal::General> {
         let height = align(height as _, block_height as _);
 
         let width_bytes = (format_desc.bits as u64 * width as u64) / (8 * block_width as u64);
-        let row_pitch = align(width_bytes, limits.min_buffer_copy_pitch_alignment);
+        let row_pitch = align(width_bytes, limits.optimal_buffer_copy_pitch_alignment);
         let down_size = (row_pitch * height * depth as u64) / block_height as u64;
 
         let mut down_buffer =


### PR DESCRIPTION
Closes #2201 
Fixes #2041
Allows WebRender to avoid hard-coding the texture limits. cc @zakorgy 

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12, vulkan
- [ ] `rustfmt` run on changed code
