### PR TITLE
[hal] Fix typo in documentation

### DIFF
--- a/src/hal/src/pso/output_merger.rs
+++ b/src/hal/src/pso/output_merger.rs
@@ -126,7 +126,7 @@ impl BlendOp {
 }
 
 /// Specifies whether to use blending, and if so,
-/// which operatiosn to use for color and alpha channels.
+/// which operations to use for color and alpha channels.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum BlendState {


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code