### PR TITLE
MacOS vulkan portability support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Change Log
 
+### backend-vulkan-0.2.2 (14-06-2019)
+  - allow building on macOS for Vulkan Portability
+
 ### backend-metal-0.2.1 (14-06-2019)
   - fixed memory leaks in render pass descriptors and function strings
 
 ### hal-0.2.1 (10-06-2019)
   - `Debug` implementations
+
+### backend-vulkan-0.2.1 (23-05-2019)
+  - fix `VK_EXT_debug_utils` check at startup
 
 ## hal-0.2.0 (10-05-2019)
   - pipeline cache support

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,10 @@ else
 		EXCLUDES+= --exclude gfx-backend-metal
 		FEATURES_HAL=vulkan
 	endif
-	ifeq ($(UNAME_S),Darwin)
+	ifeq ($(TARGET),aarch64-apple-ios)
 		EXCLUDES+= --exclude gfx-backend-vulkan
+	endif
+	ifeq ($(UNAME_S),Darwin)
 		FEATURES_HAL=metal
 	endif
 endif

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-vulkan"
-version = "0.2.1"
+version = "0.2.2"
 description = "Vulkan API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -31,6 +31,9 @@ winit = { version = "0.19", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2.5"
+core-graphics = "0.17"
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 x11 = { version = "2.15", features = ["xlib"]}

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -14,16 +14,23 @@ extern crate lazy_static;
 extern crate shared_library;
 extern crate smallvec;
 
+#[cfg(target_os = "macos")]
+extern crate core_graphics;
+#[cfg(target_os = "macos")]
+#[macro_use]
+extern crate objc;
+
 #[cfg(windows)]
 extern crate winapi;
 #[cfg(feature = "winit")]
 extern crate winit;
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
 extern crate x11;
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
 extern crate xcb;
 
-use ash::extensions::{ext, khr};
+
+use ash::extensions::{self, ext::DebugUtils};
 use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0};
 use ash::vk;
 #[cfg(not(feature = "use-rtld-next"))]
@@ -59,20 +66,22 @@ mod window;
 lazy_static! {
     static ref LAYERS: Vec<&'static CStr> = vec![#[cfg(debug_assertions)] CStr::from_bytes_with_nul(b"VK_LAYER_LUNARG_standard_validation\0").expect("Wrong extension string")];
     static ref EXTENSIONS: Vec<&'static CStr> = vec![#[cfg(debug_assertions)] CStr::from_bytes_with_nul(b"VK_EXT_debug_utils\0").expect("Wrong extension string")];
-    static ref DEVICE_EXTENSIONS: Vec<&'static CStr> = vec![khr::Swapchain::name()];
+    static ref DEVICE_EXTENSIONS: Vec<&'static CStr> = vec![extensions::khr::Swapchain::name()];
     static ref SURFACE_EXTENSIONS: Vec<&'static CStr> = vec![
-        khr::Surface::name(),
+        extensions::khr::Surface::name(),
         // Platform-specific WSI extensions
         #[cfg(all(unix, not(target_os = "android")))]
-        khr::XlibSurface::name(),
+        extensions::khr::XlibSurface::name(),
         #[cfg(all(unix, not(target_os = "android")))]
-        khr::XcbSurface::name(),
+        extensions::khr::XcbSurface::name(),
         #[cfg(all(unix, not(target_os = "android")))]
-        khr::WaylandSurface::name(),
+        extensions::khr::WaylandSurface::name(),
         #[cfg(target_os = "android")]
-        khr::AndroidSurface::name(),
+        extensions::khr::AndroidSurface::name(),
         #[cfg(target_os = "windows")]
-        khr::Win32Surface::name(),
+        extensions::khr::Win32Surface::name(),
+        #[cfg(target_os = "macos")]
+        extensions::mvk::MacOSSurface::name(),
     ];
 }
 
@@ -97,7 +106,7 @@ lazy_static! {
 
 pub struct RawInstance(
     pub ash::Instance,
-    Option<(ext::DebugUtils, vk::DebugUtilsMessengerEXT)>,
+    Option<(DebugUtils, vk::DebugUtilsMessengerEXT)>,
 );
 
 impl Drop for RawInstance {
@@ -371,9 +380,9 @@ impl Instance {
         let debug_messenger = {
             // make sure VK_EXT_debug_utils is available
             if instance_extensions.iter().any(|props| unsafe {
-                CStr::from_ptr(props.extension_name.as_ptr()) == ext::DebugUtils::name()
+                CStr::from_ptr(props.extension_name.as_ptr()) == DebugUtils::name()
             }) {
-                let ext = ext::DebugUtils::new(entry, &instance);
+                let ext = DebugUtils::new(entry, &instance);
                 let info = vk::DebugUtilsMessengerCreateInfoEXT {
                     s_type: vk::StructureType::DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
                     p_next: ptr::null(),

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -42,7 +42,7 @@ impl Drop for RawSurface {
 }
 
 impl Instance {
-    #[cfg(all(unix, not(target_os = "android")))]
+    #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
     pub fn create_surface_from_xlib(&self, dpy: *mut vk::Display, window: vk::Window) -> Surface {
         let entry = VK_ENTRY
             .as_ref()
@@ -80,7 +80,7 @@ impl Instance {
         self.create_surface_from_vk_surface_khr(surface, width, height, 1)
     }
 
-    #[cfg(all(unix, not(target_os = "android")))]
+    #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
     pub fn create_surface_from_xcb(
         &self,
         connection: *mut vk::xcb_connection_t,
@@ -194,16 +194,15 @@ impl Instance {
         }
 
         let surface = {
+            let info = vk::Win32SurfaceCreateInfoKHR {
+                s_type: vk::StructureType::WIN32_SURFACE_CREATE_INFO_KHR,
+                p_next: ptr::null(),
+                flags: vk::Win32SurfaceCreateFlagsKHR::empty(),
+                hinstance: hinstance as *mut _,
+                hwnd: hwnd as *mut _,
+            };
             let win32_loader = khr::Win32Surface::new(entry, &self.raw.0);
             unsafe {
-                let info = vk::Win32SurfaceCreateInfoKHR {
-                    s_type: vk::StructureType::WIN32_SURFACE_CREATE_INFO_KHR,
-                    p_next: ptr::null(),
-                    flags: vk::Win32SurfaceCreateFlagsKHR::empty(),
-                    hinstance: hinstance as *mut _,
-                    hwnd: hwnd as *mut _,
-                };
-
                 win32_loader
                     .create_win32_surface(&info, None)
                     .expect("Unable to create Win32 surface")
@@ -228,9 +227,50 @@ impl Instance {
         self.create_surface_from_vk_surface_khr(surface, width, height, 1)
     }
 
+    #[cfg(target_os = "macos")]
+    pub fn create_surface_from_nsview(&self, view: *mut c_void) -> Surface {
+        use ash::extensions::mvk;
+        use core_graphics::geometry::CGRect;
+        use objc::runtime::Object;
+
+        let entry = VK_ENTRY
+            .as_ref()
+            .expect("Unable to load Vulkan entry points");
+
+        if !self.extensions.contains(&mvk::MacOSSurface::name()) {
+            panic!("Vulkan driver does not support VK_MVK_MACOS_SURFACE");
+        }
+
+        let surface = {
+            let mac_os_loader = mvk::MacOSSurface::new(entry, &self.raw.0);
+            let info = vk::MacOSSurfaceCreateInfoMVK {
+                s_type: vk::StructureType::WIN32_SURFACE_CREATE_INFO_KHR,
+                p_next: ptr::null(),
+                flags: vk::MacOSSurfaceCreateFlagsMVK::empty(),
+                p_view: view,
+            };
+
+            unsafe {
+                mac_os_loader
+                    .create_mac_os_surface_mvk(&info, None)
+                    .expect("Unable to create macOS surface")
+            }
+        };
+
+        let (width, height) = {
+            //TODO: this is probably wrong, needs refinement
+            let bounds: CGRect = unsafe {
+                msg_send![view as *mut Object, bounds]
+            };
+            (bounds.size.width as u32, bounds.size.height as u32)
+        };
+
+        self.create_surface_from_vk_surface_khr(surface, width, height, 1)
+    }
+
     #[cfg(feature = "winit")]
     pub fn create_surface(&self, window: &winit::Window) -> Surface {
-        #[cfg(all(unix, not(target_os = "android")))]
+        #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
         {
             use winit::os::unix::WindowExt;
 
@@ -271,6 +311,12 @@ impl Instance {
             let hinstance = unsafe { GetModuleHandleW(ptr::null()) };
             let hwnd = window.get_hwnd();
             self.create_surface_from_hwnd(hinstance as *mut _, hwnd as *mut _)
+        }
+        #[cfg(target_os = "macos")]
+        {
+            use winit::os::macos::WindowExt;
+
+            self.create_surface_from_nsview(window.get_nsview())
         }
     }
 


### PR DESCRIPTION
Fixes #2796 
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan, Metal
- [ ] `rustfmt` run on changed code

Users need to ensure that Vulkan loader is available and ICD paths are set up. I launched the example with the following command line:
```bash
LD_LIBRARY_PATH=<vulkan_sdk>/macOS/lib/ VK_ICD_FILENAMES=<gfx-portability>/libportability-icd/portability-macos-debug.json cargo run --bin quad --features vulkan
```