### PR TITLE
[vk] add max_image_array_layers limit

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -783,6 +783,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             max_image_2d_size: limits.max_image_dimension2_d,
             max_image_3d_size: limits.max_image_dimension3_d,
             max_image_cube_size: limits.max_image_dimension_cube,
+            max_image_array_layers: limits.max_image_array_layers as _,
             max_texel_elements: limits.max_texel_buffer_elements as _,
             max_patch_size: limits.max_tessellation_patch_size as PatchSize,
             max_viewports: limits.max_viewports as _,


### PR DESCRIPTION
This is a follow up to #2698
Fixes https://github.com/szeged/webrender/issues/277
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan
- [ ] `rustfmt` run on changed code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/2732)
<!-- Reviewable:end -->
