### PR TITLE
[mtl] use copyless vec helper

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -24,6 +24,7 @@ hal = { path = "../../hal", version = "0.1", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 arrayvec = "0.4"
 bitflags = "1.0"
+copyless = "0.1"
 log = { version = "0.4" }
 winit = { version = "0.18", optional = true }
 dispatch = { version = "0.1", optional = true }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -20,6 +20,7 @@ use hal::{
 use range_alloc::RangeAllocator;
 
 use cocoa::foundation::{NSRange, NSUInteger};
+use copyless::VecHelper;
 use foreign_types::ForeignType;
 use metal::{
     self,
@@ -945,7 +946,7 @@ impl hal::Device<Backend> for Device {
                             .content
                             .contains(n::DescriptorContent::DYNAMIC_BUFFER)
                         {
-                            dynamic_buffers.push(n::MultiStageData {
+                            dynamic_buffers.alloc().init(n::MultiStageData {
                                 vs: if layout.stages.contains(pso::ShaderStageFlags::VERTEX) {
                                     stage_infos[0].2.buffers
                                 } else {
@@ -1028,7 +1029,7 @@ impl hal::Device<Backend> for Device {
                 }
             }
 
-            infos.push(n::DescriptorSetInfo {
+            infos.alloc().init(n::DescriptorSetInfo {
                 offsets,
                 dynamic_buffers,
             });
@@ -1351,7 +1352,7 @@ impl hal::Device<Backend> for Device {
                 .iter()
                 .position(|(ref vb, offset)| vb.binding == binding && base_offset == *offset)
                 .unwrap_or_else(|| {
-                    vertex_buffers.push((original.clone(), base_offset));
+                    vertex_buffers.alloc().init((original.clone(), base_offset));
                     vertex_buffers.len() - 1
                 });
             let mtl_buffer_index = attribute_buffer_index as usize + relative_index;


### PR DESCRIPTION
Metal piece of #2702

This is just an optimization. Main idea is to bring structure construction closer to the placement spot. I.e. instead of doing 1) construct 2) try extending the vector 3) write into it, we now do 2-1-3, which allows the compiler to construct the data in place (without any `box` magic).

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
