### PR TITLE
[hal] Add deny(missing_debug_implementations) to enforce debug printers

### DIFF
--- a/src/hal/src/backend.rs
+++ b/src/hal/src/backend.rs
@@ -11,6 +11,7 @@ use fxhash::FxHasher;
 /// Bare-metal queue group.
 ///
 /// Denotes all queues created from one queue family.
+#[derive(Debug)]
 pub struct RawQueueGroup<B: Backend> {
     pub family: B::QueueFamily,
     pub queues: Vec<B::CommandQueue>,

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -131,6 +131,7 @@ bitflags!(
 ///
 /// Defines a buffer slice used for acquiring the indices on draw commands.
 /// Indices are used to lookup vertex indices in the vertex buffers.
+#[derive(Debug)]
 pub struct IndexBufferView<'a, B: Backend> {
     /// The buffer to bind.
     pub buffer: &'a B::Buffer,

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -37,10 +37,12 @@ pub use self::transfer::*;
 /// Trait indicating how many times a Submit object can be submitted to a command buffer.
 pub trait Shot {}
 /// Indicates a Submit that can only be submitted once.
+#[derive(Debug)]
 pub enum OneShot {}
 impl Shot for OneShot {}
 
 /// Indicates a Submit that can be submitted multiple times.
+#[derive(Debug)]
 pub enum MultiShot {}
 impl Shot for MultiShot {}
 
@@ -51,6 +53,7 @@ pub trait Level {}
 
 /// Vulkan describes a primary command buffer as one which can be directly submitted
 /// to a queue, and can execute `Secondary` command buffers.
+#[derive(Debug)]
 pub enum Primary {}
 impl Level for Primary {}
 
@@ -60,6 +63,7 @@ impl Level for Primary {}
 /// to a queue, but can be executed by a primary command buffer. This allows
 /// multiple secondary command buffers to be constructed which do specific
 /// things and can then be composed together into primary command buffers.
+#[derive(Debug)]
 pub enum Secondary {}
 impl Level for Secondary {}
 

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -28,6 +28,12 @@ pub union ClearColorRaw {
     _align: [u32; 4],
 }
 
+impl std::fmt::Debug for ClearColorRaw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        writeln![f, "ClearColorRaw"]
+    }
+}
+
 /// A variant of `ClearDepthStencil` that has a `#[repr(C)]` layout
 /// and so is used when a known layout is needed.
 #[repr(C)]

--- a/src/hal/src/command/render_pass.rs
+++ b/src/hal/src/command/render_pass.rs
@@ -12,6 +12,7 @@ use crate::{buffer, pass, pso, query};
 use crate::{Backend, DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset};
 
 /// Specifies how commands for the following renderpasses will be recorded.
+#[derive(Debug)]
 pub enum SubpassContents {
     /// Contents of the subpass will be inline in the command buffer,
     /// NOT in secondary command buffers.
@@ -27,6 +28,7 @@ pub enum SubpassContents {
 ///
 /// Where methods are undocumented, they are identical to the methods on the `RawCommandBuffer`
 /// trait with the same names.
+#[derive(Debug)]
 pub struct RenderSubpassCommon<B, C> {
     cmb: C,
     _marker: PhantomData<B>,
@@ -220,6 +222,7 @@ impl<B: Backend, C: BorrowMut<B::CommandBuffer>> RenderSubpassCommon<B, C> {
 
 /// An object that records commands into a command buffer inline, that is,
 /// without secondary command buffers.
+#[derive(Debug)]
 pub struct RenderPassInlineEncoder<'a, B: Backend>(
     RenderSubpassCommon<B, &'a mut B::CommandBuffer>,
 )
@@ -298,6 +301,7 @@ impl<'a, B: Backend> Drop for RenderPassInlineEncoder<'a, B> {
 
 /// An object that records commands into a command buffer where each command must
 /// be a call to execute a secondary command buffer.
+#[derive(Debug)]
 pub struct RenderPassSecondaryEncoder<'a, B: Backend>(&'a mut B::CommandBuffer)
 where
     B::CommandBuffer: 'a;
@@ -370,6 +374,7 @@ impl<'a, B: Backend> Drop for RenderPassSecondaryEncoder<'a, B> {
 }
 
 /// A secondary command buffer recorded entirely within a subpass.
+#[derive(Debug)]
 pub struct SubpassCommandBuffer<B: Backend, S: Shot, R = <B as Backend>::CommandBuffer>(
     RenderSubpassCommon<B, R>,
     PhantomData<S>,

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs, unused)]
+#![deny(missing_debug_implementations, missing_docs, unused)]
 
 //! Low-level graphics abstraction for Rust. Mostly operates on data, not types.
 //! Designed for use by libraries and higher-level abstractions only.
@@ -527,6 +527,7 @@ pub type SubmissionResult<T> = Result<T, SubmissionError>;
 /// hardware queues it provides.
 ///
 /// This structure is typically created using an `Adapter`.
+#[derive(Debug)]
 pub struct Gpu<B: Backend> {
     /// Logical device for a given backend.
     pub device: B::Device,

--- a/src/hal/src/mapping.rs
+++ b/src/hal/src/mapping.rs
@@ -30,6 +30,7 @@ impl From<device::OutOfMemory> for Error {
 }
 
 /// Mapping reader
+#[derive(Debug)]
 pub struct Reader<'a, B: Backend, T: 'a> {
     pub(crate) slice: &'a [T],
     pub(crate) memory: &'a B::Memory,
@@ -52,6 +53,7 @@ impl<'a, B: Backend, T: 'a> ops::Deref for Reader<'a, B, T> {
 /// Mapping writer.
 /// Currently is not possible to make write-only slice so while it is technically possible
 /// to read from Writer, it will lead to an undefined behavior. Please do not read from it.
+#[derive(Debug)]
 pub struct Writer<'a, B: Backend, T: 'a> {
     pub(crate) slice: &'a mut [T],
     pub(crate) memory: &'a B::Memory,

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -134,6 +134,7 @@ pub struct SubpassDependency {
 }
 
 /// Description of a subpass for renderpass creation.
+#[derive(Debug)]
 pub struct SubpassDesc<'a> {
     /// Which attachments will be used as color buffers.
     pub colors: &'a [AttachmentRef],

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -200,6 +200,7 @@ pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
 /// Writes the actual descriptors to be bound into a descriptor set. Should be provided
 /// to the `write_descriptor_sets` method of a `Device`.
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct DescriptorSetWrite<'a, B: Backend, WI>
 where
     WI: IntoIterator,
@@ -220,7 +221,7 @@ where
 ///
 /// [`DescriptorSetWrite`]: struct.DescriptorSetWrite.html
 #[allow(missing_docs)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Descriptor<'a, B: Backend> {
     Sampler(&'a B::Sampler),
     Image(&'a B::ImageView, Layout),
@@ -233,7 +234,7 @@ pub enum Descriptor<'a, B: Backend> {
 /// Copies a range of descriptors to be bound from one descriptor set to another Should be
 /// provided to the `copy_descriptor_sets` method of a `Device`.
 #[allow(missing_docs)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct DescriptorSetCopy<'a, B: Backend> {
     pub src_set: &'a B::DescriptorSet,
     pub src_binding: DescriptorBinding,

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -237,7 +237,7 @@ impl Default for Specialization<'_> {
 }
 
 #[doc(hidden)]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct SpecializationStorage {
     constants: Vec<SpecializationConstant>,
     data: Vec<u8>,
@@ -264,9 +264,11 @@ where
 }
 
 #[doc(hidden)]
+#[derive(Debug)]
 pub struct SpecConstListNil;
 
 #[doc(hidden)]
+#[derive(Debug)]
 pub struct SpecConstListCons<H, T> {
     pub head: (u32, H),
     pub tail: T,

--- a/src/hal/src/queue/capability.rs
+++ b/src/hal/src/queue/capability.rs
@@ -2,15 +2,20 @@
 use crate::queue::QueueType;
 
 /// General capability, supporting graphics, compute and transfer operations.
+#[derive(Debug)]
 pub enum General {}
 /// Graphics capability, supporting graphics and transfer operations.
+#[derive(Debug)]
 pub enum Graphics {}
 /// Compute capability, supporting compute and transfer operations.
+#[derive(Debug)]
 pub enum Compute {}
 /// Transfer capability, supporting only transfer operations.
+#[derive(Debug)]
 pub enum Transfer {}
 
 /// Graphics or compute capability.
+#[derive(Debug)]
 pub enum GraphicsOrCompute {}
 
 /// A Capability is an object that specifies what kind of operations

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -38,6 +38,7 @@ pub trait QueueFamily: Debug + Any + Send + Sync {
 pub struct QueueFamilyId(pub usize);
 
 /// Strong-typed group of queues of the same queue family.
+#[derive(Debug)]
 pub struct QueueGroup<B: Backend, C> {
     family: QueueFamilyId,
     /// Command queues created in this family.
@@ -72,6 +73,7 @@ impl<B: Backend, C: Capability> QueueGroup<B, C> {
 
 /// Contains a list of all instantiated queues. Conceptually structured as a collection of
 /// `QueueGroup`s, one for each queue family.
+#[derive(Debug)]
 pub struct Queues<B: Backend>(pub(crate) Vec<RawQueueGroup<B>>);
 
 impl<B: Backend> Queues<B> {

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -39,6 +39,7 @@ pub enum QueueType {
 }
 
 /// Submission information for a command queue.
+#[derive(Debug)]
 pub struct Submission<Ic, Iw, Is> {
     /// Command buffers to submit.
     pub command_buffers: Ic,

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -374,6 +374,7 @@ impl SwapchainConfig {
 
 /// Marker value returned if the swapchain no longer matches the surface properties exactly,
 /// but can still be used to present to the surface successfully.
+#[derive(Debug)]
 pub struct Suboptimal;
 
 /// Error on acquiring the next image from a swapchain.


### PR DESCRIPTION
Fixes #2560
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- [x] `rustfmt` run on changed code
