### PR TITLE
Remove `!is_emscripten` override for constant buffer support in GL backend

### DIFF
--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -298,8 +298,7 @@ pub fn get_all(gl: &gl::Gl) -> (Info, Capabilities, PrivateCaps) {
                                                                Ext ("GL_ARB_framebuffer_sRGB")]),
         constant_buffer_supported:         info.is_supported(&[Core(3,1),
                                                                Es  (3,0),
-                                                               Ext ("GL_ARB_uniform_buffer_object")])
-                                           && !is_emscripten,
+                                                               Ext ("GL_ARB_uniform_buffer_object")]),
         unordered_access_view_supported:   info.is_supported(&[Core(4,0)]), //TODO: extension
         separate_blending_slots_supported: info.is_supported(&[Core(4,0),
                                                                Es  (3,2), // see `glDisablei`


### PR DESCRIPTION
Fixes #2726.

PR checklist:
- [x] tested examples with the following backends: GL
- [x] `rustfmt` run on changed code
