### PR TITLE
[mtl] expose clip distance feature

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -392,6 +392,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             } else {
                 hal::Features::empty()
             }
+            | hal::Features::SHADER_CLIP_DISTANCE
     }
 
     fn limits(&self) -> hal::Limits {


### PR DESCRIPTION
I haven't fully verified that this is correct, but SPIRV-Cross seems to handle it in some way, and vkQuake3 doesn't complain any more :)

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
