### PR TITLE
Quite a few gl backend fence fixes

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -35,4 +35,18 @@ wasm-bindgen = "0.2.39"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.6"
-features = [ "console", "Document", "Element", "HtmlCanvasElement", "WebGlBuffer", "WebGlRenderingContext", "WebGl2RenderingContext", "WebGlProgram", "WebGlSampler", "WebGlShader", "WebGlTexture", "Window" ]
+features = [
+    "console",
+    "Document",
+    "Element",
+    "HtmlCanvasElement",
+    "Performance",
+    "WebGlBuffer",
+    "WebGlRenderingContext",
+    "WebGl2RenderingContext",
+    "WebGlProgram",
+    "WebGlSampler",
+    "WebGlShader",
+    "WebGlTexture",
+    "Window",
+]

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1610,7 +1610,7 @@ impl d::Device<B> for Device {
         let performance = web_sys::window().unwrap().performance().unwrap();
         let start = performance.now();;
         let get_elapsed = || {
-            ((performance.now() - start) * 1000.0) as u64
+            ((performance.now() - start) * 1_000_000.0) as u64
         };
 
         match wait {
@@ -1629,10 +1629,12 @@ impl d::Device<B> for Device {
                 Ok(true)
             }
             d::WaitFor::Any => {
+                const FENCE_WAIT_NS: u64 = 100_000;
+
                 let fences: Vec<_> = fences.into_iter().collect();
                 loop {
                     for fence in &fences {
-                        if self.wait_for_fence(fence.borrow(), 1000)? {
+                        if self.wait_for_fence(fence.borrow(), FENCE_WAIT_NS)? {
                             return Ok(true);
                         }
                     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1584,7 +1584,11 @@ impl d::Device<B> for Device {
                         }
                         Ok(false)
                     }
-                    _ => Ok(true),
+                    glow::CONDITION_SATISFIED | glow::ALREADY_SIGNALED => {
+                        fence.0.set(n::FenceInner::Idle { signaled: true });
+                        Ok(true)
+                    },
+                    _ => unreachable!(),
                 }
             }
             n::FenceInner::Pending(None) => {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1543,31 +1543,13 @@ impl d::Device<B> for Device {
         Ok(n::Semaphore)
     }
 
-    fn create_fence(&self, signalled: bool) -> Result<n::Fence, d::OutOfMemory> {
-        let sync = if signalled && self.share.private_caps.sync {
-            let gl = &self.share.context;
-            Some(unsafe { gl.fence_sync(glow::SYNC_GPU_COMMANDS_COMPLETE, 0).unwrap() })
-        } else {
-            None
-        };
-        Ok(n::Fence::new(sync))
+    fn create_fence(&self, signaled: bool) -> Result<n::Fence, d::OutOfMemory> {
+        let cell = Cell::new(n::FenceInner::Idle { signaled });
+        Ok(n::Fence(cell))
     }
 
-    unsafe fn reset_fences<I>(&self, fences: I) -> Result<(), d::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<n::Fence>,
-    {
-        let gl = &self.share.context;
-        for fence in fences {
-            let fence = fence.borrow();
-            if let Some(sync) = fence.0.get() {
-                if self.share.private_caps.sync && gl.is_sync(sync) {
-                    gl.delete_sync(sync);
-                }
-            }
-            fence.0.set(None);
-        }
+    unsafe fn reset_fence(&self, fence: &n::Fence) -> Result<(), d::OutOfMemory> {
+        fence.0.replace(n::FenceInner::Idle { signaled: false });
         Ok(())
     }
 
@@ -1576,26 +1558,100 @@ impl d::Device<B> for Device {
         fence: &n::Fence,
         timeout_ns: u64,
     ) -> Result<bool, d::OomOrDeviceLost> {
-        if !self.share.private_caps.sync {
-            return Ok(true);
-        }
-        match wait_fence(fence, &self.share, timeout_ns) {
-            glow::TIMEOUT_EXPIRED => Ok(false),
-            glow::WAIT_FAILED => {
-                if let Err(err) = self.share.check() {
-                    error!("Error when waiting on fence: {:?}", err);
+        // TODO:
+        // This can be called by multiple objects wanting to ensure they have exclusive
+        // access to a resource. How much does this call costs ? The status of the fence
+        // could be cached to avoid calling this more than once (in core or in the backend ?).
+        let gl = &self.share.context;
+        match fence.0.get() {
+            n::FenceInner::Idle { signaled } => {
+                if !signaled {
+                    warn!("Fence ptr {:?} is not pending, waiting not possible", fence.0.as_ptr());
                 }
-                Ok(false)
+                Ok(signaled)
             }
-            _ => Ok(true),
+            n::FenceInner::Pending(Some(sync)) => {
+                // TODO: Could `wait_sync` be used here instead?
+                match gl.client_wait_sync(
+                    sync,
+                    glow::SYNC_FLUSH_COMMANDS_BIT,
+                    timeout_ns as i32,
+                ) {
+                    glow::TIMEOUT_EXPIRED => Ok(false),
+                    glow::WAIT_FAILED => {
+                        if let Err(err) = self.share.check() {
+                            error!("Error when waiting on fence: {:?}", err);
+                        }
+                        Ok(false)
+                    }
+                    _ => Ok(true),
+                }
+            }
+            n::FenceInner::Pending(None) => {
+                // No sync capability, we fallback to waiting for *everything* to finish
+                gl.flush();
+                fence.0.set(n::FenceInner::Idle { signaled: true });
+                Ok(true)
+            }
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    unsafe fn wait_for_fences<I>(
+        &self,
+        fences: I,
+        wait: d::WaitFor,
+        timeout_ns: u64,
+    ) -> Result<bool, d::OomOrDeviceLost>
+    where
+        I: IntoIterator,
+        I::Item: Borrow<n::Fence>,
+    {
+        let performance = web_sys::window().unwrap().performance().unwrap();
+        let start = performance.now();;
+        let get_elapsed = || {
+            ((performance.now() - start) * 1000.0) as u64
+        };
+
+        match wait {
+            d::WaitFor::All => {
+                for fence in fences {
+                    if !self.wait_for_fence(fence.borrow(), 0)? {
+                        let elapsed_ns = get_elapsed();
+                        if elapsed_ns > timeout_ns {
+                            return Ok(false);
+                        }
+                        if !self.wait_for_fence(fence.borrow(), timeout_ns - elapsed_ns)? {
+                            return Ok(false);
+                        }
+                    }
+                }
+                Ok(true)
+            }
+            d::WaitFor::Any => {
+                let fences: Vec<_> = fences.into_iter().collect();
+                loop {
+                    for fence in &fences {
+                        if self.wait_for_fence(fence.borrow(), 1000)? {
+                            return Ok(true);
+                        }
+                    }
+                    if get_elapsed() >= timeout_ns {
+                        return Ok(false);
+                    }
+                }
+            }
         }
     }
 
     unsafe fn get_fence_status(&self, fence: &n::Fence) -> Result<bool, d::DeviceLost> {
-        let gl = &self.share.context;
-
-        let status = gl.get_sync_status(fence.0.get().unwrap());
-        Ok(status == glow::SIGNALED)
+        Ok(match fence.0.get() {
+            n::FenceInner::Pending(Some(sync)) => {
+                self.share.context.get_sync_status(sync) == glow::SIGNALED
+            }
+            n::FenceInner::Pending(None) => false,
+            n::FenceInner::Idle { signaled } => signaled,
+        })
     }
 
     fn create_event(&self) -> Result<(), d::OutOfMemory> {
@@ -1707,11 +1763,11 @@ impl d::Device<B> for Device {
     }
 
     unsafe fn destroy_fence(&self, fence: n::Fence) {
-        let gl = &self.share.context;
-        if let Some(sync) = fence.0.get() {
-            if self.share.private_caps.sync && gl.is_sync(sync) {
-                gl.delete_sync(sync);
+        match fence.0.get() {
+            n::FenceInner::Pending(Some(sync)) => {
+                self.share.context.delete_sync(sync);
             }
+            _ => {},
         }
     }
 
@@ -1741,27 +1797,5 @@ impl d::Device<B> for Device {
             self.share.context.finish();
         }
         Ok(())
-    }
-}
-
-pub(crate) fn wait_fence(fence: &n::Fence, share: &Starc<Share>, timeout_ns: u64) -> u32 {
-    // TODO:
-    // This can be called by multiple objects wanting to ensure they have exclusive
-    // access to a resource. How much does this call costs ? The status of the fence
-    // could be cached to avoid calling this more than once (in core or in the backend ?).
-    let gl = &share.context;
-    unsafe {
-        if share.private_caps.sync {
-            // TODO: Could `wait_sync` be used here instead?
-            gl.client_wait_sync(
-                fence.0.get().expect("No fence was set"),
-                glow::SYNC_FLUSH_COMMANDS_BIT,
-                timeout_ns as i32,
-            )
-        } else {
-            // We fallback to waiting for *everything* to finish
-            gl.flush();
-            glow::CONDITION_SATISFIED
-        }
     }
 }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -49,16 +49,16 @@ impl Buffer {
 #[derive(Debug)]
 pub struct BufferView;
 
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum FenceInner {
+    Idle { signaled: bool },
+    Pending(Option<<GlContext as glow::Context>::Fence>),
+}
+
 #[derive(Debug)]
-pub struct Fence(pub(crate) Cell<Option<<GlContext as glow::Context>::Fence>>);
+pub struct Fence(pub(crate) Cell<FenceInner>);
 unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}
-
-impl Fence {
-    pub(crate) fn new(sync: Option<<GlContext as glow::Context>::Fence>) -> Self {
-        Fence(Cell::new(sync))
-    }
-}
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum BindingTypes {


### PR DESCRIPTION
~~gl fences can now be in three states, raw (meaning they are backed by a raw
fence which is signaled or unsignaled), fake-signaled, and fake-unsignaled.
When creating a new fence, fences will start in the fake-unsignaled or
fake-signaled fence depending on how they are created.  waiting on a
fake-unsignaled fence will turn it into an unsignaled real raw fence and then
that and any further wait will wait on the real fence.~~

~~Before, fences created in the 'signaled' state would be created with a
raw *unsignaled* fence which was wrong, and reset fences would be set to None,
causing incorrect panics on future fence operations.  This change should fix
both these issues.~~

I wasn't thinking clearly about how fences were supposed to work, the gl fence implementation now mimics the metal backend, which is vastly more correct.

Additionally, on wasm32, a replacement `Device::wait_fences` is added which does
not use `thread::sleep` or rely on `std::time` (which are unavailable in wasm32).

Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code
