### PR TITLE
Replace glsl-to-spirv with shaderc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_install:
   # see https://docs.travis-ci.com/user/trusty-ci-environment/
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && make travis-sdl2 && export CXX=g++-5; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update && brew install sdl2; fi
-  - if [[ $TRAVIS_OS_NAME == "windows" ]]; then choco install make; fi
+  - if [[ $TRAVIS_OS_NAME == "windows" ]]; then choco install make ninja; fi
   - rustup self update
   - rustup target add $TARGET; true
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -31,9 +31,9 @@ env_logger = "0.5"
 image = "0.19"
 log = "0.4"
 winit = "0.18"
-glsl-to-spirv = "0.1.4"
 gfx-hal = { path = "../src/hal", version = "0.1" }
 gfx-backend-empty = { path = "../src/backend/empty", version = "0.1" }
+shaderc = "0.3.16"
 
 [dependencies.gfx-backend-gl]
 path = "../src/backend/gl"

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -17,12 +17,12 @@ edition = "2018"
 name = "gfx_warden"
 
 [features]
-default = ["glsl-to-spirv"]
+default = ["shaderc"]
 vulkan = ["gfx-backend-vulkan"]
 dx12 = ["gfx-backend-dx12"]
 metal = ["gfx-backend-metal"]
 gl = ["gfx-backend-gl"]
-gl-headless = ["gfx-backend-gl"] # "glsl-to-spirv"
+gl-headless = ["gfx-backend-gl"] # "shaderc"
 
 #TODO: keep Warden backend-agnostic?
 
@@ -33,7 +33,7 @@ log = "0.4"
 ron = "0.2.1"
 serde = { version = "1", features = ["serde_derive"] }
 env_logger = { version = "0.5", optional = true }
-glsl-to-spirv = { version = "0.1", optional = true }
+shaderc = { version = "0.3.16", optional = true }
 
 [dependencies.gfx-backend-vulkan]
 path = "../../src/backend/vulkan"
@@ -59,4 +59,4 @@ optional = true
 
 [[example]]
 name = "basic"
-required-features = ["gl", "glsl-to-spirv"]
+required-features = ["gl", "shaderc"]

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -107,7 +107,7 @@ impl Harness {
             //println!("\t{:?}", adapter.info);
             println!("\tScene '{}':", tg.name);
 
-            #[cfg(not(feature = "glsl-to-spirv"))]
+            #[cfg(not(feature = "shaderc"))]
             {
                 let all_spirv = tg.scene.resources.values().all(|res| match *res {
                     warden::raw::Resource::Shader(ref name) => name.ends_with(".spirv"),

--- a/src/warden/src/lib.rs
+++ b/src/warden/src/lib.rs
@@ -7,8 +7,8 @@ extern crate log;
 #[macro_use]
 extern crate serde;
 extern crate failure;
-#[cfg(feature = "glsl-to-spirv")]
-extern crate glsl_to_spirv;
+#[cfg(feature = "shaderc")]
+extern crate shaderc;
 
 pub mod gpu;
 pub mod raw;


### PR DESCRIPTION
Replaces glsl-to-spirv with shaderc.

glsl-to-spirv is deprecated and the author states: ["use shaderc-rs instead"](https://crates.io/crates/glsl-to-spirv).

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12, vulkan
- [x] `rustfmt` run on changed code

Note: `make reftests` is failing for dx12 on master, so it’s failing on this branch too. It passes for vulkan.