### PR TITLE
Fix `gfx_hal::memory::Properties` to match `VkMemoryPropertyFlagBits`

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -634,6 +634,12 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                     type_flags |= Properties::DEVICE_LOCAL;
                 }
                 if mem
+                  .property_flags
+                  .intersects(vk::MemoryPropertyFlags::HOST_VISIBLE)
+                {
+                    type_flags |= Properties::CPU_VISIBLE;
+                }
+                if mem
                     .property_flags
                     .intersects(vk::MemoryPropertyFlags::HOST_COHERENT)
                 {
@@ -644,12 +650,6 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                     .intersects(vk::MemoryPropertyFlags::HOST_CACHED)
                 {
                     type_flags |= Properties::CPU_CACHED;
-                }
-                if mem
-                    .property_flags
-                    .intersects(vk::MemoryPropertyFlags::HOST_VISIBLE)
-                {
-                    type_flags |= Properties::CPU_VISIBLE;
                 }
                 if mem
                     .property_flags

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -42,22 +42,22 @@ bitflags!(
         /// Device local memory on the GPU.
         const DEVICE_LOCAL   = 0x1;
 
-        /// CPU-GPU coherent.
-        ///
-        /// Non-coherent memory requires explicit flushing.
-        const COHERENT     = 0x2;
-
         /// Host visible memory can be accessed by the CPU.
         ///
         /// Backends must provide at least one cpu visible memory.
-        const CPU_VISIBLE   = 0x4;
+        const CPU_VISIBLE   = 0x2;
+
+        /// CPU-GPU coherent.
+        ///
+        /// Non-coherent memory requires explicit flushing.
+        const COHERENT     = 0x4;
 
         /// Cached memory by the CPU
         const CPU_CACHED = 0x8;
 
         /// Memory that may be lazily allocated as needed on the GPU
         /// and *must not* be visible to the CPU.
-        const LAZILY_ALLOCATED = 0x20;
+        const LAZILY_ALLOCATED = 0x10;
     }
 );
 


### PR DESCRIPTION
This commit updates the `COHERENT`, `CPU_VISIBLE` and `LAZILY_ALLOCATED` flags to match the order and values defined by Vulkan.

See https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryPropertyFlagBits.html

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: `vulkan`
- [x] `rustfmt` run on changed code
