### PR TITLE
[mtl] better pipeline layout

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -13,6 +13,28 @@ end of the VS buffer table.
 
 When argument buffers are supported, each descriptor set becomes a buffer binding,
 but the general placement rule is the same.
+
+## Command recording
+
+One-time-submit primary command buffers are recorded "live" into `MTLCommandBuffer`.
+Special care is taken to the recording state: active bindings are restored at the
+start of any render or compute pass.
+
+Multi-submit and secondary command buffers are recorded as "soft" commands into
+`Journal`. Actual native recording is done at either `submit` or `execute_commands`
+correspondingly. When that happens, we `enqueue` the command buffer at the start
+of recording, which allows the driver to work on pass translation at the same time
+as we are recording the following passes.
+
+## Memory
+
+In general, "Shared" storage is used for CPU-coherent memory. "Managed" is used for
+non-coherent CPU-visible memory. Finally, "Private" storage is backing device-local
+memory types.
+
+Metal doesn't have CPU-visible memory for textures. We only allow RGBA8 2D textures
+to be allocated from it, and only for the matter of transfer operations, which is
+the minimum required by Vulkan. In fact, these become just glorified staging buffers.
 !*/
 
 #[macro_use]

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -1,3 +1,20 @@
+/*!
+# Metal backend internals.
+
+## Pipeline Layout
+
+In Metal, push constants, vertex buffers, and resources in the descriptor sets
+are all placed together in the native resource bindings, which work similarly to D3D11:
+there are tables of textures, buffers, and samplers.
+
+We put push constants first (if any) in the table, followed by descriptor set 0
+resource, followed by other descriptor sets. The vertex buffers are bound at the very
+end of the VS buffer table.
+
+When argument buffers are supported, each descriptor set becomes a buffer binding,
+but the general placement rule is the same.
+!*/
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -200,14 +200,6 @@ pub struct PipelineLayout {
     pub(crate) total_push_constants: u32,
 }
 
-impl PipelineLayout {
-    /// Get the first vertex buffer index to be used by attributes.
-    #[inline(always)]
-    pub(crate) fn attribute_buffer_index(&self) -> ResourceIndex {
-        self.total.vs.buffers as _
-    }
-}
-
 #[derive(Clone)]
 pub struct ModuleInfo {
     pub library: metal::Library,
@@ -265,7 +257,6 @@ pub struct GraphicsPipeline {
     pub(crate) fs_lib: Option<metal::Library>,
     pub(crate) raw: metal::RenderPipelineState,
     pub(crate) primitive_type: metal::MTLPrimitiveType,
-    pub(crate) attribute_buffer_index: ResourceIndex,
     pub(crate) vs_pc_info: Option<PushConstantInfo>,
     pub(crate) ps_pc_info: Option<PushConstantInfo>,
     pub(crate) rasterizer_state: Option<RasterizerState>,

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -4,7 +4,7 @@ use glsl_to_spirv;
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{self, Read};
+use std::io::Read;
 use std::path::PathBuf;
 use std::{iter, slice};
 


### PR DESCRIPTION
Fixes #2848
Basic approach is described in the comments. We put push constants first, descriptors later, and vertex buffers at the end.

Based on #2840
Actually, it makes it impossible to use argument buffers together with push constants. We need a way to set argument buffer overrides in spirv-cross to fix that.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
