### PR TITLE
gl: Add wgl WSI backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ EXCLUDES:=
 FEATURES_EXTRA:=mint serialize
 FEATURES_HAL:=
 FEATURES_HAL2:=
+FEATURES_HAL3:=
 
 SDL2_DEST=$(HOME)/deps
 SDL2_CONFIG=$(SDL2_DEST)/usr/bin/sdl2-config
@@ -25,6 +26,7 @@ ifeq ($(OS),Windows_NT)
 	else
 		FEATURES_HAL2=dx12
 	endif
+	FEATURES_HAL3=wgl
 else
 	UNAME_S:=$(shell uname -s)
 	EXCLUDES+= --exclude gfx-backend-dx12
@@ -55,6 +57,7 @@ check:
 	cd examples && cargo check $(CHECK_TARGET_FLAG) --features "gl"
 	cd examples && cargo check $(CHECK_TARGET_FLAG) --features "$(FEATURES_HAL)"
 	cd examples && cargo check $(CHECK_TARGET_FLAG) --features "$(FEATURES_HAL2)"
+	cd examples && cargo check $(CHECK_TARGET_FLAG) --features "$(FEATURES_HAL3)"
 	cd src/warden && cargo check $(CHECK_TARGET_FLAG) --no-default-features
 	cd src/warden && cargo check $(CHECK_TARGET_FLAG) --features "env_logger gl gl-headless $(FEATURES_HAL) $(FEATURES_HAL2)"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 [features]
 default = []
 metal = ["gfx-backend-metal"]
-gl = ["gfx-backend-gl"]
+gl = ["gfx-backend-gl", "gfx-backend-gl/glutin"]
+wgl = ["gfx-backend-gl", "gfx-backend-gl/winit", "gfx-backend-gl/wgl"]
 dx11 = ["gfx-backend-dx11"]
 dx12 = ["gfx-backend-dx12"]
 vulkan = ["gfx-backend-vulkan"]
@@ -40,7 +41,7 @@ glsl-to-spirv = "0.1.4"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.gfx-backend-gl]
 path = "../src/backend/gl"
 version = "0.2"
-features = ["glutin"]
+default-features = false
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.gfx-backend-gl]

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -4,7 +4,8 @@
         feature = "dx11",
         feature = "dx12",
         feature = "metal",
-        feature = "gl"
+        feature = "gl",
+        feature = "wgl"
     )),
     allow(dead_code, unused_extern_crates, unused_imports)
 )]
@@ -13,7 +14,7 @@
 extern crate gfx_backend_dx11 as back;
 #[cfg(feature = "dx12")]
 extern crate gfx_backend_dx12 as back;
-#[cfg(feature = "gl")]
+#[cfg(any(feature = "gl", feature = "wgl"))]
 extern crate gfx_backend_gl as back;
 #[cfg(feature = "metal")]
 extern crate gfx_backend_metal as back;
@@ -77,7 +78,8 @@ const COLOR_RANGE: i::SubresourceRange = i::SubresourceRange {
     feature = "dx11",
     feature = "dx12",
     feature = "metal",
-    feature = "gl"
+    feature = "gl",
+    feature = "wgl"
 ))]
 fn main() {
     #[cfg(target_arch = "wasm32")]
@@ -862,8 +864,9 @@ fn main() {
     feature = "dx11",
     feature = "dx12",
     feature = "metal",
-    feature = "gl"
+    feature = "gl",
+    feature = "wgl"
 )))]
 fn main() {
-    println!("You need to enable the native API feature (vulkan/metal) in order to test the LL");
+    println!("You need to enable the native API feature (vulkan/metal/dx11/dx12/gl/wgl) in order to test the LL");
 }

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -11,12 +11,14 @@ readme = "README.md"
 documentation = "https://docs.rs/gfx-backend-gl"
 workspace = "../../.."
 edition = "2018"
+build = "build.rs"
 
 [lib]
 name = "gfx_backend_gl"
 
 [features]
 default = ["glutin"]
+wgl = []
 
 [dependencies]
 bitflags = "1"
@@ -25,9 +27,11 @@ gfx-hal = { path = "../../hal", version = "0.2" }
 smallvec = "0.6"
 glow = { git = "https://github.com/grovesNL/glow", rev = "abc536c6b9b6a96c7f6c758d938fcb38f9b55938" }
 spirv_cross = { version = "0.14.0", features = ["glsl"] }
+lazy_static = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.21", optional = true }
+winit = { version = "0.19", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"
@@ -50,3 +54,9 @@ features = [
     "WebGlTexture",
     "Window",
 ]
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3" }
+
+[build-dependencies]
+gl_generator = "0.11"

--- a/src/backend/gl/build.rs
+++ b/src/backend/gl/build.rs
@@ -1,0 +1,32 @@
+use gl_generator::{Api, Fallbacks, Profile, Registry};
+use std::env;
+use std::fs::File;
+use std::path::PathBuf;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+    let dest = PathBuf::from(&env::var("OUT_DIR").unwrap());
+
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if target.contains("windows") {
+        let mut file = File::create(&dest.join("wgl_sys.rs")).unwrap();
+        Registry::new(Api::Wgl, (1, 0), Profile::Core, Fallbacks::All, [])
+            .write_bindings(gl_generator::StaticGenerator, &mut file)
+            .unwrap();
+
+        let mut file = File::create(&dest.join("wgl_ext_sys.rs")).unwrap();
+        Registry::new(
+            Api::Wgl,
+            (1, 0),
+            Profile::Core,
+            Fallbacks::All,
+            [
+                "WGL_ARB_create_context",
+                "WGL_ARB_pbuffer",
+            ],
+        )
+        .write_bindings(gl_generator::StructGenerator, &mut file)
+        .unwrap();
+    }
+}

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1817,7 +1817,7 @@ impl d::Device<B> for Device {
         let context = {
             use crate::window::wgl::PresentContext;
 
-            let context = PresentContext::new(surface, &self.share.instance_ctxt);
+            let context = PresentContext::new(surface, &self.share.instance_context);
             context.make_current();
             context
         };
@@ -1862,7 +1862,7 @@ impl d::Device<B> for Device {
 
         #[cfg(feature = "wgl")]
         let swapchain = {
-            self.share.instance_ctxt.make_current();
+            self.share.instance_context.make_current();
             Swapchain { fbos, context, extent: config.extent }
         };
         #[cfg(feature = "glutin")]

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1805,9 +1805,9 @@ impl d::Device<B> for Device {
         let gl = &self.share.context;
 
         let (int_format, iformat, itype) = match config.format {
-            Format::Rgba8Unorm => (gl::RGBA8, gl::RGBA, gl::UNSIGNED_BYTE),
-            Format::Bgra8Unorm => (gl::RGBA8, gl::BGRA, gl::UNSIGNED_BYTE),
-            Format::Rgba8Srgb => (gl::SRGB8_ALPHA8, gl::RGBA, gl::UNSIGNED_BYTE),
+            Format::Rgba8Unorm => (glow::RGBA8, glow::RGBA, glow::UNSIGNED_BYTE),
+            Format::Bgra8Unorm => (glow::RGBA8, glow::BGRA, glow::UNSIGNED_BYTE),
+            Format::Rgba8Srgb => (glow::SRGB8_ALPHA8, glow::RGBA, glow::UNSIGNED_BYTE),
             _ => unimplemented!(),
         };
 
@@ -1827,9 +1827,8 @@ impl d::Device<B> for Device {
 
         for _ in 0..config.image_count {
             unsafe {
-                let mut fbo = 0;
-                gl.GenFramebuffers(1, &mut fbo);
-                gl.BindFramebuffer(gl::FRAMEBUFFER, fbo);
+                let fbo = gl.create_framebuffer().unwrap();
+                gl.bind_framebuffer(glow::FRAMEBUFFER, Some(fbo));
                 fbos.push(fbo);
 
                 let Extent2D { width, height } = config.extent;
@@ -1844,14 +1843,14 @@ impl d::Device<B> for Device {
 
                 match image.kind {
                     n::ImageKind::Surface(surface) => {
-                        gl.FramebufferRenderbuffer(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, gl::RENDERBUFFER, surface);
+                        gl.framebuffer_renderbuffer(glow::FRAMEBUFFER, glow::COLOR_ATTACHMENT0, glow::RENDERBUFFER, Some(surface));
                     }
                     n::ImageKind::Texture(texture, textype) => {
                         if self.share.private_caps.framebuffer_texture {
-                            gl.FramebufferTexture(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, texture, 0);
+                            gl.framebuffer_texture(glow::FRAMEBUFFER, glow::COLOR_ATTACHMENT0, Some(texture), 0);
                         } else {
-                            gl.BindTexture(textype, texture);
-                            gl.FramebufferTexture2D(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, textype, texture, 0);
+                            gl.bind_texture(textype, Some(texture));
+                            gl.framebuffer_texture_2d(glow::FRAMEBUFFER, glow::COLOR_ATTACHMENT0, textype, Some(texture), 0);
                         }
                     }
                 }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1832,100 +1832,31 @@ impl d::Device<B> for Device {
                 gl.BindFramebuffer(gl::FRAMEBUFFER, fbo);
                 fbos.push(fbo);
 
-                let image = if config.image_layers > 1
-                    || config.image_usage.contains(i::Usage::STORAGE)
-                    || config.image_usage.contains(i::Usage::SAMPLED)
-                {
-                    let mut name = 0;
-                    gl.GenTextures(1, &mut name);
-                    match config.extent {
-                        Extent2D {
-                            width: w,
-                            height: h,
-                        } => {
-                            gl.BindTexture(gl::TEXTURE_2D, name);
-                            if self.share.private_caps.image_storage {
-                                gl.TexStorage2D(
-                                    gl::TEXTURE_2D,
-                                    config.image_layers as _,
-                                    int_format,
-                                    w as _,
-                                    h as _,
-                                );
-                            } else {
-                                gl.TexParameteri(
-                                    gl::TEXTURE_2D,
-                                    gl::TEXTURE_MAX_LEVEL,
-                                    (config.image_layers - 1) as _,
-                                );
-                                let mut w = w;
-                                let mut h = h;
-                                for i in 0..config.image_layers {
-                                    gl.TexImage2D(
-                                        gl::TEXTURE_2D,
-                                        i as _,
-                                        int_format as _,
-                                        w as _,
-                                        h as _,
-                                        0,
-                                        iformat,
-                                        itype,
-                                        std::ptr::null(),
-                                    );
-                                    w = std::cmp::max(w / 2, 1);
-                                    h = std::cmp::max(h / 2, 1);
-                                }
-                            }
+                let Extent2D { width, height } = config.extent;
+                let image = self.create_image(
+                    i::Kind::D2(width, height, config.image_layers, 1),
+                    1,
+                    config.format,
+                    i::Tiling::Optimal,
+                    config.image_usage,
+                    i::ViewCapabilities::empty(),
+                ).unwrap();
 
-                            gl.FramebufferTexture(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, name, 0);
-
-                            dbg!(gl.CheckFramebufferStatus(gl::FRAMEBUFFER));
-                            dbg!(self.share.check());
+                match image.kind {
+                    n::ImageKind::Surface(surface) => {
+                        gl.FramebufferRenderbuffer(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, gl::RENDERBUFFER, surface);
+                    }
+                    n::ImageKind::Texture(texture, textype) => {
+                        if self.share.private_caps.framebuffer_texture {
+                            gl.FramebufferTexture(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, texture, 0);
+                        } else {
+                            gl.BindTexture(textype, texture);
+                            gl.FramebufferTexture2D(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, textype, texture, 0);
                         }
-                    };
-                    n::ImageKind::Texture(name, gl::TEXTURE_2D)
-                } else {
-                    let mut name = 0;
-                    gl.GenRenderbuffers(1, &mut name);
-                    match config.extent {
-                        Extent2D {
-                            width: w,
-                            height: h,
-                        } => {
-                            gl.BindRenderbuffer(gl::RENDERBUFFER, name);
-                            gl.RenderbufferStorage(gl::RENDERBUFFER, int_format, w as _, h as _);
-                        }
-                    };
-
-                    gl.FramebufferRenderbuffer(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, gl::RENDERBUFFER, name);
-
-                    dbg!(gl.CheckFramebufferStatus(gl::FRAMEBUFFER));
-                    dbg!(self.share.check());
-
-                    n::ImageKind::Surface(name)
-                };
-
-                let surface_desc = config.format.base_format().0.desc();
-                let bytes_per_texel = surface_desc.bits / 8;
-                let ext = config.extent;
-                let size = (ext.width * ext.height) as u64 * bytes_per_texel as u64;
-
-                if let Err(err) = self.share.check() {
-                    panic!(
-                        "Error creating swapchain image: {:?} with {:?} format",
-                        err, config.format
-                    );
+                    }
                 }
 
-                images.push(n::Image {
-                    kind: image,
-                    channel,
-                    requirements: memory::Requirements {
-                        size,
-                        alignment: 1,
-                        type_mask: 0x7,
-                    },
-                });
+                images.push(image);
             }
         }
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -56,6 +56,7 @@ pub(crate) struct GlContainer {
 }
 
 impl GlContainer {
+    #[cfg(feature = "glutin")]
     fn make_current(&self) {
         // Unimplemented
     }
@@ -236,7 +237,7 @@ struct Share {
     ///
     /// Parenting context for all device contexts shared with it.
     /// Used for querying basic information and spawning shared contexts.
-    instance_ctxt: DeviceContext,
+    instance_context: DeviceContext,
 
     info: Info,
     features: hal::Features,
@@ -465,7 +466,7 @@ impl PhysicalDevice {
         // create the shared context
         let share = Share {
             context: gl,
-            instance_ctxt,
+            instance_context,
             info,
             features,
             legacy_features,

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -40,16 +40,17 @@ pub use crate::window::glutin::{config_context, Headless, Surface, Swapchain};
 #[cfg(target_arch = "wasm32")]
 pub use crate::window::web::{Surface, Swapchain, Window};
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "glutin"))]
+#[cfg(feature = "wgl")]
+use window::wgl::{DeviceContext, Surface, Swapchain};
+#[cfg(feature = "wgl")]
+pub use window::wgl::{Instance};
+
+#[cfg(not(target_arch = "wasm32"))]
 pub use glow::native::Context as GlContext;
 #[cfg(target_arch = "wasm32")]
 pub use glow::web::Context as GlContext;
 use glow::Context;
 
-#[cfg(feature = "wgl")]
-use window::wgl::{DeviceContext, Surface, Swapchain};
-#[cfg(feature = "wgl")]
-pub use window::wgl::{Instance};
 
 pub(crate) struct GlContainer {
     context: GlContext,
@@ -381,12 +382,12 @@ unsafe impl<T: ?Sized> Sync for Wstarc<T> {}
 #[derive(Debug)]
 pub struct PhysicalDevice(Starc<Share>);
 
-#[cfg(feature = "glutin")]
+#[cfg(any(feature = "glutin", target_arch = "wasm32"))]
 type DeviceContext = ();
 
 impl PhysicalDevice {
     #[allow(unused)]
-    fn new_adapter(gl: GlContainer) -> hal::Adapter<Backend> {
+    fn new_adapter(instance_context: DeviceContext, gl: GlContainer) -> hal::Adapter<Backend> {
         // query information
         let (info, features, legacy_features, limits, private_caps) = info::query_all(&gl);
         info!("Vendor: {:?}", info.platform_name.vendor);

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1000,7 +1000,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
     }
     }
 
-    #[cfg(all(not(target_arch = "wasm32"), feature = "glutin"))]
+    #[cfg(all(not(target_arch = "wasm32"), any(feature = "glutin", feature = "wgl")))]
     unsafe fn present<'a, W, Is, S, Iw>(
         &mut self,
         swapchains: Is,
@@ -1015,10 +1015,12 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
         let gl = &self.share.context;
 
         for (swapchain, index) in swapchains {
+            let extent = swapchain.borrow().extent;
+
             #[cfg(feature = "wgl")]
             swapchain.borrow().make_current();
 
-            gl.bind_framebuffer(glow::READ_FRAMEBUFFER, self.state.fbo);
+            gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(swapchain.borrow().fbos[index as usize]));
             gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, None);
             gl.blit_framebuffer(
                 0,

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1040,7 +1040,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
         }
 
         #[cfg(feature = "wgl")]
-        self.share.instance_ctxt.make_current();
+        self.share.instance_context.make_current();
 
         Ok(None)
     }

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1036,7 +1036,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
             );
 
             #[cfg(feature = "glutin")]
-            swapchain.0.borrow().context.swap_buffers().unwrap();
+            swapchain.borrow().context.swap_buffers().unwrap();
             #[cfg(feature = "wgl")]
             swapchain.borrow().swap_buffers();
         }

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -238,7 +238,7 @@ impl CommandQueue {
             unsafe {
                 gl.viewport_f32_slice(0, viewports.len() as i32, &viewports);
                 gl.depth_range_f64_slice(0, depth_ranges.len() as i32, &depth_ranges);
-            }
+        }
         }
 
         // Reset scissors
@@ -566,7 +566,7 @@ impl CommandQueue {
                     }
                     Double => {
                         gl.vertex_attrib_pointer_f64(location, size, format, stride, offset as i32)
-                    }
+                }
                 }
 
                 if rate != 0 {
@@ -612,8 +612,8 @@ impl CommandQueue {
                 match texture_target {
                     glow::TEXTURE_2D => {
                         gl.bind_texture(glow::TEXTURE_2D, Some(dst_texture));
-                        gl.tex_sub_image_2d_pixel_buffer_offset(
-                            glow::TEXTURE_2D,
+                gl.tex_sub_image_2d_pixel_buffer_offset(
+                    glow::TEXTURE_2D,
                             data.image_layers.level as _,
                             data.image_offset.x,
                             data.image_offset.y,
@@ -622,7 +622,7 @@ impl CommandQueue {
                             texture_format,
                             pixel_type,
                             data.buffer_offset as i32,
-                        );
+                );
                     }
                     glow::TEXTURE_2D_ARRAY => {
                         gl.bind_texture(glow::TEXTURE_2D_ARRAY, Some(dst_texture));
@@ -811,13 +811,13 @@ impl CommandQueue {
                         _ => panic!("Unsupported uniform datatype!"),
                     }
                 }
-            } 
-            com::Command::BindRasterizer { rasterizer } => { 
+            }
+            com::Command::BindRasterizer { rasterizer } => {
                 use crate::hal::pso::FrontFace::*;
                 use crate::hal::pso::PolygonMode::*;
-                
+
                 let gl = &self.share.context;
-                
+
                 unsafe {
                     gl.front_face(match rasterizer.front_face {
                         Clockwise => glow::CW,
@@ -860,18 +860,18 @@ impl CommandQueue {
                 }
 
                 if !self.share.info.is_webgl() && !self.share.info.version.is_embedded {
-                    match false {
-                        //TODO
+                match false {
+                    //TODO
                         true => unsafe { gl.enable(glow::MULTISAMPLE) },
                         false => unsafe { gl.disable(glow::MULTISAMPLE) },
-                    }
                 }
+            }
             }
             com::Command::BindDepth { depth } => {
                 use crate::hal::pso::Comparison::*;
-                
+
                 let gl = &self.share.context;
-                
+
                 match depth {
                     hal::pso::DepthTest::On { fun, write } => unsafe {
                         gl.enable(glow::DEPTH_TEST);
@@ -997,7 +997,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
             } else {
                 None
             }));
-        }
+    }
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "glutin"))]
@@ -1007,15 +1007,16 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
         _wait_semaphores: Iw,
     ) -> Result<Option<hal::window::Suboptimal>, hal::window::PresentError>
     where
-        W: 'a + Borrow<window::glutin::Swapchain>,
+        W: 'a + Borrow<crate::Swapchain>,
         Is: IntoIterator<Item = (&'a W, hal::SwapImageIndex)>,
         S: 'a + Borrow<native::Semaphore>,
         Iw: IntoIterator<Item = &'a S>,
     {
         let gl = &self.share.context;
 
-        for swapchain in swapchains {
-            let extent = swapchain.0.borrow().extent;
+        for (swapchain, index) in swapchains {
+            #[cfg(feature = "wgl")]
+            swapchain.borrow().make_current();
 
             gl.bind_framebuffer(glow::READ_FRAMEBUFFER, self.state.fbo);
             gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, None);
@@ -1032,8 +1033,14 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
                 glow::LINEAR,
             );
 
+            #[cfg(feature = "glutin")]
             swapchain.0.borrow().context.swap_buffers().unwrap();
+            #[cfg(feature = "wgl")]
+            swapchain.borrow().swap_buffers();
         }
+
+        #[cfg(feature = "wgl")]
+        self.share.instance_ctxt.make_current();
 
         Ok(None)
     }

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -91,7 +91,7 @@ impl hal::Swapchain<B> for Swapchain {
 // and actually respect the swapchain configuration provided by the user.
 #[derive(Debug)]
 pub struct Surface {
-    context: Starc<glutin::WindowedContext<glutin::PossiblyCurrent>>,
+    pub(crate) context: Starc<glutin::WindowedContext<glutin::PossiblyCurrent>>,
 }
 
 impl Surface {
@@ -172,7 +172,7 @@ impl hal::Surface<B> for Surface {
 impl hal::Instance for Surface {
     type Backend = B;
     fn enumerate_adapters(&self) -> Vec<hal::Adapter<B>> {
-        let adapter = PhysicalDevice::new_adapter(GlContainer::from_fn_proc(|s| {
+        let adapter = PhysicalDevice::new_adapter((), GlContainer::from_fn_proc(|s| {
             self.context.get_proc_address(s) as *const _
         }));
         vec![adapter]
@@ -212,7 +212,7 @@ impl Headless {
 impl hal::Instance for Headless {
     type Backend = B;
     fn enumerate_adapters(&self) -> Vec<hal::Adapter<B>> {
-        let adapter = PhysicalDevice::new_adapter(GlContainer::from_fn_proc(|s| {
+        let adapter = PhysicalDevice::new_adapter((), GlContainer::from_fn_proc(|s| {
             self.0.get_proc_address(s) as *const _
         }));
         vec![adapter]

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -70,6 +70,8 @@ pub struct Swapchain {
     pub(crate) context: Starc<glutin::WindowedContext<glutin::PossiblyCurrent>>,
     // Extent because the window lies
     pub(crate) extent: Extent2D,
+    ///
+    pub(crate) fbos: Vec<native::FrameBuffer>,
 }
 
 impl hal::Swapchain<B> for Swapchain {
@@ -164,124 +166,6 @@ impl hal::Surface<B> for Surface {
 
     fn supports_queue_family(&self, _: &QueueFamily) -> bool {
         true
-    }
-}
-
-impl Device {
-    pub(crate) fn create_swapchain_impl(
-        &self,
-        surface: &mut Surface,
-        config: hal::SwapchainConfig,
-    ) -> (Swapchain, Vec<native::Image>) {
-        let swapchain = Swapchain {
-            extent: config.extent,
-            context: surface.context.clone(),
-        };
-
-        let gl = &self.share.context;
-
-        let (int_format, iformat, itype) = match config.format {
-            f::Format::Rgba8Unorm => (glow::RGBA8, glow::RGBA, glow::UNSIGNED_BYTE),
-            f::Format::Bgra8Unorm => (glow::RGBA8, glow::BGRA, glow::UNSIGNED_BYTE),
-            f::Format::Rgba8Srgb => (glow::SRGB8_ALPHA8, glow::RGBA, glow::UNSIGNED_BYTE),
-            _ => unimplemented!(),
-        };
-
-        let channel = config.format.base_format().1;
-
-        let images = (0..config.image_count)
-            .map(|_| unsafe {
-                let image = if config.image_layers > 1
-                    || config.image_usage.contains(image::Usage::STORAGE)
-                    || config.image_usage.contains(image::Usage::SAMPLED)
-                {
-                    let name = gl.create_texture().unwrap();
-                    match config.extent {
-                        Extent2D {
-                            width: w,
-                            height: h,
-                        } => {
-                            gl.bind_texture(glow::TEXTURE_2D, Some(name));
-                            if self.share.private_caps.image_storage {
-                                gl.tex_storage_2d(
-                                    glow::TEXTURE_2D,
-                                    config.image_layers as _,
-                                    int_format,
-                                    w as _,
-                                    h as _,
-                                );
-                            } else {
-                                gl.tex_parameter_i32(
-                                    glow::TEXTURE_2D,
-                                    glow::TEXTURE_MAX_LEVEL,
-                                    (config.image_layers - 1) as _,
-                                );
-                                let mut w = w;
-                                let mut h = h;
-                                for i in 0..config.image_layers {
-                                    gl.tex_image_2d(
-                                        glow::TEXTURE_2D,
-                                        i as _,
-                                        int_format as _,
-                                        w as _,
-                                        h as _,
-                                        0,
-                                        iformat,
-                                        itype,
-                                        None,
-                                    );
-                                    w = std::cmp::max(w / 2, 1);
-                                    h = std::cmp::max(h / 2, 1);
-                                }
-                            }
-                        }
-                    };
-                    native::ImageKind::Texture {
-                        texture: name,
-                        target: glow::TEXTURE_2D,
-                        format: iformat,
-                        pixel_type: itype,
-                    }
-                } else {
-                    let name = gl.create_renderbuffer().unwrap();
-                    match config.extent {
-                        Extent2D {
-                            width: w,
-                            height: h,
-                        } => {
-                            gl.bind_renderbuffer(glow::RENDERBUFFER, Some(name));
-                            gl.renderbuffer_storage(glow::RENDERBUFFER, int_format, w as _, h as _);
-                        }
-                    };
-                    native::ImageKind::Surface(name)
-                };
-
-                let surface_desc = config.format.base_format().0.desc();
-                let bytes_per_texel = surface_desc.bits / 8;
-                let ext = config.extent;
-                let size = (ext.width * ext.height) as u64 * bytes_per_texel as u64;
-                let type_mask = self.share.image_memory_type_mask();
-
-                if let Err(err) = self.share.check() {
-                    panic!(
-                        "Error creating swapchain image: {:?} with {:?} format",
-                        err, config.format
-                    );
-                }
-
-                native::Image {
-                    kind: image,
-                    channel,
-                    requirements: memory::Requirements {
-                        size,
-                        alignment: 1,
-                        type_mask,
-                    },
-                }
-            })
-            .collect::<Vec<_>>();
-
-        (swapchain, images)
     }
 }
 

--- a/src/backend/gl/src/window/mod.rs
+++ b/src/backend/gl/src/window/mod.rs
@@ -2,3 +2,6 @@
 pub mod glutin;
 #[cfg(target_arch = "wasm32")]
 pub mod web;
+
+#[cfg(feature = "wgl")]
+pub mod wgl;

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -258,7 +258,7 @@ impl Device {
 impl hal::Instance for Surface {
     type Backend = B;
     fn enumerate_adapters(&self) -> Vec<hal::Adapter<B>> {
-        let adapter = PhysicalDevice::new_adapter(GlContainer::from_new_canvas()); // TODO: Move to `self` like native/window
+        let adapter = PhysicalDevice::new_adapter((), GlContainer::from_new_canvas()); // TODO: Move to `self` like native/window
         vec![adapter]
     }
 }

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -37,6 +37,7 @@ pub(crate) struct Entry {
     lib: HMODULE,
 }
 
+unsafe impl Send for Entry {}
 unsafe impl Sync for Entry {}
 
 impl Entry {

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -1,0 +1,383 @@
+
+use std::ptr;
+use std::sync::Arc;
+use std::os::raw::c_void;
+use std::ffi::{CStr, CString, OsStr};
+use std::os::windows::ffi::OsStrExt;
+use crate::hal::window::Extent2D;
+use crate::hal::{self, format as f, image, memory, CompositeAlpha};
+
+use hal::image::{NumSamples, Size};
+use hal::format::Format;
+use crate::{native, QueueFamily, PhysicalDevice, Backend};
+
+use winapi::shared::minwindef::*;
+use winapi::shared::windef::*;
+use winapi::um::libloaderapi::*;
+use winapi::um::wingdi::*;
+use winapi::um::winuser::*;
+use std::mem;
+
+pub mod wgl_sys {
+    include!(concat!(env!("OUT_DIR"), "/wgl_sys.rs"));
+}
+
+pub mod wgl_ext_sys {
+    include!(concat!(env!("OUT_DIR"), "/wgl_ext_sys.rs"));
+}
+
+#[link(name = "opengl32")]
+extern "C" {}
+
+#[cfg(feature = "winit")]
+use winit;
+
+pub(crate) struct Entry {
+    hwnd: HWND,
+    pub(crate) hdc: HDC,
+    pub(crate) wgl: wgl_ext_sys::Wgl,
+    lib: HMODULE,
+}
+
+unsafe impl Sync for Entry { }
+
+impl Entry {
+    pub fn new() -> Self {
+        unsafe {
+            let mut class: WNDCLASSEXW = std::mem::zeroed();
+        let instance = GetModuleHandleW(std::ptr::null());
+        let class_name = OsStr::new("regl")
+            .encode_wide()
+            .chain(Some(0).into_iter())
+            .collect::<Vec<_>>();
+
+        class.cbSize = std::mem::size_of::<WNDCLASSEXW>() as UINT;
+        class.lpszClassName = class_name.as_ptr();
+        class.lpfnWndProc = Some(DefWindowProcW);
+
+        RegisterClassExW(&class);
+
+        let hwnd = CreateWindowExW(
+            0,
+            class_name.as_ptr(),
+            std::ptr::null(),
+            0,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            instance,
+            std::ptr::null_mut(),
+        );
+
+        let hdc = GetDC(hwnd);
+
+        let desc = PIXELFORMATDESCRIPTOR {
+            nSize: std::mem::size_of::<PIXELFORMATDESCRIPTOR>() as u16,
+            nVersion: 1,
+            dwFlags: PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
+            iPixelType: PFD_TYPE_RGBA,
+            cColorBits: 32,
+            cRedBits: 0,
+            cRedShift: 0,
+            cGreenBits: 0,
+            cGreenShift: 0,
+            cBlueBits: 0,
+            cBlueShift: 0,
+            cAlphaBits: 8,
+            cAlphaShift: 0,
+            cAccumBits: 0,
+            cAccumRedBits: 0,
+            cAccumGreenBits: 0,
+            cAccumBlueBits: 0,
+            cAccumAlphaBits: 0,
+            cDepthBits: 0,
+            cStencilBits: 0,
+            cAuxBuffers: 0,
+            iLayerType: PFD_MAIN_PLANE,
+            bReserved: 0,
+            dwLayerMask: 0,
+            dwVisibleMask: 0,
+            dwDamageMask: 0,
+        };
+
+        let format_id = unsafe { ChoosePixelFormat(hdc, &desc) };
+        SetPixelFormat(hdc, format_id, &desc);
+
+        let hglrc = wglCreateContext(hdc);
+
+        println!("{:?}", (hwnd, hdc, format_id, hglrc));
+
+        dbg!(wglMakeCurrent(hdc, hglrc));
+
+        let name = OsStr::new("opengl32.dll")
+                .encode_wide()
+                .chain(Some(0).into_iter())
+                .collect::<Vec<_>>();
+
+        let lib = dbg!(LoadLibraryW(name.as_ptr()));
+
+        let wgl = wgl_ext_sys::Wgl::load_with(|sym| {
+            let sym = CString::new(sym.as_bytes()).unwrap();
+            let addr = wgl_sys::GetProcAddress(sym.as_ptr()) as *const ();
+            if !addr.is_null() {
+                addr as *const _
+            } else {
+                GetProcAddress(lib, sym.as_ptr()) as *const _
+            }
+        });
+
+        Entry { hwnd, hdc: hdc as _, wgl, lib }
+        }
+    }
+}
+
+lazy_static! {
+    // Entry function pointers
+    pub(crate) static ref WGL_ENTRY: Entry = Entry::new();
+}
+
+pub struct Instance {
+    pub(crate) ctxt: DeviceContext,
+}
+
+impl Instance {
+    pub fn create(name: &str, version: u32) -> Self {
+        unsafe {
+            let glrc = dbg!(WGL_ENTRY.wgl.CreateContextAttribsARB(
+                WGL_ENTRY.hdc as *const _,
+                ptr::null(),
+                ptr::null()
+            ) as HGLRC);
+
+            dbg!(wglMakeCurrent(WGL_ENTRY.hdc as *mut _, glrc));
+
+            Instance { ctxt: DeviceContext {
+                ctxt: Context { glrc },
+                hdc: WGL_ENTRY.hdc,
+            }}
+        }
+    }
+
+    #[cfg(windows)]
+    pub fn create_surface_from_hwnd(
+        &self, hwnd: *mut c_void
+    ) -> Surface {
+        Surface { hwnd: hwnd as *mut _}
+    }
+
+    #[cfg(feature = "winit")]
+    pub fn create_surface(&self, window: &winit::Window) -> Surface {
+        use winit::os::windows::WindowExt;
+
+        let hwnd = window.get_hwnd();
+        self.create_surface_from_hwnd(hwnd as *mut _)
+    }
+}
+
+impl hal::Instance for Instance {
+    type Backend = Backend;
+
+    fn enumerate_adapters(&self) -> Vec<hal::Adapter<Backend>> {
+        let adapter = PhysicalDevice::new_adapter(self.ctxt, |s| unsafe {
+            let sym = CString::new(s.as_bytes()).unwrap();
+            let addr = wgl_sys::GetProcAddress(sym.as_ptr()) as *const ();
+            if !addr.is_null() {
+                addr as *const _
+            } else {
+                GetProcAddress(WGL_ENTRY.lib, sym.as_ptr()) as *const _
+            }
+        });
+        vec![adapter]
+    }
+}
+
+#[derive(Debug)]
+pub struct Surface {
+    pub(crate) hwnd: HWND,
+}
+
+// TODO: high -msiglreith
+unsafe impl Send for Surface { }
+unsafe impl Sync for Surface { }
+
+
+impl Surface {
+    fn get_extent(&self) -> hal::window::Extent2D {
+        let mut rect: RECT = unsafe { mem::uninitialized() };
+        unsafe { GetClientRect(self.hwnd, &mut rect); }
+        hal::window::Extent2D {
+            width: (rect.right - rect.left) as _,
+            height: (rect.bottom - rect.top) as _,
+        }
+    }
+}
+
+impl hal::Surface<Backend> for Surface {
+    fn kind(&self) -> hal::image::Kind {
+        unimplemented!()
+    }
+
+    fn compatibility(
+        &self, physical_device: &PhysicalDevice
+    ) -> (hal::SurfaceCapabilities, Option<Vec<Format>>, Vec<hal::PresentMode>) {
+        let extent = self.get_extent();
+
+        let caps = hal::SurfaceCapabilities {
+            image_count: 2..3,
+            current_extent: Some(extent),
+            extents: extent..hal::window::Extent2D {
+                width: extent.width + 1,
+                height: extent.height + 1,
+            },
+            max_image_layers: 1,
+            usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
+            composite_alpha: CompositeAlpha::OPAQUE, //TODO
+        };
+        let present_modes = vec![
+            hal::PresentMode::Fifo, //TODO
+        ];
+
+        (caps, Some(vec![f::Format::Rgba8Srgb, f::Format::Bgra8Srgb]), present_modes)
+    }
+
+    fn supports_queue_family(&self, queue_family: &QueueFamily) -> bool {
+        true
+    }
+}
+
+#[derive(Debug)]
+pub struct Swapchain {
+    pub(crate) fbos: Vec<native::FrameBuffer>,
+    pub(crate) context: PresentContext,
+    pub(crate) extent: Extent2D,
+}
+impl Swapchain {
+    pub(crate) fn make_current(&self) {
+        self.context.make_current();
+    }
+
+    pub(crate) fn swap_buffers(&self) {
+        self.context.swap_buffers();
+    }
+}
+
+impl hal::Swapchain<Backend> for Swapchain {
+    unsafe fn acquire_image(
+        &mut self, _timeout_ns: u64,
+        _semaphore: Option<&native::Semaphore>,
+        _fence: Option<&native::Fence>,
+    ) -> Result<(hal::SwapImageIndex, Option<hal::window::Suboptimal>), hal::AcquireError> {
+        Ok((0, None)) // TODO
+    }
+}
+
+/// Basic abstraction for wgl context handles.
+#[derive(Debug, Copy, Clone)]
+struct Context {
+    glrc: HGLRC,
+}
+
+impl Context {
+    unsafe fn make_current(&self, hdc: HDC) {
+        wglMakeCurrent(hdc, self.glrc);
+    }
+}
+
+/// Owned context for devices and instances.
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct DeviceContext {
+    /// Owned wgl context.
+    ctxt: Context,
+
+    /// Device context owned by the corresponding instance.
+    ///
+    /// This refers to either a pbuffer or dummy window. Therefore not used for actual presentation.
+    hdc: HDC,
+}
+
+// TODO
+unsafe impl Send for DeviceContext { }
+unsafe impl Sync for DeviceContext { }
+
+impl DeviceContext {
+    pub(crate) fn make_current(&self) {
+        unsafe { self.ctxt.make_current(self.hdc); }
+    }
+}
+
+/// Owned context for swapchains which soley is required for presentation.
+#[derive(Debug)]
+pub(crate) struct PresentContext {
+    /// Owned wgl context.
+    ctxt: Context,
+
+    /// Device context of the corresponding presentation surface.
+    hdc: HDC,
+}
+
+// TODO
+unsafe impl Send for PresentContext { }
+unsafe impl Sync for PresentContext { }
+
+
+impl PresentContext {
+    pub(crate) fn new(surface: &Surface, device_ctxt: &DeviceContext) -> Self {
+        // TODO: configuration options
+        unsafe {
+            let hdc = dbg!(GetDC(surface.hwnd));
+
+            let desc = PIXELFORMATDESCRIPTOR {
+                nSize: std::mem::size_of::<PIXELFORMATDESCRIPTOR>() as u16,
+                nVersion: 1,
+                dwFlags: PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
+                iPixelType: PFD_TYPE_RGBA,
+                cColorBits: 32,
+                cRedBits: 0,
+                cRedShift: 0,
+                cGreenBits: 0,
+                cGreenShift: 0,
+                cBlueBits: 0,
+                cBlueShift: 0,
+                cAlphaBits: 8,
+                cAlphaShift: 0,
+                cAccumBits: 0,
+                cAccumRedBits: 0,
+                cAccumGreenBits: 0,
+                cAccumBlueBits: 0,
+                cAccumAlphaBits: 0,
+                cDepthBits: 0,
+                cStencilBits: 0,
+                cAuxBuffers: 0,
+                iLayerType: PFD_MAIN_PLANE,
+                bReserved: 0,
+                dwLayerMask: 0,
+                dwVisibleMask: 0,
+                dwDamageMask: 0,
+            };
+
+            let format_id = ChoosePixelFormat(hdc, &desc);
+            SetPixelFormat(hdc, format_id, &desc);
+
+            let glrc = dbg!(WGL_ENTRY.wgl.CreateContextAttribsARB(
+                hdc as *const _,
+                device_ctxt.ctxt.glrc as _,
+                ptr::null()
+            ) as HGLRC);
+
+            wglMakeCurrent(hdc, glrc);
+
+            PresentContext { ctxt: Context { glrc }, hdc }
+        }
+    }
+
+    pub(crate) fn make_current(&self) {
+        unsafe { self.ctxt.make_current(self.hdc); }
+    }
+
+    fn swap_buffers(&self) {
+        unsafe { SwapBuffers(self.hdc); }
+    }
+}

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -1,7 +1,7 @@
 use hal::window::Extent2D;
 use hal::{self, format as f, image, CompositeAlpha};
 
-use crate::{native, Backend, PhysicalDevice, QueueFamily};
+use crate::{native, Backend, PhysicalDevice, QueueFamily, GlContainer};
 use hal::format::Format;
 
 use std::{
@@ -193,7 +193,7 @@ impl hal::Instance for Instance {
     type Backend = Backend;
 
     fn enumerate_adapters(&self) -> Vec<hal::Adapter<Backend>> {
-        let adapter = PhysicalDevice::new_adapter(self.ctxt, |s| unsafe {
+        let gl_container = GlContainer::from_fn_proc(|s| unsafe {
             let sym = CString::new(s.as_bytes()).unwrap();
             let addr = wgl_sys::GetProcAddress(sym.as_ptr()) as *const ();
             if !addr.is_null() {
@@ -202,6 +202,7 @@ impl hal::Instance for Instance {
                 GetProcAddress(WGL_ENTRY.lib, sym.as_ptr()) as *const _
             }
         });
+        let adapter = PhysicalDevice::new_adapter(self.ctxt, gl_container);
         vec![adapter]
     }
 }

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -103,7 +103,7 @@ impl Entry {
             dwDamageMask: 0,
         };
 
-        let format_id = unsafe { ChoosePixelFormat(hdc, &desc) };
+        let format_id = ChoosePixelFormat(hdc, &desc);
         SetPixelFormat(hdc, format_id, &desc);
 
         let hglrc = wglCreateContext(hdc);


### PR DESCRIPTION
Add a wgl based window interface backend for the gl backend. This allows to get closer to the Vulkan API and a step towards multithreaded OpenGL.

It's based around context sharing where we seperate two different context types: PresentContext and DeviceContext. Each swapchain will have a present context which only does blitting towards the default framebuffer of the underlying surface and presentation. The device context is backed by no real surface/window and does the usual command submission etc. All contexts are shared. Present and device contexts only share the swapchain images.

Future work would include adding glx, egl and web support. Wayland + EGL turned out to be really tricky, need to look a layer deeper I guess (below EGL?). This PR should be an initial test for this approach and therefore doesn't full employ all possible features of the hal/wgl API.

Long term goal would be to unify all backends and make `Instance` the single entrypoint for all APIs..

Related https://github.com/gfx-rs/gfx/issues/2749
