### PR TITLE
More carefully set blend settings in the gl backend

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -325,7 +325,7 @@ impl RawCommandBuffer {
         slice
     }
 
-    fn update_blend_targets(&mut self, blend_targets: &Vec<pso::ColorBlendDesc>) {
+    fn update_blend_targets(&mut self, blend_targets: &[pso::ColorBlendDesc]) {
         let max_blend_slots = blend_targets.len();
         if max_blend_slots == 0 {
             return;
@@ -335,13 +335,7 @@ impl RawCommandBuffer {
             self.cache.blend_targets.resize(max_blend_slots, None);
         }
 
-        let mut all_targets_same = true;
-        for blend_target in &blend_targets[1..] {
-            if blend_target != &blend_targets[0] {
-                all_targets_same = false;
-                break;
-            }
-        }
+        let all_targets_same = blend_targets[1..].iter().all(|target| target == &blend_targets[0]);
 
         if all_targets_same {
             let mut update_blend = false;
@@ -356,14 +350,10 @@ impl RawCommandBuffer {
             }
         } else {
             for (slot, blend_target) in blend_targets.iter().enumerate() {
-                let cached_target = self.cache.blend_targets.get_mut(slot).unwrap();
+                let cached_target = &mut self.cache.blend_targets[slot];
                 let update_blend = match cached_target {
-                    Some(cache) => {
-                        cache != blend_target
-                    }
-                    None => {
-                        true
-                    }
+                    Some(cache) => cache != blend_target,
+                    None => true,
                 };
 
                 if update_blend {

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -107,8 +107,8 @@ pub enum Command {
     SetDrawColorBuffers(usize),
     SetPatchSize(i32),
     BindProgram(<GlContext as glow::Context>::Program),
-    BindBlendSlot(ColorSlot, pso::ColorBlendDesc),
-    SetAllBlendSlots(pso::ColorBlendDesc),
+    SetBlend(pso::ColorBlendDesc),
+    SetBlendSlot(ColorSlot, pso::ColorBlendDesc),
     BindAttribute(n::AttributeDesc, n::RawBuffer, i32, u32),
     //UnbindAttribute(n::AttributeDesc),
     CopyBufferToBuffer(n::RawBuffer, n::RawBuffer, command::BufferCopy),
@@ -346,7 +346,7 @@ impl RawCommandBuffer {
                 }
             }
             if update_blend {
-                self.push_cmd(Command::SetAllBlendSlots(blend_targets[0]));
+                self.push_cmd(Command::SetBlend(blend_targets[0]));
             }
         } else {
             for (slot, (blend_target, cached_target)) in blend_targets
@@ -364,7 +364,7 @@ impl RawCommandBuffer {
                         &self.id,
                         &mut self.memory,
                         &mut self.buf,
-                        Command::BindBlendSlot(slot as _, *blend_target)
+                        Command::SetBlendSlot(slot as _, *blend_target)
                     );
                 }
             }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -344,10 +344,16 @@ impl RawCommandBuffer {
         }
 
         if all_targets_same {
+            let mut update_blend = false;
             for cached_target in &mut self.cache.blend_targets {
-                *cached_target = Some(blend_targets[0]);
+                if cached_target.as_ref() != Some(&blend_targets[0]) {
+                    *cached_target = Some(blend_targets[0]);
+                    update_blend = true;
+                }
             }
-            self.push_cmd(Command::BindAllBlendSlots(blend_targets[0]));
+            if update_blend {
+                self.push_cmd(Command::BindAllBlendSlots(blend_targets[0]));
+            }
         } else {
             for (slot, blend_target) in blend_targets.iter().enumerate() {
                 let cached_target = self.cache.blend_targets.get_mut(slot).unwrap();

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -471,7 +471,9 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
         legacy |= LegacyFeatures::INSTANCED_ATTRIBUTE_BINDING;
     }
 
-    let per_draw_buffer_blending = info.is_supported(&[Core(4, 0), Es(3, 2)]) && !info.is_webgl();
+    let per_draw_buffer_blending =
+        info.is_supported(&[Core(4, 0), Es(3, 2), Ext("GL_EXT_draw_buffers2")])
+        && !info.is_webgl();
     if per_draw_buffer_blending {
         features |= Features::INDEPENDENT_BLENDING;
     }

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -192,6 +192,8 @@ pub struct PrivateCaps {
     pub depth_range_f64_precision: bool,
     /// Whether draw buffers are supported
     pub draw_buffers: bool,
+    /// Whether or not glColorMaski / glBlendEquationi / glBlendFunci are available
+    pub per_draw_buffer_blending: bool,
 }
 
 /// OpenGL implementation information
@@ -469,6 +471,11 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
         legacy |= LegacyFeatures::INSTANCED_ATTRIBUTE_BINDING;
     }
 
+    let per_draw_buffer_blending = info.is_supported(&[Core(4, 0), Es(3, 2)]) && !info.is_webgl();
+    if per_draw_buffer_blending {
+        features |= Features::INDEPENDENT_BLENDING;
+    }
+
     let emulate_map = info.version.is_embedded;
 
     let private = PrivateCaps {
@@ -490,7 +497,8 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
             && info.is_supported(&[Ext("GL_EXT_texture_filter_anisotropic")]),
         emulate_map, // TODO
         depth_range_f64_precision: !info.version.is_embedded, // TODO
-        draw_buffers: !info.version.is_embedded, // TODO
+        draw_buffers: info.is_supported(&[Core(2, 0), Es(3, 0)]),
+        per_draw_buffer_blending,
     };
 
     (info, features, legacy, limits, private)

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -534,8 +534,8 @@ impl CommandQueue {
             com::Command::BindBlendSlot(slot, ref blend) => {
                 state::bind_blend_slot(&self.share, slot, blend);
             }
-            com::Command::BindAllBlendSlots(ref blend) => {
-                state::bind_all_blend_slots(&self.share, blend);
+            com::Command::SetAllBlendSlots(ref blend) => {
+                state::set_all_blend_slots(&self.share, blend);
             }
             com::Command::BindAttribute(ref attribute, handle, stride, rate) => unsafe {
                 use crate::native::VertexAttribFunction::*;

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -531,11 +531,11 @@ impl CommandQueue {
             com::Command::BindProgram(program) => unsafe {
                 self.share.context.use_program(Some(program));
             },
-            com::Command::BindBlendSlot(slot, ref blend) => {
-                state::bind_blend_slot(&self.share, slot, blend);
+            com::Command::SetBlend(ref blend) => {
+                state::set_blend(&self.share.context, blend);
             }
-            com::Command::SetAllBlendSlots(ref blend) => {
-                state::set_all_blend_slots(&self.share, blend);
+            com::Command::SetBlendSlot(slot, ref blend) => {
+                state::set_blend_slot(&self.share, slot, blend);
             }
             com::Command::BindAttribute(ref attribute, handle, stride, rate) => unsafe {
                 use crate::native::VertexAttribFunction::*;

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -534,6 +534,9 @@ impl CommandQueue {
             com::Command::BindBlendSlot(slot, ref blend) => {
                 state::bind_blend_slot(&self.share, slot, blend);
             }
+            com::Command::BindAllBlendSlots(ref blend) => {
+                state::bind_all_blend_slots(&self.share, blend);
+            }
             com::Command::BindAttribute(ref attribute, handle, stride, rate) => unsafe {
                 use crate::native::VertexAttribFunction::*;
 

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -192,7 +192,7 @@ pub(crate) fn bind_blend_slot(share: &Share, slot: ColorSlot, desc: &pso::ColorB
     }
 }
 
-pub(crate) fn bind_all_blend_slots(share: &Share, desc: &pso::ColorBlendDesc) {
+pub(crate) fn set_all_blend_slots(share: &Share, desc: &pso::ColorBlendDesc) {
     use crate::hal::pso::ColorMask as Cm;
 
     let gl = &share.context;

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -131,7 +131,7 @@ fn map_blend_op(operation: pso::BlendOp) -> (u32, u32, u32) {
     }
 }
 
-pub(crate) fn bind_blend(gl: &GlContainer, desc: &pso::ColorBlendDesc) {
+pub(crate) fn set_blend(gl: &GlContainer, desc: &pso::ColorBlendDesc) {
     use crate::hal::pso::ColorMask as Cm;
 
     match desc.1 {
@@ -157,7 +157,7 @@ pub(crate) fn bind_blend(gl: &GlContainer, desc: &pso::ColorBlendDesc) {
     }
 }
 
-pub(crate) fn bind_blend_slot(share: &Share, slot: ColorSlot, desc: &pso::ColorBlendDesc) {
+pub(crate) fn set_blend_slot(share: &Share, slot: ColorSlot, desc: &pso::ColorBlendDesc) {
     use crate::hal::pso::ColorMask as Cm;
 
     let gl = &share.context;
@@ -184,36 +184,6 @@ pub(crate) fn bind_blend_slot(share: &Share, slot: ColorSlot, desc: &pso::ColorB
     unsafe {
         gl.color_mask_draw_buffer(
             slot as _,
-            desc.0.contains(Cm::RED) as _,
-            desc.0.contains(Cm::GREEN) as _,
-            desc.0.contains(Cm::BLUE) as _,
-            desc.0.contains(Cm::ALPHA) as _,
-        );
-    }
-}
-
-pub(crate) fn set_all_blend_slots(share: &Share, desc: &pso::ColorBlendDesc) {
-    use crate::hal::pso::ColorMask as Cm;
-
-    let gl = &share.context;
-
-    match desc.1 {
-        pso::BlendState::On { color, alpha } => unsafe {
-            let (color_eq, color_src, color_dst) = map_blend_op(color);
-            let (alpha_eq, alpha_src, alpha_dst) = map_blend_op(alpha);
-            gl.enable(glow::BLEND);
-            gl.blend_equation_separate(color_eq, alpha_eq);
-            gl.blend_func_separate(
-                color_src, color_dst, alpha_src, alpha_dst,
-            );
-        },
-        pso::BlendState::Off => unsafe {
-            gl.disable(glow::BLEND);
-        },
-    };
-
-    unsafe {
-        gl.color_mask(
             desc.0.contains(Cm::RED) as _,
             desc.0.contains(Cm::GREEN) as _,
             desc.0.contains(Cm::BLUE) as _,

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -161,39 +161,64 @@ pub(crate) fn bind_blend_slot(share: &Share, slot: ColorSlot, desc: &pso::ColorB
     use crate::hal::pso::ColorMask as Cm;
 
     let gl = &share.context;
-    let supports_draw_buffers = share.private_caps.draw_buffers;
+    if !share.private_caps.draw_buffers || !share.private_caps.per_draw_buffer_blending {
+        warn!("independent blending is not supported");
+        return;
+    }
 
     match desc.1 {
         pso::BlendState::On { color, alpha } => unsafe {
             let (color_eq, color_src, color_dst) = map_blend_op(color);
             let (alpha_eq, alpha_src, alpha_dst) = map_blend_op(alpha);
-            if supports_draw_buffers {
-                gl.enable_draw_buffer(glow::BLEND, slot as _);
-                gl.blend_equation_separate_draw_buffer(slot as _, color_eq, alpha_eq);
-                gl.blend_func_separate_draw_buffer(
-                    slot as _, color_src, color_dst, alpha_src, alpha_dst,
-                );
-            } else {
-                warn!("Draw buffers are not supported");
-            }
+            gl.enable_draw_buffer(glow::BLEND, slot as _);
+            gl.blend_equation_separate_draw_buffer(slot as _, color_eq, alpha_eq);
+            gl.blend_func_separate_draw_buffer(
+                slot as _, color_src, color_dst, alpha_src, alpha_dst,
+            );
         },
         pso::BlendState::Off => unsafe {
             gl.disable_draw_buffer(glow::BLEND, slot as _);
         },
     };
 
-    if supports_draw_buffers {
-        unsafe {
-            gl.color_mask_draw_buffer(
-                slot as _,
-                desc.0.contains(Cm::RED) as _,
-                desc.0.contains(Cm::GREEN) as _,
-                desc.0.contains(Cm::BLUE) as _,
-                desc.0.contains(Cm::ALPHA) as _,
+    unsafe {
+        gl.color_mask_draw_buffer(
+            slot as _,
+            desc.0.contains(Cm::RED) as _,
+            desc.0.contains(Cm::GREEN) as _,
+            desc.0.contains(Cm::BLUE) as _,
+            desc.0.contains(Cm::ALPHA) as _,
+        );
+    }
+}
+
+pub(crate) fn bind_all_blend_slots(share: &Share, desc: &pso::ColorBlendDesc) {
+    use crate::hal::pso::ColorMask as Cm;
+
+    let gl = &share.context;
+
+    match desc.1 {
+        pso::BlendState::On { color, alpha } => unsafe {
+            let (color_eq, color_src, color_dst) = map_blend_op(color);
+            let (alpha_eq, alpha_src, alpha_dst) = map_blend_op(alpha);
+            gl.enable(glow::BLEND);
+            gl.blend_equation_separate(color_eq, alpha_eq);
+            gl.blend_func_separate(
+                color_src, color_dst, alpha_src, alpha_dst,
             );
-        }
-    } else {
-        warn!("Draw buffers are not supported");
+        },
+        pso::BlendState::Off => unsafe {
+            gl.disable(glow::BLEND);
+        },
+    };
+
+    unsafe {
+        gl.color_mask(
+            desc.0.contains(Cm::RED) as _,
+            desc.0.contains(Cm::GREEN) as _,
+            desc.0.contains(Cm::BLUE) as _,
+            desc.0.contains(Cm::ALPHA) as _,
+        );
     }
 }
 


### PR DESCRIPTION
This should enable the gl backend to support multiple draw buffers with all the
same blend settings even if glColorMaski / glBlendEquationi / glBlendFunci are
not available.

(Edit: also it should fix several problems, blend settings do not appear to work at all without this even with a single output target if glColorMaski / glBlendEquationi / glBlendFunci are not available)

Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code
