### PR TITLE
mtl: Remove unnecessary `Vec::clear()`

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -3192,7 +3192,6 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         T::Item: Borrow<com::ClearValueRaw>,
     {
         // fill out temporary clear values per attachment
-        self.temp.clear_values.clear();
         self.temp
             .clear_values
             .resize(render_pass.attachments.len(), None);


### PR DESCRIPTION
I think that there's `resize()` already so we don't need to clear/truncate it first which brings some impact performance to iOS devices.

Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
  - [x] metal
- [x] `rustfmt` run on changed code
