### PR TITLE
Add release_resources to CommandPool::reset

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -542,7 +542,7 @@ impl<B: Backend> RendererState<B> {
                     .device
                     .reset_fence(framebuffer_fence)
                     .unwrap();
-                command_pool.reset();
+                command_pool.reset(false);
 
                 // Rendering
                 let mut cmd_buffer = command_pool.acquire_command_buffer::<command::OneShot>();

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -763,7 +763,7 @@ fn main() {
             device
                 .reset_fence(&submission_complete_fences[frame_idx])
                 .expect("Failed to reset fence");
-            cmd_pools[frame_idx].reset();
+            cmd_pools[frame_idx].reset(false);
         }
 
         // Rendering

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2500,7 +2500,7 @@ unsafe impl Send for CommandPool {}
 unsafe impl Sync for CommandPool {}
 
 impl hal::pool::RawCommandPool<Backend> for CommandPool {
-    unsafe fn reset(&mut self) {
+    unsafe fn reset(&mut self, _release_resources: bool) {
         //unimplemented!()
     }
 

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -81,7 +81,7 @@ unsafe impl Send for RawCommandPool {}
 unsafe impl Sync for RawCommandPool {}
 
 impl pool::RawCommandPool<Backend> for RawCommandPool {
-    unsafe fn reset(&mut self) {
+    unsafe fn reset(&mut self, _release_resources: bool) {
         match self.allocator {
             CommandPoolAllocator::Shared(ref allocator) => {
                 allocator.Reset();

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -507,7 +507,7 @@ impl queue::QueueFamily for QueueFamily {
 #[derive(Debug)]
 pub struct RawCommandPool;
 impl pool::RawCommandPool<Backend> for RawCommandPool {
-    unsafe fn reset(&mut self) {
+    unsafe fn reset(&mut self, _: bool) {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -61,7 +61,7 @@ pub struct RawCommandPool {
 }
 
 impl pool::RawCommandPool<Backend> for RawCommandPool {
-    unsafe fn reset(&mut self) {
+    unsafe fn reset(&mut self, _release_resources: bool) {
         let mut memory = self
             .memory
             .try_lock()

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2153,9 +2153,9 @@ impl RawCommandQueue<Backend> for CommandQueue {
 }
 
 impl pool::RawCommandPool<Backend> for CommandPool {
-    unsafe fn reset(&mut self) {
+    unsafe fn reset(&mut self, release_resources: bool) {
         for cmd_buffer in &self.allocated {
-            cmd_buffer.borrow_mut().reset(&self.shared, false);
+            cmd_buffer.borrow_mut().reset(&self.shared, release_resources);
         }
     }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -837,7 +837,7 @@ impl hal::Device<Backend> for Device {
 
     unsafe fn destroy_command_pool(&self, mut pool: command::CommandPool) {
         use hal::pool::RawCommandPool;
-        pool.reset();
+        pool.reset(false);
     }
 
     unsafe fn create_render_pass<'a, IA, IS, ID>(

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -16,12 +16,18 @@ pub struct RawCommandPool {
 }
 
 impl pool::RawCommandPool<Backend> for RawCommandPool {
-    unsafe fn reset(&mut self) {
+    unsafe fn reset(&mut self, release_resources: bool) {
+        let flags = if release_resources {
+            vk::CommandPoolResetFlags::RELEASE_RESOURCES
+        } else {
+            vk::CommandPoolResetFlags::empty()
+        };
+
         assert_eq!(
             Ok(()),
             self.device
                 .0
-                .reset_command_pool(self.raw, vk::CommandPoolResetFlags::empty())
+                .reset_command_pool(self.raw, flags)
         );
     }
 

--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -28,7 +28,7 @@ pub trait RawCommandPool<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Reset the command pool and the corresponding command buffers.
     ///
     /// # Synchronization: You may _not_ free the pool if a command buffer is still in use (pool memory still in use)
-    unsafe fn reset(&mut self);
+    unsafe fn reset(&mut self, release_resources: bool);
 
     /// Allocate a single command buffers from the pool.
     fn allocate_one(&mut self, level: RawLevel) -> B::CommandBuffer {
@@ -76,8 +76,8 @@ impl<B: Backend, C> CommandPool<B, C> {
     /// Reset the command pool and the corresponding command buffers.
     ///
     /// # Synchronization: You may _not_ free the pool if a command buffer is still in use (pool memory still in use)
-    pub unsafe fn reset(&mut self) {
-        self.raw.reset();
+    pub unsafe fn reset(&mut self, release_resources: bool) {
+        self.raw.reset(release_resources);
     }
 
     /// Allocates a new primary command buffer from the pool.


### PR DESCRIPTION
Fixes #2407.

The behavior of this parameter on various backends:
- dx11: no effect (RawCommandPool::reset is a no-op)
- dx12: no effect (ID3D12CommandAllocator::Reset always releases
  resources)
- gl: no effect (OwnedBuffer implementation always clears all data)
- vulkan: if true, pass RELEASE_RESOURCES flag to reset_command_pool
- metal: pass value to CommandBufferInner::reset

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx11, dx12, gl, vulkan
- [x] `rustfmt` run on changed code
