### PR TITLE
Allow multisampling sample mask to be set to null

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -600,10 +600,13 @@ impl d::Device<B> for Device {
 
                 let multisampling_state = match desc.multisampling {
                     Some(ref ms) => {
-                        let sample_mask = [
-                            (ms.sample_mask & 0xFFFFFFFF) as u32,
-                            ((ms.sample_mask >> 32) & 0xFFFFFFFF) as u32,
-                        ];
+                        let sample_mask = match ms.sample_mask {
+                            Some(mask) => Some([
+                                (mask & 0xFFFFFFFF) as u32,
+                                ((mask >> 32) & 0xFFFFFFFF) as u32,
+                            ]),
+                            None => None
+                        };
                         sample_masks.push(sample_mask);
 
                         vk::PipelineMultisampleStateCreateInfo {
@@ -616,7 +619,10 @@ impl d::Device<B> for Device {
                             ),
                             sample_shading_enable: ms.sample_shading.is_some() as _,
                             min_sample_shading: ms.sample_shading.unwrap_or(0.0),
-                            p_sample_mask: sample_masks.last().unwrap().as_ptr(),
+                            p_sample_mask: match sample_masks.last().unwrap() {
+                                Some(mask) => mask.as_ptr(),
+                                None => ptr::null()
+                            },
                             alpha_to_coverage_enable: ms.alpha_coverage as _,
                             alpha_to_one_enable: ms.alpha_to_one as _,
                         }

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -273,7 +273,7 @@ pub struct Multisampling {
     ///
     pub sample_shading: Option<f32>,
     ///
-    pub sample_mask: SampleMask,
+    pub sample_mask: Option<SampleMask>,
     /// Toggles alpha-to-coverage multisampling, which can produce nicer edges
     /// when many partially-transparent polygons are overlapping.
     /// See [here]( https://msdn.microsoft.com/en-us/library/windows/desktop/bb205072(v=vs.85).aspx#Alpha_To_Coverage) for a full description.


### PR DESCRIPTION
https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VkSampleMask states:
> If pSampleMask is NULL, it is treated as if the mask has all bits enabled, i.e. no coverage is removed from fragments.

I believe it makes sense to follow this behaviour and make the field optional in gfx-hal.

Example of usage before this change:
```
pipeline_desc.multisampling = Some(pso::Multisampling {
    rasterization_samples: rasterization_samples,
    sample_shading: None,
    sample_mask: 0xFFFFFFFFFFFFFFFF,
    alpha_coverage: false,
    alpha_to_one: false
});
```
After:
```
pipeline_desc.multisampling = Some(pso::Multisampling {
    rasterization_samples: rasterization_samples,
    sample_shading: None,
    sample_mask: None,
    alpha_coverage: false,
    alpha_to_one: false
});
```

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- [x] `rustfmt` run on changed code
