### PR TITLE
Some long-needed rustfmt changes

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,4 @@
 newline_style = "Native"
+blank_lines_upper_bound = 2
+spaces_around_ranges = true
+imports_layout = "HorizontalVertical"


### PR DESCRIPTION
> blank_lines_upper_bound = 2

This allows us to put more than a single blank line between important sections. I was really confused when rustfmt started erasing my empty lines separating `use` sections from the other items, for example. No more!

> spaces_around_ranges = true

Ranges are often used with non-trivial values on both sides, so spaces look much better.

> imports_layout = "HorizontalVertical"

A compromise...