### PR TITLE
[hal] Add debug printing to `Adapter`

### DIFF
--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -145,6 +145,7 @@ pub struct AdapterInfo {
 /// `physical_device` field. However, if only a single queue family is needed or if no
 /// additional device features are required, then the `Adapter::open_with` convenience method
 /// can be used instead.
+#[derive(Debug)]
 pub struct Adapter<B: Backend> {
     /// General information about this adapter.
     pub info: AdapterInfo,

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -33,8 +33,8 @@ pub use self::queue::{
     Submission, Supports, Transfer,
 };
 pub use self::window::{
-    AcquireError, CompositeAlpha, PresentMode, Surface, SurfaceCapabilities,
-    SwapImageIndex, Swapchain, SwapchainConfig,
+    AcquireError, CompositeAlpha, PresentMode, Surface, SurfaceCapabilities, SwapImageIndex,
+    Swapchain, SwapchainConfig,
 };
 
 pub mod adapter;

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -11,9 +11,9 @@ pub mod family;
 
 use std::any::Any;
 use std::borrow::Borrow;
+use std::fmt;
 use std::iter;
 use std::marker::PhantomData;
-use std::fmt;
 
 use crate::command::{Primary, Submittable};
 use crate::error::HostExecutionError;

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -59,8 +59,8 @@ use crate::Backend;
 use std::any::Any;
 use std::borrow::Borrow;
 use std::cmp::{max, min};
-use std::iter;
 use std::fmt;
+use std::iter;
 use std::ops::Range;
 
 /// Error occurred during swapchain creation.


### PR DESCRIPTION
Fixes #2560
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- [x] `rustfmt` run on changed code
