### PR TITLE
[dx12] Fix blit_image post barriers

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1703,7 +1703,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
         // post barriers
         for bar in &mut barriers {
-            let mut transition = *bar.u.Transition_mut();
+            let mut transition = bar.u.Transition_mut();
             mem::swap(&mut transition.StateBefore, &mut transition.StateAfter);
         }
         self.raw


### PR DESCRIPTION
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/gfx/2768)
<!-- Reviewable:end -->
