### PR TITLE
[dx12] add missing SAMPLER_ANISOTROPY feature flag

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1037,7 +1037,8 @@ impl hal::Instance for Instance {
                     Features::MULTI_DRAW_INDIRECT |
                     Features::FORMAT_BC |
                     Features::INSTANCE_RATE |
-                    Features::SAMPLER_MIP_LOD_BIAS,
+                    Features::SAMPLER_MIP_LOD_BIAS |
+                    Features::SAMPLER_ANISOTROPY,
                 limits: Limits { // TODO
                     max_image_1d_size: d3d12::D3D12_REQ_TEXTURE1D_U_DIMENSION as _,
                     max_image_2d_size: d3d12::D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION as _,


### PR DESCRIPTION
16x anisotropic filtering is supported across all feature levels, but the dx12 backend does not expose the `SAMPLER_ANISOTROPY` feature flag for the `PhysicalDevice`

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12
- [ ] `rustfmt` run on changed code
