### PR TITLE
vulkan: don't unconditionally link xlib or xcb

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/gfx-backend-vulkan"
 workspace = "../../.."
 
 [features]
-default = ["winit"]
+default = ["winit", "x11"]
 use-rtld-next = ["shared_library"]
 
 [lib]
@@ -33,5 +33,5 @@ winit = { version = "0.19", optional = true }
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
-x11 = { version = "2.15", features = ["xlib"]}
-xcb = { version = "0.8" }
+x11 = { version = "2.15", features = ["xlib"], optional = true }
+xcb = { version = "0.8", optional = true }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -18,9 +18,9 @@ extern crate smallvec;
 extern crate winapi;
 #[cfg(feature = "winit")]
 extern crate winit;
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(all(feature = "x11", unix, not(target_os = "android")))]
 extern crate x11;
-#[cfg(all(unix, not(target_os = "android")))]
+#[cfg(all(feature = "xcb", unix, not(target_os = "android")))]
 extern crate xcb;
 
 use ash::extensions::{ext, khr};

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -42,7 +42,7 @@ impl Drop for RawSurface {
 }
 
 impl Instance {
-    #[cfg(all(unix, not(target_os = "android")))]
+    #[cfg(all(feature = "x11", unix, not(target_os = "android")))]
     pub fn create_surface_from_xlib(&self, dpy: *mut vk::Display, window: vk::Window) -> Surface {
         let entry = VK_ENTRY
             .as_ref()
@@ -80,7 +80,7 @@ impl Instance {
         self.create_surface_from_vk_surface_khr(surface, width, height, 1)
     }
 
-    #[cfg(all(unix, not(target_os = "android")))]
+    #[cfg(all(feature = "xcb", unix, not(target_os = "android")))]
     pub fn create_surface_from_xcb(
         &self,
         connection: *mut vk::xcb_connection_t,
@@ -229,8 +229,9 @@ impl Instance {
     }
 
     #[cfg(feature = "winit")]
+    #[allow(unreachable_code)]
     pub fn create_surface(&self, window: &winit::Window) -> Surface {
-        #[cfg(all(unix, not(target_os = "android")))]
+        #[cfg(all(feature = "x11", unix, not(target_os = "android")))]
         {
             use winit::os::unix::WindowExt;
 
@@ -261,7 +262,7 @@ impl Instance {
             let logical_size = window.get_inner_size().unwrap();
             let width = logical_size.width * window.get_hidpi_factor();
             let height = logical_size.height * window.get_hidpi_factor();
-            self.create_surface_android(window.get_native_window(), width as _, height as _)
+            return self.create_surface_android(window.get_native_window(), width as _, height as _);
         }
         #[cfg(windows)]
         {
@@ -270,8 +271,10 @@ impl Instance {
 
             let hinstance = unsafe { GetModuleHandleW(ptr::null()) };
             let hwnd = window.get_hwnd();
-            self.create_surface_from_hwnd(hinstance as *mut _, hwnd as *mut _)
+            return self.create_surface_from_hwnd(hinstance as *mut _, hwnd as *mut _);
         }
+        let _ = window;
+        panic!("No suitable WSI enabled!");
     }
 
     pub fn create_surface_from_vk_surface_khr(


### PR DESCRIPTION
Reduces gratuitous foreign dependencies for some applications.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
  - vulkan
- [ ] `rustfmt` run on changed code
