### PR TITLE
Fix incorrect alignment assumptions in create_shader_module

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -42,7 +42,7 @@ struct Dimensions<T> {
 }
 
 use std::cell::RefCell;
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 use std::mem::size_of;
 use std::rc::Rc;
 use std::{fs, iter};
@@ -1332,22 +1332,16 @@ impl<B: Backend> PipelineState<B> {
         let pipeline = {
             let vs_module = {
                 let glsl = fs::read_to_string("colour-uniform/data/quad.vert").unwrap();
-                let spirv: Vec<u8> =
-                    glsl_to_spirv::compile(&glsl, glsl_to_spirv::ShaderType::Vertex)
-                        .unwrap()
-                        .bytes()
-                        .map(|b| b.unwrap())
-                        .collect();
+                let file = glsl_to_spirv::compile(&glsl, glsl_to_spirv::ShaderType::Fragment)
+                    .unwrap();
+                let spirv: Vec<u32> = hal::read_spirv(file).unwrap();
                 device.create_shader_module(&spirv).unwrap()
             };
             let fs_module = {
                 let glsl = fs::read_to_string("colour-uniform/data/quad.frag").unwrap();
-                let spirv: Vec<u8> =
-                    glsl_to_spirv::compile(&glsl, glsl_to_spirv::ShaderType::Fragment)
-                        .unwrap()
-                        .bytes()
-                        .map(|b| b.unwrap())
-                        .collect();
+                let file = glsl_to_spirv::compile(&glsl, glsl_to_spirv::ShaderType::Fragment)
+                    .unwrap();
+                let spirv: Vec<u32> = hal::read_spirv(file).unwrap();
                 device.create_shader_module(&spirv).unwrap()
             };
 

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -22,7 +22,6 @@ use hal::{Backend, Compute, DescriptorPool, Device, Instance, PhysicalDevice, Qu
 extern crate glsl_to_spirv;
 
 use std::fs;
-use std::io::Read;
 
 #[cfg(any(feature = "vulkan", feature = "dx11", feature = "dx12", feature = "metal"))]
 fn main() {
@@ -54,11 +53,9 @@ fn main() {
     let (device, mut queue_group) = adapter.open_with::<_, Compute>(1, |_family| true).unwrap();
 
     let glsl = fs::read_to_string("compute/shader/collatz.comp").unwrap();
-    let spirv: Vec<u8> = glsl_to_spirv::compile(&glsl, glsl_to_spirv::ShaderType::Compute)
-        .unwrap()
-        .bytes()
-        .map(|b| b.unwrap())
-        .collect();
+    let file = glsl_to_spirv::compile(&glsl, glsl_to_spirv::ShaderType::Compute)
+        .unwrap();
+    let spirv: Vec<u32> = hal::read_spirv(file).unwrap();
     let shader = unsafe { device.create_shader_module(&spirv) }.unwrap();
 
     let (pipeline_layout, pipeline, set_layout, mut desc_pool) = {

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -532,12 +532,12 @@ fn main() {
     .expect("Can't create pipeline layout");
     let pipeline = {
         let vs_module = {
-            let spirv = include_bytes!("data/quad.vert.spv");
-            unsafe { device.create_shader_module(spirv) }.unwrap()
+            let spirv = hal::read_spirv(Cursor::new(&include_bytes!("data/quad.vert.spv")[..])).unwrap();
+            unsafe { device.create_shader_module(&spirv) }.unwrap()
         };
         let fs_module = {
-            let spirv = include_bytes!("./data/quad.frag.spv");
-            unsafe { device.create_shader_module(spirv) }.unwrap()
+            let spirv = hal::read_spirv(Cursor::new(&include_bytes!("./data/quad.frag.spv")[..])).unwrap();
+            unsafe { device.create_shader_module(&spirv) }.unwrap()
         };
 
         let pipeline = {

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1065,7 +1065,7 @@ impl hal::Device<Backend> for Device {
 
     unsafe fn create_shader_module(
         &self,
-        raw_data: &[u8],
+        raw_data: &[u32],
     ) -> Result<ShaderModule, device::ShaderError> {
         Ok(ShaderModule::Spirv(raw_data.into()))
     }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2523,7 +2523,7 @@ impl hal::pool::RawCommandPool<Backend> for CommandPool {
 //#[derivative(Debug)]
 pub enum ShaderModule {
     Dxbc(Vec<u8>),
-    Spirv(Vec<u8>),
+    Spirv(Vec<u32>),
 }
 
 // TODO: temporary

--- a/src/backend/dx11/src/shader.rs
+++ b/src/backend/dx11/src/shader.rs
@@ -30,7 +30,7 @@ fn gen_query_error(err: SpirvErrorCode) -> device::ShaderError {
 }
 
 pub(crate) fn compile_spirv_entrypoint(
-    raw_data: &[u8],
+    raw_data: &[u32],
     stage: pso::Stage,
     source: &pso::EntryPoint<Backend>,
     layout: &PipelineLayout,
@@ -144,16 +144,8 @@ pub(crate) fn compile_hlsl_shader(
     }
 }
 
-fn parse_spirv(raw_data: &[u8]) -> Result<spirv::Ast<hlsl::Target>, device::ShaderError> {
-    // spec requires "codeSize must be a multiple of 4"
-    assert_eq!(raw_data.len() & 3, 0);
-
-    let module = spirv::Module::from_words(unsafe {
-        slice::from_raw_parts(
-            raw_data.as_ptr() as *const u32,
-            raw_data.len() / mem::size_of::<u32>(),
-        )
-    });
+fn parse_spirv(raw_data: &[u32]) -> Result<spirv::Ast<hlsl::Target>, device::ShaderError> {
+    let module = spirv::Module::from_words(raw_data);
 
     spirv::Ast::parse(&module).map_err(|err| {
         let msg = match err {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -231,16 +231,8 @@ impl GraphicsPipelineStateSubobjectStream {
 }
 
 impl Device {
-    fn parse_spirv(raw_data: &[u8]) -> Result<spirv::Ast<hlsl::Target>, d::ShaderError> {
-        // spec requires "codeSize must be a multiple of 4"
-        assert_eq!(raw_data.len() & 3, 0);
-
-        let module = spirv::Module::from_words(unsafe {
-            slice::from_raw_parts(
-                raw_data.as_ptr() as *const u32,
-                raw_data.len() / mem::size_of::<u32>(),
-            )
-        });
+    fn parse_spirv(raw_data: &[u32]) -> Result<spirv::Ast<hlsl::Target>, d::ShaderError> {
+        let module = spirv::Module::from_words(raw_data);
 
         spirv::Ast::parse(&module).map_err(|err| {
             let msg = match err {
@@ -1786,7 +1778,7 @@ impl d::Device<B> for Device {
 
     unsafe fn create_shader_module(
         &self,
-        raw_data: &[u8],
+        raw_data: &[u32],
     ) -> Result<r::ShaderModule, d::ShaderError> {
         Ok(r::ShaderModule::Spirv(raw_data.into()))
     }

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -17,7 +17,7 @@ use std::ops::Range;
 #[derive(Debug, Hash)]
 pub enum ShaderModule {
     Compiled(BTreeMap<String, native::Blob>),
-    Spirv(Vec<u8>),
+    Spirv(Vec<u32>),
 }
 unsafe impl Send for ShaderModule {}
 unsafe impl Sync for ShaderModule {}

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -213,7 +213,7 @@ impl hal::Device<Backend> for Device {
         unimplemented!()
     }
 
-    unsafe fn create_shader_module(&self, _: &[u8]) -> Result<(), device::ShaderError> {
+    unsafe fn create_shader_module(&self, _: &[u32]) -> Result<(), device::ShaderError> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 use std::cell::{Cell, RefCell};
 use std::ops::Range;
 use std::sync::{Arc, Mutex, RwLock};
-use std::{mem, slice};
+use std::slice;
 
 use glow::Context;
 use crate::{GlContainer, GlContext};
@@ -133,16 +133,8 @@ impl Device {
         }
     }
 
-    fn parse_spirv(&self, raw_data: &[u8]) -> Result<spirv::Ast<glsl::Target>, d::ShaderError> {
-        // spec requires "codeSize must be a multiple of 4"
-        assert_eq!(raw_data.len() & 3, 0);
-
-        let module = spirv::Module::from_words(unsafe {
-            slice::from_raw_parts(
-                raw_data.as_ptr() as *const u32,
-                raw_data.len() / mem::size_of::<u32>(),
-            )
-        });
+    fn parse_spirv(&self, raw_data: &[u32]) -> Result<spirv::Ast<glsl::Target>, d::ShaderError> {
+        let module = spirv::Module::from_words(raw_data);
 
         spirv::Ast::parse(&module).map_err(|err| {
             let msg = match err {
@@ -927,7 +919,7 @@ impl d::Device<B> for Device {
 
     unsafe fn create_shader_module(
         &self,
-        raw_data: &[u8],
+        raw_data: &[u32],
     ) -> Result<n::ShaderModule, d::ShaderError> {
         Ok(n::ShaderModule::Spirv(raw_data.into()))
     }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -224,7 +224,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
 #[derive(Clone, Debug, Hash)]
 pub enum ShaderModule {
     Raw(Shader),
-    Spirv(Vec<u8>),
+    Spirv(Vec<u32>),
 }
 
 #[derive(Debug)]

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -36,7 +36,7 @@ pub type PoolResourceIndex = u32;
 /// depend on pipeline layout, in which case the value would become `Compiled`.
 pub enum ShaderModule {
     Compiled(ModuleInfo),
-    Raw(Vec<u8>),
+    Raw(Vec<u32>),
 }
 
 impl fmt::Debug for ShaderModule {
@@ -213,7 +213,7 @@ pub struct ModuleInfo {
 }
 
 pub struct PipelineCache {
-    pub(crate) modules: FastStorageMap<msl::CompilerOptions, FastStorageMap<Vec<u8>, ModuleInfo>>,
+    pub(crate) modules: FastStorageMap<msl::CompilerOptions, FastStorageMap<Vec<u32>, ModuleInfo>>,
 }
 
 impl fmt::Debug for PipelineCache {

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1018,17 +1018,14 @@ impl d::Device<B> for Device {
 
     unsafe fn create_shader_module(
         &self,
-        spirv_data: &[u8],
+        spirv_data: &[u32],
     ) -> Result<n::ShaderModule, d::ShaderError> {
-        // spec requires "codeSize must be a multiple of 4"
-        assert_eq!(spirv_data.len() & 3, 0);
-
         let info = vk::ShaderModuleCreateInfo {
             s_type: vk::StructureType::SHADER_MODULE_CREATE_INFO,
             p_next: ptr::null(),
             flags: vk::ShaderModuleCreateFlags::empty(),
-            code_size: spirv_data.len(),
-            p_code: spirv_data as *const _ as *const u32,
+            code_size: spirv_data.len() * 4,
+            p_code: spirv_data.as_ptr(),
         };
 
         let module = self.raw.0.create_shader_module(&info, None);

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -380,7 +380,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// shader stages as described in *Compute Pipelines* and *Graphics Pipelines*.
     unsafe fn create_shader_module(
         &self,
-        spirv_data: &[u8],
+        spirv_data: &[u32],
     ) -> Result<B::ShaderModule, ShaderError>;
 
     /// Destroy a shader module module

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -27,7 +27,7 @@ pub use self::adapter::{
 };
 pub use self::device::Device;
 pub use self::pool::CommandPool;
-pub use self::pso::DescriptorPool;
+pub use self::pso::{DescriptorPool, read_spirv};
 pub use self::queue::{
     Capability, CommandQueue, Compute, General, Graphics, QueueFamily, QueueGroup, QueueType,
     Submission, Supports, Transfer,

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -3,7 +3,7 @@
 //! This module contains items used to create and manage Pipelines.
 
 use crate::{device, pass, Backend};
-use std::{borrow::Cow, fmt, ops::Range};
+use std::{borrow::Cow, fmt, io, ops::Range, slice};
 
 mod compute;
 mod descriptor;
@@ -288,7 +288,7 @@ where
         let offset = storage.data.len() as u16;
         storage.data.extend_from_slice(unsafe {
             // Inspecting bytes is always safe.
-            std::slice::from_raw_parts(&self.head.1 as *const H as *const u8, size)
+            slice::from_raw_parts(&self.head.1 as *const H as *const u8, size)
         });
         storage.constants.push(SpecializationConstant {
             id: self.head.0,
@@ -355,4 +355,61 @@ macro_rules! spec_const_list {
             $crate::spec_const_list!(@ $({ counter += 1; counter - 1 } => $constant),*).into()
         }
     };
+}
+
+/// Safely read SPIR-V
+///
+/// Converts to native endianness and returns correctly aligned storage without unnecessary
+/// copying. Returns an `InvalidData` error if the input is trivially not SPIR-V.
+///
+/// This function can also be used to convert an already in-memory `&[u8]` to a valid `Vec<u32>`,
+/// but prefer working with `&[u32]` from the start whenever possible.
+///
+/// # Examples
+/// ```no_run
+/// let mut file = std::fs::File::open("/path/to/shader.spv").unwrap();
+/// let words = gfx_hal::read_spirv(&mut file).unwrap();
+/// ```
+/// ```
+/// const SPIRV: &[u8] = &[
+///     0x03, 0x02, 0x23, 0x07, // ...
+/// ];
+/// let words = gfx_hal::read_spirv(std::io::Cursor::new(&SPIRV[..])).unwrap();
+/// ```
+pub fn read_spirv<R: io::Read + io::Seek>(mut x: R) -> io::Result<Vec<u32>> {
+    let size = x.seek(io::SeekFrom::End(0))?;
+    if size % 4 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "input length not divisible by 4",
+        ));
+    }
+    if size > usize::max_value() as u64 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "input too long"));
+    }
+    let words = (size / 4) as usize;
+    let mut result = Vec::<u32>::with_capacity(words);
+    x.seek(io::SeekFrom::Start(0))?;
+    unsafe {
+        // Writing all bytes through a pointer with less strict alignment when our type has no
+        // invalid bitpatterns is safe.
+        x.read_exact(slice::from_raw_parts_mut(
+            result.as_mut_ptr() as *mut u8,
+            words * 4,
+        ))?;
+        result.set_len(words);
+    }
+    const MAGIC_NUMBER: u32 = 0x07230203;
+    if result.len() > 0 && result[0] == MAGIC_NUMBER.swap_bytes() {
+        for word in &mut result {
+            *word = word.swap_bytes();
+        }
+    }
+    if result.len() == 0 || result[0] != MAGIC_NUMBER {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "input missing SPIR-V magic number",
+        ));
+    }
+    Ok(result)
 }


### PR DESCRIPTION
The Vulkan spec [mandates](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderModuleCreateInfo.html):

> pCode must be a valid pointer to an array of codeSize / 4 uint32_t values

The address of some random `&[u8]` does not satisfy this for the obvious alignment reasons. Additionally, most other backends used unsafe code to transmute `&[u8]` to `&[u32]`, which is similarly UB. This is a breaking change.

It'd be nice to have somewhere to factor the `read_spv` helper out to.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
  - vulkan
- [ ] `rustfmt` run on changed code