### PR TITLE
Rework of gl memory / buffer handling

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = "1"
 log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.2" }
 smallvec = "0.6"
-glow = { version = "0.2.0" }
+glow = { git = "https://github.com/grovesNL/glow", rev = "054aabc1bfbad472e4a08bc55912552d8211daee" }
 spirv_cross = { version = "0.14.0", features = ["glsl"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = "1"
 log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.2" }
 smallvec = "0.6"
-glow = { git = "https://github.com/grovesNL/glow", rev = "054aabc1bfbad472e4a08bc55912552d8211daee" }
+glow = { git = "https://github.com/grovesNL/glow", rev = "7131fc75c1afb460161dd84b9d44fadef24f5a90" }
 spirv_cross = { version = "0.14.0", features = ["glsl"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = "1"
 log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.2" }
 smallvec = "0.6"
-glow = { git = "https://github.com/grovesNL/glow", rev = "7131fc75c1afb460161dd84b9d44fadef24f5a90" }
+glow = { git = "https://github.com/grovesNL/glow", rev = "6c74ffbea64e8fbaa1ec9e94e7f5f6791663a70e" }
 spirv_cross = { version = "0.14.0", features = ["glsl"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -148,7 +148,7 @@ struct Cache {
     // Active primitive topology, set by the current pipeline.
     primitive: Option<u32>,
     // Active index type and buffer range, set by the current index buffer.
-    index_type_range: Option<(hal::IndexType, Range<u64>)>,
+    index_type_range: Option<(hal::IndexType, Range<buffer::Offset>)>,
     // Stencil reference values (front, back).
     stencil_ref: Option<(pso::StencilValue, pso::StencilValue)>,
     // Blend color.
@@ -165,7 +165,7 @@ struct Cache {
     // Blend per attachment.
     blend_targets: Option<Vec<Option<pso::ColorBlendDesc>>>,
     // Maps bound vertex buffer offset (index) to handle / buffer range
-    vertex_buffers: Vec<Option<(n::RawBuffer, Range<u64>)>>,
+    vertex_buffers: Vec<Option<(n::RawBuffer, Range<buffer::Offset>)>>,
     // Active vertex buffer descriptions.
     vertex_buffer_descs: Vec<Option<pso::VertexBufferDesc>>,
     // Active attributes.

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1088,8 +1088,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
     unsafe fn dispatch_indirect(&mut self, buffer: &n::Buffer, offset: buffer::Offset) {
         let (raw_buffer, range) = buffer.borrow().as_bound();
-        assert_eq!(range.start, 0, "buffer offset unsupported in indirect draw");
-        self.push_cmd(Command::DispatchIndirect(raw_buffer, offset));
+        self.push_cmd(Command::DispatchIndirect(raw_buffer, range.start + offset));
     }
 
     unsafe fn copy_buffer<T>(&mut self, src: &n::Buffer, dst: &n::Buffer, regions: T)

--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -44,19 +44,6 @@ pub fn wrap_to_gl(w: i::WrapMode) -> u32 {
     }
 }
 
-/*
-pub fn buffer_usage_to_gl_target(usage: buffer::Usage) -> Option<u32> {
-    use self::buffer::Usage;
-    match usage & (Usage::UNIFORM | Usage::INDEX | Usage::VERTEX | Usage::INDIRECT) {
-        Usage::UNIFORM => Some(glow::UNIFORM_BUFFER),
-        Usage::INDEX => Some(glow::ELEMENT_ARRAY_BUFFER),
-        Usage::VERTEX => Some(glow::ARRAY_BUFFER),
-        Usage::INDIRECT => unimplemented!(),
-        _ => None,
-    }
-}
-*/
-
 pub fn primitive_to_gl_primitive(primitive: Primitive) -> u32 {
     match primitive {
         Primitive::PointList => glow::POINTS,

--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -1,5 +1,5 @@
 use crate::hal::format::Format;
-use crate::hal::{buffer, image as i, Primitive};
+use crate::hal::{image as i, Primitive};
 use crate::native::VertexAttribFunction;
 
 /*
@@ -44,6 +44,7 @@ pub fn wrap_to_gl(w: i::WrapMode) -> u32 {
     }
 }
 
+/*
 pub fn buffer_usage_to_gl_target(usage: buffer::Usage) -> Option<u32> {
     use self::buffer::Usage;
     match usage & (Usage::UNIFORM | Usage::INDEX | Usage::VERTEX | Usage::INDIRECT) {
@@ -54,6 +55,7 @@ pub fn buffer_usage_to_gl_target(usage: buffer::Usage) -> Option<u32> {
         _ => None,
     }
 }
+*/
 
 pub fn primitive_to_gl_primitive(primitive: Primitive) -> u32 {
     match primitive {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1121,7 +1121,7 @@ impl d::Device<B> for Device {
             let ptr = memory.emulate_map_allocation.replace(None).unwrap();
             let allocation = slice::from_raw_parts_mut(ptr, memory.size as usize);
             // TODO: Access
-            gl.buffer_data_u8_slice(memory.target, &allocation, glow::DYNAMIC_DRAW);
+            gl.buffer_sub_data(memory.target, 0, &allocation);
             let _ = Box::from_raw(allocation);
         } else {
             gl.unmap_buffer(memory.target);
@@ -1153,7 +1153,7 @@ impl d::Device<B> for Device {
             if self.share.private_caps.emulate_map {
                 let ptr = mem.emulate_map_allocation.get().unwrap();
                 let slice = slice::from_raw_parts_mut(ptr.offset(offset as isize), size as usize);;
-                gl.buffer_data_u8_slice(mem.target, slice, glow::DYNAMIC_DRAW);
+                gl.buffer_sub_data(mem.target, offset as i32, slice);
             } else {
                 gl.flush_mapped_buffer_range(mem.target, offset as i32, size as i32);
             }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -486,8 +486,16 @@ impl d::Device<B> for Device {
             //TODO: use *Named calls to avoid binding
             gl.bind_buffer(target, Some(raw));
             if self.share.private_caps.buffer_storage {
-                //TODO: glow::DYNAMIC_STORAGE_BIT | glow::MAP_PERSISTENT_BIT
-                gl.buffer_storage(target, size as i32, None, glow::MAP_READ_BIT | glow::MAP_WRITE_BIT);
+                gl.buffer_storage(
+                    target,
+                    size as i32,
+                    None,
+                    glow::MAP_READ_BIT
+                        | glow::MAP_WRITE_BIT
+                        | glow::MAP_PERSISTENT_BIT
+                        | glow::MAP_COHERENT_BIT
+                        | glow::DYNAMIC_STORAGE_BIT
+                );
             } else {
                 gl.buffer_data_size(target, size as i32, glow::DYNAMIC_DRAW);
             }
@@ -1067,7 +1075,7 @@ impl d::Device<B> for Device {
         let caps = &self.share.private_caps;
 
         assert!(caps.buffer_role_change);
-        let access = memory.map_flags();
+        let access = memory.map_flags() | glow::MAP_PERSISTENT_BIT | glow::MAP_COHERENT_BIT;
 
         let offset = *range.start().unwrap_or(&0);
         let size = *range.end().unwrap_or(&memory.size) - offset;

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1129,10 +1129,7 @@ impl d::Device<B> for Device {
 
         if self.share.private_caps.emulate_map {
             let ptr = memory.emulate_map_allocation.replace(None).unwrap();
-            let allocation = slice::from_raw_parts_mut(ptr, memory.size as usize);
-            // TODO: Access
-            gl.buffer_sub_data_u8_slice(memory.target, 0, &allocation);
-            let _ = Box::from_raw(allocation);
+            let _ = Box::from_raw(slice::from_raw_parts_mut(ptr, memory.size as usize));
         } else {
             gl.unmap_buffer(memory.target);
         }
@@ -1162,7 +1159,7 @@ impl d::Device<B> for Device {
 
             if self.share.private_caps.emulate_map {
                 let ptr = mem.emulate_map_allocation.get().unwrap();
-                let slice = slice::from_raw_parts_mut(ptr.offset(offset as isize), size as usize);;
+                let slice = slice::from_raw_parts_mut(ptr.offset(offset as isize), size as usize);
                 gl.buffer_sub_data_u8_slice(mem.target, offset as i32, slice);
             } else {
                 gl.flush_mapped_buffer_range(mem.target, offset as i32, size as i32);

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1048,6 +1048,7 @@ impl d::Device<B> for Device {
             // Buffers are only allowed to be INDEX usage XOR another type of usage, they are not
             // allowed to have both INDEX and non-INDEX usage.
             if !(buffer::Usage::INDEX | buffer::Usage::TRANSFER_SRC | buffer::Usage::TRANSFER_DST).contains(usage) {
+                error!("gl backend does not allow a buffer to be used for both INDEX and non-INDEX usage");
                 (0, 1)
             } else {
                 // Alignment of 4 covers indexes of type u16 and u32

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -209,6 +209,41 @@ impl Share {
         }
         Ok(())
     }
+
+    fn buffer_memory_type_mask(&self, usage: buffer::Usage) -> u64 {
+        let mut type_mask = 0;
+        for (type_index, &(_, role)) in self.memory_types.iter().enumerate() {
+            match role {
+                MemoryRole::Buffer {
+                    allowed_usage,
+                    ..
+                } => {
+                    if allowed_usage.contains(usage) {
+                        type_mask |= 1 << type_index;
+                    }
+                }
+                MemoryRole::Image => {},
+            }
+        }
+        if type_mask == 0 {
+            error!("gl backend capability does not allow a buffer with usage {:?}", usage);
+        }
+        type_mask
+    }
+
+    fn image_memory_type_mask(&self) -> u64 {
+        let mut type_mask = 0;
+        for (type_index, &(_, role)) in self.memory_types.iter().enumerate() {
+            match role {
+                MemoryRole::Buffer { .. } => {},
+                MemoryRole::Image => {
+                    type_mask |= 1 << type_index;
+                },
+            }
+        }
+        assert_ne!(type_mask, 0);
+        type_mask
+    }
 }
 
 /// Single-threaded `Arc`.

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -490,7 +490,6 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         let caps = &self.0.private_caps;
         assert!(caps.map || caps.emulate_map);
 
-        // TODO: Remove COHERENT flag and move toward explicit flushing and invalidation.
         let memory_types = vec![
             // Faked DEVICE_LOCAL memory for images, no gl buffer is actually allocated for it.
             hal::MemoryType {
@@ -500,7 +499,6 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             // Memory type for uses other than images and INDEX
             hal::MemoryType {
                 properties: Properties::CPU_VISIBLE
-                    | Properties::COHERENT
                     | Properties::CPU_CACHED,
                 heap_index: 1,
             },
@@ -509,7 +507,6 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             // buffers with INDEX usage.
             hal::MemoryType {
                 properties: Properties::CPU_VISIBLE
-                    | Properties::COHERENT
                     | Properties::CPU_CACHED,
                 heap_index: 1,
             },

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -364,6 +364,10 @@ impl PhysicalDevice {
                 heap_index: CPU_VISIBLE_HEAP,
             });
             buffer_role_memory_types.push(hal::MemoryType {
+                properties: memory::Properties::CPU_VISIBLE | memory::Properties::COHERENT,
+                heap_index: CPU_VISIBLE_HEAP,
+            });
+            buffer_role_memory_types.push(hal::MemoryType {
                 properties: memory::Properties::CPU_VISIBLE | memory::Properties::CPU_CACHED,
                 heap_index: CPU_VISIBLE_HEAP,
             });
@@ -397,14 +401,7 @@ impl PhysicalDevice {
                     memory_types.push((
                         buffer_role_memory_type,
                         MemoryRole::Buffer {
-                            allowed_usage: buffer::Usage::TRANSFER_SRC
-                                | buffer::Usage::TRANSFER_DST
-                                | buffer::Usage::UNIFORM_TEXEL
-                                | buffer::Usage::STORAGE_TEXEL
-                                | buffer::Usage::UNIFORM
-                                | buffer::Usage::STORAGE
-                                | buffer::Usage::VERTEX
-                                | buffer::Usage::INDIRECT,
+                            allowed_usage: buffer::Usage::all() - buffer::Usage::INDEX,
                             target: glow::PIXEL_PACK_BUFFER,
                         }
                     ));
@@ -414,15 +411,7 @@ impl PhysicalDevice {
                     memory_types.push((
                         buffer_role_memory_type,
                         MemoryRole::Buffer {
-                            allowed_usage: buffer::Usage::TRANSFER_SRC
-                                | buffer::Usage::TRANSFER_DST
-                                | buffer::Usage::UNIFORM_TEXEL
-                                | buffer::Usage::STORAGE_TEXEL
-                                | buffer::Usage::UNIFORM
-                                | buffer::Usage::STORAGE
-                                | buffer::Usage::INDEX
-                                | buffer::Usage::VERTEX
-                                | buffer::Usage::INDIRECT,
+                            allowed_usage: buffer::Usage::all(),
                             target: glow::PIXEL_PACK_BUFFER,
                         }
                     ));

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -487,10 +487,10 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
     fn memory_properties(&self) -> hal::MemoryProperties {
         use crate::hal::memory::Properties;
 
-        // COHERENT flags require that the backend does flushing and invalidation
-        // by itself. If we move towards persistent mapping we need to re-evaluate it.
         let caps = &self.0.private_caps;
         assert!(caps.map || caps.emulate_map);
+
+        // TODO: Remove COHERENT flag and move toward explicit flushing and invalidation.
         let memory_types = vec![
             // Faked DEVICE_LOCAL memory for images, no gl buffer is actually allocated for it.
             hal::MemoryType {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -511,13 +511,14 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
                 properties: Properties::CPU_VISIBLE
                     | Properties::COHERENT
                     | Properties::CPU_CACHED,
-                heap_index: 2,
+                heap_index: 1,
             },
         ];
 
         hal::MemoryProperties {
             memory_types,
-            memory_heaps: vec![!0, !0, !0],
+            // heap 0 is DEVICE_LOCAL, heap 1 is CPU_VISIBLE
+            memory_heaps: vec![!0, !0],
         }
     }
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -29,21 +29,19 @@ pub enum Buffer {
         usage: buffer::Usage,
     },
     Bound {
-        // Image memory types are faked and have no associated buffer.
-        buffer: Option<RawBuffer>,
+        buffer: RawBuffer,
         range: Range<buffer::Offset>,
     },
 }
 
 impl Buffer {
-    // Asserts that the buffer is a bound, CPU_VISIBLE buffer and returns the raw gl buffer along
-    // with its sub-range.
+    // Asserts that the buffer is bound and returns the raw gl buffer along with its sub-range.
     pub(crate) fn as_bound(&self) -> (RawBuffer, Range<u64>) {
         match self {
             Buffer::Unbound { .. } => panic!("Expected bound buffer!"),
             Buffer::Bound {
                 buffer, range, ..
-            } => (buffer.expect("unsupported buffer type"), range.clone()),
+            } => (*buffer, range.clone()),
         }
     }
 }
@@ -250,13 +248,13 @@ pub enum ShaderModule {
 #[derive(Debug)]
 pub struct Memory {
     pub(crate) properties: Properties,
-    // Image memory types are faked and have no associated buffer
+    // Image memory is faked and has no associated gl buffer
     pub(crate) buffer: Option<RawBuffer>,
-    pub(crate) target: u32,
     /// Allocation size
     pub(crate) size: u64,
-    pub(crate) emulate_map_allocation: Cell<Option<*mut u8>>,
+    pub(crate) target: u32,
     pub(crate) map_flags: u32,
+    pub(crate) emulate_map_allocation: Cell<Option<*mut u8>>,
 }
 
 unsafe impl Send for Memory {}

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -1,4 +1,4 @@
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::ops::Range;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -255,7 +255,7 @@ pub struct Memory {
     pub(crate) target: u32,
     /// Allocation size
     pub(crate) size: u64,
-    pub(crate) emulate_map_allocation: RefCell<*mut u8>,
+    pub(crate) emulate_map_allocation: Cell<Option<*mut u8>>,
 }
 
 unsafe impl Send for Memory {}

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -250,38 +250,17 @@ pub enum ShaderModule {
 #[derive(Debug)]
 pub struct Memory {
     pub(crate) properties: Properties,
-    // DEVICE_LOCAL memory types are faked and have no associated buffer
+    // Image memory types are faked and have no associated buffer
     pub(crate) buffer: Option<RawBuffer>,
     pub(crate) target: u32,
     /// Allocation size
     pub(crate) size: u64,
     pub(crate) emulate_map_allocation: Cell<Option<*mut u8>>,
+    pub(crate) map_flags: u32,
 }
 
 unsafe impl Send for Memory {}
 unsafe impl Sync for Memory {}
-
-impl Memory {
-    pub fn can_upload(&self) -> bool {
-        self.properties.contains(Properties::CPU_VISIBLE)
-    }
-
-    pub fn can_download(&self) -> bool {
-        self.properties
-            .contains(Properties::CPU_VISIBLE | Properties::CPU_CACHED)
-    }
-
-    pub fn map_flags(&self) -> u32 {
-        let mut flags = 0;
-        if self.can_download() {
-            flags |= glow::MAP_READ_BIT;
-        }
-        if self.can_upload() {
-            flags |= glow::MAP_WRITE_BIT;
-        }
-        flags
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct RenderPass {

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -248,11 +248,11 @@ pub enum ShaderModule {
 #[derive(Debug)]
 pub struct Memory {
     pub(crate) properties: Properties,
-    // Image memory is faked and has no associated gl buffer
-    pub(crate) buffer: Option<RawBuffer>,
+    /// Gl buffer and the target that should be used for transfer operations.  Image memory is faked
+    /// and has no associated buffer, so this will be None for image memory.
+    pub(crate) buffer: Option<(RawBuffer, u32)>,
     /// Allocation size
     pub(crate) size: u64,
-    pub(crate) target: u32,
     pub(crate) map_flags: u32,
     pub(crate) emulate_map_allocation: Cell<Option<*mut u8>>,
 }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -29,7 +29,7 @@ pub enum Buffer {
         usage: buffer::Usage,
     },
     Bound {
-        // DEVICE_LOCAL memory types are faked and have no associated buffer.
+        // Image memory types are faked and have no associated buffer.
         buffer: Option<RawBuffer>,
         range: Range<buffer::Offset>,
     },

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -612,7 +612,7 @@ impl CommandQueue {
                     r.image_extent.height as _,
                     glow::RGBA,
                     glow::UNSIGNED_BYTE,
-                    0,
+                    r.buffer_offset as i32,
                 );
                 gl.bind_buffer(glow::PIXEL_UNPACK_BUFFER, None);
             },

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -628,7 +628,7 @@ impl CommandQueue {
                 gl.active_texture(glow::TEXTURE0);
                 gl.bind_buffer(glow::PIXEL_PACK_BUFFER, Some(buffer));
                 gl.bind_texture(glow::TEXTURE_2D, Some(texture));
-                gl.get_tex_image(
+                gl.get_tex_image_pixel_buffer_offset(
                     glow::TEXTURE_2D,
                     r.image_layers.level as _,
                     //r.image_offset.x,
@@ -637,7 +637,7 @@ impl CommandQueue {
                     //r.image_extent.height as _,
                     glow::RGBA,
                     glow::UNSIGNED_BYTE,
-                    None,
+                    r.buffer_offset as i32,
                 );
                 gl.bind_buffer(glow::PIXEL_PACK_BUFFER, None);
             },

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -254,6 +254,7 @@ impl Device {
                 let bytes_per_texel = surface_desc.bits / 8;
                 let ext = config.extent;
                 let size = (ext.width * ext.height) as u64 * bytes_per_texel as u64;
+                let type_mask = self.share.image_memory_type_mask();
 
                 if let Err(err) = self.share.check() {
                     panic!(
@@ -268,7 +269,7 @@ impl Device {
                     requirements: memory::Requirements {
                         size,
                         alignment: 1,
-                        type_mask: 0x7,
+                        type_mask,
                     },
                 }
             })

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -225,6 +225,7 @@ impl Device {
                 let bytes_per_texel = surface_desc.bits / 8;
                 let ext = config.extent;
                 let size = (ext.width * ext.height) as u64 * bytes_per_texel as u64;
+                let type_mask = self.share.image_memory_type_mask();
 
                 if let Err(err) = self.share.check() {
                     panic!(
@@ -239,7 +240,7 @@ impl Device {
                     requirements: memory::Requirements {
                         size,
                         alignment: 1,
-                        type_mask: 0x7,
+                        type_mask,
                     },
                 }
             })


### PR DESCRIPTION
Allocates native buffers to back memory as soon as allocate_memory is called,
hal buffers become logical sub-ranges of native buffers.

This is still WIP, there is a lot of room for improvement here.  Separate INDEX
memory could be reserved only for webgl, there could be separate upload /
download memory, and the end of buffer sub-ranges could be checked with asserts
in debug mode.

Fixes #2812
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code
