### PR TITLE
Change `surface.capabilities_and_formats(device)` to `surface.compatibility(device)` in the docs

### DIFF
--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -136,7 +136,7 @@ impl Extent2D {
 }
 
 /// Describes information about what a `Surface`'s properties are.
-/// Fetch this with `surface.capabilities_and_formats(device)`.
+/// Fetch this with `surface.compatibility(device)`.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SurfaceCapabilities {


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
