### PR TITLE
Update env_logger, image, ron and ash versions

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -27,8 +27,8 @@ name = "compute"
 path = "compute/main.rs"
 
 [dependencies]
-env_logger = "0.5"
-image = "0.19"
+env_logger = "0.6"
+image = "0.21"
 log = "0.4"
 winit = "0.19"
 glsl-to-spirv = "0.1.4"

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "1"
 log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
-ash = "0.28.0"
+ash = "0.29.0"
 gfx-hal = { path = "../../hal", version = "0.1" }
 smallvec = "0.6"
 winit = { version = "0.19", optional = true }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -178,13 +178,13 @@ unsafe fn display_debug_utils_object_name_info_ext(
 
                 match object_name {
                     Some(name) => format!(
-                        "(type: {}, hndl: {}, name: {})",
+                        "(type: {:?}, hndl: {}, name: {})",
                         obj_info.object_type,
                         &obj_info.object_handle.to_string(),
                         name
                     ),
                     None => format!(
-                        "(type: {}, hndl: {})",
+                        "(type: {:?}, hndl: {})",
                         obj_info.object_type,
                         &obj_info.object_handle.to_string()
                     ),
@@ -210,7 +210,7 @@ unsafe extern "system" fn debug_utils_messenger_callback(
         vk::DebugUtilsMessageSeverityFlagsEXT::VERBOSE => log::Level::Trace,
         _ => log::Level::Warn,
     };
-    let message_type = &format!("{}", message_type);
+    let message_type = &format!("{:?}", message_type);
     let message_id_number: i32 = callback_data.message_id_number as i32;
 
     let message_id_name = if callback_data.p_message_id_name.is_null() {

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -30,9 +30,9 @@ gl-headless = ["gfx-backend-gl"] # "glsl-to-spirv"
 failure = "0.1"
 gfx-hal = { path = "../hal", version = "0.1", features = ["serde"] }
 log = "0.4"
-ron = "0.2.1"
+ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
-env_logger = { version = "0.5", optional = true }
+env_logger = { version = "0.6", optional = true }
 glsl-to-spirv = { version = "0.1", optional = true }
 
 [dependencies.gfx-backend-vulkan]


### PR DESCRIPTION
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
vulkan
- [x] `rustfmt` run on changed code

I updated everything I could test on my system, except the opengl dependencies where the glutin changes looked fairly involved and should be done by someone who better understands the backend.

The ash changes are because the Display output has been moved to Debug, as per the changelog: https://github.com/MaikKlein/ash/blob/master/Changelog.md