### PR TITLE
Update Glutin to 0.21.0

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -105,13 +105,13 @@ const COLOR_RANGE: i::SubresourceRange = i::SubresourceRange {
 
 trait SurfaceTrait {
     #[cfg(feature = "gl")]
-    fn get_window_t(&self) -> &back::glutin::WindowedContext;
+    fn get_window_t(&self) -> &back::glutin::WindowedContext<back::glutin::PossiblyCurrent>;
 }
 
 impl SurfaceTrait for <back::Backend as hal::Backend>::Surface {
     #[cfg(feature = "gl")]
-    fn get_window_t(&self) -> &back::glutin::WindowedContext {
-        self.get_window()
+    fn get_window_t(&self) -> &back::glutin::WindowedContext<back::glutin::PossiblyCurrent> {
+        self.get_context()
     }
 }
 
@@ -387,7 +387,7 @@ impl<B: Backend> RendererState<B> {
                             winit::WindowEvent::Resized(dims) => {
                                 #[cfg(feature = "gl")]
                                 backend.surface.get_window_t().resize(dims.to_physical(
-                                    backend.surface.get_window_t().get_hidpi_factor(),
+                                    backend.surface.get_window_t().window().get_hidpi_factor(),
                                 ));
                                 recreate_swapchain = true;
                             }
@@ -685,12 +685,11 @@ fn create_backend(window_state: &mut WindowState) -> (BackendState<back::Backend
         let builder =
             back::config_context(back::glutin::ContextBuilder::new(), ColorFormat::SELF, None)
                 .with_vsync(true);
-        back::glutin::WindowedContext::new_windowed(
+        let context = builder.build_windowed(
             window_state.wb.take().unwrap(),
-            builder,
             &window_state.events_loop,
-        )
-        .unwrap()
+        ).unwrap();
+        unsafe { context.make_current() }.expect("Unable to make context current")
     };
 
     let surface = back::Surface::from_window(window);

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -685,10 +685,9 @@ fn create_backend(window_state: &mut WindowState) -> (BackendState<back::Backend
         let builder =
             back::config_context(back::glutin::ContextBuilder::new(), ColorFormat::SELF, None)
                 .with_vsync(true);
-        let context = builder.build_windowed(
-            window_state.wb.take().unwrap(),
-            &window_state.events_loop,
-        ).unwrap();
+        let context = builder
+            .build_windowed(window_state.wb.take().unwrap(), &window_state.events_loop)
+            .unwrap();
         unsafe { context.make_current() }.expect("Unable to make context current")
     };
 

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -115,7 +115,8 @@ fn main() {
             let builder =
                 back::config_context(back::glutin::ContextBuilder::new(), ColorFormat::SELF, None)
                     .with_vsync(true);
-            back::glutin::WindowedContext::new_windowed(wb, builder, &events_loop).unwrap()
+            let context = builder.build_windowed(wb, &events_loop).unwrap();
+            unsafe { context.make_current() }.expect("Unable to make context current")
         };
         #[cfg(target_arch = "wasm32")]
         let window = { back::Window };
@@ -652,9 +653,10 @@ fn main() {
                     winit::WindowEvent::Resized(dims) => {
                         println!("resized to {:?}", dims);
                         #[cfg(feature = "gl")]
-                        surface
-                            .get_window()
-                            .resize(dims.to_physical(surface.get_window().get_hidpi_factor()));
+                        {
+                            let context = surface.get_context();
+                            context.resize(dims.to_physical(context.window().get_hidpi_factor()));
+                        }
                         recreate_swapchain = true;
                         resize_dims.width = dims.width as u32;
                         resize_dims.height = dims.height as u32;

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -27,7 +27,7 @@ glow = { version = "0.2.0" }
 spirv_cross = { version = "0.14.0", features = ["glsl"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-glutin = { version = "0.20", optional = true }
+glutin = { version = "0.21", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -566,11 +566,10 @@ impl Instance {
         let size = glutin::dpi::PhysicalSize::from((800, 600));
         let builder = glutin::ContextBuilder::new()
             .with_hardware_acceleration(Some(false));
-        let context: glutin::Context<glutin::NotCurrent> = HeadlessContextExt::build_osmesa(builder, size)
-            .expect("failed to create osmesa context");
-        let context = unsafe {
-            context.make_current()
-        }.expect("failed to make context current");
+        let context: glutin::Context<glutin::NotCurrent> =
+            HeadlessContextExt::build_osmesa(builder, size)
+                .expect("failed to create osmesa context");
+        let context = unsafe { context.make_current() }.expect("failed to make context current");
         let headless = Headless::from_context(context);
         Instance::Headless(headless)
     }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -563,7 +563,6 @@ impl Instance {
     #[cfg(target_os = "linux")]
     pub fn create(_: &str, _: u32) -> Instance {
         use glutin::os::unix::OsMesaContextExt;
-        use glutin::ContextTrait;
         let size = glutin::dpi::PhysicalSize::from((800, 600));
         let builder = glutin::ContextBuilder::new()
             .with_hardware_acceleration(Some(false));

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -562,11 +562,11 @@ impl Instance {
     /// TODO: Update portability to make this more flexible
     #[cfg(target_os = "linux")]
     pub fn create(_: &str, _: u32) -> Instance {
-        use glutin::os::unix::OsMesaContextExt;
+        use glutin::os::unix::HeadlessContextExt;
         let size = glutin::dpi::PhysicalSize::from((800, 600));
         let builder = glutin::ContextBuilder::new()
             .with_hardware_acceleration(Some(false));
-        let context: glutin::Context = OsMesaContextExt::new_osmesa(builder, size)
+        let context: glutin::Context<glutin::NotCurrent> = HeadlessContextExt::build_osmesa(builder, size)
             .expect("failed to create osmesa context");
         unsafe {
             context.make_current()

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -568,11 +568,10 @@ impl Instance {
             .with_hardware_acceleration(Some(false));
         let context: glutin::Context<glutin::NotCurrent> = HeadlessContextExt::build_osmesa(builder, size)
             .expect("failed to create osmesa context");
-        unsafe {
+        let context = unsafe {
             context.make_current()
-                .expect("failed to make context current");
-        }
-        let headless = Headless(context);
+        }.expect("failed to make context current");
+        let headless = Headless::from_context(context);
         Instance::Headless(headless)
     }
 }

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1007,7 +1007,7 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
                 glow::LINEAR,
             );
 
-            swapchain.0.borrow().window.swap_buffers().unwrap();
+            swapchain.0.borrow().context.swap_buffers().unwrap();
         }
 
         Ok(None)

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -15,8 +15,8 @@
 //!     // First create a window using glutin.
 //!     let mut events_loop = EventsLoop::new();
 //!     let wb = WindowBuilder::new();
-//!     let cb = ContextBuilder::new().with_vsync(true);
-//!     let glutin_window = WindowedContext::new_windowed(wb, cb, &events_loop).unwrap();
+//!     let glutin_window = ContextBuilder::new().with_vsync(true).build_windowed(wb, &events_loop).unwrap();
+//!     let glutin_window = unsafe { glutin_window.make_current() }.expect("Failed to make the context current");
 //!
 //!     // Then use the glutin window to create a gfx surface.
 //!     let surface = Surface::from_window(glutin_window);
@@ -36,9 +36,10 @@
 //!
 //! fn main() {
 //!     let events_loop = EventsLoop::new();
-//!     let context = Context::new_headless(&events_loop, ContextBuilder::new(), glutin::dpi::PhysicalSize::new(0.0, 0.0))
+//!     let context = ContextBuilder::new().build_headless(&events_loop, glutin::dpi::PhysicalSize::new(0.0, 0.0))
 //!         .expect("Failed to build headless context");
-//!     let headless = Headless(context);
+//!     let context = unsafe { context.make_current() }.expect("Failed to make the context current");
+//!     let headless = Headless::from_context(context);
 //!     let _adapters = headless.enumerate_adapters();
 //! }
 //! ```

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -49,7 +49,7 @@ use crate::{native, Backend as B, Device, GlContainer, PhysicalDevice, QueueFami
 
 use glow::Context;
 
-use glutin::{self, ContextTrait};
+use glutin;
 
 fn get_window_extent(window: &glutin::WindowedContext) -> image::Extent {
     let px = window

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -52,8 +52,7 @@ use glow::Context;
 
 use glutin;
 
-fn get_window_extent(window: &glutin::Window) -> image::Extent
-{
+fn get_window_extent(window: &glutin::Window) -> image::Extent {
     let px = window
         .get_inner_size()
         .unwrap()

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -224,12 +224,11 @@ fn main() {
         use gfx_backend_gl::glutin;
         println!("Warding GL:");
         let events_loop = glutin::EventsLoop::new();
-        let window = glutin::WindowedContext::new_windowed(
-            glutin::WindowBuilder::new(),
-            glutin::ContextBuilder::new().with_gl_profile(glutin::GlProfile::Core),
-            &events_loop,
-        )
-        .unwrap();
+        let window = glutin::ContextBuilder::new()
+            .with_gl_profile(glutin::GlProfile::Core)
+            .build_windowed(glutin::WindowBuilder::new(), &events_loop)
+            .unwrap();
+        let window = unsafe { window.make_current() }.expect("Unable to make window current");
         let instance = gfx_backend_gl::Surface::from_window(window);
         num_failures += harness.run(instance, Disabilities::default());
     }
@@ -238,9 +237,11 @@ fn main() {
         use gfx_backend_gl::glutin;
         println!("Warding GL headless:");
         let events_loop = glutin::EventsLoop::new();
-        let context =
-            glutin::Context::new_headless(&events_loop, glutin::ContextBuilder::new(), glutin::dpi::PhysicalSize::new(0.0, 0.0)).unwrap();
-        let instance = gfx_backend_gl::Headless(context);
+        let context = glutin::ContextBuilder::new()
+            .build_headless(&events_loop, glutin::dpi::PhysicalSize::new(0.0, 0.0))
+            .unwrap();
+        let context = unsafe { context.make_current() }.expect("Unable to make context current");
+        let instance = gfx_backend_gl::Headless::from_context(context);
         num_failures += harness.run(instance, Disabilities::default());
     }
     let _ = harness;


### PR DESCRIPTION
Fixes #2757

Note that this represents a significant change to the public API of the OpenGL backend. In addition to the various type changes needed due to changes in Glutin 0.21:

1) In Glutin 0.21, `make_current()` consumes the `Context` struct. So it is not possible for the types in `gfx-backend-gl::window::glutin` to make themselves the current context anymore. After this PR, the calling code must make the context current before instantiating any gfx windowing types.

1) `gfx-backend-gl::window::glutin::Headless` must now carry a Starc because only _non_-current contexts implement `Send` and `Sync` in Glutin 0.21, but only _current_ contexts can be used to implement `hal::Instance`. To help with constructing a `Headless`, I have added `Headless::from_context()`.

1) `get_window()` has been renamed `get_context()` to reflect that, in Glutin 0.21, `glutin::WindowedContext` dereferences to `glutin::Context` rather than `glutin::Window` and additional steps must be taken to access the `Window`.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: OpenGL
- [x] `rustfmt` run on changed code
