### PR TITLE
[pre-ll] Add BC1 (DXT1), BC3 (DXT5) S3TC texture formats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,9 @@ matrix:
     # Windows 64bit
     - os: windows
       rust: stable
-
+      # caching on windows is slow, can cause failures:
+      # "No output has been received in the last 10m0s..."
+      cache: false
 
 branches:
   except:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ path = "examples/render_target/main.rs"
 
 [dev-dependencies]
 cgmath = "0.17"
-gfx_gl = "0.5"
+gfx_gl = "0.6"
 rand = "0.5"
 genmesh = "0.5"
 noise = "0.2" #TODO: update

--- a/src/backend/dx11/src/data.rs
+++ b/src/backend/dx11/src/data.rs
@@ -40,6 +40,7 @@ pub fn map_format(format: Format, is_target: bool) -> Option<DXGI_FORMAT> {
     use core::format::ChannelType::*;
     Some(match format.0 {
         R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 => return None,
+        BC1_R8_G8_B8 | BC3_R8_G8_B8_A8 => return None,
         R8 => match format.1 {
             Int   => DXGI_FORMAT_R8_SINT,
             Uint  => DXGI_FORMAT_R8_UINT,
@@ -153,6 +154,7 @@ pub fn map_surface(surface: SurfaceType) -> Option<DXGI_FORMAT> {
     Some(match surface {
         R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 => return None,
         R16_G16_B16 => return None,
+        BC1_R8_G8_B8 | BC3_R8_G8_B8_A8 => return None,
         R8              => DXGI_FORMAT_R8_TYPELESS,
         R8_G8           => DXGI_FORMAT_R8G8_TYPELESS,
         R8_G8_B8_A8     => DXGI_FORMAT_R8G8B8A8_TYPELESS,

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -29,5 +29,5 @@ name = "gfx_device_gl"
 
 [dependencies]
 log = "0.4"
-gfx_gl = { git = "https://github.com/alexheretic/gfx_gl", branch = "s3tc" }
+gfx_gl = "0.6"
 gfx_core = { path = "../../core", version = "0.9" }

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -29,5 +29,5 @@ name = "gfx_device_gl"
 
 [dependencies]
 log = "0.4"
-gfx_gl = "0.5"
+gfx_gl = { git = "https://github.com/alexheretic/gfx_gl", branch = "s3tc" }
 gfx_core = { path = "../../core", version = "0.9" }

--- a/src/backend/metal/src/map.rs
+++ b/src/backend/metal/src/map.rs
@@ -217,7 +217,7 @@ pub fn map_format(format: Format, is_target: bool) -> Option<MTLPixelFormat> {
     use metal::MTLPixelFormat::*;
 
     Some(match format.0 {
-        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 => return None,
+        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 | BC1_R8_G8_B8| BC3_R8_G8_B8_A8 => return None,
         R8 => match format.1 {
             Int   => R8Sint,
             Uint  => R8Uint,
@@ -339,7 +339,8 @@ pub fn map_channel_hint(hint: SurfaceType) -> Option<ChannelType> {
     use core::format::ChannelType::*;
 
     Some(match hint {
-        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 | R16_G16_B16 | R32_G32_B32 | D16 => {
+        R4_G4 | R4_G4_B4_A4 | R5_G5_B5_A1 | R5_G6_B5 | R16_G16_B16 | R32_G32_B32 | D16
+        | BC1_R8_G8_B8 | BC3_R8_G8_B8_A8 => {
             return None
         }
         R8 | R8_G8 | R8_G8_B8_A8 | R10_G10_B10_A2 | R16 | R16_G16 | R16_G16_B16_A16 | R32 |

--- a/src/backend/vulkan/src/data.rs
+++ b/src/backend/vulkan/src/data.rs
@@ -167,6 +167,7 @@ pub fn map_format(surface: SurfaceType, chan: ChannelType) -> Option<vk::Format>
             Srgb  => vk::FORMAT_R8G8B8A8_SRGB,
             _ => return None,
         },
+        BC1_R8_G8_B8 | BC3_R8_G8_B8_A8 => return None,
         R10_G10_B10_A2 => match chan {
             Int   => vk::FORMAT_A2R10G10B10_SINT_PACK32,
             Uint  => vk::FORMAT_A2R10G10B10_UINT_PACK32,

--- a/src/core/src/format.rs
+++ b/src/core/src/format.rs
@@ -152,6 +152,12 @@ impl_formats! {
     D24_S8          : Vec1<Unorm, Uint> = u32 {8} [TextureSurface, DepthSurface, StencilSurface],
     D32             : Vec1<Float> = f32 {0} [TextureSurface, DepthSurface],
     //D32_S8          : Vec1<Unorm, Float, Uint> = (f32, u32) {32} [TextureSurface, DepthSurface, StencilSurface],
+
+    // S3TC https://en.wikipedia.org/wiki/S3_Texture_Compression
+    // DXT1/BC1
+    BC1_R8_G8_B8   : Vec4<Int, Uint, Inorm, Unorm, Srgb> = [u8; 3] {0} [TextureSurface],
+    // DXT5/BC3
+    BC3_R8_G8_B8_A8 : Vec4<Int, Uint, Inorm, Unorm, Srgb> = [u8; 4] {8} [TextureSurface],
 }
 
 

--- a/src/core/src/format.rs
+++ b/src/core/src/format.rs
@@ -61,7 +61,7 @@ impl_channel_type! {
 }
 
 macro_rules! impl_formats {
-    { $($name:ident : $container:ident < $($channel:ident),* > = $data_type:ty {$alpha_bits:expr} [ $($imp_trait:ident),* ] ,)* } => {
+    { $($name:ident : $container:ident < $($channel:ident),* > = $data_type:ty {$alpha_bits:expr} [ $($imp_trait:ident),* ], doc = $doc:expr ,)* } => {
         /// Type of the allocated texture surface. It is supposed to only
         /// carry information about the number of bits per each channel.
         /// The actual types are up to the views to decide and interpret.
@@ -71,7 +71,7 @@ macro_rules! impl_formats {
         #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
         #[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
         pub enum SurfaceType {
-            $( $name, )*
+            $( #[doc = $doc] $name, )*
         }
         impl SurfaceType {
             /// Return the total number of bits for this format.
@@ -92,6 +92,7 @@ macro_rules! impl_formats {
             #[allow(missing_docs, non_camel_case_types)]
             #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
             #[cfg_attr(feature="serialize", derive(Serialize, Deserialize))]
+            #[doc = $doc]
             pub enum $name {}
             impl SurfaceTyped for $name {
                 type DataType = $data_type;
@@ -115,49 +116,52 @@ macro_rules! impl_formats {
 
 
 impl_formats! {
-    R4_G4           : Vec2<Unorm> = u8 {0}  [TextureSurface, RenderSurface],
-    R4_G4_B4_A4     : Vec4<Unorm> = u16 {4} [TextureSurface, RenderSurface],
-    R5_G5_B5_A1     : Vec4<Unorm> = u16 {1} [TextureSurface, RenderSurface],
-    R5_G6_B5        : Vec3<Unorm> = u16 {0} [TextureSurface, RenderSurface],
+    R4_G4           : Vec2<Unorm> = u8 {0}  [TextureSurface, RenderSurface], doc = "",
+    R4_G4_B4_A4     : Vec4<Unorm> = u16 {4} [TextureSurface, RenderSurface], doc = "",
+    R5_G5_B5_A1     : Vec4<Unorm> = u16 {1} [TextureSurface, RenderSurface], doc = "",
+    R5_G6_B5        : Vec3<Unorm> = u16 {0} [TextureSurface, RenderSurface], doc = "",
     R8              : Vec1<Int, Uint, Inorm, Unorm> = u8 {0}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R8_G8           : Vec2<Int, Uint, Inorm, Unorm> = [u8; 2] {0}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R8_G8_B8_A8     : Vec4<Int, Uint, Inorm, Unorm, Srgb> = [u8; 4] {8}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R10_G10_B10_A2  : Vec4<Uint, Unorm> = u32 {2}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R11_G11_B10     : Vec4<Unorm, Float> = u32 {0}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R16             : Vec1<Int, Uint, Inorm, Unorm, Float> = u16 {0}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R16_G16         : Vec2<Int, Uint, Inorm, Unorm, Float> = [u16; 2] {0}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R16_G16_B16     : Vec3<Int, Uint, Inorm, Unorm, Float> = [u16; 3] {0}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R16_G16_B16_A16 : Vec4<Int, Uint, Inorm, Unorm, Float> = [u16; 4] {16}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R32             : Vec1<Int, Uint, Float> = u32 {0}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R32_G32         : Vec2<Int, Uint, Float> = [u32; 2] {0}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R32_G32_B32     : Vec3<Int, Uint, Float> = [u32; 3] {0}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     R32_G32_B32_A32 : Vec4<Int, Uint, Float> = [u32; 4] {32}
-        [BufferSurface, TextureSurface, RenderSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
     B8_G8_R8_A8     : Vec4<Unorm, Srgb> = [u8; 4] {32}
-        [BufferSurface, TextureSurface, RenderSurface],
-    D16             : Vec1<Unorm> = F16 {0} [TextureSurface, DepthSurface],
-    D24             : Vec1<Unorm> = f32 {8} [TextureSurface, DepthSurface], //hacky stencil bits
-    D24_S8          : Vec1<Unorm, Uint> = u32 {8} [TextureSurface, DepthSurface, StencilSurface],
-    D32             : Vec1<Float> = f32 {0} [TextureSurface, DepthSurface],
+        [BufferSurface, TextureSurface, RenderSurface], doc = "",
+    D16             : Vec1<Unorm> = F16 {0} [TextureSurface, DepthSurface], doc = "",
+    D24             : Vec1<Unorm> = f32 {8} [TextureSurface, DepthSurface], doc = "", //hacky stencil bits
+    D24_S8          : Vec1<Unorm, Uint> = u32 {8} [TextureSurface, DepthSurface, StencilSurface], doc = "",
+    D32             : Vec1<Float> = f32 {0} [TextureSurface, DepthSurface], doc = "",
     //D32_S8          : Vec1<Unorm, Float, Uint> = (f32, u32) {32} [TextureSurface, DepthSurface, StencilSurface],
 
-    // S3TC https://en.wikipedia.org/wiki/S3_Texture_Compression
-    // DXT1/BC1
     BC1_R8_G8_B8   : Vec4<Int, Uint, Inorm, Unorm, Srgb> = [u8; 3] {0} [TextureSurface],
-    // DXT5/BC3
+        doc = "Block Compression 1 also known as DXT1, S3TC. See \
+               [S3TC wiki](https://wikipedia.org/wiki/S3_Texture_Compression).\
+               \n\nCurrently supported in the gfx_device_gl backend only.",
     BC3_R8_G8_B8_A8 : Vec4<Int, Uint, Inorm, Unorm, Srgb> = [u8; 4] {8} [TextureSurface],
+        doc = "Block Compression 3 also known as DXT5, S3TC. See \
+               [S3TC wiki](https://wikipedia.org/wiki/S3_Texture_Compression).\
+               \n\nCurrently supported in the gfx_device_gl backend only.",
 }
 
 

--- a/src/window/sdl/src/lib.rs
+++ b/src/window/sdl/src/lib.rs
@@ -88,7 +88,7 @@ fn sdl2_pixel_format_from_gfx(format: Format) -> Option<PixelFormatEnum> {
         }
         R4_G4 | R8 | R8_G8 | R11_G11_B10 | R16 | R16_G16 | R16_G16_B16 |
         R16_G16_B16_A16 | R32 | R32_G32 | R32_G32_B32 | R32_G32_B32_A32 | D16 | D24 |
-        D24_S8 | D32 => None,
+        D24_S8 | D32 | BC1_R8_G8_B8 | BC3_R8_G8_B8_A8 => None,
     }
 }
 


### PR DESCRIPTION
Adds compressed BC1 & BC3 image formats for gfx_device_gl/opengl. Image data is expected to be already compressed.

New formats:
* `SurfaceType::BC1_R8_G8_B8` (DXT1)
* `SurfaceType::BC3_R8_G8_B8_A8` (DXT5)

Each supports rgb & srgb.

Resolves #2688

## Motive
I've been investigating texture compression to reduce VRAM usage in my game Robo Instructus. For this end I wanted more efficient 8-bit channel rgb & rgba storage with good opengl driver & hardware support.

S3TC is old and the best supported compression available (see https://opengl.gpuinfo.org/listcompressedformats.php). Patent issues are now history (see https://en.wikipedia.org/wiki/S3_Texture_Compression). For testing I used [GPUOpen-Tools/Compressonator](https://github.com/GPUOpen-Tools/Compressonator) for encoding, which is quite fast and seems to have decent quality.

* `BC1_R8_G8_B8` offers 8:1 compression over `R8_G8_B8_A8`
* `BC3_R8_G8_B8_A8` offers 4:1 compression over `R8_G8_B8_A8`

I didn't include BC2/DXT3, or BC7 as I don't plan to use it. However, support for this format can be trivially added on top of this change.

## No ETC2?
I did investigate ETC2 compression too which is newer yet features wide support. However, I found actual _hardware_ support for ETC2 on the desktop is much more limited that it may appear. It was a bit of a downer to see no VRAM usage reduction on my polaris RX480 when using ETC2 compressed textures. ETC2 formats also didn't seem to work without the `GL_ARB_texture_storage`/immutable storage code paths, whereas I've tested the BC1 & BC3 formats working either way. That can probably be addressed, but I didn't.

For the above reasons I decided against using ETC2 in the game & adding it here. Note though; similarly to BC2, this change will make it simpler to support ETC2 formats in future if desired.

## Issues
### OpenGL Extensions
~This code requires S3TC extensions added to `gfx_gl`. The changes there are ready to go if this PR is wanted. The gfx_gl dependency line needs to be changed:~
~https://github.com/gfx-rs/gfx_gl/pull/38~
Extensions now available in gfx_gl `0.6`.

### API support
Robo Instructus is an OpenGL 3.3 game so I'm not personally interested in other API support for these formats at the moment. Also considering pre-ll code is in support mode, and unsupported formats already seem common I thought it wasn't a big deal not supporting other APIs.

### Naming
I went with Vulkan naming style ie prefix with BC1. Maybe you guys have a better idea of what you'd like to name the formats. I'm not hugely fussed here.

### Format documentation
~It would be nice to have documentation for the new formats. Mentioning there various other pseudonyms & API support will probably help people wondering what BC1 does & means. However, the `impl_formats!` macro prevents easy documentation.~ I've added this. Other formats can now be fairly easily documented too.