### PR TITLE
Handle & document behavior re: framebuffers with any dimension == 0

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -633,6 +633,10 @@ impl WindowState {
         let events_loop = winit::EventsLoop::new();
 
         let wb = winit::WindowBuilder::new()
+            .with_min_dimensions(winit::dpi::LogicalSize::new(
+                1.0,
+                1.0,
+            ))
             .with_dimensions(winit::dpi::LogicalSize::new(
                 DIMS.width as _,
                 DIMS.height as _,

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -81,6 +81,10 @@ fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
     let wb = winit::WindowBuilder::new()
+        .with_min_dimensions(winit::dpi::LogicalSize::new(
+            1.0,
+            1.0,
+        ))
         .with_dimensions(winit::dpi::LogicalSize::new(
             DIMS.width as _,
             DIMS.height as _,

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -354,7 +354,10 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// which references the compute pipeline, has finished execution.
     unsafe fn destroy_compute_pipeline(&self, pipeline: B::ComputePipeline);
 
-    /// Create a new framebuffer object
+    /// Create a new framebuffer object.
+    ///
+    /// # Safety
+    /// - `extent.width`, `extent.height` and `extent.depth` **must** be greater than `0`.
     unsafe fn create_framebuffer<I>(
         &self,
         pass: &B::RenderPass,


### PR DESCRIPTION
Fixes #2777:
- Add documentation to `create_framebuffer` indicating minimum dimensions
- Set minimum window dimensions of (1, 1) in examples

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [*] tested examples with the following backends: gl, vulkan
- [*] `rustfmt` run on changed code
