### PR TITLE
Fill out some viewport/framebuffer limits

### DIFF
--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -1097,13 +1097,13 @@ impl Internal {
     }
 
     fn find_blit_shader(&self, src: &Image) -> Option<*mut d3d11::ID3D11PixelShader> {
-        use format::ChannelType::*;
+        use format::ChannelType as Ct;
 
         match src.format.base_format().1 {
-            Uint => Some(self.ps_blit_2d_uint.as_raw()),
-            Int => Some(self.ps_blit_2d_int.as_raw()),
-            Unorm | Snorm | Sfloat | Srgb => Some(self.ps_blit_2d_float.as_raw()),
-            _ => None,
+            Ct::Uint => Some(self.ps_blit_2d_uint.as_raw()),
+            Ct::Sint => Some(self.ps_blit_2d_int.as_raw()),
+            Ct::Unorm | Ct::Snorm | Ct::Sfloat | Ct::Srgb => Some(self.ps_blit_2d_float.as_raw()),
+            Ct::Ufloat | Ct::Uscaled | Ct::Sscaled => None,
         }
     }
 

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -346,6 +346,12 @@ impl hal::Instance for Instance {
                 max_texel_elements: d3d11::D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION as _, //TODO
                 max_patch_size: 0,                                                    // TODO
                 max_viewports: d3d11::D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE as _,
+                max_viewport_dimensions: [d3d11::D3D11_VIEWPORT_BOUNDS_MAX; 2],
+                max_framebuffer_extent: hal::image::Extent { //TODO
+                    width: 4096,
+                    height: 4096,
+                    depth: 1,
+                },
                 max_compute_work_group_count: [
                     d3d11::D3D11_CS_THREAD_GROUP_MAX_X,
                     d3d11::D3D11_CS_THREAD_GROUP_MAX_Y,
@@ -358,17 +364,18 @@ impl hal::Instance for Instance {
                     d3d11::D3D11_REQ_MULTI_ELEMENT_STRUCTURE_SIZE_IN_BYTES as _,
                 max_vertex_input_bindings: d3d11::D3D11_IA_VERTEX_INPUT_RESOURCE_SLOT_COUNT as _, // TODO: verify same as attributes
                 max_vertex_output_components: d3d11::D3D11_VS_OUTPUT_REGISTER_COUNT as _, // TODO
-                optimal_buffer_copy_offset_alignment: 1,                                      // TODO
-                optimal_buffer_copy_pitch_alignment: 1,                                       // TODO
                 min_texel_buffer_offset_alignment: 1,                                     // TODO
                 min_uniform_buffer_offset_alignment: 16, // TODO: verify
                 min_storage_buffer_offset_alignment: 1,  // TODO
                 framebuffer_color_samples_count: 1,      // TODO
                 framebuffer_depth_samples_count: 1,      // TODO
                 framebuffer_stencil_samples_count: 1,    // TODO
-                max_color_attachments: 1,                // TODO
+                max_color_attachments: d3d11::D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT as _,
+                buffer_image_granularity: 1,
                 non_coherent_atom_size: 1,               // TODO
                 max_sampler_anisotropy: 16.,
+                optimal_buffer_copy_offset_alignment: 1,                                      // TODO
+                optimal_buffer_copy_pitch_alignment: 1,                                       // TODO
                 min_vertex_input_binding_stride_alignment: 1,
                 .. hal::Limits::default() //TODO
             };

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1043,7 +1043,13 @@ impl hal::Instance for Instance {
                     max_image_array_layers: d3d12::D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION as _,
                     max_texel_elements: 0,
                     max_patch_size: 0,
-                    max_viewports: 0,
+                    max_viewports: d3d12::D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE as _,
+                    max_viewport_dimensions: [d3d12::D3D12_VIEWPORT_BOUNDS_MAX as _; 2],
+                    max_framebuffer_extent: hal::image::Extent { //TODO
+                        width: 4096,
+                        height: 4096,
+                        depth: 1,
+                    },
                     max_compute_work_group_count: [
                         d3d12::D3D12_CS_THREAD_GROUP_MAX_X,
                         d3d12::D3D12_CS_THREAD_GROUP_MAX_Y,
@@ -1059,8 +1065,6 @@ impl hal::Instance for Instance {
                     max_vertex_input_attribute_offset: 255, // TODO
                     max_vertex_input_binding_stride: d3d12::D3D12_REQ_MULTI_ELEMENT_STRUCTURE_SIZE_IN_BYTES as _,
                     max_vertex_output_components: 16, // TODO
-                    optimal_buffer_copy_offset_alignment: d3d12::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as _,
-                    optimal_buffer_copy_pitch_alignment: d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as _,
                     min_texel_buffer_offset_alignment: 1, // TODO
                     min_uniform_buffer_offset_alignment: 256, // Required alignment for CBVs
                     min_storage_buffer_offset_alignment: 1, // TODO
@@ -1069,9 +1073,12 @@ impl hal::Instance for Instance {
                     framebuffer_color_samples_count: 0b101,
                     framebuffer_depth_samples_count: 0b101,
                     framebuffer_stencil_samples_count: 0b101,
-                    max_color_attachments: 1, // TODO
+                    max_color_attachments: d3d12::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT as _,
+                    buffer_image_granularity: 1,
                     non_coherent_atom_size: 1, //TODO: confirm
                     max_sampler_anisotropy: 16.,
+                    optimal_buffer_copy_offset_alignment: d3d12::D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT as _,
+                    optimal_buffer_copy_pitch_alignment: d3d12::D3D12_TEXTURE_DATA_PITCH_ALIGNMENT as _,
                     min_vertex_input_binding_stride_alignment: 1,
                     .. Limits::default() //TODO
                 },

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -404,6 +404,12 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             // Note: The maximum number of supported viewports and scissor rectangles varies by device.
             // TODO: read from Metal Feature Sets.
             max_viewports: 1,
+            max_viewport_dimensions: [pc.max_texture_size as _; 2],
+            max_framebuffer_extent: hal::image::Extent { //TODO
+                width: pc.max_texture_size as _,
+                height: pc.max_texture_size as _,
+                depth: pc.max_texture_layers as _,
+            },
 
             optimal_buffer_copy_offset_alignment: pc.buffer_alignment,
             optimal_buffer_copy_pitch_alignment: 4,
@@ -425,6 +431,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             framebuffer_stencil_samples_count: 0b101, // TODO
             max_color_attachments: 1,                 // TODO
 
+            buffer_image_granularity: 1,
             // Note: we issue Metal buffer-to-buffer copies on memory flush/invalidate,
             // and those need to operate on sizes being multiples of 4.
             non_coherent_atom_size: 4,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -774,13 +774,19 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         let max_group_size = limits.max_compute_work_group_size;
 
         Limits {
-            max_image_1d_size: limits.max_image_dimension1_d as _,
-            max_image_2d_size: limits.max_image_dimension2_d as _,
-            max_image_3d_size: limits.max_image_dimension3_d as _,
-            max_image_cube_size: limits.max_image_dimension_cube as _,
+            max_image_1d_size: limits.max_image_dimension1_d,
+            max_image_2d_size: limits.max_image_dimension2_d,
+            max_image_3d_size: limits.max_image_dimension3_d,
+            max_image_cube_size: limits.max_image_dimension_cube,
             max_texel_elements: limits.max_texel_buffer_elements as _,
             max_patch_size: limits.max_tessellation_patch_size as PatchSize,
             max_viewports: limits.max_viewports as _,
+            max_viewport_dimensions: limits.max_viewport_dimensions,
+            max_framebuffer_extent: image::Extent {
+                width: limits.max_framebuffer_width,
+                height: limits.max_framebuffer_height,
+                depth: limits.max_framebuffer_layers,
+            },
             max_compute_work_group_count: [
                 max_group_count[0] as _,
                 max_group_count[1] as _,
@@ -806,6 +812,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             framebuffer_stencil_samples_count: limits.framebuffer_stencil_sample_counts.as_raw()
                 as _,
             max_color_attachments: limits.max_color_attachments as _,
+            buffer_image_granularity: limits.buffer_image_granularity,
             non_coherent_atom_size: limits.non_coherent_atom_size as _,
             max_sampler_anisotropy: limits.max_sampler_anisotropy,
             min_vertex_input_binding_stride_alignment: 1,

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -345,6 +345,8 @@ pub struct Limits {
 
     ///
     pub min_memory_map_alignment: usize,
+    ///
+    pub buffer_image_granularity: buffer::Offset,
     /// The alignment of the start of buffer used as a texel buffer, in bytes, non-zero.
     pub min_texel_buffer_offset_alignment: buffer::Offset,
     /// The alignment of the start of buffer used for uniform buffer updates, in bytes, non-zero.


### PR DESCRIPTION
We can't remove the hard-coded defaults from gfx-portability until the backends start actually exposing sensible values....
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
