### PR TITLE
hal: Merge use statements in image module

### DIFF
--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -3,11 +3,11 @@
 //! An image is a block of GPU memory representing a grid of texels.
 
 use std::ops::Range;
-
-use crate::buffer::Offset as RawOffset;
-use crate::device;
-use crate::format;
-use crate::pso::{Comparison, Rect};
+use crate::{
+    buffer::Offset as RawOffset,
+    device, format,
+    pso::{Comparison, Rect},
+};
 
 /// Dimension size.
 pub type Size = u32;


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
  - [x] metal
- [x] `rustfmt` run on changed code
