### PR TITLE
upgrade vulkan backend to 2018 edition

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["The Gfx-rs Developers"]
 readme = "README.md"
 documentation = "https://docs.rs/gfx-backend-vulkan"
 workspace = "../../.."
+edition = "2018"
 
 [features]
 default = ["winit", "x11"]

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -6,13 +6,13 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::{mem, ptr};
 
-use hal::format::Aspects;
-use hal::image::{Filter, Layout, SubresourceRange};
-use hal::range::RangeArg;
-use hal::{buffer, command as com, memory, pso, query};
-use hal::{DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount};
-use {conv, native as n};
-use {Backend, RawDevice};
+use crate::hal::format::Aspects;
+use crate::hal::image::{Filter, Layout, SubresourceRange};
+use crate::hal::range::RangeArg;
+use crate::hal::{buffer, command as com, memory, pso, query};
+use crate::hal::{DrawCount, IndexCount, InstanceCount, VertexCount, VertexOffset, WorkGroupCount};
+use crate::{conv, native as n};
+use crate::{Backend, RawDevice};
 
 #[derive(Debug)]
 pub struct CommandBuffer {

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -1,10 +1,10 @@
 use ash::vk;
 
-use hal::range::RangeArg;
-use hal::{buffer, command, format, image, pass, pso, query};
-use hal::{CompositeAlpha, Features, IndexType, PresentMode, Primitive};
+use crate::hal::range::RangeArg;
+use crate::hal::{buffer, command, format, image, pass, pso, query};
+use crate::hal::{CompositeAlpha, Features, IndexType, PresentMode, Primitive};
 
-use native as n;
+use crate::native as n;
 use std::borrow::Borrow;
 use std::mem;
 use std::ptr;
@@ -26,7 +26,7 @@ pub fn map_tiling(tiling: image::Tiling) -> vk::ImageTiling {
 }
 
 pub fn map_component(component: format::Component) -> vk::ComponentSwizzle {
-    use hal::format::Component::*;
+    use crate::hal::format::Component::*;
     match component {
         Zero => vk::ComponentSwizzle::ZERO,
         One => vk::ComponentSwizzle::ONE,
@@ -54,7 +54,7 @@ pub fn map_index_type(index_type: IndexType) -> vk::IndexType {
 }
 
 pub fn map_image_layout(layout: image::Layout) -> vk::ImageLayout {
-    use hal::image::Layout as Il;
+    use crate::hal::image::Layout as Il;
     match layout {
         Il::General => vk::ImageLayout::GENERAL,
         Il::ColorAttachmentOptimal => vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
@@ -125,7 +125,7 @@ pub fn map_subresource_range(range: &image::SubresourceRange) -> vk::ImageSubres
 }
 
 pub fn map_attachment_load_op(op: pass::AttachmentLoadOp) -> vk::AttachmentLoadOp {
-    use hal::pass::AttachmentLoadOp as Alo;
+    use crate::hal::pass::AttachmentLoadOp as Alo;
     match op {
         Alo::Load => vk::AttachmentLoadOp::LOAD,
         Alo::Clear => vk::AttachmentLoadOp::CLEAR,
@@ -134,7 +134,7 @@ pub fn map_attachment_load_op(op: pass::AttachmentLoadOp) -> vk::AttachmentLoadO
 }
 
 pub fn map_attachment_store_op(op: pass::AttachmentStoreOp) -> vk::AttachmentStoreOp {
-    use hal::pass::AttachmentStoreOp as Aso;
+    use crate::hal::pass::AttachmentStoreOp as Aso;
     match op {
         Aso::Store => vk::AttachmentStoreOp::STORE,
         Aso::DontCare => vk::AttachmentStoreOp::DONT_CARE,
@@ -182,7 +182,7 @@ pub fn map_mip_filter(filter: image::Filter) -> vk::SamplerMipmapMode {
 }
 
 pub fn map_wrap(wrap: image::WrapMode) -> vk::SamplerAddressMode {
-    use hal::image::WrapMode as Wm;
+    use crate::hal::image::WrapMode as Wm;
     match wrap {
         Wm::Tile => vk::SamplerAddressMode::REPEAT,
         Wm::Mirror => vk::SamplerAddressMode::MIRRORED_REPEAT,
@@ -240,7 +240,7 @@ pub fn map_front_face(ff: pso::FrontFace) -> vk::FrontFace {
 }
 
 pub fn map_comparison(fun: pso::Comparison) -> vk::CompareOp {
-    use hal::pso::Comparison::*;
+    use crate::hal::pso::Comparison::*;
     match fun {
         Never => vk::CompareOp::NEVER,
         Less => vk::CompareOp::LESS,
@@ -254,7 +254,7 @@ pub fn map_comparison(fun: pso::Comparison) -> vk::CompareOp {
 }
 
 pub fn map_stencil_op(op: pso::StencilOp) -> vk::StencilOp {
-    use hal::pso::StencilOp::*;
+    use crate::hal::pso::StencilOp::*;
     match op {
         Keep => vk::StencilOp::KEEP,
         Zero => vk::StencilOp::ZERO,
@@ -289,7 +289,7 @@ pub fn map_stencil_side(side: &pso::StencilFace) -> vk::StencilOpState {
 }
 
 pub fn map_blend_factor(factor: pso::Factor) -> vk::BlendFactor {
-    use hal::pso::Factor::*;
+    use crate::hal::pso::Factor::*;
     match factor {
         Zero => vk::BlendFactor::ZERO,
         One => vk::BlendFactor::ONE,
@@ -314,7 +314,7 @@ pub fn map_blend_factor(factor: pso::Factor) -> vk::BlendFactor {
 }
 
 pub fn map_blend_op(operation: pso::BlendOp) -> (vk::BlendOp, vk::BlendFactor, vk::BlendFactor) {
-    use hal::pso::BlendOp::*;
+    use crate::hal::pso::BlendOp::*;
     match operation {
         Add { src, dst } => (
             vk::BlendOp::ADD,
@@ -503,8 +503,8 @@ pub fn map_view_kind(
     ty: vk::ImageType,
     is_cube: bool,
 ) -> Option<vk::ImageViewType> {
-    use image::ViewKind::*;
-    use vk::ImageType;
+    use crate::image::ViewKind::*;
+    use crate::vk::ImageType;
 
     Some(match (ty, kind) {
         (ImageType::TYPE_1D, D1) => vk::ImageViewType::TYPE_1D,

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -3,14 +3,14 @@ use ash::version::DeviceV1_0;
 use ash::vk;
 use smallvec::SmallVec;
 
-use hal;
-use hal::error::HostExecutionError;
-use hal::memory::Requirements;
-use hal::pool::CommandPoolCreateFlags;
-use hal::pso::VertexInputRate;
-use hal::range::RangeArg;
-use hal::{buffer, device as d, format, image, mapping, pass, pso, query, queue};
-use hal::{Features, MemoryTypeId, SwapchainConfig};
+use crate::hal;
+use crate::hal::error::HostExecutionError;
+use crate::hal::memory::Requirements;
+use crate::hal::pool::CommandPoolCreateFlags;
+use crate::hal::pso::VertexInputRate;
+use crate::hal::range::RangeArg;
+use crate::hal::{buffer, device as d, format, image, mapping, pass, pso, query, queue};
+use crate::hal::{Features, MemoryTypeId, SwapchainConfig};
 
 use std::borrow::Borrow;
 use std::ffi::CString;
@@ -18,9 +18,9 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::{mem, ptr};
 
-use pool::RawCommandPool;
-use {conv, native as n, result, window as w};
-use {Backend as B, Device};
+use crate::pool::RawCommandPool;
+use crate::{conv, native as n, result, window as w};
+use crate::{Backend as B, Device};
 
 impl d::Device<B> for Device {
     unsafe fn allocate_memory(
@@ -558,7 +558,7 @@ impl d::Device<B> for Device {
                     line_width,
                 });
 
-                use hal::Primitive::PatchList;
+                use crate::hal::Primitive::PatchList;
                 if let PatchList(patch_control_points) = desc.input_assembler.primitive {
                     info_tessellation_states.push(vk::PipelineTessellationStateCreateInfo {
                         s_type: vk::StructureType::PIPELINE_TESSELLATION_STATE_CREATE_INFO,
@@ -1048,7 +1048,7 @@ impl d::Device<B> for Device {
         &self,
         sampler_info: image::SamplerInfo,
     ) -> Result<n::Sampler, d::AllocationError> {
-        use hal::pso::Comparison;
+        use crate::hal::pso::Comparison;
 
         let (anisotropy_enable, max_anisotropy) = match sampler_info.anisotropic {
             image::Anisotropic::Off => (vk::FALSE, 1.0),
@@ -1549,7 +1549,7 @@ impl d::Device<B> for Device {
 
         // Patch the pointers now that we have all the storage allocated
         for raw in &mut raw_writes {
-            use vk::DescriptorType as Dt;
+            use crate::vk::DescriptorType as Dt;
             match raw.descriptor_type {
                 Dt::SAMPLER
                 | Dt::SAMPLED_IMAGE

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -36,12 +36,15 @@ use ash::vk;
 #[cfg(not(feature = "use-rtld-next"))]
 use ash::{Entry, LoadingError};
 
-use hal::adapter::DeviceType;
-use hal::error::{DeviceCreationError, HostExecutionError};
-use hal::device::{DeviceLost, OutOfMemory, SurfaceLost};
-use hal::pso::PipelineStage;
-use hal::{format, image, memory, queue, window::{PresentError, Suboptimal}};
-use hal::{Features, Limits, PatchSize, QueueType, SwapImageIndex};
+use crate::hal::adapter::DeviceType;
+use crate::hal::device::{DeviceLost, OutOfMemory, SurfaceLost};
+use crate::hal::error::{DeviceCreationError, HostExecutionError};
+use crate::hal::pso::PipelineStage;
+use crate::hal::{
+    format, image, memory, queue,
+    window::{PresentError, Suboptimal},
+};
+use crate::hal::{Features, Limits, PatchSize, QueueType, SwapImageIndex};
 
 use std::borrow::{Borrow, Cow};
 use std::ffi::{CStr, CString};
@@ -667,7 +670,7 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
         let memory_types = mem_properties.memory_types[..mem_properties.memory_type_count as usize]
             .iter()
             .map(|mem| {
-                use memory::Properties;
+                use crate::memory::Properties;
                 let mut type_flags = Properties::empty();
 
                 if mem

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -1,10 +1,10 @@
+use crate::hal::image::SubresourceRange;
+use crate::hal::pso;
+use crate::{Backend, RawDevice};
 use ash::version::DeviceV1_0;
 use ash::vk;
-use hal::image::SubresourceRange;
-use hal::pso;
 use std::borrow::Borrow;
 use std::sync::Arc;
-use {Backend, RawDevice};
 
 #[derive(Debug, Hash)]
 pub struct Semaphore(pub vk::Semaphore);

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -4,10 +4,10 @@ use smallvec::SmallVec;
 use std::ptr;
 use std::sync::Arc;
 
-use command::CommandBuffer;
-use conv;
-use hal::{command, pool};
-use {Backend, RawDevice};
+use crate::command::CommandBuffer;
+use crate::conv;
+use crate::hal::{command, pool};
+use crate::{Backend, RawDevice};
 
 #[derive(Debug)]
 pub struct RawCommandPool {

--- a/src/backend/vulkan/src/result.rs
+++ b/src/backend/vulkan/src/result.rs
@@ -1,6 +1,6 @@
 use ash::vk;
 
-use hal::error::{DeviceCreationError, HostExecutionError};
+use crate::hal::error::{DeviceCreationError, HostExecutionError};
 
 // Generic error codes from Vulkan
 #[derive(Debug)]

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -5,15 +5,15 @@ use std::sync::Arc;
 use ash::extensions::khr;
 use ash::vk;
 
-use hal;
-use hal::format::Format;
-use hal::image::{NumSamples, Size};
+use crate::hal;
+use crate::hal::format::Format;
+use crate::hal::image::{NumSamples, Size};
 
 #[cfg(feature = "winit")]
 use winit;
 
-use {conv, native};
-use {Backend, Instance, PhysicalDevice, QueueFamily, RawInstance, VK_ENTRY};
+use crate::{conv, native};
+use crate::{Backend, Instance, PhysicalDevice, QueueFamily, RawInstance, VK_ENTRY};
 
 #[derive(Derivative)]
 #[derivative(Debug)]


### PR DESCRIPTION
Fixes #2827 

Ran `cargo fix --edition`
Ran `cargo fix --edition-idioms`

PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends: Vulkan-1.1.108
- [X] `rustfmt` run on changed code
     + there were more changes than what I committed but they weren't relevant to anything in this commit so i didn't include them.
