### PR TITLE
fix the `Limits::framebuffer_color_samples_count` field on the gl backend

### DIFF
--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -337,7 +337,8 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
     use self::Requirement::*;
     let info = Info::get(gl);
     let max_texture_size = get_usize(gl, glow::MAX_TEXTURE_SIZE).unwrap_or(64) as u32;
-    let max_color_attachments = get_usize(gl, glow::MAX_COLOR_ATTACHMENTS).unwrap_or(8) as u8;
+    let max_samples = get_usize(gl, glow::MAX_SAMPLES).unwrap_or(8);
+    let max_samples_mask = (max_samples * 2 - 1) as u8;
 
     let mut limits = Limits {
         max_image_1d_size: max_texture_size,
@@ -352,7 +353,7 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
         min_texel_buffer_offset_alignment: 1,   // TODO
         min_uniform_buffer_offset_alignment: 1, // TODO
         min_storage_buffer_offset_alignment: 1, // TODO
-        framebuffer_color_samples_count: max_color_attachments,
+        framebuffer_color_samples_count: max_samples_mask,
         non_coherent_atom_size: 1,
         ..Limits::default()
     };


### PR DESCRIPTION
It is supposed to be a mask of acceptable sample counts (which must be a power
of 2).  We assume here that GL_MAX_SAMPLES is a power of 2, all powers of 2 less
than it are acceptable sample counts.

Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code
