### PR TITLE
Metal presentation signposts

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -20,8 +20,9 @@ auto-capture = []
 name = "gfx_backend_metal"
 
 [dependencies]
-gfx-hal = { path = "../../hal", version = "0.1" }
+hal = { path = "../../hal", version = "0.1", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
+arrayvec = "0.4"
 bitflags = "1.0"
 log = { version = "0.4" }
 winit = { version = "0.18", optional = true }

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -1,10 +1,12 @@
-use gfx_hal as hal;
+use hal;
 
 use crate::PrivateCapabilities;
 
-use self::hal::format::{Format, Properties, Swizzle};
-use self::hal::pso::{Comparison, StencilOp};
-use self::hal::{image, pass, pso, IndexType};
+use hal::{
+    image, pass, pso, IndexType,
+    format::{Format, Properties, Swizzle},
+    pso::{Comparison, StencilOp},
+};
 use metal::*;
 
 impl PrivateCapabilities {

--- a/src/backend/metal/src/internal.rs
+++ b/src/backend/metal/src/internal.rs
@@ -1,19 +1,22 @@
-use gfx_hal as hal;
+use crate::{
+    conversions as conv,
+    PrivateCapabilities,
+};
 
-use crate::conversions as conv;
-use crate::PrivateCapabilities;
+use hal::{
+    pso,
+    backend::FastHashMap,
+    command::ClearColorRaw,
+    format::{Aspects, ChannelType},
+    image::Filter,
+};
 
 use metal;
 use parking_lot::{Mutex, RawRwLock};
 use storage_map::{StorageMap, StorageMapGuard};
 
-use self::hal::backend::FastHashMap;
-use self::hal::command::ClearColorRaw;
-use self::hal::format::{Aspects, ChannelType};
-use self::hal::image::Filter;
-use self::hal::pso;
-
 use std::mem;
+
 
 pub type FastStorageMap<K, V> = StorageMap<RawRwLock, FastHashMap<K, V>>;
 pub type FastStorageGuard<'a, V> = StorageMapGuard<'a, RawRwLock, V>;

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -190,8 +190,8 @@ impl Instance {
         window::SurfaceInner::new(None, layer)
     }
 
-    pub fn create_surface_from_layer(&self, layer: CAMetalLayer) -> Surface {
-        unsafe { self.create_from_layer(layer) }.into_surface()
+    pub fn create_surface_from_layer(&self, layer: CAMetalLayer, enable_signposts: bool) -> Surface {
+        unsafe { self.create_from_layer(layer) }.into_surface(enable_signposts)
     }
 }
 
@@ -238,14 +238,16 @@ impl Instance {
         window::SurfaceInner::new(NonNull::new(view), render_layer)
     }
 
-    pub fn create_surface_from_nsview(&self, nsview: *mut c_void) -> Surface {
-        unsafe { self.create_from_nsview(nsview) }.into_surface()
+    pub fn create_surface_from_nsview(
+        &self, nsview: *mut c_void, enable_signposts: bool
+    ) -> Surface {
+        unsafe { self.create_from_nsview(nsview) }.into_surface(enable_signposts)
     }
 
     #[cfg(feature = "winit")]
     pub fn create_surface(&self, window: &winit::Window) -> Surface {
         use winit::os::macos::WindowExt;
-        self.create_surface_from_nsview(window.get_nsview())
+        self.create_surface_from_nsview(window.get_nsview(), false)
     }
 }
 
@@ -293,14 +295,16 @@ impl Instance {
         window::SurfaceInner::new(NonNull::new(view), render_layer)
     }
 
-    pub fn create_surface_from_uiview(&self, uiview: *mut c_void) -> Surface {
-        unsafe { self.create_from_uiview(uiview) }.into_surface()
+    pub fn create_surface_from_uiview(
+        &self, uiview: *mut c_void, enable_signposts: bool
+    ) -> Surface {
+        unsafe { self.create_from_uiview(uiview) }.into_surface(enable_signposts)
     }
 
     #[cfg(feature = "winit")]
     pub fn create_surface(&self, window: &winit::Window) -> Surface {
         use winit::os::ios::WindowExt;
-        self.create_surface_from_uiview(window.get_uiview())
+        self.create_surface_from_uiview(window.get_uiview(), false)
     }
 }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -1,18 +1,32 @@
-use gfx_hal as hal;
-use range_alloc;
 #[macro_use]
 extern crate bitflags;
-use cocoa;
-use foreign_types;
 #[macro_use]
 extern crate objc;
 #[macro_use]
 extern crate log;
 
+use hal;
+use hal::queue::QueueFamilyId;
+use range_alloc::RangeAllocator;
+
+use cocoa;
+use cocoa::foundation::NSInteger;
+use core_graphics::base::CGFloat;
+use core_graphics::geometry::CGRect;
+use foreign_types::ForeignTypeRef;
+use metal::MTLFeatureSet;
+use metal::MTLLanguageVersion;
+use objc::runtime::{Object, BOOL, YES};
+use parking_lot::{Condvar, Mutex};
 #[cfg(feature = "dispatch")]
 use dispatch;
 #[cfg(feature = "winit")]
 use winit;
+
+use std::mem;
+use std::os::raw::c_void;
+use std::ptr::NonNull;
+use std::sync::Arc;
 
 mod command;
 mod conversions;
@@ -28,21 +42,6 @@ pub use crate::window::{AcquireMode, CAMetalLayer, Surface, Swapchain};
 
 pub type GraphicsCommandPool = CommandPool;
 
-use std::mem;
-use std::os::raw::c_void;
-use std::ptr::NonNull;
-use std::sync::Arc;
-
-use self::hal::queue::QueueFamilyId;
-
-use cocoa::foundation::NSInteger;
-use core_graphics::base::CGFloat;
-use core_graphics::geometry::CGRect;
-use foreign_types::ForeignTypeRef;
-use metal::MTLFeatureSet;
-use metal::MTLLanguageVersion;
-use objc::runtime::{Object, BOOL, YES};
-use parking_lot::{Condvar, Mutex};
 
 //TODO: investigate why exactly using `u8` here is slower (~5% total).
 /// A type representing Metal binding's resource index.
@@ -68,6 +67,7 @@ impl Default for OnlineRecording {
 
 const MAX_ACTIVE_COMMAND_BUFFERS: usize = 1 << 14;
 const MAX_VISIBILITY_QUERIES: usize = 1 << 14;
+const MAX_COLOR_ATTACHMENTS: usize = 4;
 
 #[derive(Debug, Clone, Copy)]
 pub struct QueueFamily {}
@@ -88,7 +88,7 @@ struct VisibilityShared {
     /// Availability buffer is in shared memory, it has N double words for
     /// query results followed by N words for the availability.
     buffer: metal::Buffer,
-    allocator: Mutex<range_alloc::RangeAllocator<hal::query::Id>>,
+    allocator: Mutex<RangeAllocator<hal::query::Id>>,
     availability_offset: hal::buffer::Offset,
     condvar: Condvar,
 }
@@ -115,7 +115,7 @@ impl Shared {
                     * (mem::size_of::<u64>() + mem::size_of::<u32>()) as u64,
                 metal::MTLResourceOptions::StorageModeShared,
             ),
-            allocator: Mutex::new(range_alloc::RangeAllocator::new(
+            allocator: Mutex::new(RangeAllocator::new(
                 0..MAX_VISIBILITY_QUERIES as hal::query::Id,
             )),
             availability_offset: (MAX_VISIBILITY_QUERIES * mem::size_of::<u64>())

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -1,11 +1,14 @@
-use crate::command::IndexBuffer;
-use crate::native::RasterizerState;
-use crate::{BufferPtr, ResourceIndex, SamplerPtr, TexturePtr};
+use crate::{
+    BufferPtr, ResourceIndex, SamplerPtr, TexturePtr,
+    command::IndexBuffer,
+    native::RasterizerState,
+};
 
-use crate::hal;
+use hal;
 use metal;
 
 use std::ops::Range;
+
 
 pub type CacheResourceIndex = u32;
 

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -26,15 +26,20 @@ use parking_lot::{Mutex, MutexGuard};
 // texture pointer by an acquired drawable.
 pub type CAMetalLayer = *mut Object;
 
+/// This is a random ID to be used for signposts associated with swapchain events.
+const SIGNPOST_ID: u32 = 0x100;
+
 pub struct Surface {
     inner: Arc<SurfaceInner>,
     main_thread_id: thread::ThreadId,
 }
 
 #[derive(Debug)]
-pub struct SurfaceInner {
+pub(crate) struct SurfaceInner {
     view: Option<NonNull<Object>>,
     render_layer: Mutex<CAMetalLayer>,
+    /// Place start/end signposts for the duration of frames held
+    enable_signposts: bool,
 }
 
 unsafe impl Send for SurfaceInner {}
@@ -63,10 +68,12 @@ impl SurfaceInner {
         SurfaceInner {
             view,
             render_layer: Mutex::new(layer),
+            enable_signposts: false,
         }
     }
 
-    pub fn into_surface(self) -> Surface {
+    pub fn into_surface(mut self, enable_signposts: bool) -> Surface {
+        self.enable_signposts = enable_signposts;
         Surface {
             inner: Arc::new(self),
             main_thread_id: thread::current().id(),
@@ -80,6 +87,11 @@ impl SurfaceInner {
         let layer_ref = self.render_layer.lock();
         autoreleasepool(|| {
             // for the drawable
+            let _signpost = if self.enable_signposts {
+                Some(native::Signpost::new(SIGNPOST_ID, [0, 0, 0, 0]))
+            } else {
+                None
+            };
             let (drawable, texture_temp): (&metal::DrawableRef, &metal::TextureRef) = unsafe {
                 let drawable = msg_send![*layer_ref, nextDrawable];
                 (drawable, msg_send![drawable, texture])
@@ -93,7 +105,12 @@ impl SurfaceInner {
                 Some(index) => {
                     let mut frame = frames[index].inner.lock();
                     assert!(frame.drawable.is_none());
+                    frame.iteration += 1;
                     frame.drawable = Some(drawable.to_owned());
+                    if self.enable_signposts && false {
+                        //Note: could encode the `iteration` here if we need it
+                        frame.signpost = Some(native::Signpost::new(SIGNPOST_ID, [1, index as usize, 0, 0]));
+                    }
 
                     debug!("Next is frame[{}]", index);
                     Ok((index, frame))
@@ -141,6 +158,7 @@ impl SurfaceInner {
 #[derive(Debug)]
 struct FrameInner {
     drawable: Option<metal::Drawable>,
+    signpost: Option<native::Signpost>,
     /// If there is a `drawable`, availability indicates if it's free for grabs.
     /// If there is `None`, `available == false` means that the frame has already
     /// been acquired and the `drawable` will appear at some point.
@@ -148,6 +166,7 @@ struct FrameInner {
     /// Stays true for as long as the drawable is circulating through the
     /// CAMetalLayer's frame queue.
     linked: bool,
+    iteration: usize,
     last_frame: usize,
 }
 
@@ -195,7 +214,9 @@ impl Drop for Swapchain {
 impl Swapchain {
     fn clear_drawables(&self) {
         for frame in self.frames.iter() {
-            frame.inner.lock().drawable = None;
+            let mut inner = frame.inner.lock();
+            inner.drawable = None;
+            inner.signpost = None;
         }
     }
 
@@ -204,6 +225,7 @@ impl Swapchain {
     pub(crate) fn take_drawable(&self, index: hal::SwapImageIndex) -> Result<metal::Drawable, ()> {
         let mut frame = self.frames[index as usize].inner.lock();
         assert!(!frame.available && frame.linked);
+        frame.signpost = None;
 
         match frame.drawable.take() {
             Some(drawable) => {
@@ -220,6 +242,9 @@ impl Swapchain {
     }
 
     fn signal_sync(&self, sync: hal::FrameSync<Backend>) {
+        if false { // mark the method as used
+            native::Signpost::place(SIGNPOST_ID, [0, 0, 0, 0]);
+        }
         match sync {
             hal::FrameSync::Semaphore(semaphore) => {
                 if let Some(ref system) = semaphore.system {
@@ -442,8 +467,14 @@ impl Device {
                     Frame {
                         inner: Mutex::new(FrameInner {
                             drawable,
+                            signpost: if index != 0 && surface.inner.enable_signposts {
+                                Some(native::Signpost::new(SIGNPOST_ID, [1, index as usize, 0, 0]))
+                            } else {
+                                None
+                            },
                             available: true,
                             linked: true,
+                            iteration: 0,
                             last_frame: 0,
                         }),
                         texture: texture.to_owned(),
@@ -502,6 +533,10 @@ impl hal::Swapchain<Backend> for Swapchain {
                 debug!("Found drawable of frame {}, acquiring", index);
                 frame.available = false;
                 frame.last_frame = self.last_frame;
+                if self.surface.enable_signposts {
+                    //Note: could encode the `iteration` here if we need it
+                    frame.signpost = Some(native::Signpost::new(SIGNPOST_ID, [1, index, 0, 0]));
+                }
                 self.signal_sync(sync);
                 return Ok(index as _);
             }
@@ -557,6 +592,10 @@ impl hal::Swapchain<Backend> for Swapchain {
         assert!(frame.available);
         frame.last_frame = self.last_frame;
         frame.available = false;
+        if self.surface.enable_signposts {
+            //Note: could encode the `iteration` here if we need it
+            frame.signpost = Some(native::Signpost::new(SIGNPOST_ID, [1, index, 0, 0]));
+        }
 
         Ok(index as _)
     }

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -1,17 +1,15 @@
-use gfx_hal as hal;
+use crate::{
+    native,
+    Backend, QueueFamily,
+    device::{Device, PhysicalDevice},
+    internal::Channel,
+};
 
-use crate::device::{Device, PhysicalDevice};
-use crate::internal::Channel;
-use crate::native;
-use crate::{Backend, QueueFamily};
-
-use std::ptr::NonNull;
-use std::sync::Arc;
-use std::thread;
-
-use self::hal::window::Extent2D;
-use self::hal::{format, image};
-use self::hal::{Backbuffer, SwapchainConfig, CompositeAlpha};
+use hal::{
+    format, image,
+    Backbuffer, SwapchainConfig, CompositeAlpha,
+    window::Extent2D,
+};
 
 use core_graphics::base::CGFloat;
 use core_graphics::geometry::{CGRect, CGSize};
@@ -20,6 +18,11 @@ use metal;
 use objc::rc::autoreleasepool;
 use objc::runtime::Object;
 use parking_lot::{Mutex, MutexGuard};
+
+use std::ptr::NonNull;
+use std::sync::Arc;
+use std::thread;
+
 
 //TODO: make it a weak pointer, so that we know which
 // frames can be replaced if we receive an unknown


### PR DESCRIPTION
Allows us to get a better idea of the swapchain performance when looking at a system trace. Disabled by default.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
