### PR TITLE
[vk] request surface extensions based on platform

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -60,10 +60,15 @@ lazy_static! {
     static ref SURFACE_EXTENSIONS: Vec<&'static CStr> = vec![
         khr::Surface::name(),
         // Platform-specific WSI extensions
+        #[cfg(all(unix, not(target_os = "android")))]
         khr::XlibSurface::name(),
+        #[cfg(all(unix, not(target_os = "android")))]
         khr::XcbSurface::name(),
+        #[cfg(all(unix, not(target_os = "android")))]
         khr::WaylandSurface::name(),
+        #[cfg(target_os = "android")]
         khr::AndroidSurface::name(),
+        #[cfg(target_os = "windows")]
         khr::Win32Surface::name(),
     ];
 }


### PR DESCRIPTION
Silences warnings on Windows about being unable to find the VK_KHR_xlib_surface, VK_KHR_xcb_surface, VK_KHR_wayland_surface and VK_KHR_android_surface extensions.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vk
- [x] `rustfmt` run on changed code
