### PR TITLE
[hal] Rename ClearColor::Type to ClearColor::Stype for consistency

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -567,7 +567,7 @@ impl<B: Backend> RendererState<B> {
                         self.render_pass.render_pass.as_ref().unwrap(),
                         framebuffer,
                         self.viewport.rect,
-                        &[command::ClearValue::Color(command::ClearColor::Float([
+                        &[command::ClearValue::Color(command::ClearColor::Sfloat([
                             cr, cg, cb, 1.0,
                         ]))],
                     );

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -778,7 +778,7 @@ fn main() {
                     &render_pass,
                     &framebuffers[swap_image],
                     viewport.rect,
-                    &[command::ClearValue::Color(command::ClearColor::Float([
+                    &[command::ClearValue::Color(command::ClearColor::Sfloat([
                         0.8, 0.8, 0.8, 1.0,
                     ]))],
                 );

--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -85,7 +85,7 @@
 		"empty": Graphics(
 			framebuffer: "fbo",
 			clear_values: [
-				Color(Float((0.8, 0.8, 0.8, 1.0))),
+				Color(Sfloat((0.8, 0.8, 0.8, 1.0))),
 			],
 			pass: ("pass", {
 				"main": (commands: [
@@ -95,7 +95,7 @@
 		"pass-through": Graphics(
 			framebuffer: "fbo",
 			clear_values: [
-				Color(Float((0.8, 0.8, 0.8, 1.0))),
+				Color(Sfloat((0.8, 0.8, 0.8, 1.0))),
 			],
 			pass: ("pass", {
 				"main": (commands: [

--- a/reftests/scenes/transfer.ron
+++ b/reftests/scenes/transfer.ron
@@ -143,7 +143,7 @@
 		"clear-image": Transfer(
 			ClearImage(
 				image: "image.output",
-				color: Float((0.501, 0.501, 0.501, 0.501)),
+				color: Sfloat((0.501, 0.501, 0.501, 0.501)),
 				depth_stencil: (0.0, 0),
 				ranges: [
 					(

--- a/reftests/scenes/vertex-offset.ron
+++ b/reftests/scenes/vertex-offset.ron
@@ -154,7 +154,7 @@
         "offset-aligned": Graphics(
             framebuffer: "fbo",
             clear_values: [
-                Color(Float((0.0, 0.0, 0.0, 0.0))),
+                Color(Sfloat((0.0, 0.0, 0.0, 0.0))),
             ],
             pass: ("pass", {
                 "main": (commands: [
@@ -169,7 +169,7 @@
         "offset-overlap": Graphics(
             framebuffer: "fbo",
             clear_values: [
-                Color(Float((0.0, 0.0, 0.0, 0.0))),
+                Color(Sfloat((0.0, 0.0, 0.0, 0.0))),
             ],
             pass: ("pass", {
                 "main": (commands: [

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -675,7 +675,7 @@ impl Internal {
         clear: command::ClearColor,
     ) {
         match clear {
-            command::ClearColor::Float(value) => {
+            command::ClearColor::Sfloat(value) => {
                 unsafe {
                     ptr::copy(
                         &PartialClearInfo {
@@ -697,7 +697,7 @@ impl Internal {
                     )
                 };
             }
-            command::ClearColor::Int(value) => {
+            command::ClearColor::Sint(value) => {
                 unsafe {
                     ptr::copy(
                         &PartialClearInfo {
@@ -1234,7 +1234,7 @@ impl Internal {
                     }
 
                     match value {
-                        command::ClearColor::Float(_) => unsafe {
+                        command::ClearColor::Sfloat(_) => unsafe {
                             context.PSSetShader(
                                 self.ps_partial_clear_float.as_raw(),
                                 ptr::null_mut(),
@@ -1248,7 +1248,7 @@ impl Internal {
                                 0,
                             );
                         },
-                        command::ClearColor::Int(_) => unsafe {
+                        command::ClearColor::Sint(_) => unsafe {
                             context.PSSetShader(
                                 self.ps_partial_clear_int.as_raw(),
                                 ptr::null_mut(),

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1484,11 +1484,11 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
                     | ChannelType::Sfloat
                     | ChannelType::Uscaled
                     | ChannelType::Sscaled
-                    | ChannelType::Srgb => ClearColor::Float(unsafe { raw_clear.float32 }),
+                    | ChannelType::Srgb => ClearColor::Sfloat(unsafe { raw_clear.float32 }),
 
                     ChannelType::Uint => ClearColor::Uint(unsafe { raw_clear.uint32 }),
 
-                    ChannelType::Sint => ClearColor::Int(unsafe { raw_clear.int32 }),
+                    ChannelType::Sint => ClearColor::Sint(unsafe { raw_clear.int32 }),
                 }
             }
 

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2650,7 +2650,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     let channel = self.state.target_formats.colors[index].1;
                     //Note: technically we should be able to derive the Channel from the
                     // `value` variant, but this is blocked by the portability that is
-                    // always passing the attachment clears as `ClearColor::Float` atm.
+                    // always passing the attachment clears as `ClearColor::Sfloat` atm.
                     raw_value = com::ClearColorRaw::from(value);
                     let com = soft::RenderCommand::BindBufferData {
                         stage: pso::Stage::Fragment,

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -75,8 +75,8 @@ pub fn map_image_aspects(aspects: format::Aspects) -> vk::ImageAspectFlags {
 
 pub fn map_clear_color(value: command::ClearColor) -> vk::ClearColorValue {
     match value {
-        command::ClearColor::Float(v) => vk::ClearColorValue { float32: v },
-        command::ClearColor::Int(v) => vk::ClearColorValue { int32: v },
+        command::ClearColor::Sfloat(v) => vk::ClearColorValue { float32: v },
+        command::ClearColor::Sint(v) => vk::ClearColorValue { int32: v },
         command::ClearColor::Uint(v) => vk::ClearColorValue { uint32: v },
     }
 }

--- a/src/hal/src/command/graphics.rs
+++ b/src/hal/src/command/graphics.rs
@@ -16,9 +16,9 @@ use crate::{buffer, image, pso, query};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ClearColor {
     /// Standard floating-point `vec4` color
-    Float(pso::ColorValue),
+    Sfloat(pso::ColorValue),
     /// Integer vector to clear `ivec4` targets.
-    Int([i32; 4]),
+    Sint([i32; 4]),
     /// Unsigned int vector to clear `uvec4` targets.
     Uint([u32; 4]),
 }
@@ -36,12 +36,12 @@ macro_rules! impl_clear {
 }
 
 impl_clear! {
-    [f32; 4] = Float[0, 1, 2, 3],
-    [f32; 3] = Float[0, 1, 2, 0],
-    [f32; 2] = Float[0, 1, 0, 0],
-    [i32; 4] = Int  [0, 1, 2, 3],
-    [i32; 3] = Int  [0, 1, 2, 0],
-    [i32; 2] = Int  [0, 1, 0, 0],
+    [f32; 4] = Sfloat[0, 1, 2, 3],
+    [f32; 3] = Sfloat[0, 1, 2, 0],
+    [f32; 2] = Sfloat[0, 1, 0, 0],
+    [i32; 4] = Sint  [0, 1, 2, 3],
+    [i32; 3] = Sint  [0, 1, 2, 0],
+    [i32; 2] = Sint  [0, 1, 0, 0],
     [u32; 4] = Uint [0, 1, 2, 3],
     [u32; 3] = Uint [0, 1, 2, 0],
     [u32; 2] = Uint [0, 1, 0, 0],
@@ -49,12 +49,12 @@ impl_clear! {
 
 impl From<f32> for ClearColor {
     fn from(v: f32) -> Self {
-        ClearColor::Float([v, 0.0, 0.0, 0.0])
+        ClearColor::Sfloat([v, 0.0, 0.0, 0.0])
     }
 }
 impl From<i32> for ClearColor {
     fn from(v: i32) -> Self {
-        ClearColor::Int([v, 0, 0, 0])
+        ClearColor::Sint([v, 0, 0, 0])
     }
 }
 impl From<u32> for ClearColor {
@@ -66,8 +66,8 @@ impl From<u32> for ClearColor {
 impl From<ClearColor> for ClearColorRaw {
     fn from(cv: ClearColor) -> Self {
         match cv {
-            ClearColor::Float(cv) => ClearColorRaw { float32: cv },
-            ClearColor::Int(cv) => ClearColorRaw { int32: cv },
+            ClearColor::Sfloat(cv) => ClearColorRaw { float32: cv },
+            ClearColor::Sint(cv) => ClearColorRaw { int32: cv },
             ClearColor::Uint(cv) => ClearColorRaw { uint32: cv },
         }
     }


### PR DESCRIPTION
Fixes #2781
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- [x] `rustfmt` run on changed code
