### PR TITLE
android only supports a subset of the standard validation layers

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -59,18 +59,18 @@ mod window;
 lazy_static! {
     static ref LAYERS: Vec<&'static CStr> = if cfg!(all(target_os = "android", debug_assertions)) {
         vec![
-            CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_core_validation\0").expect("Wrong extension string"),
-            CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_object_tracker\0").expect("Wrong extension string"),
-            CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_parameter_validation\0").expect("Wrong extension string"),
-            CStr::from_bytes_with_nul(b"VK_LAYER_GOOGLE_threading\0").expect("Wrong extension string"),
-            CStr::from_bytes_with_nul(b"VK_LAYER_GOOGLE_unique_objects\0").expect("Wrong extension string"),
+            CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_core_validation\0").unwrap(),
+            CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_object_tracker\0").unwrap(),
+            CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_parameter_validation\0").unwrap(),
+            CStr::from_bytes_with_nul(b"VK_LAYER_GOOGLE_threading\0").unwrap(),
+            CStr::from_bytes_with_nul(b"VK_LAYER_GOOGLE_unique_objects\0").unwrap(),
         ]
     } else if cfg!(debug_assertions) {
-        vec![CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_standard_validation\0").expect("Wrong extension string")]
+        vec![CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_standard_validation\0").unwrap()]
     } else {
         vec![]
     };
-    static ref EXTENSIONS: Vec<&'static CStr> = vec![#[cfg(debug_assertions)] CStr::from_bytes_with_nul(b"VK_EXT_debug_utils\0").expect("Wrong extension string")];
+    static ref EXTENSIONS: Vec<&'static CStr> = vec![#[cfg(debug_assertions)] CStr::from_bytes_with_nul(b"VK_EXT_debug_utils\0").unwrap()];
     static ref DEVICE_EXTENSIONS: Vec<&'static CStr> = vec![khr::Swapchain::name()];
     static ref SURFACE_EXTENSIONS: Vec<&'static CStr> = vec![
         khr::Surface::name(),

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -57,7 +57,19 @@ mod window;
 
 // CStr's cannot be constant yet, until const fn lands we need to use a lazy_static
 lazy_static! {
-    static ref LAYERS: Vec<&'static CStr> = vec![#[cfg(debug_assertions)] CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_standard_validation\0").expect("Wrong extension string")];
+    static ref LAYERS: Vec<&'static CStr> = if cfg!(all(target_os = "android", debug_assertions)) {
+        vec![
+            CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_core_validation\0").expect("Wrong extension string"),
+            CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_object_tracker\0").expect("Wrong extension string"),
+            CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_parameter_validation\0").expect("Wrong extension string"),
+            CStr::from_bytes_with_nul(b"VK_LAYER_GOOGLE_threading\0").expect("Wrong extension string"),
+            CStr::from_bytes_with_nul(b"VK_LAYER_GOOGLE_unique_objects\0").expect("Wrong extension string"),
+        ]
+    } else if cfg!(debug_assertions) {
+        vec![CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_standard_validation\0").expect("Wrong extension string")]
+    } else {
+        vec![]
+    };
     static ref EXTENSIONS: Vec<&'static CStr> = vec![#[cfg(debug_assertions)] CStr::from_bytes_with_nul(b"VK_EXT_debug_utils\0").expect("Wrong extension string")];
     static ref DEVICE_EXTENSIONS: Vec<&'static CStr> = vec![khr::Swapchain::name()];
     static ref SURFACE_EXTENSIONS: Vec<&'static CStr> = vec![


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/gfx/issues/1805 I think.

The android ndk only ships with five validation layers and does not support `VK_LAYER_LUNARG_standard_validation`. This PR only enables the validation layers android supports.

```
VK_LAYER_LUNARG_core_validation
VK_LAYER_LUNARG_object_tracker
VK_LAYER_LUNARG_parameter_validation
VK_LAYER_GOOGLE_threading
VK_LAYER_GOOGLE_unique_objects
```

Additionally, the vulkan validation layers repo is only setup to build those 5 validation layers on android [source](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/build-android/jni/Android.mk).