### PR TITLE
[vk] expose NON_FILL_POLYGON_MODE feature flag

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -739,6 +739,9 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         if features.depth_bias_clamp != 0 {
             bits |= Features::DEPTH_BIAS_CLAMP;
         }
+        if features.fill_mode_non_solid != 0 {
+            bits |= Features::NON_FILL_POLYGON_MODE;
+        }
         if features.depth_bounds != 0 {
             bits |= Features::DEPTH_BOUNDS;
         }


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vk
- [ ] `rustfmt` run on changed code
