### PR TITLE
Derive Debug for All Backend Instances

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.2.0"
+version = "0.2.1"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -99,6 +99,7 @@ pub(crate) struct ViewInfo {
     range: image::SubresourceRange,
 }
 
+#[derive(Debug)]
 pub struct Instance {
     pub(crate) factory: ComPtr<IDXGIFactory>,
     pub(crate) dxgi_version: dxgi::DxgiVersion,

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.2.0"
+version = "0.2.1"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -670,6 +670,7 @@ impl Drop for Device {
     }
 }
 
+#[derive(Debug)]
 pub struct Instance {
     pub(crate) factory: native::WeakPtr<dxgi1_4::IDXGIFactory4>,
 }

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-empty"
-version = "0.2.0"
+version = "0.2.1"
 description = "Empty backend for gfx-rs"
 license = "MIT OR Apache-2.0"
 authors = ["The Gfx-rs Developers"]

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -866,6 +866,7 @@ impl hal::Swapchain<Backend> for Swapchain {
     }
 }
 
+#[derive(Debug)]
 pub struct Instance;
 
 impl Instance {

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-metal"
-version = "0.2.1"
+version = "0.2.2"
 description = "Metal API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -141,6 +141,7 @@ impl Shared {
     }
 }
 
+#[derive(Debug)]
 pub struct Instance;
 
 impl hal::Instance for Instance {


### PR DESCRIPTION
This is a backport of #2869 to the hal-0.2 branch. There are no changes to Vulkan because its `Instance` already derives `Debug`. None of the OpenGL backend changes found in the master branch version are included because the OpenGL backend does not provide `Instance` on the hal-0.2 branch.

I have verified that this branch with this commit can be used in wgpu to enable fixing gfx-rs/wgpu#76.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: dx11, dx12, vulkan
- [x] `rustfmt` run on changed code
