### PR TITLE
[pre-ll] Bump versions to match crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ gfx_core = { path = "src/core", version = "0.9" }
 gfx = { path = "src/render", version = "0.18" }
 gfx_macros = { path = "src/macros", version = "0.2" }
 gfx_device_gl = { path = "src/backend/gl", version = "0.16" }
-gfx_window_glutin = { path = "src/window/glutin", version = "0.30" }
+gfx_window_glutin = { path = "src/window/glutin", version = "0.31" }
 gfx_window_glfw = { path = "src/window/glfw", version = "0.17", optional = true }
 gfx_window_sdl = { path = "src/window/sdl", version = "0.9", optional = true }
 

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_dx11"
-version = "0.8.1"
+version = "0.8.2"
 description = "DirectX-11 backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_device_gl"
-version = "0.16.0"
+version = "0.16.1"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_core"
-version = "0.9.0"
+version = "0.9.1"
 description = "Core library of Gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.18.0"
+version = "0.18.1"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/dxgi/Cargo.toml
+++ b/src/window/dxgi/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_dxgi"
-version = "0.19.0"
+version = "0.19.1"
 description = "DXGI window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/glfw/Cargo.toml
+++ b/src/window/glfw/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glfw"
-version = "0.17.0"
+version = "0.17.1"
 description = "GLFW window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/glutin/Cargo.toml
+++ b/src/window/glutin/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_glutin"
-version = "0.30.0"
+version = "0.31.0"
 description = "Glutin window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/window/glutin/README.md
+++ b/src/window/glutin/README.md
@@ -9,7 +9,7 @@ Make sure you have the following in your `Cargo.toml`:
 ```toml
 gfx_core = "0.9"
 gfx_device_gl = "0.16"
-gfx_window_glutin = "0.30.0"
+gfx_window_glutin = "0.31.0"
 glutin = "0.20"
 ```
 

--- a/src/window/sdl/Cargo.toml
+++ b/src/window/sdl/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_window_sdl"
-version = "0.9.0"
+version = "0.9.1"
 description = "SDL2 window for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
Last month, a handful of pre-ll crates had a patch version bumped, but the crate versions were not updated in Github. Additionally, the prior version was yanked from crates (e.g. gfx was bumped to 0.18.1, which 0.18.0 yanked).

Both of these things together causes issues with [cargo patches](https://doc.rust-lang.org/cargo/reference/manifest.html#the-patch-section), as the patch has the original version, which cargo tries to resolve against the new version. Since the original is yanked, the patch is not valid and then is not used if it's not explicitly added to the `Cargo.lock` file (which is pretty painful to do manually).

This PR bumps these versions in the `pre-ll` branch so that the repo better reflects what is published and those branched off this repo can be a valid `[patch.crates-io]` patch.