### PR TITLE
[0.2/mtl] metal-rs update

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -28,7 +28,7 @@ copyless = "0.1"
 log = { version = "0.4" }
 winit = { version = "0.19", optional = true }
 dispatch = { version = "0.1", optional = true }
-metal = { version = "0.14.0", features = ["private"] }
+metal = { version = "0.15", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1722,7 +1722,7 @@ impl hal::Device<Backend> for Device {
 
             let device = self.shared.device.lock();
             let arg_array = metal::Array::from_owned_slice(&arguments);
-            let encoder = device.new_argument_encoder(&arg_array);
+            let encoder = device.new_argument_encoder(arg_array);
 
             let total_size = encoder.encoded_length();
             let raw = device.new_buffer(total_size, MTLResourceOptions::empty());
@@ -1765,7 +1765,7 @@ impl hal::Device<Backend> for Device {
                 })
                 .collect::<Vec<_>>();
             let arg_array = metal::Array::from_owned_slice(&arguments);
-            let encoder = self.shared.device.lock().new_argument_encoder(&arg_array);
+            let encoder = self.shared.device.lock().new_argument_encoder(arg_array);
 
             Ok(n::DescriptorSetLayout::ArgumentBuffer(encoder, stage_flags))
         } else {


### PR DESCRIPTION
Fixes the string leaking.
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends: Metal
- [ ] `rustfmt` run on changed code
