### PR TITLE
[vulkan] make create_surface_from_vk_surface_khr public

### DIFF
--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -271,7 +271,7 @@ impl Instance {
         }
     }
 
-    fn create_surface_from_vk_surface_khr(
+    pub fn create_surface_from_vk_surface_khr(
         &self,
         surface: vk::SurfaceKHR,
         width: Size,


### PR DESCRIPTION
This PR exposes the `create_surface_from_vk_surface_khr` function, which should make it easier to use the Vulkan backend with libraries like GLFW and SDL.

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
