### PR TITLE
Remove `buffer_role_change` flag and correct some buffer target logic

### DIFF
--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -170,9 +170,9 @@ pub struct PrivateCaps {
     pub framebuffer: bool,
     /// FBO support to call `glFramebufferTexture`
     pub framebuffer_texture: bool,
-    /// Can bind a buffer to a different target than was
-    /// used upon the buffer creation/initialization
-    pub buffer_role_change: bool,
+    /// If true, then buffers used as ELEMENT_ARRAY_BUFFER may be created / initialized / used as
+    /// other targets, if false they must not be mixed with other targets.
+    pub index_buffer_role_change: bool,
     pub buffer_storage: bool,
     pub image_storage: bool,
     pub clear_buffer: bool,
@@ -477,7 +477,7 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
         framebuffer: info.is_supported(&[Core(3, 0), Es(2, 0), Ext("GL_ARB_framebuffer_object")]),
         // TODO && gl.GenFramebuffers.is_loaded(),
         framebuffer_texture: info.is_supported(&[Core(3, 0)]), //TODO: double check
-        buffer_role_change: true || !info.version.is_embedded, // TODO
+        index_buffer_role_change: !info.is_webgl(),
         image_storage: info.is_supported(&[Core(4, 2), Ext("GL_ARB_texture_storage")]),
         buffer_storage: info.is_supported(&[Core(4, 4), Ext("GL_ARB_buffer_storage")]),
         clear_buffer: info.is_supported(&[Core(3, 0), Es(3, 0)]),

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -173,14 +173,11 @@ impl Error {
 const DEVICE_LOCAL_HEAP: usize = 0;
 const CPU_VISIBLE_HEAP: usize = 1;
 
+/// Memory types in the OpenGL backend are either usable for buffers and are backed by a real OpenGL
+/// buffer, or are used for images and are fake and not backed by any real raw buffer.
 #[derive(Copy, Clone)]
-enum MemoryRole {
-    Buffer {
-        allowed_usage: buffer::Usage,
-        /// If the raw buffer requires a specific target only, this will be set to that specifc
-        /// target.  Otherwise, it will be set to a generic target suitable for transfer operations.
-        target: u32,
-    },
+enum MemoryUsage {
+    Buffer(buffer::Usage),
     Image,
 }
 
@@ -194,7 +191,7 @@ struct Share {
     private_caps: info::PrivateCaps,
     // Indicates if there is an active logical device.
     open: Cell<bool>,
-    memory_types: Vec<(hal::MemoryType, MemoryRole)>,
+    memory_types: Vec<(hal::MemoryType, MemoryUsage)>,
 }
 
 impl Share {
@@ -212,17 +209,14 @@ impl Share {
 
     fn buffer_memory_type_mask(&self, usage: buffer::Usage) -> u64 {
         let mut type_mask = 0;
-        for (type_index, &(_, role)) in self.memory_types.iter().enumerate() {
-            match role {
-                MemoryRole::Buffer {
-                    allowed_usage,
-                    ..
-                } => {
-                    if allowed_usage.contains(usage) {
+        for (type_index, &(_, kind)) in self.memory_types.iter().enumerate() {
+            match kind {
+                MemoryUsage::Buffer(buffer_usage) => {
+                    if buffer_usage.contains(usage) {
                         type_mask |= 1 << type_index;
                     }
                 }
-                MemoryRole::Image => {},
+                MemoryUsage::Image => {},
             }
         }
         if type_mask == 0 {
@@ -233,10 +227,10 @@ impl Share {
 
     fn image_memory_type_mask(&self) -> u64 {
         let mut type_mask = 0;
-        for (type_index, &(_, role)) in self.memory_types.iter().enumerate() {
-            match role {
-                MemoryRole::Buffer { .. } => {},
-                MemoryRole::Image => {
+        for (type_index, &(_, kind)) in self.memory_types.iter().enumerate() {
+            match kind {
+                MemoryUsage::Buffer(_) => {},
+                MemoryUsage::Image => {
                     type_mask |= 1 << type_index;
                 },
             }
@@ -351,139 +345,54 @@ impl PhysicalDevice {
         let vendor: std::string::String = info.platform_name.vendor.clone();
         let renderer: std::string::String = info.platform_name.renderer.clone();
 
-        // An array of hal `MemoryType`s each corresponding to a set of memory types generated for
-        // every allowed role.  In the OpenGL backend, depending on platform capabilities, we may
-        // need multiple different memory types with the same properties / heap_index but different
-        // allowed opengl roles.
-        let mut buffer_role_memory_types = Vec::new();
+        let mut memory_types = Vec::new();
+
+        let mut add_memory_type = |memory_type: hal::MemoryType| {
+            if private_caps.index_buffer_role_change {
+                // If `index_buffer_role_change` is true, we can use a buffer for any role
+                memory_types.push((
+                    memory_type,
+                    MemoryUsage::Buffer(buffer::Usage::all()),
+                ));
+            } else {
+                // If `index_buffer_role_change` is false, ELEMENT_ARRAY_BUFFER buffers may not be
+                // mixed with other targets, so we need to provide one type of memory for INDEX
+                // usage only and another type for all other uses.
+                memory_types.push((
+                    memory_type,
+                    MemoryUsage::Buffer(buffer::Usage::INDEX),
+                ));
+                memory_types.push((
+                    memory_type,
+                    MemoryUsage::Buffer(buffer::Usage::all() - buffer::Usage::INDEX),
+                ));
+            }
+        };
 
         // Mimicking vulkan, memory types with more flags should come before those with fewer flags
         if private_caps.map {
-            buffer_role_memory_types.push(hal::MemoryType {
+            add_memory_type(hal::MemoryType {
                 properties: memory::Properties::CPU_VISIBLE | memory::Properties::CPU_CACHED | memory::Properties::COHERENT,
                 heap_index: CPU_VISIBLE_HEAP,
             });
-            buffer_role_memory_types.push(hal::MemoryType {
+            add_memory_type(hal::MemoryType {
                 properties: memory::Properties::CPU_VISIBLE | memory::Properties::COHERENT,
                 heap_index: CPU_VISIBLE_HEAP,
             });
-            buffer_role_memory_types.push(hal::MemoryType {
+            add_memory_type(hal::MemoryType {
                 properties: memory::Properties::CPU_VISIBLE | memory::Properties::CPU_CACHED,
                 heap_index: CPU_VISIBLE_HEAP,
             });
         } else if private_caps.emulate_map {
-            buffer_role_memory_types.push(hal::MemoryType {
+            add_memory_type(hal::MemoryType {
                 properties: memory::Properties::CPU_VISIBLE | memory::Properties::CPU_CACHED,
                 heap_index: CPU_VISIBLE_HEAP,
             });
         }
-        buffer_role_memory_types.push(hal::MemoryType {
+        add_memory_type(hal::MemoryType {
             properties: memory::Properties::DEVICE_LOCAL,
             heap_index: DEVICE_LOCAL_HEAP,
         });
-
-        let mut memory_types = Vec::new();
-
-        for &buffer_role_memory_type in &buffer_role_memory_types {
-            if private_caps.buffer_role_change {
-                if info.is_webgl() {
-                    // For security reasons, WebGL does not allow "element array buffers" to be used
-                    // as any other kind of buffer (even when `buffer_role_change` is true).  We
-                    // need to provide unique types of memory specifically for buffers with INDEX
-                    // usage if we are on WebGL.
-                    memory_types.push((
-                        buffer_role_memory_type,
-                        MemoryRole::Buffer {
-                            allowed_usage: buffer::Usage::INDEX,
-                            target: glow::ELEMENT_ARRAY_BUFFER,
-                        }
-                    ));
-                    memory_types.push((
-                        buffer_role_memory_type,
-                        MemoryRole::Buffer {
-                            allowed_usage: buffer::Usage::all() - buffer::Usage::INDEX,
-                            target: glow::PIXEL_PACK_BUFFER,
-                        }
-                    ));
-                } else {
-                    // If we have `buffer_role_change` capability and are not on WebGL, a buffer can
-                    // be used for any role.
-                    memory_types.push((
-                        buffer_role_memory_type,
-                        MemoryRole::Buffer {
-                            allowed_usage: buffer::Usage::all(),
-                            target: glow::PIXEL_PACK_BUFFER,
-                        }
-                    ));
-                }
-            } else {
-                // If we do not have `buffer_role_change` capability, we must add a separate set of
-                // memory types for every role.
-                memory_types.push((
-                    buffer_role_memory_type,
-                    MemoryRole::Buffer {
-                        allowed_usage: buffer::Usage::TRANSFER_SRC,
-                        target: glow::PIXEL_PACK_BUFFER,
-                    }
-                ));
-                memory_types.push((
-                    buffer_role_memory_type,
-                    MemoryRole::Buffer {
-                        allowed_usage: buffer::Usage::TRANSFER_DST,
-                        target: glow::PIXEL_UNPACK_BUFFER,
-                    }
-                ));
-                memory_types.push((
-                    buffer_role_memory_type,
-                    MemoryRole::Buffer {
-                        allowed_usage: buffer::Usage::UNIFORM_TEXEL | buffer::Usage::STORAGE_TEXEL,
-                        target: glow::TEXTURE_BUFFER,
-                    }
-                ));
-                memory_types.push((
-                    buffer_role_memory_type,
-                    MemoryRole::Buffer {
-                        allowed_usage: buffer::Usage::UNIFORM,
-                        target: glow::UNIFORM_BUFFER,
-                    }
-                ));
-                memory_types.push((
-                    buffer_role_memory_type,
-                    MemoryRole::Buffer {
-                        allowed_usage: buffer::Usage::UNIFORM,
-                        target: glow::UNIFORM_BUFFER,
-                    }
-                ));
-                memory_types.push((
-                    buffer_role_memory_type,
-                    MemoryRole::Buffer {
-                        allowed_usage: buffer::Usage::STORAGE,
-                        target: glow::SHADER_STORAGE_BUFFER,
-                    }
-                ));
-                memory_types.push((
-                    buffer_role_memory_type,
-                    MemoryRole::Buffer {
-                        allowed_usage: buffer::Usage::INDEX,
-                        target: glow::ELEMENT_ARRAY_BUFFER,
-                    }
-                ));
-                memory_types.push((
-                    buffer_role_memory_type,
-                    MemoryRole::Buffer {
-                        allowed_usage: buffer::Usage::VERTEX,
-                        target: glow::ARRAY_BUFFER,
-                    }
-                ));
-                memory_types.push((
-                    buffer_role_memory_type,
-                    MemoryRole::Buffer {
-                        allowed_usage: buffer::Usage::INDIRECT,
-                        target: glow::DRAW_INDIRECT_BUFFER,
-                    }
-                ));
-            }
-        }
 
         // There is always a single device-local memory type for images
         memory_types.push((
@@ -491,7 +400,7 @@ impl PhysicalDevice {
                 properties: memory::Properties::DEVICE_LOCAL,
                 heap_index: DEVICE_LOCAL_HEAP,
             },
-            MemoryRole::Image,
+            MemoryUsage::Image,
         ));
 
         assert!(memory_types.len() <= 64);

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -248,8 +248,8 @@ pub enum ShaderModule {
 #[derive(Debug)]
 pub struct Memory {
     pub(crate) properties: Properties,
-    /// Gl buffer and the target that should be used for transfer operations.  Image memory is faked
-    /// and has no associated buffer, so this will be None for image memory.
+    /// Gl buffer and the target that should be used for map operations.  Image memory is faked and
+    /// has no associated buffer, so this will be None for image memory.
     pub(crate) buffer: Option<(RawBuffer, u32)>,
     /// Allocation size
     pub(crate) size: u64,

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -583,17 +583,17 @@ impl CommandQueue {
             }*/
             com::Command::CopyBufferToBuffer(src, dst, ref r) => unsafe {
                 let gl = &self.share.context;
-                gl.bind_buffer(glow::PIXEL_UNPACK_BUFFER, Some(src));
-                gl.bind_buffer(glow::PIXEL_PACK_BUFFER, Some(dst));
+                gl.bind_buffer(glow::COPY_READ_BUFFER, Some(src));
+                gl.bind_buffer(glow::COPY_WRITE_BUFFER, Some(dst));
                 gl.copy_buffer_sub_data(
-                    glow::PIXEL_UNPACK_BUFFER,
-                    glow::PIXEL_PACK_BUFFER,
+                    glow::COPY_READ_BUFFER,
+                    glow::COPY_WRITE_BUFFER,
                     r.src as _,
                     r.dst as _,
                     r.size as _,
                 );
-                gl.bind_buffer(glow::PIXEL_UNPACK_BUFFER, None);
-                gl.bind_buffer(glow::PIXEL_PACK_BUFFER, None);
+                gl.bind_buffer(glow::COPY_READ_BUFFER, None);
+                gl.bind_buffer(glow::COPY_WRITE_BUFFER, None);
             },
             com::Command::CopyBufferToTexture(buffer, texture, textype, ref r) => unsafe {
                 // TODO: Fix format and active texture


### PR DESCRIPTION
`buffer_role_change` is replaced by `index_buffer_role_change` which is limited
solely to buffers used as GL_ELEMENT_ARRAY_BUFFER target.  This is simpler, as
only a single buffer role is ever isolated.

This commit also:
* contains some minor corrections for buffer binding to more appropriate targets
* removes an old, improper assert that made it impossible to map memory on
  `buffer_role_change` targets anyway.

Fixes #2844
PR checklist:
- [*] `make` succeeds (on *nix)
- [*] `make reftests` succeeds
- [*] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code
