### PR TITLE
[hal] Merge use statements in memory module

### DIFF
--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -1,9 +1,7 @@
 //! Types to describe the properties of memory allocated for gfx resources.
 
-use crate::Backend;
-use crate::{buffer, image, queue};
-use std::mem;
-use std::ops::Range;
+use crate::{Backend, buffer, image, queue};
+use std::{mem, ops::Range};
 
 /// A trait for plain-old-data types.
 ///


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
  - [x] metal
- [x] `rustfmt` run on changed code
