### PR TITLE
Add Events API and implement for Vulkan backend

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -2338,6 +2338,22 @@ impl hal::Device<Backend> for Device {
         Ok(*fence.mutex.lock())
     }
 
+    fn create_event(&self) -> Result<(), device::OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn get_event_status(&self, event: &()) -> Result<bool, device::OomOrDeviceLost> {
+        unimplemented!()
+    }
+
+    unsafe fn set_event(&self, event: &()) -> Result<(), device::OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn reset_event(&self, event: &()) -> Result<(), device::OutOfMemory> {
+        unimplemented!()
+    }
+
     unsafe fn free_memory(&self, memory: Memory) {
         for (_range, internal) in memory.local_buffers.borrow_mut().iter() {
             unsafe {
@@ -2418,6 +2434,10 @@ impl hal::Device<Backend> for Device {
     }
 
     unsafe fn destroy_semaphore(&self, _semaphore: Semaphore) {
+        //unimplemented!()
+    }
+
+    unsafe fn destroy_event(&self, _event: ()) {
         //unimplemented!()
     }
 

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2144,8 +2144,7 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
     unsafe fn wait_events<'a, I, J>(
         &mut self,
         _: I,
-        _: pso::PipelineStage,
-        _: pso::PipelineStage,
+        _: Range<pso::PipelineStage>,
         _: J
     ) where
         I: IntoIterator,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2133,6 +2133,29 @@ impl hal::command::RawCommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
+    unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {
+        unimplemented!()
+    }
+
+    unsafe fn reset_event(&mut self, _: &(), _: pso::PipelineStage) {
+        unimplemented!()
+    }
+
+    unsafe fn wait_events<'a, I, J>(
+        &mut self,
+        _: I,
+        _: pso::PipelineStage,
+        _: pso::PipelineStage,
+        _: J
+    ) where
+        I: IntoIterator,
+        I::Item: Borrow<()>,
+        J: IntoIterator,
+        J::Item: Borrow<memory::Barrier<'a, Backend>>,
+    {
+        unimplemented!()
+    }
+
     unsafe fn begin_query(&mut self, _query: query::Query<Backend>, _flags: query::ControlFlags) {
         unimplemented!()
     }
@@ -3054,6 +3077,7 @@ impl hal::Backend for Backend {
 
     type Fence = Fence;
     type Semaphore = Semaphore;
+    type Event = ();
     type QueryPool = QueryPool;
 }
 

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -2385,14 +2385,13 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     unsafe fn wait_events<'a, I, J>(
         &mut self,
         _: I,
-        _: pso::PipelineStage,
-        _: pso::PipelineStage,
+        _: Range<pso::PipelineStage>,
         _: J
     ) where
         I: IntoIterator,
-    I::Item: Borrow<()>,
-    J: IntoIterator,
-    J::Item: Borrow<memory::Barrier<'a, Backend>>,
+        I::Item: Borrow<()>,
+        J: IntoIterator,
+        J::Item: Borrow<memory::Barrier<'a, Backend>>,
     {
         unimplemented!()
     }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -2374,6 +2374,29 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         );
     }
 
+    unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {
+        unimplemented!()
+    }
+
+    unsafe fn reset_event(&mut self, _: &(), _: pso::PipelineStage) {
+        unimplemented!()
+    }
+
+    unsafe fn wait_events<'a, I, J>(
+        &mut self,
+        _: I,
+        _: pso::PipelineStage,
+        _: pso::PipelineStage,
+        _: J
+    ) where
+        I: IntoIterator,
+    I::Item: Borrow<()>,
+    J: IntoIterator,
+    J::Item: Borrow<memory::Barrier<'a, Backend>>,
+    {
+        unimplemented!()
+    }
+
     unsafe fn begin_query(&mut self, query: query::Query<Backend>, flags: query::ControlFlags) {
         let query_ty = match query.pool.ty {
             native::query::HeapType::Occlusion => {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2886,6 +2886,22 @@ impl d::Device<B> for Device {
         }
     }
 
+    fn create_event(&self) -> Result<(), d::OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn get_event_status(&self, event: &()) -> Result<bool, d::OomOrDeviceLost> {
+        unimplemented!()
+    }
+
+    unsafe fn set_event(&self, event: &()) -> Result<(), d::OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn reset_event(&self, event: &()) -> Result<(), d::OutOfMemory> {
+        unimplemented!()
+    }
+
     unsafe fn free_memory(&self, memory: r::Memory) {
         memory.heap.destroy();
         if let Some(buffer) = memory.resource {
@@ -3001,6 +3017,10 @@ impl d::Device<B> for Device {
 
     unsafe fn destroy_semaphore(&self, semaphore: r::Semaphore) {
         semaphore.raw.destroy();
+    }
+
+    unsafe fn destroy_event(&self, event: ()) {
+        unimplemented!()
     }
 
     unsafe fn create_swapchain(

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1159,6 +1159,7 @@ impl hal::Backend for Backend {
 
     type Fence = resource::Fence;
     type Semaphore = resource::Semaphore;
+    type Event = ();
     type QueryPool = resource::QueryPool;
 }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -793,8 +793,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     unsafe fn wait_events<'a, I, J>(
         &mut self,
         _: I,
-        _: pso::PipelineStage,
-        _: pso::PipelineStage,
+        _: Range<pso::PipelineStage>,
         _: J
     ) where
         I: IntoIterator,

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -49,6 +49,7 @@ impl hal::Backend for Backend {
 
     type Fence = ();
     type Semaphore = ();
+    type Event = ();
     type QueryPool = ();
 }
 
@@ -345,6 +346,22 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
+    fn create_event(&self) -> Result<(), device::OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn get_event_status(&self, _: &()) -> Result<bool, device::OomOrDeviceLost> {
+        unimplemented!()
+    }
+
+    unsafe fn set_event(&self, _: &()) -> Result<(), device::OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn reset_event(&self, _: &()) -> Result<(), device::OutOfMemory> {
+        unimplemented!()
+    }
+
     unsafe fn create_query_pool(&self, _: query::Type, _: u32) -> Result<(), query::CreationError> {
         unimplemented!()
     }
@@ -447,6 +464,10 @@ impl hal::Device<Backend> for Device {
     }
 
     unsafe fn destroy_semaphore(&self, _: ()) {
+        unimplemented!()
+    }
+
+    unsafe fn destroy_event(&self, _: ()) {
         unimplemented!()
     }
 
@@ -758,6 +779,29 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         _: hal::DrawCount,
         _: u32,
     ) {
+        unimplemented!()
+    }
+
+    unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {
+        unimplemented!()
+    }
+
+    unsafe fn reset_event(&mut self, _: &(), _: pso::PipelineStage) {
+        unimplemented!()
+    }
+
+    unsafe fn wait_events<'a, I, J>(
+        &mut self,
+        _: I,
+        _: pso::PipelineStage,
+        _: pso::PipelineStage,
+        _: J
+    ) where
+        I: IntoIterator,
+        I::Item: Borrow<()>,
+        J: IntoIterator,
+        J::Item: Borrow<memory::Barrier<'a, Backend>>,
+    {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1270,6 +1270,29 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
+    unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {
+        unimplemented!()
+    }
+
+    unsafe fn reset_event(&mut self, _: &(), _: pso::PipelineStage) {
+        unimplemented!()
+    }
+
+    unsafe fn wait_events<'a, I, J>(
+        &mut self,
+        _: I,
+        _: pso::PipelineStage,
+        _: pso::PipelineStage,
+        _: J
+    ) where
+        I: IntoIterator,
+    I::Item: Borrow<()>,
+    J: IntoIterator,
+    J::Item: Borrow<memory::Barrier<'a, Backend>>,
+    {
+        unimplemented!()
+    }
+
     unsafe fn begin_query(&mut self, _query: query::Query<Backend>, _flags: query::ControlFlags) {
         unimplemented!()
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1281,8 +1281,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
     unsafe fn wait_events<'a, I, J>(
         &mut self,
         _: I,
-        _: pso::PipelineStage,
-        _: pso::PipelineStage,
+        _: Range<pso::PipelineStage>,
         _: J
     ) where
         I: IntoIterator,

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1608,6 +1608,22 @@ impl d::Device<B> for Device {
         }
     }
 
+    fn create_event(&self) -> Result<(), d::OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn get_event_status(&self, event: &()) -> Result<bool, d::OomOrDeviceLost> {
+        unimplemented!()
+    }
+
+    unsafe fn set_event(&self, event: &()) -> Result<(), d::OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn reset_event(&self, event: &()) -> Result<(), d::OutOfMemory> {
+        unimplemented!()
+    }
+
     unsafe fn free_memory(&self, _memory: n::Memory) {
         // Nothing to do
     }
@@ -1705,6 +1721,10 @@ impl d::Device<B> for Device {
 
     unsafe fn destroy_semaphore(&self, _: n::Semaphore) {
         // Nothing to do
+    }
+
+    unsafe fn destroy_event(&self, event: ()) {
+        unimplemented!()
     }
 
     unsafe fn create_swapchain(

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -94,6 +94,7 @@ impl hal::Backend for Backend {
 
     type Fence = native::Fence;
     type Semaphore = native::Semaphore;
+    type Event = ();
     type QueryPool = ();
 }
 

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -4150,6 +4150,29 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             .issue_many(commands);
     }
 
+    unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {
+        unimplemented!()
+    }
+
+    unsafe fn reset_event(&mut self, _: &(), _: pso::PipelineStage) {
+        unimplemented!()
+    }
+
+    unsafe fn wait_events<'a, I, J>(
+        &mut self,
+        _: I,
+        _: pso::PipelineStage,
+        _: pso::PipelineStage,
+        _: J
+    ) where
+        I: IntoIterator,
+    I::Item: Borrow<()>,
+    J: IntoIterator,
+    J::Item: Borrow<memory::Barrier<'a, Backend>>,
+    {
+        unimplemented!()
+    }
+
     unsafe fn begin_query(&mut self, query: query::Query<Backend>, flags: query::ControlFlags) {
         match query.pool {
             native::QueryPool::Occlusion(ref pool_range) => {

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -4161,8 +4161,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     unsafe fn wait_events<'a, I, J>(
         &mut self,
         _: I,
-        _: pso::PipelineStage,
-        _: pso::PipelineStage,
+        _: Range<pso::PipelineStage>,
         _: J
     ) where
         I: IntoIterator,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2557,6 +2557,26 @@ impl hal::Device<Backend> for Device {
     }
     unsafe fn destroy_fence(&self, _fence: n::Fence) {}
 
+    fn create_event(&self) -> Result<(), OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn get_event_status(&self, event: &()) -> Result<bool, OomOrDeviceLost> {
+        unimplemented!()
+    }
+
+    unsafe fn set_event(&self, event: &()) -> Result<(), OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn reset_event(&self, event: &()) -> Result<(), OutOfMemory> {
+        unimplemented!()
+    }
+
+    unsafe fn destroy_event(&self, event: ()) {
+        unimplemented!()
+    }
+
     unsafe fn create_query_pool(
         &self,
         ty: query::Type,

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -332,6 +332,7 @@ impl hal::Backend for Backend {
 
     type Fence = native::Fence;
     type Semaphore = native::Semaphore;
+    type Event = ();
     type QueryPool = native::QueryPool;
 }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1083,5 +1083,6 @@ impl hal::Backend for Backend {
 
     type Fence = native::Fence;
     type Semaphore = native::Semaphore;
+    type Event = native::Event;
     type QueryPool = native::QueryPool;
 }

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -13,6 +13,9 @@ pub struct Semaphore(pub vk::Semaphore);
 pub struct Fence(pub vk::Fence);
 
 #[derive(Debug, Hash)]
+pub struct Event(pub vk::Event);
+
+#[derive(Debug, Hash)]
 pub struct GraphicsPipeline(pub vk::Pipeline);
 
 #[derive(Debug, Hash)]

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -508,8 +508,7 @@ pub trait RawCommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     unsafe fn wait_events<'a, I, J>(
         &mut self,
         events: I,
-        src_stages: pso::PipelineStage,
-        dst_stages: pso::PipelineStage,
+        stages: Range<pso::PipelineStage>,
         barriers: J,
     ) where
         I: IntoIterator,

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -493,6 +493,30 @@ pub trait RawCommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         stride: u32,
     );
 
+    /// Signals an event once all specified stages of the shader pipeline have completed.
+    unsafe fn set_event(&mut self, event: &B::Event, stages: pso::PipelineStage);
+
+    /// Resets an event once all specified stages of the shader pipeline have completed.
+    unsafe fn reset_event(&mut self, event: &B::Event, stages: pso::PipelineStage);
+
+    /// Waits at some shader stage(s) until all events have been signalled.
+    ///
+    /// - `src_stages` specifies the shader pipeline stages in which the events were signalled.
+    /// - `dst_stages` specifies the shader pipeline stages at which execution should wait.
+    /// - `barriers` specifies a series of memory barriers to be executed before pipeline execution
+    ///   resumes.
+    unsafe fn wait_events<'a, I, J>(
+        &mut self,
+        events: I,
+        src_stages: pso::PipelineStage,
+        dst_stages: pso::PipelineStage,
+        barriers: J,
+    ) where
+        I: IntoIterator,
+        I::Item: Borrow<B::Event>,
+        J: IntoIterator,
+        J::Item: Borrow<Barrier<'a, B>>;
+
     /// Begins a query operation.  Queries count operations or record timestamps
     /// resulting from commands that occur between the beginning and end of the query,
     /// and save the results to the query pool.

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -729,6 +729,23 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Destroy a fence object
     unsafe fn destroy_fence(&self, fence: B::Fence);
 
+    /// Create an event object.
+    fn create_event(&self) -> Result<B::Event, OutOfMemory>;
+
+    /// Destroy an event object.
+    unsafe fn destroy_event(&self, event: B::Event);
+
+    /// Query the status of an event.
+    ///
+    /// Returns `true` if the event is set, or `false` if it is reset.
+    unsafe fn get_event_status(&self, event: &B::Event) -> Result<bool, OomOrDeviceLost>;
+
+    /// Sets an event.
+    unsafe fn set_event(&self, event: &B::Event) -> Result<(), OutOfMemory>;
+
+    /// Resets an event.
+    unsafe fn reset_event(&self, event: &B::Event) -> Result<(), OutOfMemory>;
+
     /// Create a new query pool object
     ///
     /// Queries are managed using query pool objects. Each query pool is a collection of a specific

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -500,6 +500,7 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send
 
     type Fence: fmt::Debug + Any + Send + Sync;
     type Semaphore: fmt::Debug + Any + Send + Sync;
+    type Event: fmt::Debug + Any + Send + Sync;
     type QueryPool: fmt::Debug + Any + Send + Sync;
 }
 


### PR DESCRIPTION
Also adds placeholder implementations for all other backends.

Fixes #2804 
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx11, dx12, vulkan, gl
- [x] `rustfmt` run on changed code