### PR TITLE
hal: Merge use statements in pass module

### DIFF
--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -1,9 +1,6 @@
 //! RenderPass handling.
 
-use crate::format::Format;
-use crate::image;
-use crate::pso::PipelineStage;
-use crate::Backend;
+use crate::{format::Format, image, pso::PipelineStage, Backend};
 use std::ops::Range;
 
 /// Specifies the operation which will be applied at the beginning of a subpass.


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
  - [x] metal
- [x] `rustfmt` run on changed code
