### PR TITLE
Reset `vertex_attrib_divisor` to `0` when needed on GL backend

### DIFF
--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -576,16 +576,14 @@ impl CommandQueue {
                     }
                 }
 
-                if rate != 0 {
-                    if self
-                        .share
-                        .legacy_features
-                        .contains(LegacyFeatures::INSTANCED_ATTRIBUTE_BINDING)
-                    {
-                        gl.vertex_attrib_divisor(location, rate);
-                    } else {
-                        error!("Binding attribute with instanced input rate is not supported");
-                    }
+                if self
+                    .share
+                    .legacy_features
+                    .contains(LegacyFeatures::INSTANCED_ATTRIBUTE_BINDING)
+                {
+                    gl.vertex_attrib_divisor(location, rate);
+                } else if rate > 0 {
+                    error!("Binding attribute with instanced input rate is not supported");
                 }
 
                 gl.enable_vertex_attrib_array(location);


### PR DESCRIPTION
This fixes `vertex_attrib_divisor` not being reset to `0` properly after using instanced drawing.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code