### PR TITLE
[pre-ll] Support HLSL semantic indexes

### DIFF
--- a/src/backend/dx11/src/factory.rs
+++ b/src/backend/dx11/src/factory.rs
@@ -587,9 +587,10 @@ impl core::Factory<R> for Factory {
                     attrib.name, elem.offset);
                 return Err(core::pso::CreationError);
             }
+            let vertex_semantic: VertexSemantic = attrib.name.as_str().into();
             layouts.push(d3d11::D3D11_INPUT_ELEMENT_DESC {
                 SemanticName: &charbuf[charpos],
-                SemanticIndex: 0,
+                SemanticIndex: vertex_semantic.index,
                 Format: match map_format(elem.format, false) {
                     Some(fm) => fm,
                     None => {
@@ -597,7 +598,7 @@ impl core::Factory<R> for Factory {
                         return Err(core::pso::CreationError);
                     }
                 },
-                InputSlot: attrib.slot as _,
+                InputSlot: attrib.slot as _, // NOTE: gfx_backend_dx11 has a vertex buffer binding per attribute.
                 AlignedByteOffset: elem.offset as _,
                 InputSlotClass: if bdesc.rate == 0 {
                     d3d11::D3D11_INPUT_PER_VERTEX_DATA
@@ -606,7 +607,7 @@ impl core::Factory<R> for Factory {
                 },
                 InstanceDataStepRate: bdesc.rate as _,
             });
-            for (out, inp) in charbuf[charpos..].iter_mut().zip(attrib.name.as_bytes().iter()) {
+            for (out, inp) in charbuf[charpos..].iter_mut().zip(vertex_semantic.name.as_bytes().iter()) {
                 *out = *inp as i8;
             }
             charpos += attrib.name.as_bytes().len() + 1;
@@ -1042,5 +1043,90 @@ pub fn ensure_unmapped(mapping: &mut MappingGate,
         }
 
         mapping.pointer = ptr::null_mut();
+    }
+}
+
+/// Hack: We're packing the semantic name/index into a `String` in the format that HLSL parses the information from (i.e. the name and index are simply concatted together). This loses some type safety and incurs a cost to marshal in and out of this struct. We're doing this to work around not changing `AttributeVar` (which could be parameterized over the `name` type and be specialized to this struct for DX11). When the next minor version of `gfx_core` is released we may be able to remove this hack.
+/// 
+/// `'s` is the lifetime of the `str` pointing at the semantic name.
+#[derive(PartialEq, Debug)]
+pub struct VertexSemantic<'s> {
+    pub name: &'s str,
+    pub index: u32,
+}
+
+impl<'s> From<&'s str> for VertexSemantic<'s> {
+    fn from(packed: &'s str) -> Self {
+        fn is_not_ascii_digit(c: char) -> bool {
+            !char::is_ascii_digit(&c)
+        }
+
+        // Note: a semantic name can't be just numeric, so this will succeed if called correctly.
+        let partition_index = packed.rfind(is_not_ascii_digit).map(|i| i + 1).unwrap();
+
+        Self {
+            name: &packed[..partition_index],
+            index: str::parse(&packed[partition_index..]).unwrap_or(0),
+        }
+    }
+}
+
+impl Into<String> for VertexSemantic<'_> {
+    fn into(self) -> String {
+        format!("{}{}", self.name, self.index)
+    }
+}
+
+#[cfg(test)]
+mod vertex_semantic_tests {
+    use super::*;
+
+    #[test]
+    fn pack() {
+        let vertex_semantic = VertexSemantic {
+            name: "TEST",
+            index: 1,
+        };
+        let packed: String = vertex_semantic.into();
+        assert_eq!("TEST1", packed);
+    }
+
+    #[test]
+    fn unpack() {
+        let test1 = "TEST1";
+        let packed: VertexSemantic = test1.into();
+        assert_eq!(
+            VertexSemantic {
+                name: "TEST",
+                index: 1,
+            },
+            packed,
+        );
+    }
+
+    #[test]
+    fn unpack_inner_numbers() {
+        let test1 = "TEST1A1";
+        let packed: VertexSemantic = test1.into();
+        assert_eq!(
+            VertexSemantic {
+                name: "TEST1A",
+                index: 1,
+            },
+            packed,
+        );
+    }
+
+    #[test]
+    fn unpack_implied_index() {
+        let test = "TEST";
+        let packed: VertexSemantic = test.into();
+        assert_eq!(
+            VertexSemantic {
+                name: "TEST",
+                index: 0,
+            },
+            packed,
+        );
     }
 }

--- a/src/backend/dx11/src/mirror.rs
+++ b/src/backend/dx11/src/mirror.rs
@@ -132,8 +132,8 @@ pub fn populate_info(info: &mut s::ProgramInfo, stage: s::Stage,
                 (hr, desc)
             };
             assert!(winerror::SUCCEEDED(hr));
-            info!("\tAttribute {}, system type {:?}, mask {}, read-write mask {}",
-                convert_str(desc.SemanticName), desc.SystemValueType, desc.Mask, desc.ReadWriteMask);
+            info!("\tAttribute {}, semantic index {}, system type {:?}, mask {}, read-write mask {}",
+                convert_str(desc.SemanticName), desc.SemanticIndex, desc.SystemValueType, desc.Mask, desc.ReadWriteMask);
             if desc.SystemValueType != d3dcommon::D3D_NAME_UNDEFINED {
                 // system value semantic detected, skipping
                 continue
@@ -143,11 +143,11 @@ pub fn populate_info(info: &mut s::ProgramInfo, stage: s::Stage,
                 continue
             }
             let name = convert_str(desc.SemanticName);
-            if desc.SemanticIndex != 0 {
-                error!("Semantic {} has non-zero index {} - not supported by the backend", name, desc.SemanticIndex);
-            }
             info.vertex_attributes.push(s::AttributeVar {
-                name: name,
+                name: crate::factory::VertexSemantic {
+                    name: &name,
+                    index: desc.SemanticIndex
+                }.into(),
                 slot: desc.Register as core::AttributeSlot,
                 base_type: map_base_type_from_component(desc.ComponentType),
                 container: mask_to_vector(desc.Mask),


### PR DESCRIPTION
Fixes #2748
PR checklist:
- [x] tested examples with the following backends: DX11

This changeset adds support for HLSL semantic indices.

Users should now be able to specify a semantic with an index (such as `"TEXCOORD1"`) in their pipeline. If one does not include the index, an index of `0` is assumed (as HLSL assumes).

Introduces a struct that can be converted to and from a packed String.

Here are some sample mappings:
- `"TEXCOORD"` -> `VertexSemantic { name: "TEXCOORD", index: 0 }` -> `"TEXCOORD0"`
- `"TEXCOORD0"` <-> `VertexSemantic { name: "TEXCOORD", index: 0 }`
- `"TEXCOORD10"` <-> `VertexSemantic { name: "TEXCOORD", index: 10 }`

On link_input, we will try linking against the semantic name and index together (e.g. `"TEXCOORD0"`) and also just the semantic name (e.g. `"TEXCOORD"`) if the semantic index is 0, in the case that the user did not explicitly provide the semantic index, esp. for GLSL compatibility).