### PR TITLE
[hal-0.1] Make Backend impl Default

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2933,8 +2933,8 @@ pub struct Semaphore;
 #[derive(Debug)]
 pub struct QueryPool;
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Backend {}
+#[derive(Default, Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Backend;
 impl hal::Backend for Backend {
     type PhysicalDevice = PhysicalDevice;
     type Device = device::Device;

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1117,8 +1117,8 @@ impl hal::Instance for Instance {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Backend {}
+#[derive(Default, Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Backend;
 impl hal::Backend for Backend {
     type PhysicalDevice = PhysicalDevice;
     type Device = Device;

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -14,8 +14,8 @@ use hal::{
 use hal::range::RangeArg;
 
 /// Dummy backend.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Backend { }
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Backend;
 impl hal::Backend for Backend {
     type PhysicalDevice = PhysicalDevice;
     type Device = Device;

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -58,8 +58,8 @@ impl Deref for GlContainer {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Backend {}
+#[derive(Default, Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Backend;
 impl hal::Backend for Backend {
     type PhysicalDevice = PhysicalDevice;
     type Device = Device;

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -313,9 +313,8 @@ impl Instance {
     }
 }
 
-
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Backend {}
+#[derive(Default, Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Backend;
 impl hal::Backend for Backend {
     type PhysicalDevice = device::PhysicalDevice;
     type Device = device::Device;

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -817,8 +817,8 @@ pub struct Device {
     raw: Arc<RawDevice>,
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub enum Backend {}
+#[derive(Default, Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Backend;
 impl hal::Backend for Backend {
     type PhysicalDevice = PhysicalDevice;
     type Device = Device;

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -367,7 +367,7 @@ pub trait Instance: Any + Send + Sync {
 /// for a graphics backend. Each backend module, such as OpenGL
 /// or Metal, will implement this trait with its own concrete types.
 #[allow(missing_docs)]
-pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send + Sync {
+pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Default + Any + Send + Sync {
     //type Instance:          Instance<Self>;
     type PhysicalDevice:      PhysicalDevice<Self>;
     type Device:              Device<Self>;


### PR DESCRIPTION
This allows types that are generic over Backend to be stored in a `specs::World`; backported to 0.1 so that it can be used with `rendy` until hal 0.2 release

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
