### PR TITLE
Remove FrameSync, add support for Metal acquiring fences

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -49,7 +49,7 @@ use std::{fs, iter};
 
 use hal::{
     buffer, command, format as f, image as i, memory as m, pass, pool, pso, window::Extent2D,
-    Adapter, Backbuffer, Backend, DescriptorPool, Device, FrameSync, Instance, Limits, MemoryType,
+    Adapter, Backbuffer, Backend, DescriptorPool, Device, Instance, Limits, MemoryType,
     PhysicalDevice, Primitive, QueueGroup, Surface, Swapchain, SwapchainConfig,
 };
 
@@ -514,7 +514,7 @@ impl<B: Backend> RendererState<B> {
                     .swapchain
                     .as_mut()
                     .unwrap()
-                    .acquire_image(!0, FrameSync::Semaphore(acquire_semaphore))
+                    .acquire_image(!0, Some(acquire_semaphore), None)
                 {
                     Ok(i) => i,
                     Err(_) => {

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -33,7 +33,7 @@ use hal::queue::Submission;
 use hal::{
     buffer, command, format as f, image as i, memory as m, pass, pool, pso, window::Extent2D,
 };
-use hal::{Backbuffer, DescriptorPool, FrameSync, Primitive, SwapchainConfig};
+use hal::{Backbuffer, DescriptorPool, Primitive, SwapchainConfig};
 use hal::{Device, Instance, PhysicalDevice, Surface, Swapchain};
 
 use std::fs;
@@ -731,7 +731,7 @@ fn main() {
         // Use guaranteed unused acquire semaphore to get the index of the next frame we will render to
         // by using acquire_image
         let swap_image = unsafe {
-            match swap_chain.acquire_image(!0, FrameSync::Semaphore(&free_acquire_semaphore)) {
+            match swap_chain.acquire_image(!0, Some(&free_acquire_semaphore), None) {
                 Ok(i) => i as usize,
                 Err(_) => {
                     recreate_swapchain = true;

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -744,7 +744,8 @@ impl hal::Swapchain<Backend> for Swapchain {
     unsafe fn acquire_image(
         &mut self,
         _timeout_ns: u64,
-        _sync: hal::FrameSync<Backend>,
+        _semaphore: Option<&Semaphore>,
+        _fence: Option<&Fence>,
     ) -> Result<hal::SwapImageIndex, hal::AcquireError> {
         // TODO: non-`_DISCARD` swap effects have more than one buffer, `FLIP`
         //       effects are dxgi 1.3 (w10+?) in which case there is

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -119,7 +119,8 @@ impl hal::Swapchain<Backend> for Swapchain {
     unsafe fn acquire_image(
         &mut self,
         _timout_ns: u64,
-        _sync: hal::FrameSync<Backend>,
+        _semaphore: Option<&r::Semaphore>,
+        _fence: Option<&r::Fence>,
     ) -> Result<hal::SwapImageIndex, hal::AcquireError> {
         // TODO: sync
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -852,7 +852,8 @@ impl hal::Swapchain<Backend> for Swapchain {
     unsafe fn acquire_image(
         &mut self,
         _: u64,
-        _: hal::FrameSync<Backend>,
+        _: Option<&()>,
+        _: Option<&()>,
     ) -> Result<hal::SwapImageIndex, hal::AcquireError> {
         unimplemented!()
     }

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -43,9 +43,16 @@
 //! }
 //! ```
 
-use crate::hal::{self, format as f, image, CompositeAlpha};
+use hal::{
+    self,
+    format as f, image,
+    CompositeAlpha,
+};
 
-use crate::{Backend as B, Device, PhysicalDevice, QueueFamily, Starc};
+use crate::{
+    native,
+    Backend as B, Device, PhysicalDevice, QueueFamily, Starc
+};
 
 use glutin::{self, GlContext};
 
@@ -70,7 +77,8 @@ impl hal::Swapchain<B> for Swapchain {
     unsafe fn acquire_image(
         &mut self,
         _timeout_ns: u64,
-        _sync: hal::FrameSync<B>,
+        _semaphore: Option<&native::Semaphore>,
+        _fence: Option<&native::Fence>,
     ) -> Result<hal::SwapImageIndex, hal::AcquireError> {
         // TODO: sync
         Ok(0)

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2039,7 +2039,8 @@ impl RawCommandQueue<Backend> for CommandQueue {
                 cmd_buffer.commit();
 
                 if let Some(fence) = fence {
-                    *fence.0.borrow_mut() = native::FenceInner::Pending(cmd_buffer.to_owned());
+                    debug!("\tmarking fence ptr {:?} as pending", fence.0.as_ptr());
+                    fence.0.replace(native::FenceInner::PendingSubmission(cmd_buffer.to_owned()));
                 }
             } else if let Some(cmd_buffer) = deferred_cmd_buffer {
                 cmd_buffer.commit();

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -403,6 +403,22 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             max_image_cube_size: pc.max_texture_size as _,
             max_image_array_layers: pc.max_texture_layers as _,
             max_texel_elements: (pc.max_texture_size * pc.max_texture_size) as usize,
+            max_uniform_buffer_range: pc.max_buffer_size,
+            max_storage_buffer_range: pc.max_buffer_size,
+            // "Maximum length of an inlined constant data buffer, per graphics or compute function"
+            max_push_constants_size: 0x1000,
+            max_memory_allocation_count: !0,
+            max_sampler_allocation_count: !0,
+            max_bound_descriptor_sets: 0x100, // arbitrary
+
+            max_per_stage_descriptor_samplers: pc.max_samplers_per_stage as usize,
+            max_per_stage_descriptor_uniform_buffers: pc.max_buffers_per_stage as usize,
+            max_per_stage_descriptor_storage_buffers: pc.max_buffers_per_stage as usize,
+            max_per_stage_descriptor_sampled_images: pc.max_textures_per_stage as usize,
+            max_per_stage_descriptor_storage_images: pc.max_textures_per_stage as usize,
+            max_per_stage_descriptor_input_attachments: pc.max_textures_per_stage as usize, //TODO
+            max_per_stage_resources: 0x100, //TODO
+
             max_patch_size: 0, // No tessellation
 
             // Note: The maximum number of supported viewports and scissor rectangles varies by device.
@@ -441,7 +457,8 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             non_coherent_atom_size: 4,
             max_sampler_anisotropy: 16.,
             min_vertex_input_binding_stride_alignment: STRIDE_GRANULARITY as u64,
-            .. hal::Limits::default() //TODO
+
+            .. hal::Limits::default() // TODO!
         }
     }
 }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -843,7 +843,11 @@ pub enum QueryPool {
 #[derive(Debug)]
 pub enum FenceInner {
     Idle { signaled: bool },
-    Pending(metal::CommandBuffer),
+    PendingSubmission(metal::CommandBuffer),
+    AcquireFrame {
+        swapchain_image: SwapchainImage,
+        iteration: usize,
+    },
 }
 
 #[derive(Debug)]

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -416,7 +416,7 @@ impl hal::Swapchain<Backend> for Swapchain {
         fence: Option<&native::Fence>,
     ) -> Result<hal::SwapImageIndex, hal::AcquireError> {
         let semaphore = semaphore.map_or(vk::Semaphore::null(), |s| s.0);
-        let fence = fence.map_or(vk::Fence::null()), |f| f.0);
+        let fence = fence.map_or(vk::Fence::null(), |f| f.0);
 
         // will block if no image is available
         let index = self

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -12,7 +12,7 @@ use hal::image::{NumSamples, Size};
 #[cfg(feature = "winit")]
 use winit;
 
-use conv;
+use {conv, native};
 use {Backend, Instance, PhysicalDevice, QueueFamily, RawInstance, VK_ENTRY};
 
 pub struct Surface {
@@ -412,12 +412,11 @@ impl hal::Swapchain<Backend> for Swapchain {
     unsafe fn acquire_image(
         &mut self,
         timeout_ns: u64,
-        sync: hal::FrameSync<Backend>,
+        semaphore: Option<&native::Semaphore>,
+        fence: Option<&native::Fence>,
     ) -> Result<hal::SwapImageIndex, hal::AcquireError> {
-        let (semaphore, fence) = match sync {
-            hal::FrameSync::Semaphore(semaphore) => (semaphore.0, vk::Fence::null()),
-            hal::FrameSync::Fence(fence) => (vk::Semaphore::null(), fence.0),
-        };
+        let semaphore = semaphore.map_or(vk::Semaphore::null(), |s| s.0);
+        let fence = fence.map_or(vk::Fence::null()), |f| f.0);
 
         // will block if no image is available
         let index = self

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::queue::{
     Submission, Supports, Transfer,
 };
 pub use self::window::{
-    AcquireError, Backbuffer, CompositeAlpha, FrameSync, PresentMode, Surface, SurfaceCapabilities,
+    AcquireError, Backbuffer, CompositeAlpha, PresentMode, Surface, SurfaceCapabilities,
     SwapImageIndex, Swapchain, SwapchainConfig,
 };
 


### PR DESCRIPTION
Fixes #2711
It makes us compatible with the updated Diligent Engine.
Also improves Metal limits and logging of fences.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
