### PR TITLE
Support copying buffer to 2d texture array in gl backend, copy with proper texture format

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = "1"
 log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.2" }
 smallvec = "0.6"
-glow = { git = "https://github.com/grovesNL/glow", rev = "6c74ffbea64e8fbaa1ec9e94e7f5f6791663a70e" }
+glow = { git = "https://github.com/grovesNL/glow", rev = "abc536c6b9b6a96c7f6c758d938fcb38f9b55938" }
 spirv_cross = { version = "0.14.0", features = ["glsl"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -117,7 +117,7 @@ pub enum Command {
         texture_target: n::TextureTarget,
         texture_format: n::TextureFormat,
         pixel_type: n::DataType,
-        command: command::BufferImageCopy,
+        data: command::BufferImageCopy,
     },
     CopyBufferToSurface(n::RawBuffer, n::Surface, command::BufferImageCopy),
     CopyTextureToBuffer {
@@ -126,7 +126,7 @@ pub enum Command {
         texture_format: n::TextureFormat,
         pixel_type: n::DataType,
         dst_buffer: n::RawBuffer,
-        command: command::BufferImageCopy,
+        data: command::BufferImageCopy,
     },
     CopySurfaceToBuffer(n::Surface, n::RawBuffer, command::BufferImageCopy),
     CopyImageToTexture(n::ImageKind, n::Texture, n::TextureTarget, command::ImageCopy),
@@ -1183,7 +1183,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
                         texture_target: target,
                         texture_format: format,
                         pixel_type,
-                        command: r,
+                        data: r,
                     }
                 },
             };
@@ -1220,7 +1220,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
                         texture_format: format,
                         pixel_type: pixel_type,
                         dst_buffer: dst_raw,
-                        command: r,
+                        data: r,
                     }
                 },
             };

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1287,7 +1287,11 @@ impl d::Device<B> for Device {
                             h = std::cmp::max(h / 2, 1);
                         }
                     }
-                    n::ImageKind::Texture(name, glow::TEXTURE_2D)
+                    n::ImageKind::Texture {
+                        texture: name,
+                        target: glow::TEXTURE_2D, 
+                        format: iformat,
+                    }
                 }
                 i::Kind::D2(w, h, l, 1) => {
                     gl.bind_texture(glow::TEXTURE_2D_ARRAY, Some(name));
@@ -1325,7 +1329,11 @@ impl d::Device<B> for Device {
                             h = std::cmp::max(h / 2, 1);
                         }
                     }
-                    n::ImageKind::Texture(name, glow::TEXTURE_2D_ARRAY)
+                    n::ImageKind::Texture {
+                        texture: name,
+                        target: glow::TEXTURE_2D_ARRAY, 
+                        format: iformat,
+                    }
                 }
                 _ => unimplemented!(),
             }
@@ -1412,14 +1420,14 @@ impl d::Device<B> for Device {
                     )))
                 }
             }
-            n::ImageKind::Texture(texture, textype) => {
+            n::ImageKind::Texture { texture, target, .. } => {
                 //TODO: check that `level` exists
                 if range.layers.start == 0 {
-                    Ok(n::ImageView::Texture(texture, textype, level))
+                    Ok(n::ImageView::Texture(texture, target, level))
                 } else if range.layers.start + 1 == range.layers.end {
                     Ok(n::ImageView::TextureLayer(
                         texture,
-                        textype,
+                        target,
                         level,
                         range.layers.start,
                     ))
@@ -1744,7 +1752,7 @@ impl d::Device<B> for Device {
         let gl = &self.share.context;
         match image.kind {
             n::ImageKind::Surface(rb) => gl.delete_renderbuffer(rb),
-            n::ImageKind::Texture(t, _) => gl.delete_texture(t),
+            n::ImageKind::Texture { texture, .. } => gl.delete_texture(texture),
         }
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1291,6 +1291,7 @@ impl d::Device<B> for Device {
                         texture: name,
                         target: glow::TEXTURE_2D, 
                         format: iformat,
+                        pixel_type: itype,
                     }
                 }
                 i::Kind::D2(w, h, l, 1) => {
@@ -1333,6 +1334,7 @@ impl d::Device<B> for Device {
                         texture: name,
                         target: glow::TEXTURE_2D_ARRAY, 
                         format: iformat,
+                        pixel_type: itype,
                     }
                 }
                 _ => unimplemented!(),

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -8,7 +8,8 @@ use crate::hal::{buffer, format, image as i, pass, pso};
 
 use crate::{Backend, GlContext};
 
-pub type TextureType = u32;
+pub type TextureTarget = u32;
+pub type TextureFormat = u32;
 
 // TODO: Consider being generic over `glow::Context` instead
 pub type VertexArray = <GlContext as glow::Context>::VertexArray;
@@ -175,7 +176,11 @@ pub struct Image {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum ImageKind {
     Surface(Surface),
-    Texture(Texture, TextureType),
+    Texture {
+        texture: Texture,
+        target: TextureTarget,
+        format: TextureFormat,
+    },
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -189,8 +194,8 @@ pub enum FatSampler {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum ImageView {
     Surface(Surface),
-    Texture(Texture, TextureType, i::Level),
-    TextureLayer(Texture, TextureType, i::Level, i::Layer),
+    Texture(Texture, TextureTarget, i::Level),
+    TextureLayer(Texture, TextureTarget, i::Level, i::Layer),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -202,7 +207,7 @@ pub(crate) enum DescSetBindings {
         offset: i32,
         size: i32,
     },
-    Texture(pso::DescriptorBinding, Texture, TextureType),
+    Texture(pso::DescriptorBinding, Texture, TextureTarget),
     Sampler(pso::DescriptorBinding, Sampler),
     SamplerInfo(pso::DescriptorBinding, i::SamplerInfo),
 }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -10,6 +10,7 @@ use crate::{Backend, GlContext};
 
 pub type TextureTarget = u32;
 pub type TextureFormat = u32;
+pub type DataType = u32;
 
 // TODO: Consider being generic over `glow::Context` instead
 pub type VertexArray = <GlContext as glow::Context>::VertexArray;
@@ -180,6 +181,7 @@ pub enum ImageKind {
         texture: Texture,
         target: TextureTarget,
         format: TextureFormat,
+        pixel_type: DataType,
     },
 }
 

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -595,8 +595,8 @@ impl CommandQueue {
                 gl.bind_buffer(glow::COPY_READ_BUFFER, None);
                 gl.bind_buffer(glow::COPY_WRITE_BUFFER, None);
             },
-            com::Command::CopyBufferToTexture(buffer, texture, textype, ref r) => unsafe {
-                // TODO: Fix format and active texture
+            com::Command::CopyBufferToTexture(buffer, texture, textype, format, ref r) => unsafe {
+                // TODO: Fix active texture
                 assert_eq!(r.image_offset.z, 0);
 
                 let gl = &self.share.context;
@@ -614,7 +614,7 @@ impl CommandQueue {
                             r.image_offset.y,
                             r.image_extent.width as _,
                             r.image_extent.height as _,
-                            glow::RGBA,
+                            format,
                             glow::UNSIGNED_BYTE,
                             r.buffer_offset as i32,
                         );
@@ -630,7 +630,7 @@ impl CommandQueue {
                             r.image_extent.width as _,
                             r.image_extent.height as _,
                             r.image_layers.layers.end as i32 - r.image_layers.layers.start as i32,
-                            glow::RGBA,
+                            format,
                             glow::UNSIGNED_BYTE,
                             r.buffer_offset as i32,
                         );
@@ -643,8 +643,8 @@ impl CommandQueue {
             com::Command::CopyBufferToSurface(..) => {
                 unimplemented!() //TODO: use FBO
             }
-            com::Command::CopyTextureToBuffer(texture, textype, buffer, ref r) => unsafe {
-                // TODO: Fix format and active texture
+            com::Command::CopyTextureToBuffer(texture, textype, format, buffer, ref r) => unsafe {
+                // TODO: Fix active texture
                 // TODO: handle partial copies gracefully
                 assert_eq!(r.image_offset, hal::image::Offset { x: 0, y: 0, z: 0 });
                 assert_eq!(textype, glow::TEXTURE_2D);
@@ -659,7 +659,7 @@ impl CommandQueue {
                     //r.image_offset.y,
                     //r.image_extent.width as _,
                     //r.image_extent.height as _,
-                    glow::RGBA,
+                    format,
                     glow::UNSIGNED_BYTE,
                     r.buffer_offset as i32,
                 );

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -595,44 +595,46 @@ impl CommandQueue {
                 gl.bind_buffer(glow::COPY_READ_BUFFER, None);
                 gl.bind_buffer(glow::COPY_WRITE_BUFFER, None);
             },
-            com::Command::CopyBufferToTexture(buffer, texture, textype, format, ref r) => unsafe {
+            com::Command::CopyBufferToTexture {
+                src_buffer, dst_texture, texture_target, texture_format, pixel_type, ref command
+            } => unsafe {
                 // TODO: Fix active texture
-                assert_eq!(r.image_offset.z, 0);
+                assert_eq!(command.image_offset.z, 0);
 
                 let gl = &self.share.context;
 
                 gl.active_texture(glow::TEXTURE0);
-                gl.bind_buffer(glow::PIXEL_UNPACK_BUFFER, Some(buffer));
+                gl.bind_buffer(glow::PIXEL_UNPACK_BUFFER, Some(src_buffer));
 
-                match textype {
+                match texture_target {
                     glow::TEXTURE_2D => {
-                        gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+                        gl.bind_texture(glow::TEXTURE_2D, Some(dst_texture));
                         gl.tex_sub_image_2d_pixel_buffer_offset(
                             glow::TEXTURE_2D,
-                            r.image_layers.level as _,
-                            r.image_offset.x,
-                            r.image_offset.y,
-                            r.image_extent.width as _,
-                            r.image_extent.height as _,
-                            format,
-                            glow::UNSIGNED_BYTE,
-                            r.buffer_offset as i32,
+                            command.image_layers.level as _,
+                            command.image_offset.x,
+                            command.image_offset.y,
+                            command.image_extent.width as _,
+                            command.image_extent.height as _,
+                            texture_format,
+                            pixel_type,
+                            command.buffer_offset as i32,
                         );
                     }
                     glow::TEXTURE_2D_ARRAY => {
-                        gl.bind_texture(glow::TEXTURE_2D_ARRAY, Some(texture));
+                        gl.bind_texture(glow::TEXTURE_2D_ARRAY, Some(dst_texture));
                         gl.tex_sub_image_3d_pixel_buffer_offset(
                             glow::TEXTURE_2D_ARRAY,
-                            r.image_layers.level as _,
-                            r.image_offset.x,
-                            r.image_offset.y,
-                            r.image_layers.layers.start as i32,
-                            r.image_extent.width as _,
-                            r.image_extent.height as _,
-                            r.image_layers.layers.end as i32 - r.image_layers.layers.start as i32,
-                            format,
-                            glow::UNSIGNED_BYTE,
-                            r.buffer_offset as i32,
+                            command.image_layers.level as _,
+                            command.image_offset.x,
+                            command.image_offset.y,
+                            command.image_layers.layers.start as i32,
+                            command.image_extent.width as _,
+                            command.image_extent.height as _,
+                            command.image_layers.layers.end as i32 - command.image_layers.layers.start as i32,
+                            texture_format,
+                            pixel_type,
+                            command.buffer_offset as i32,
                         );
                     }
                     _ => unimplemented!(),
@@ -643,25 +645,27 @@ impl CommandQueue {
             com::Command::CopyBufferToSurface(..) => {
                 unimplemented!() //TODO: use FBO
             }
-            com::Command::CopyTextureToBuffer(texture, textype, format, buffer, ref r) => unsafe {
+            com::Command::CopyTextureToBuffer {
+                src_texture, texture_target, texture_format, pixel_type, dst_buffer, ref command
+            }=> unsafe {
                 // TODO: Fix active texture
                 // TODO: handle partial copies gracefully
-                assert_eq!(r.image_offset, hal::image::Offset { x: 0, y: 0, z: 0 });
-                assert_eq!(textype, glow::TEXTURE_2D);
+                assert_eq!(command.image_offset, hal::image::Offset { x: 0, y: 0, z: 0 });
+                assert_eq!(texture_target, glow::TEXTURE_2D);
                 let gl = &self.share.context;
                 gl.active_texture(glow::TEXTURE0);
-                gl.bind_buffer(glow::PIXEL_PACK_BUFFER, Some(buffer));
-                gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+                gl.bind_buffer(glow::PIXEL_PACK_BUFFER, Some(dst_buffer));
+                gl.bind_texture(glow::TEXTURE_2D, Some(src_texture));
                 gl.get_tex_image_pixel_buffer_offset(
                     glow::TEXTURE_2D,
-                    r.image_layers.level as _,
+                    command.image_layers.level as _,
                     //r.image_offset.x,
                     //r.image_offset.y,
                     //r.image_extent.width as _,
                     //r.image_extent.height as _,
-                    format,
-                    glow::UNSIGNED_BYTE,
-                    r.buffer_offset as i32,
+                    texture_format,
+                    pixel_type,
+                    command.buffer_offset as i32,
                 );
                 gl.bind_buffer(glow::PIXEL_PACK_BUFFER, None);
             },

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -596,10 +596,10 @@ impl CommandQueue {
                 gl.bind_buffer(glow::COPY_WRITE_BUFFER, None);
             },
             com::Command::CopyBufferToTexture {
-                src_buffer, dst_texture, texture_target, texture_format, pixel_type, ref command
+                src_buffer, dst_texture, texture_target, texture_format, pixel_type, ref data
             } => unsafe {
                 // TODO: Fix active texture
-                assert_eq!(command.image_offset.z, 0);
+                assert_eq!(data.image_offset.z, 0);
 
                 let gl = &self.share.context;
 
@@ -611,30 +611,30 @@ impl CommandQueue {
                         gl.bind_texture(glow::TEXTURE_2D, Some(dst_texture));
                         gl.tex_sub_image_2d_pixel_buffer_offset(
                             glow::TEXTURE_2D,
-                            command.image_layers.level as _,
-                            command.image_offset.x,
-                            command.image_offset.y,
-                            command.image_extent.width as _,
-                            command.image_extent.height as _,
+                            data.image_layers.level as _,
+                            data.image_offset.x,
+                            data.image_offset.y,
+                            data.image_extent.width as _,
+                            data.image_extent.height as _,
                             texture_format,
                             pixel_type,
-                            command.buffer_offset as i32,
+                            data.buffer_offset as i32,
                         );
                     }
                     glow::TEXTURE_2D_ARRAY => {
                         gl.bind_texture(glow::TEXTURE_2D_ARRAY, Some(dst_texture));
                         gl.tex_sub_image_3d_pixel_buffer_offset(
                             glow::TEXTURE_2D_ARRAY,
-                            command.image_layers.level as _,
-                            command.image_offset.x,
-                            command.image_offset.y,
-                            command.image_layers.layers.start as i32,
-                            command.image_extent.width as _,
-                            command.image_extent.height as _,
-                            command.image_layers.layers.end as i32 - command.image_layers.layers.start as i32,
+                            data.image_layers.level as _,
+                            data.image_offset.x,
+                            data.image_offset.y,
+                            data.image_layers.layers.start as i32,
+                            data.image_extent.width as _,
+                            data.image_extent.height as _,
+                            data.image_layers.layers.end as i32 - data.image_layers.layers.start as i32,
                             texture_format,
                             pixel_type,
-                            command.buffer_offset as i32,
+                            data.buffer_offset as i32,
                         );
                     }
                     _ => unimplemented!(),
@@ -646,11 +646,11 @@ impl CommandQueue {
                 unimplemented!() //TODO: use FBO
             }
             com::Command::CopyTextureToBuffer {
-                src_texture, texture_target, texture_format, pixel_type, dst_buffer, ref command
+                src_texture, texture_target, texture_format, pixel_type, dst_buffer, ref data
             }=> unsafe {
                 // TODO: Fix active texture
                 // TODO: handle partial copies gracefully
-                assert_eq!(command.image_offset, hal::image::Offset { x: 0, y: 0, z: 0 });
+                assert_eq!(data.image_offset, hal::image::Offset { x: 0, y: 0, z: 0 });
                 assert_eq!(texture_target, glow::TEXTURE_2D);
                 let gl = &self.share.context;
                 gl.active_texture(glow::TEXTURE0);
@@ -658,14 +658,14 @@ impl CommandQueue {
                 gl.bind_texture(glow::TEXTURE_2D, Some(src_texture));
                 gl.get_tex_image_pixel_buffer_offset(
                     glow::TEXTURE_2D,
-                    command.image_layers.level as _,
-                    //r.image_offset.x,
-                    //r.image_offset.y,
-                    //r.image_extent.width as _,
-                    //r.image_extent.height as _,
+                    data.image_layers.level as _,
+                    //data.image_offset.x,
+                    //data.image_offset.y,
+                    //data.image_extent.width as _,
+                    //data.image_extent.height as _,
                     texture_format,
                     pixel_type,
-                    command.buffer_offset as i32,
+                    data.buffer_offset as i32,
                 );
                 gl.bind_buffer(glow::PIXEL_PACK_BUFFER, None);
             },

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -235,7 +235,11 @@ impl Device {
                             }
                         }
                     };
-                    native::ImageKind::Texture(name, glow::TEXTURE_2D)
+                    native::ImageKind::Texture {
+                        texture: name,
+                        target: glow::TEXTURE_2D,
+                        format: iformat,
+                    }
                 } else {
                     let name = gl.create_renderbuffer().unwrap();
                     match config.extent {

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -239,6 +239,7 @@ impl Device {
                         texture: name,
                         target: glow::TEXTURE_2D,
                         format: iformat,
+                        pixel_type: itype,
                     }
                 } else {
                     let name = gl.create_renderbuffer().unwrap();

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -210,6 +210,7 @@ impl Device {
                         texture: name,
                         target: glow::TEXTURE_2D,
                         format: iformat,
+                        pixel_type: itype,
                     }
                 } else {
                     let name = gl.create_renderbuffer().unwrap();

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -206,7 +206,11 @@ impl Device {
                             }
                         }
                     };
-                    native::ImageKind::Texture(name, glow::TEXTURE_2D)
+                    native::ImageKind::Texture {
+                        texture: name,
+                        target: glow::TEXTURE_2D,
+                        format: iformat,
+                    }
                 } else {
                     let name = gl.create_renderbuffer().unwrap();
                     match config.extent {


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code
