### PR TITLE
kdebug_signpost* fns don't exist on macOS 10.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,3 +103,4 @@ script:
   - if [[ $TARGET != "aarch64-apple-ios" ]]; then make all; else make check; fi
   - if [[ -n "$WASM" ]]; then make quad-wasm; fi
   #- if [[ $TRAVIS_OS_NAME == "linux" ]]; then make reftests-ci; fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then cd src/backend/metal && cargo check --all-features; fi

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 [features]
 default = ["winit"]
 auto-capture = []
+signpost = []
 
 [lib]
 name = "gfx_backend_metal"

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1075,5 +1075,7 @@ impl Signpost {
         unsafe {
             kdebug_signpost(code, args[0], args[1], args[2], args[3]);
         }
+        #[cfg(not(feature = "signpost"))]
+        let _ = (code, args);
     }
 }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1012,7 +1012,10 @@ extern "C" {
     fn dispatch_semaphore_signal(semaphore: *mut c_void) -> c_long;
     fn dispatch_semaphore_create(value: c_long) -> *mut c_void;
     fn dispatch_release(object: *mut c_void);
+}
 
+#[cfg(feature = "signpost")]
+extern "C" {
     fn kdebug_signpost(code: u32, arg1: usize, arg2: usize, arg3: usize, arg4: usize);
     fn kdebug_signpost_start(code: u32, arg1: usize, arg2: usize, arg3: usize, arg4: usize);
     fn kdebug_signpost_end(code: u32, arg1: usize, arg2: usize, arg3: usize, arg4: usize);
@@ -1052,6 +1055,7 @@ pub struct Signpost {
 
 impl Drop for Signpost {
     fn drop(&mut self) {
+        #[cfg(feature = "signpost")]
         unsafe {
             kdebug_signpost_end(self.code, self.args[0], self.args[1], self.args[2], self.args[3]);
         }
@@ -1060,12 +1064,14 @@ impl Drop for Signpost {
 
 impl Signpost {
     pub(crate) fn new(code: u32, args: [usize; 4]) -> Self {
+        #[cfg(feature = "signpost")]
         unsafe {
             kdebug_signpost_start(code, args[0], args[1], args[2], args[3]);
         }
         Signpost { code, args }
     }
     pub(crate) fn place(code: u32, args: [usize; 4]) {
+        #[cfg(feature = "signpost")]
         unsafe {
             kdebug_signpost(code, args[0], args[1], args[2], args[3]);
         }


### PR DESCRIPTION
> Fixes #issue
Doesn't fix, but found during https://github.com/gfx-rs/gfx/issues/2563

> PR checklist:
> - [ ] `make` succeeds (on *nix)
Yes.

> - [ ] `make reftests` succeeds
No, as it seems to be trying to compile with the feature this patch adds ('signpost') turned on?

> - [ ] tested examples with the following backends:
metal

> - [ ] `rustfmt` run on changed code
I don't know how, but I tried to copy the existing style.