### PR TITLE
[gl] Enable debug output for native GL

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = "1"
 log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.2" }
 smallvec = "0.6"
-glow = { git = "https://github.com/grovesNL/glow", rev = "6c74ffbea64e8fbaa1ec9e94e7f5f6791663a70e" }
+glow = { git = "https://github.com/grovesNL/glow", rev = "abc536c6b9b6a96c7f6c758d938fcb38f9b55938" }
 spirv_cross = { version = "0.14.0", features = ["glsl"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -170,6 +170,47 @@ impl Error {
     }
 }
 
+fn debug_message_callback(
+    source: u32,
+    gltype: u32,
+    id: u32,
+    severity: u32,
+    message: &str,
+) {
+    let source_str = match source {
+        glow::DEBUG_SOURCE_API => "API",
+        glow::DEBUG_SOURCE_WINDOW_SYSTEM => "Window System",
+        glow::DEBUG_SOURCE_SHADER_COMPILER => "ShaderCompiler",
+        glow::DEBUG_SOURCE_THIRD_PARTY => "Third Party",
+        glow::DEBUG_SOURCE_APPLICATION => "Application",
+        glow::DEBUG_SOURCE_OTHER => "Other",
+        _ => unreachable!(),
+    };
+
+    let log_severity = match severity {
+        glow::DEBUG_SEVERITY_HIGH => log::Level::Error,
+        glow::DEBUG_SEVERITY_MEDIUM => log::Level::Warn,
+        glow::DEBUG_SEVERITY_LOW => log::Level::Info,
+        glow::DEBUG_SEVERITY_NOTIFICATION => log::Level::Trace,
+        _ => unreachable!(),
+    };
+
+    let type_str = match gltype {
+        glow::DEBUG_TYPE_DEPRECATED_BEHAVIOR => "Deprecated Behavior",
+        glow::DEBUG_TYPE_ERROR => "Error",
+        glow::DEBUG_TYPE_MARKER => "Marker",
+        glow::DEBUG_TYPE_OTHER => "Other",
+        glow::DEBUG_TYPE_PERFORMANCE => "Performance",
+        glow::DEBUG_TYPE_POP_GROUP => "Pop Group",
+        glow::DEBUG_TYPE_PORTABILITY => "Portability",
+        glow::DEBUG_TYPE_PUSH_GROUP => "Push Group",
+        glow::DEBUG_TYPE_UNDEFINED_BEHAVIOR => "Undefined Behavior",
+        _ => unreachable!(),
+    };
+
+    log!(log_severity, "[{}/{}] ID {} : {}", source_str, type_str, id, message);
+}
+
 const DEVICE_LOCAL_HEAP: usize = 0;
 const CPU_VISIBLE_HEAP: usize = 1;
 
@@ -521,6 +562,15 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
 
         // initialize permanent states
         let gl = &self.0.context;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            if cfg!(debug_assertions) {
+                gl.enable(glow::DEBUG_OUTPUT);
+                gl.debug_message_callback(debug_message_callback);
+            }
+        }
+
         if self
             .0
             .legacy_features


### PR DESCRIPTION
Will fix #2826 when grovesNL/glow#20 lands.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: gl
- [x] `rustfmt` run on changed code
