### PR TITLE
[hal-0.2] Query VK_EXT_debug_utils support before creating messenger

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -369,18 +369,25 @@ impl Instance {
 
         #[cfg(debug_assertions)]
         let debug_messenger = {
-            let ext = ext::DebugUtils::new(entry, &instance);
-            let info = vk::DebugUtilsMessengerCreateInfoEXT {
-                s_type: vk::StructureType::DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
-                p_next: ptr::null(),
-                flags: vk::DebugUtilsMessengerCreateFlagsEXT::empty(),
-                message_severity: vk::DebugUtilsMessageSeverityFlagsEXT::all(),
-                message_type: vk::DebugUtilsMessageTypeFlagsEXT::all(),
-                pfn_user_callback: Some(debug_utils_messenger_callback),
-                p_user_data: ptr::null_mut(),
-            };
-            let handle = unsafe { ext.create_debug_utils_messenger(&info, None) }.unwrap();
-            Some((ext, handle))
+            // make sure VK_EXT_debug_utils is available
+            if instance_extensions.iter().any(|props| unsafe {
+                CStr::from_ptr(props.extension_name.as_ptr()) == ext::DebugUtils::name()
+            }) {
+                let ext = ext::DebugUtils::new(entry, &instance);
+                let info = vk::DebugUtilsMessengerCreateInfoEXT {
+                    s_type: vk::StructureType::DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
+                    p_next: ptr::null(),
+                    flags: vk::DebugUtilsMessengerCreateFlagsEXT::empty(),
+                    message_severity: vk::DebugUtilsMessageSeverityFlagsEXT::all(),
+                    message_type: vk::DebugUtilsMessageTypeFlagsEXT::all(),
+                    pfn_user_callback: Some(debug_utils_messenger_callback),
+                    p_user_data: ptr::null_mut(),
+                };
+                let handle = unsafe { ext.create_debug_utils_messenger(&info, None) }.unwrap();
+                Some((ext, handle))
+            } else {
+                None
+            }
         };
         #[cfg(not(debug_assertions))]
         let debug_messenger = None;

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-hal"
-version = "0.2.0"
+version = "0.2.1"
 description = "gfx-rs hardware abstraction layer"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
Backports #2778 to hal-0.2

cc @kvark 

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
