### PR TITLE
Add missing `Timeout` variant for `AcquireError`

### DIFF
--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -438,6 +438,7 @@ impl hal::Swapchain<Backend> for Swapchain {
                 }
             }
             Err(vk::Result::NOT_READY) => Err(hal::AcquireError::NotReady),
+            Err(vk::Result::TIMEOUT) => Err(hal::AcquireError::Timeout),
             Err(vk::Result::ERROR_OUT_OF_DATE_KHR) => {
                 Err(hal::AcquireError::OutOfDate)
             }

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -383,9 +383,12 @@ pub enum AcquireError {
     /// Out of either host or device memory.
     #[fail(display = "{}", _0)]
     OutOfMemory(device::OutOfMemory),
-    /// No image was ready after the specified timeout expired.
+    /// No image was ready and no timeout was specified.
     #[fail(display = "No images ready")]
     NotReady,
+    /// No image was ready after the specified timeout expired.
+    #[fail(display = "No images ready after the specified timeout expired")]
+    Timeout,
     /// The swapchain is no longer in sync with the surface, needs to be re-created.
     #[fail(display = "Swapchain is out of date")]
     OutOfDate,


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12 vk
- [ ] `rustfmt` run on changed code
