### PR TITLE
[mtl] Events

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2564,6 +2564,7 @@ impl hal::Device<Backend> for Device {
                         return Ok(false);
                     }
                     thread::sleep(time::Duration::from_millis(1));
+                    self.shared.queue_blocker.lock().triage();
                 }
             }
             n::FenceInner::AcquireFrame { ref swapchain_image, iteration } => {
@@ -2605,8 +2606,9 @@ impl hal::Device<Backend> for Device {
     }
 
     unsafe fn set_event(&self, event: &n::Event) -> Result<(), OutOfMemory> {
-        self.shared.queue_blocker.lock().set_host_event(&event.0);
-        Ok(event.0.store(true, Ordering::Release))
+        event.0.store(true, Ordering::Release);
+        self.shared.queue_blocker.lock().triage();
+        Ok(())
     }
 
     unsafe fn reset_event(&self, event: &n::Event) -> Result<(), OutOfMemory> {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2526,11 +2526,13 @@ impl hal::Device<Backend> for Device {
         debug!("Creating fence ptr {:?} with signal={}", cell.as_ptr(), signaled);
         Ok(n::Fence(cell))
     }
+
     unsafe fn reset_fence(&self, fence: &n::Fence) -> Result<(), OutOfMemory> {
         debug!("Resetting fence ptr {:?}", fence.0.as_ptr());
         fence.0.replace(n::FenceInner::Idle { signaled: false });
         Ok(())
     }
+
     unsafe fn wait_for_fence(
         &self,
         fence: &n::Fence,
@@ -2576,6 +2578,7 @@ impl hal::Device<Backend> for Device {
             }
         }
     }
+
     unsafe fn get_fence_status(&self, fence: &n::Fence) -> Result<bool, DeviceLost> {
         Ok(match *fence.0.borrow() {
             n::FenceInner::Idle { signaled } => signaled,
@@ -2588,6 +2591,7 @@ impl hal::Device<Backend> for Device {
             }
         })
     }
+
     unsafe fn destroy_fence(&self, _fence: n::Fence) {
         //empty
     }
@@ -2601,6 +2605,7 @@ impl hal::Device<Backend> for Device {
     }
 
     unsafe fn set_event(&self, event: &n::Event) -> Result<(), OutOfMemory> {
+        self.shared.queue_blocker.lock().set_host_event(&event.0);
         Ok(event.0.store(true, Ordering::Release))
     }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -138,6 +138,7 @@ struct VisibilityShared {
 struct Shared {
     device: Mutex<metal::Device>,
     queue: Mutex<command::QueueInner>,
+    queue_blocker: Mutex<command::QueueBlocker>,
     service_pipes: internal::ServicePipes,
     disabilities: PrivateDisabilities,
     private_caps: PrivateCapabilities,
@@ -169,6 +170,7 @@ impl Shared {
                 &device,
                 Some(MAX_ACTIVE_COMMAND_BUFFERS),
             )),
+            queue_blocker: Mutex::new(command::QueueBlocker::default()),
             service_pipes: internal::ServicePipes::new(&device),
             disabilities: PrivateDisabilities {
                 broken_viewport_near_depth: device.name().starts_with("Intel")

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -392,7 +392,7 @@ impl hal::Backend for Backend {
 
     type Fence = native::Fence;
     type Semaphore = native::Semaphore;
-    type Event = ();
+    type Event = native::Event;
     type QueryPool = native::QueryPool;
 }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -35,6 +35,20 @@ memory types.
 Metal doesn't have CPU-visible memory for textures. We only allow RGBA8 2D textures
 to be allocated from it, and only for the matter of transfer operations, which is
 the minimum required by Vulkan. In fact, these become just glorified staging buffers.
+
+## Events
+
+Events are represented by just an atomic bool. When recording, a command buffer keeps
+track of all events set or reset. Signalling within a command buffer is therefore a
+matter of simply checking that local list. When making a submission, used events are
+also accumulated temporarily, so that we can change their values in the completion
+handler of the last command buffer. We also check this list in order to resolve events
+fired in one command buffer and waited in another one within the same submission.
+
+Waiting for an event from a different submission is accomplished similar to waiting
+for the host. We block all the submissions until the host blockers are resolved, and
+these are checked at certain points like setting an event by the device, or waiting
+for a fence.
 !*/
 
 #[macro_use]

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -175,6 +175,7 @@ impl Shared {
             disabilities: PrivateDisabilities {
                 broken_viewport_near_depth: device.name().starts_with("Intel")
                     && !device.supports_feature_set(MTLFeatureSet::macOS_GPUFamily1_v4),
+                broken_layered_clear_image: device.name().starts_with("Intel"),
             },
             private_caps,
             device: Mutex::new(device),
@@ -853,7 +854,10 @@ impl PrivateCapabilities {
 
 #[derive(Clone, Copy, Debug)]
 struct PrivateDisabilities {
+    /// Near depth is not respected properly on some Intel GPUs.
     broken_viewport_near_depth: bool,
+    /// Multi-target clears don't appear to work properly on Intel GPUs.
+    broken_layered_clear_image: bool,
 }
 
 trait AsNative {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -27,7 +27,7 @@ use std::{
     ops::Range,
     os::raw::{c_long, c_void},
     ptr,
-    sync::Arc,
+    sync::{Arc, atomic::AtomicBool},
 };
 
 
@@ -1006,6 +1006,10 @@ pub struct Fence(pub(crate) RefCell<FenceInner>);
 
 unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}
+
+//TODO: review the atomic ordering
+#[derive(Debug)]
+pub struct Event(pub(crate) Arc<AtomicBool>);
 
 extern "C" {
     fn dispatch_semaphore_wait(semaphore: *mut c_void, timeout: u64) -> c_long;

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -398,7 +398,7 @@ pub struct Sampler(pub(crate) metal::SamplerState);
 unsafe impl Send for Sampler {}
 unsafe impl Sync for Sampler {}
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Semaphore {
     pub(crate) system: Option<SystemSemaphore>,
     pub(crate) image_ready: Arc<Mutex<Option<SwapchainImage>>>,


### PR DESCRIPTION
Fixes #2809
Passes the relevant Vulkan CTS test! Although, might still have logic flows due to complexity of the synchronization here.

Based on #2840 and #2857

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
