### PR TITLE
Fix colour-uniform example

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1332,7 +1332,7 @@ impl<B: Backend> PipelineState<B> {
         let pipeline = {
             let vs_module = {
                 let glsl = fs::read_to_string("colour-uniform/data/quad.vert").unwrap();
-                let file = glsl_to_spirv::compile(&glsl, glsl_to_spirv::ShaderType::Fragment)
+                let file = glsl_to_spirv::compile(&glsl, glsl_to_spirv::ShaderType::Vertex)
                     .unwrap();
                 let spirv: Vec<u32> = hal::read_spirv(file).unwrap();
                 device.create_shader_module(&spirv).unwrap()


### PR DESCRIPTION
#2833 seems to have inadvertently broken this example
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vk, mtl
- [ ] `rustfmt` run on changed code
