### PR TITLE
[0.2] Backport renderpass resolve attachments fix

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-vulkan"
-version = "0.2.2"
+version = "0.2.3"
 description = "Vulkan API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -160,14 +160,15 @@ impl d::Device<B> for Device {
                     .iter()
                     .map(|&id| id as u32)
                     .collect::<Box<[_]>>();
+                let resolves = subpass.resolves.iter().map(make_ref).collect::<Box<[_]>>();
 
-                (colors, depth_stencil, inputs, preserves)
+                (colors, depth_stencil, inputs, preserves, resolves)
             })
             .collect::<Box<[_]>>();
 
         let subpasses = attachment_refs
             .iter()
-            .map(|(colors, depth_stencil, inputs, preserves)| {
+            .map(|(colors, depth_stencil, inputs, preserves, resolves)| {
                 vk::SubpassDescription {
                     flags: vk::SubpassDescriptionFlags::empty(),
                     pipeline_bind_point: vk::PipelineBindPoint::GRAPHICS,
@@ -175,7 +176,7 @@ impl d::Device<B> for Device {
                     p_input_attachments: inputs.as_ptr(),
                     color_attachment_count: colors.len() as u32,
                     p_color_attachments: colors.as_ptr(),
-                    p_resolve_attachments: ptr::null(), // TODO
+                    p_resolve_attachments: if resolves.is_empty() { ptr::null() } else { resolves.as_ptr() },
                     p_depth_stencil_attachment: match depth_stencil {
                         Some(ref aref) => aref as *const _,
                         None => ptr::null(),


### PR DESCRIPTION
Backport of https://github.com/gfx-rs/gfx/pull/2813/files

I am able to get MSAA working on wgpu only with these changes.

Includes a new minor release, is there a process I should be aware of here?
The new release is needed because it is impractical to get wgpu to use these changes without a new release because of rendy's dependency on gfx-hal.
Simply using a specific git commit fails because rendy and wgpu both need to refer to the same trait from gfx-hal.

Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- ~~[ ] `rustfmt` run on changed code~~