### PR TITLE
[dx12] Remove extra flags on certain MemoryTypes

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -975,6 +975,9 @@ impl hal::Instance for Instance {
                         // a corresponding buffer for mapping.
                         if i == MemoryGroup::ImageOnly as _ || i == MemoryGroup::TargetOnly as _ {
                             ty.properties.remove(Properties::CPU_VISIBLE);
+                            // Coherent and cached can only be on memory types that are cpu visible
+                            ty.properties.remove(Properties::COHERENT);
+                            ty.properties.remove(Properties::CPU_CACHED);
                         }
                         ty
                     }));


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12
- [ ] `rustfmt` run on changed code

I might be misunderstanding how closely gfx-hal and the backends follow the Vulkan Spec but, according to the [Vulkan Spec](https://vulkan.lunarg.com/doc/view/1.0.30.0/linux/vkspec.chunked/ch10s02.html), MemoryTypes can not be `COHERENT` or `CPU_CACHED` without also being `CPU_VISIBLE`. Before this change, removing just the `CPU_VISIBLE` flag would cause some MemoryTypes to have a flag of `COHERENT` or `COHERENT | CPU_CACHED`. This change removes the extra flags as they shouldn't be on there with MemoryTypes that are not `CPU_VISIBLE`.