### PR TITLE
Hardcoded immutable samplers in Metal

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1874,6 +1874,8 @@ impl hal::Device<Backend> for Device {
         &self,
         info: image::SamplerInfo,
     ) -> Result<Sampler, device::AllocationError> {
+        assert!(info.normalized);
+
         let op = match info.comparison {
             Some(_) => d3d11::D3D11_FILTER_REDUCTION_TYPE_COMPARISON,
             None => d3d11::D3D11_FILTER_REDUCTION_TYPE_STANDARD,

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2362,6 +2362,7 @@ impl d::Device<B> for Device {
         &self,
         info: image::SamplerInfo,
     ) -> Result<r::Sampler, d::AllocationError> {
+        assert!(info.normalized);
         let handle = self.sampler_pool.lock().unwrap().alloc_handle();
 
         let op = match info.comparison {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1031,6 +1031,8 @@ impl d::Device<B> for Device {
         &self,
         info: i::SamplerInfo,
     ) -> Result<n::FatSampler, d::AllocationError> {
+        assert!(info.normalized);
+
         if !self
             .share
             .legacy_features

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -25,7 +25,7 @@ hal = { path = "../../hal", version = "0.2", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 arrayvec = "0.4"
 bitflags = "1.0"
-copyless = "0.1"
+copyless = "0.1.4"
 log = { version = "0.4" }
 winit = { version = "0.19", optional = true }
 dispatch = { version = "0.1", optional = true }
@@ -36,6 +36,6 @@ block = "0.1"
 cocoa = "0.18"
 core-graphics = "0.17"
 smallvec = "0.6"
-spirv_cross = { version = "0.14.2", features = ["msl"] }
+spirv_cross = { version = "0.15", features = ["msl"] }
 parking_lot = "0.6.3"
 storage-map = "0.1.2"

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -439,6 +439,11 @@ const ARGUMENT_BUFFER_SUPPORT: &[MTLFeatureSet] = &[
     MTLFeatureSet::macOS_GPUFamily1_v3,
 ];
 
+const MUTABLE_COMPARISON_SAMPLER_SUPPORT: &[MTLFeatureSet] = &[
+    MTLFeatureSet::macOS_GPUFamily1_v1,
+    MTLFeatureSet::iOS_GPUFamily3_v1,
+];
+
 const ASTC_PIXEL_FORMAT_FEATURES: &[MTLFeatureSet] = &[
     MTLFeatureSet::iOS_GPUFamily2_v1,
     MTLFeatureSet::iOS_GPUFamily2_v2,
@@ -591,6 +596,7 @@ struct PrivateCapabilities {
     resource_heaps: bool,
     argument_buffers: bool,
     shared_textures: bool,
+    mutable_comparison_samplers: bool,
     base_instance: bool,
     dual_source_blending: bool,
     low_power: bool,
@@ -716,6 +722,7 @@ impl PrivateCapabilities {
             argument_buffers: experiments.argument_buffers
                 && Self::supports_any(&device, ARGUMENT_BUFFER_SUPPORT),
             shared_textures: !os_is_mac,
+            mutable_comparison_samplers: Self::supports_any(&device, MUTABLE_COMPARISON_SAMPLER_SUPPORT),
             base_instance: Self::supports_any(&device, BASE_INSTANCE_SUPPORT),
             dual_source_blending: Self::supports_any(&device, DUAL_SOURCE_BLEND_SUPPORT),
             low_power: !os_is_mac || device.is_low_power(),

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1096,7 +1096,7 @@ impl d::Device<B> for Device {
                     vk::BorderColor::FLOAT_TRANSPARENT_BLACK
                 }
             },
-            unnormalized_coordinates: vk::FALSE,
+            unnormalized_coordinates: if sampler_info.normalized { vk::FALSE } else { vk::TRUE },
         };
 
         let result = self.raw.0.create_sampler(&info, None);

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -107,6 +107,8 @@ pub type ColorSlot = u8;
 pub type SamplerSlot = u8;
 
 bitflags! {
+    //TODO: add a feature for non-normalized samplers
+    //TODO: add a feature for mutable comparison samplers
     /// Features that the device supports.
     /// These only include features of the core interface and not API extensions.
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
Also adds unnormalized sampling to HAL.
Blocked on spirv_cross 0.15.0 release.

Fixes #2837
Partially fulfills #2883 
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
