### PR TITLE
Bump Travis osx_image to xcode9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,18 @@ matrix:
     - env: MACOSX_DEPLOYMENT_TARGET=10.9
       os: osx
       rust: stable
-      osx_image: xcode9
+      osx_image: xcode9.4
       compiler: clang
     - env: MACOSX_DEPLOYMENT_TARGET=10.9
       os: osx
       rust: nightly
-      osx_image: xcode9
+      osx_image: xcode9.4
       compiler: clang
 
     # iPhoneOS 64bit
     - env: TARGET=aarch64-apple-ios
       os: osx
-      osx_image: xcode9
+      osx_image: xcode9.4
       rust: nightly
 
     # Windows 64bit


### PR DESCRIPTION
Checking if this fixes Travis CI on macOS/iOS (xcode9.4 is the default now)