### PR TITLE
[mtl] add multisampling basics

### DIFF
--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -1075,7 +1075,7 @@ pub fn map_texture_usage(usage: image::Usage, tiling: image::Tiling) -> MTLTextu
     if usage.intersects(U::COLOR_ATTACHMENT | U::DEPTH_STENCIL_ATTACHMENT) {
         texture_usage |= MTLTextureUsage::RenderTarget;
     }
-    if usage.intersects(U::SAMPLED) {
+    if usage.intersects(U::SAMPLED | U::INPUT_ATTACHMENT) {
         texture_usage |= MTLTextureUsage::ShaderRead;
     }
     if usage.intersects(U::STORAGE) {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1462,6 +1462,14 @@ impl hal::Device<Backend> for Device {
             .depth_stencil_states
             .prepare(&pipeline_desc.depth_stencil, &*device);
 
+        if let Some(multisampling) = &pipeline_desc.multisampling {
+            pipeline.set_sample_count(multisampling.rasterization_samples as u64);
+            pipeline.set_alpha_to_coverage_enabled(multisampling.alpha_coverage);
+            pipeline.set_alpha_to_one_enabled(multisampling.alpha_to_one);
+            // TODO: sample_mask
+            // TODO: sample_shading
+        }
+
         device
             .new_render_pipeline_state(&pipeline)
             .map(|raw| n::GraphicsPipeline {


### PR DESCRIPTION
Sets multisampling state for `MTLRenderPipelineDescriptor` and maps the `Image::Usage::INPUT_ATTACHMENT` flag to `MtlTextureUsage::ShaderRead`. This is enough to implement multisampling if you resolve the samples yourself using a fragment shader on a fullscreen quad in a separate subpass. Doesn't implement resolve attachments, but it looks like that could be added relatively easily in the future.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: mtl
- [x] `rustfmt` run on changed code
