### PR TITLE
Derive Debug for All Backend Instances

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -99,6 +99,7 @@ pub(crate) struct ViewInfo {
     range: image::SubresourceRange,
 }
 
+#[derive(Debug)]
 pub struct Instance {
     pub(crate) factory: ComPtr<IDXGIFactory>,
     pub(crate) dxgi_version: dxgi::DxgiVersion,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -670,6 +670,7 @@ impl Drop for Device {
     }
 }
 
+#[derive(Debug)]
 pub struct Instance {
     pub(crate) factory: native::WeakPtr<dxgi1_4::IDXGIFactory4>,
 }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -909,6 +909,7 @@ impl hal::Swapchain<Backend> for Swapchain {
     }
 }
 
+#[derive(Debug)]
 pub struct Instance;
 
 impl Instance {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -616,6 +616,7 @@ impl hal::QueueFamily for QueueFamily {
 }
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "glutin"))]
+#[derive(Debug)]
 pub enum Instance {
     Headless(Headless),
     Surface(Surface)

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -316,6 +316,7 @@ where
         .with_srgb(color_base.1 == f::ChannelType::Srgb)
 }
 
+#[derive(Debug)]
 pub struct Headless(pub Starc<glutin::Context<glutin::PossiblyCurrent>>);
 
 impl Headless {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -186,6 +186,7 @@ pub struct Experiments {
     pub argument_buffers: bool,
 }
 
+#[derive(Debug)]
 pub struct Instance {
     pub experiments: Experiments,
 }


### PR DESCRIPTION
Fixing https://github.com/gfx-rs/wgpu/issues/76 is blocked on the `Instance` types for all the backends not implementing `Debug`. This patch adds `#[derive(Debug)]` to all the instances.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx11, dx12, vulkan
- [x] `rustfmt` run on changed code
