### PR TITLE
[ios][metal] xcode11 supports metal on ios simulators

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -35,6 +35,6 @@ block = "0.1"
 cocoa = "0.18"
 core-graphics = "0.17"
 smallvec = "0.6"
-spirv_cross = { version = "0.14", features = ["msl"] }
+spirv_cross = { version = "0.14.2", features = ["msl"] }
 parking_lot = "0.6.3"
 storage-map = "0.1.2"

--- a/src/backend/metal/build.rs
+++ b/src/backend/metal/build.rs
@@ -20,8 +20,9 @@ fn main() {
 
     let (sdk_name, platform_args): (_, &[_]) = match (os, arch) {
         ("ios", "aarch64") => ("iphoneos", &["-mios-version-min=8.0"]),
+        ("ios", "x86_64") => ("iphonesimulator", &["-mios-simulator-version-min=8.0"]),
         ("ios", "armv7s") | ("ios", "armv7") => panic!("32-bit iOS does not have metal support"),
-        ("ios", "i386") | ("ios", "x86_64") => panic!("iOS simulator does not have metal support"),
+        ("ios", "i386") => panic!("32-bit iOS simulator does not have metal support"),
         ("darwin", _) => ("macosx", &["-mmacosx-version-min=10.11"]),
         _ => panic!("unsupported target {}", target),
     };


### PR DESCRIPTION
This adds support for the iOS simulator. Xcode11 (in beta) supports metal in the simulator with pretty decent performance.

I had some trouble with spirv-cross as well (`-std=c++14` doesn't appear to be set), but I hackily worked around that to test this.

![Screen Shot 2019-06-26 at 5 02 34 PM](https://user-images.githubusercontent.com/6643140/60223018-4da6a900-9834-11e9-8709-7bfb4e68f1a8.png)
