### PR TITLE
Upgrade to winit 0.20.0

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -35,7 +35,7 @@ gfx-hal = { path = "../src/hal", version = "0.3" }
 gfx-backend-empty = { path = "../src/backend/empty", version = "0.3" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-winit = "0.19"
+winit = "0.20.0-alpha2"
 glsl-to-spirv = "0.1.4"
 
 [dependencies.gfx-backend-gl]

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -51,9 +51,10 @@ use hal::{DescriptorPool, Primitive, SwapchainConfig};
 use hal::{Device, Instance, PhysicalDevice, Surface, Swapchain};
 
 use std::io::Cursor;
+use std::mem::ManuallyDrop;
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-const DIMS: Extent2D = Extent2D { width: 1024,height: 768 };
+const DIMS: Extent2D = Extent2D { width: 1024, height: 768 };
 
 const ENTRY_NAME: &str = "main";
 
@@ -96,33 +97,33 @@ fn main() {
     env_logger::init();
 
     #[cfg(not(target_arch = "wasm32"))]
-    let mut events_loop = winit::EventsLoop::new();
+    let event_loop = winit::event_loop::EventLoop::new();
 
     #[cfg(not(target_arch = "wasm32"))]
-    let wb = winit::WindowBuilder::new()
-        .with_min_dimensions(winit::dpi::LogicalSize::new(1.0, 1.0))
-        .with_dimensions(winit::dpi::LogicalSize::new(
+    let wb = winit::window::WindowBuilder::new()
+        .with_min_inner_size(winit::dpi::LogicalSize::new(1.0, 1.0))
+        .with_inner_size(winit::dpi::LogicalSize::new(
             DIMS.width as _,
             DIMS.height as _,
         ))
         .with_title("quad".to_string());
     // instantiate backend
     #[cfg(not(feature = "gl"))]
-    let (_window, _instance, mut adapters, mut surface) = {
-        let window = wb.build(&events_loop).unwrap();
+    let (_window, _instance, mut adapters, surface) = {
+        let window = wb.build(&event_loop).unwrap();
         let instance = back::Instance::create("gfx-rs quad", 1);
         let surface = instance.create_surface(&window);
         let adapters = instance.enumerate_adapters();
         (window, instance, adapters, surface)
     };
     #[cfg(feature = "gl")]
-    let (window, mut adapters, mut surface) = {
+    let (window, mut adapters, surface) = {
         #[cfg(not(target_arch = "wasm32"))]
         let (window, surface) = {
             let builder =
                 back::config_context(back::glutin::ContextBuilder::new(), ColorFormat::SELF, None)
                     .with_vsync(true);
-            let windowed_context = builder.build_windowed(wb, &events_loop).unwrap();
+            let windowed_context = builder.build_windowed(wb, &event_loop).unwrap();
             let (context, window) = unsafe { windowed_context.make_current().expect("Unable to make context current").split() };
             let surface = back::Surface::from_context(context);
             (window, surface)
@@ -142,631 +143,717 @@ fn main() {
         println!("{:?}", adapter.info);
     }
 
-    let mut adapter = adapters.remove(0);
-    let memory_types = adapter.physical_device.memory_properties().memory_types;
-    let limits = adapter.physical_device.limits();
+    let adapter = adapters.remove(0);
 
-    // Build a new device and associated command queues
-    let (device, mut queue_group) = adapter
-        .open_with::<_, hal::Graphics>(1, |family| surface.supports_queue_family(family))
-        .unwrap();
+    let mut renderer = Renderer::new(surface, adapter);
 
-    let mut command_pool = unsafe {
-        device.create_command_pool_typed(&queue_group, pool::CommandPoolCreateFlags::empty())
-    }
-    .expect("Can't create command pool");
+    #[cfg(target_arch = "wasm32")]
+    renderer.render();
 
-    // Setup renderpass and pipeline
-    let set_layout = unsafe {
-        device.create_descriptor_set_layout(
-            &[
-                pso::DescriptorSetLayoutBinding {
-                    binding: 0,
-                    ty: pso::DescriptorType::SampledImage,
-                    count: 1,
-                    stage_flags: ShaderStageFlags::FRAGMENT,
-                    immutable_samplers: false,
-                },
-                pso::DescriptorSetLayoutBinding {
-                    binding: 1,
-                    ty: pso::DescriptorType::Sampler,
-                    count: 1,
-                    stage_flags: ShaderStageFlags::FRAGMENT,
-                    immutable_samplers: false,
-                },
-            ],
-            &[],
-        )
-    }
-    .expect("Can't create descriptor set layout");
+    #[cfg(not(target_arch = "wasm32"))]
+    // It is important that the closure move captures the Renderer,
+    // otherwise it will not be dropped when the event loop exits.
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = winit::event_loop::ControlFlow::Wait;
 
-    // Descriptors
-    let mut desc_pool = unsafe {
-        device.create_descriptor_pool(
-            1, // sets
-            &[
-                pso::DescriptorRangeDesc {
-                    ty: pso::DescriptorType::SampledImage,
-                    count: 1,
-                },
-                pso::DescriptorRangeDesc {
-                    ty: pso::DescriptorType::Sampler,
-                    count: 1,
-                },
-            ],
-            pso::DescriptorPoolCreateFlags::empty(),
-        )
-    }
-    .expect("Can't create descriptor pool");
-    let desc_set = unsafe { desc_pool.allocate_set(&set_layout) }.unwrap();
-
-    // Buffer allocations
-    println!("Memory types: {:?}", memory_types);
-
-    let buffer_stride = std::mem::size_of::<Vertex>() as u64;
-    let buffer_len = QUAD.len() as u64 * buffer_stride;
-
-    assert_ne!(buffer_len, 0);
-    let mut vertex_buffer =
-        unsafe { device.create_buffer(buffer_len, buffer::Usage::VERTEX) }.unwrap();
-
-    let buffer_req = unsafe { device.get_buffer_requirements(&vertex_buffer) };
-
-    let upload_type = memory_types
-        .iter()
-        .enumerate()
-        .position(|(id, mem_type)| {
-            // type_mask is a bit field where each bit represents a memory type. If the bit is set
-            // to 1 it means we can use that type for our buffer. So this code finds the first
-            // memory type that has a `1` (or, is allowed), and is visible to the CPU.
-            buffer_req.type_mask & (1 << id) != 0
-                && mem_type.properties.contains(m::Properties::CPU_VISIBLE)
-        })
-        .unwrap()
-        .into();
-
-    let buffer_memory = unsafe { device.allocate_memory(upload_type, buffer_req.size) }.unwrap();
-
-    unsafe { device.bind_buffer_memory(&buffer_memory, 0, &mut vertex_buffer) }.unwrap();
-
-    // TODO: check transitions: read/write mapping and vertex buffer read
-    unsafe {
-        let mut vertices = device
-            .acquire_mapping_writer::<Vertex>(&buffer_memory, 0 .. buffer_req.size)
-            .unwrap();
-        vertices[0 .. QUAD.len()].copy_from_slice(&QUAD);
-        device.release_mapping_writer(vertices).unwrap();
-    }
-
-    // Image
-    let img_data = include_bytes!("data/logo.png");
-
-    let img = image::load(Cursor::new(&img_data[..]), image::PNG)
-        .unwrap()
-        .to_rgba();
-    let (width, height) = img.dimensions();
-    let kind = i::Kind::D2(width as i::Size, height as i::Size, 1, 1);
-    let row_alignment_mask = limits.optimal_buffer_copy_pitch_alignment as u32 - 1;
-    let image_stride = 4usize;
-    let row_pitch = (width * image_stride as u32 + row_alignment_mask) & !row_alignment_mask;
-    let upload_size = (height * row_pitch) as u64;
-
-    let mut image_upload_buffer =
-        unsafe { device.create_buffer(upload_size, buffer::Usage::TRANSFER_SRC) }.unwrap();
-    let image_mem_reqs = unsafe { device.get_buffer_requirements(&image_upload_buffer) };
-    let image_upload_memory =
-        unsafe { device.allocate_memory(upload_type, image_mem_reqs.size) }.unwrap();
-
-    unsafe { device.bind_buffer_memory(&image_upload_memory, 0, &mut image_upload_buffer) }
-        .unwrap();
-
-    // copy image data into staging buffer
-    unsafe {
-        let mut data = device
-            .acquire_mapping_writer::<u8>(&image_upload_memory, 0 .. image_mem_reqs.size)
-            .unwrap();
-        for y in 0 .. height as usize {
-            let row = &(*img)
-                [y * (width as usize) * image_stride .. (y + 1) * (width as usize) * image_stride];
-            let dest_base = y * row_pitch as usize;
-            data[dest_base .. dest_base + row.len()].copy_from_slice(row);
-        }
-        device.release_mapping_writer(data).unwrap();
-    }
-
-    let mut image_logo = unsafe {
-        device.create_image(
-            kind,
-            1,
-            ColorFormat::SELF,
-            i::Tiling::Optimal,
-            i::Usage::TRANSFER_DST | i::Usage::SAMPLED,
-            i::ViewCapabilities::empty(),
-        )
-    }
-    .unwrap();
-    let image_req = unsafe { device.get_image_requirements(&image_logo) };
-
-    let device_type = memory_types
-        .iter()
-        .enumerate()
-        .position(|(id, memory_type)| {
-            image_req.type_mask & (1 << id) != 0
-                && memory_type.properties.contains(m::Properties::DEVICE_LOCAL)
-        })
-        .unwrap()
-        .into();
-    let image_memory = unsafe { device.allocate_memory(device_type, image_req.size) }.unwrap();
-
-    unsafe { device.bind_image_memory(&image_memory, 0, &mut image_logo) }.unwrap();
-    let image_srv = unsafe {
-        device.create_image_view(
-            &image_logo,
-            i::ViewKind::D2,
-            ColorFormat::SELF,
-            Swizzle::NO,
-            COLOR_RANGE.clone(),
-        )
-    }
-    .unwrap();
-
-    let sampler = unsafe {
-        device.create_sampler(i::SamplerInfo::new(i::Filter::Linear, i::WrapMode::Clamp))
-    }
-    .expect("Can't create sampler");
-
-    unsafe {
-        device.write_descriptor_sets(vec![
-            pso::DescriptorSetWrite {
-                set: &desc_set,
-                binding: 0,
-                array_offset: 0,
-                descriptors: Some(pso::Descriptor::Image(&image_srv, i::Layout::ShaderReadOnlyOptimal)),
-            },
-            pso::DescriptorSetWrite {
-                set: &desc_set,
-                binding: 1,
-                array_offset: 0,
-                descriptors: Some(pso::Descriptor::Sampler(&sampler)),
-            },
-        ]);
-    }
-
-    // copy buffer to texture
-    let mut copy_fence = device.create_fence(false).expect("Could not create fence");
-    unsafe {
-        let mut cmd_buffer = command_pool.acquire_command_buffer::<command::OneShot>();
-        cmd_buffer.begin();
-
-        let image_barrier = m::Barrier::Image {
-            states: (i::Access::empty(), i::Layout::Undefined)
-                .. (i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal),
-            target: &image_logo,
-            families: None,
-            range: COLOR_RANGE.clone(),
-        };
-
-        cmd_buffer.pipeline_barrier(
-            PipelineStage::TOP_OF_PIPE .. PipelineStage::TRANSFER,
-            m::Dependencies::empty(),
-            &[image_barrier],
-        );
-
-        cmd_buffer.copy_buffer_to_image(
-            &image_upload_buffer,
-            &image_logo,
-            i::Layout::TransferDstOptimal,
-            &[command::BufferImageCopy {
-                buffer_offset: 0,
-                buffer_width: row_pitch / (image_stride as u32),
-                buffer_height: height as u32,
-                image_layers: i::SubresourceLayers {
-                    aspects: f::Aspects::COLOR,
-                    level: 0,
-                    layers: 0 .. 1,
-                },
-                image_offset: i::Offset { x: 0, y: 0, z: 0 },
-                image_extent: i::Extent {
-                    width,
-                    height,
-                    depth: 1,
-                },
-            }],
-        );
-
-        let image_barrier = m::Barrier::Image {
-            states: (i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal)
-                .. (i::Access::SHADER_READ, i::Layout::ShaderReadOnlyOptimal),
-            target: &image_logo,
-            families: None,
-            range: COLOR_RANGE.clone(),
-        };
-        cmd_buffer.pipeline_barrier(
-            PipelineStage::TRANSFER .. PipelineStage::FRAGMENT_SHADER,
-            m::Dependencies::empty(),
-            &[image_barrier],
-        );
-
-        cmd_buffer.finish();
-
-        queue_group.queues[0].submit_without_semaphores(Some(&cmd_buffer), Some(&mut copy_fence));
-
-        device
-            .wait_for_fence(&copy_fence, !0)
-            .expect("Can't wait for fence");
-    }
-
-    unsafe {
-        device.destroy_fence(copy_fence);
-    }
-
-    let (caps, formats, _present_modes) = surface.compatibility(&mut adapter.physical_device);
-    println!("formats: {:?}", formats);
-    let format = formats.map_or(f::Format::Rgba8Srgb, |formats| {
-        formats
-            .iter()
-            .find(|format| format.base_format().1 == ChannelType::Srgb)
-            .map(|format| *format)
-            .unwrap_or(formats[0])
-    });
-
-    let swap_config = SwapchainConfig::from_caps(&caps, format, DIMS);
-    println!("{:?}", swap_config);
-    let extent = swap_config.extent.to_extent();
-
-    let (mut swap_chain, mut backbuffer) =
-        unsafe { device.create_swapchain(&mut surface, swap_config, None) }
-            .expect("Can't create swapchain");
-
-    let render_pass = {
-        let attachment = pass::Attachment {
-            format: Some(format),
-            samples: 1,
-            ops: pass::AttachmentOps::new(
-                pass::AttachmentLoadOp::Clear,
-                pass::AttachmentStoreOp::Store,
-            ),
-            stencil_ops: pass::AttachmentOps::DONT_CARE,
-            layouts: i::Layout::Undefined .. i::Layout::Present,
-        };
-
-        let subpass = pass::SubpassDesc {
-            colors: &[(0, i::Layout::ColorAttachmentOptimal)],
-            depth_stencil: None,
-            inputs: &[],
-            resolves: &[],
-            preserves: &[],
-        };
-
-        let dependency = pass::SubpassDependency {
-            passes: pass::SubpassRef::External .. pass::SubpassRef::Pass(0),
-            stages: PipelineStage::COLOR_ATTACHMENT_OUTPUT
-                .. PipelineStage::COLOR_ATTACHMENT_OUTPUT,
-            accesses: i::Access::empty()
-                .. (i::Access::COLOR_ATTACHMENT_READ | i::Access::COLOR_ATTACHMENT_WRITE),
-        };
-
-        unsafe { device.create_render_pass(&[attachment], &[subpass], &[dependency]) }
-            .expect("Can't create render pass")
-    };
-
-    let (mut frame_images, mut framebuffers) = {
-        let pairs = backbuffer
-            .into_iter()
-            .map(|image| unsafe {
-                let rtv = device
-                    .create_image_view(
-                        &image,
-                        i::ViewKind::D2,
-                        format,
-                        Swizzle::NO,
-                        COLOR_RANGE.clone(),
-                    )
-                    .unwrap();
-                (image, rtv)
-            })
-            .collect::<Vec<_>>();
-        let fbos = pairs
-            .iter()
-            .map(|&(_, ref rtv)| unsafe {
-                device
-                    .create_framebuffer(&render_pass, Some(rtv), extent)
-                    .unwrap()
-            })
-            .collect::<Vec<_>>();
-        (pairs, fbos)
-    };
-
-    // Define maximum number of frames we want to be able to be "in flight" (being computed
-    // simultaneously) at once
-    let frames_in_flight = 3;
-
-    // Number of image acquisition semaphores is based on the number of swapchain images, not frames in flight,
-    // plus one extra which we can guarantee is unused at any given time by swapping it out with the ones
-    // in the rest of the queue.
-    let mut image_acquire_semaphores = Vec::with_capacity(frame_images.len());
-    let mut free_acquire_semaphore = device
-        .create_semaphore()
-        .expect("Could not create semaphore");
-
-    // The number of the rest of the resources is based on the frames in flight.
-    let mut submission_complete_semaphores = Vec::with_capacity(frames_in_flight);
-    let mut submission_complete_fences = Vec::with_capacity(frames_in_flight);
-    // Note: We don't really need a different command pool per frame in such a simple demo like this,
-    // but in a more 'real' application, it's generally seen as optimal to have one command pool per
-    // thread per frame. There is a flag that lets a command pool reset individual command buffers
-    // which are created from it, but by default the whole pool (and therefore all buffers in it)
-    // must be reset at once. Furthermore, it is often the case that resetting a whole pool is actually
-    // faster and more efficient for the hardware than resetting individual command buffers, so it's
-    // usually best to just make a command pool for each set of buffers which need to be reset at the
-    // same time (each frame). In our case, each pool will only have one command buffer created from it,
-    // though.
-    let mut cmd_pools = Vec::with_capacity(frames_in_flight);
-    let mut cmd_buffers = Vec::with_capacity(frames_in_flight);
-
-    cmd_pools.push(command_pool);
-    for _ in 1 .. frames_in_flight {
-        unsafe {
-            cmd_pools.push(
-                device
-                    .create_command_pool_typed(&queue_group, pool::CommandPoolCreateFlags::empty())
-                    .expect("Can't create command pool"),
-            );
-        }
-    }
-
-    for _ in 0 .. frame_images.len() {
-        image_acquire_semaphores.push(
-            device
-                .create_semaphore()
-                .expect("Could not create semaphore"),
-        );
-    }
-
-    for i in 0 .. frames_in_flight {
-        submission_complete_semaphores.push(
-            device
-                .create_semaphore()
-                .expect("Could not create semaphore"),
-        );
-        submission_complete_fences.push(
-            device
-                .create_fence(true)
-                .expect("Could not create semaphore"),
-        );
-        cmd_buffers.push(cmd_pools[i].acquire_command_buffer::<command::MultiShot>());
-    }
-
-    let pipeline_layout = unsafe {
-        device.create_pipeline_layout(
-            std::iter::once(&set_layout),
-            &[(pso::ShaderStageFlags::VERTEX, 0 .. 8)],
-        )
-    }
-    .expect("Can't create pipeline layout");
-    let pipeline = {
-        let vs_module = {
-            let spirv =
-                hal::read_spirv(Cursor::new(&include_bytes!("data/quad.vert.spv")[..])).unwrap();
-            unsafe { device.create_shader_module(&spirv) }.unwrap()
-        };
-        let fs_module = {
-            let spirv =
-                hal::read_spirv(Cursor::new(&include_bytes!("./data/quad.frag.spv")[..])).unwrap();
-            unsafe { device.create_shader_module(&spirv) }.unwrap()
-        };
-
-        let pipeline = {
-            let (vs_entry, fs_entry) = (
-                pso::EntryPoint {
-                    entry: ENTRY_NAME,
-                    module: &vs_module,
-                    specialization: hal::spec_const_list![0.8f32],
-                },
-                pso::EntryPoint {
-                    entry: ENTRY_NAME,
-                    module: &fs_module,
-                    specialization: pso::Specialization::default(),
-                },
-            );
-
-            let shader_entries = pso::GraphicsShaderSet {
-                vertex: vs_entry,
-                hull: None,
-                domain: None,
-                geometry: None,
-                fragment: Some(fs_entry),
-            };
-
-            let subpass = Subpass {
-                index: 0,
-                main_pass: &render_pass,
-            };
-
-            let mut pipeline_desc = pso::GraphicsPipelineDesc::new(
-                shader_entries,
-                Primitive::TriangleList,
-                pso::Rasterizer::FILL,
-                &pipeline_layout,
-                subpass,
-            );
-            pipeline_desc.blender.targets.push(pso::ColorBlendDesc {
-                mask: pso::ColorMask::ALL,
-                blend: Some(pso::BlendState::ALPHA),
-            });
-            pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
-                binding: 0,
-                stride: std::mem::size_of::<Vertex>() as u32,
-                rate: VertexInputRate::Vertex,
-            });
-
-            pipeline_desc.attributes.push(pso::AttributeDesc {
-                location: 0,
-                binding: 0,
-                element: pso::Element {
-                    format: f::Format::Rg32Sfloat,
-                    offset: 0,
-                },
-            });
-            pipeline_desc.attributes.push(pso::AttributeDesc {
-                location: 1,
-                binding: 0,
-                element: pso::Element {
-                    format: f::Format::Rg32Sfloat,
-                    offset: 8,
-                },
-            });
-
-            unsafe { device.create_graphics_pipeline(&pipeline_desc, None) }
-        };
-
-        unsafe {
-            device.destroy_shader_module(vs_module);
-        }
-        unsafe {
-            device.destroy_shader_module(fs_module);
-        }
-
-        pipeline.unwrap()
-    };
-
-    // Rendering setup
-    let mut viewport = pso::Viewport {
-        rect: pso::Rect {
-            x: 0,
-            y: 0,
-            w: extent.width as _,
-            h: extent.height as _,
-        },
-        depth: 0.0 .. 1.0,
-    };
-
-    //
-    let mut running = true;
-    let mut recreate_swapchain = false;
-    let mut resize_dims = Extent2D {
-        width: 0,
-        height: 0,
-    };
-    let mut frame: u64 = 0;
-    while running {
-        running = !cfg!(target_arch = "wasm32");
-        #[cfg(not(target_arch = "wasm32"))]
-        events_loop.poll_events(|event| {
-            if let winit::Event::WindowEvent { event, .. } = event {
-                #[allow(unused_variables)]
+        match event {
+            winit::event::Event::WindowEvent { event, .. } => {
                 match event {
-                    winit::WindowEvent::KeyboardInput {
+                    winit::event::WindowEvent::CloseRequested => *control_flow = winit::event_loop::ControlFlow::Exit,
+                    winit::event::WindowEvent::KeyboardInput {
                         input:
-                            winit::KeyboardInput {
-                                virtual_keycode: Some(winit::VirtualKeyCode::Escape),
+                            winit::event::KeyboardInput {
+                                virtual_keycode: Some(winit::event::VirtualKeyCode::Escape),
                                 ..
                             },
                         ..
-                    }
-                    | winit::WindowEvent::CloseRequested => running = false,
-                    winit::WindowEvent::Resized(dims) => {
+                    } => *control_flow = winit::event_loop::ControlFlow::Exit,
+                    winit::event::WindowEvent::Resized(dims) => {
                         println!("resized to {:?}", dims);
                         #[cfg(feature = "gl")]
                         {
-                            let context = surface.get_context();
-                            context.resize(dims.to_physical(window.get_hidpi_factor()));
+                            let context = renderer.surface.get_context();
+                            context.resize(dims.to_physical(window.hidpi_factor()));
                         }
-                        recreate_swapchain = true;
-                        resize_dims.width = dims.width as u32;
-                        resize_dims.height = dims.height as u32;
+                        let dimensions = Extent2D {
+                            width: dims.width as u32,
+                            height: dims.height as u32,
+                        };
+                        renderer.dimensions = dimensions;
+                        renderer.recreate_swapchain();
                     }
-                    _ => (),
+                    _ => { }
                 }
             }
-        });
-
-        // Window was resized so we must recreate swapchain and framebuffers
-        if recreate_swapchain {
-            device.wait_idle().unwrap();
-
-            let (caps, formats, _present_modes) =
-                surface.compatibility(&mut adapter.physical_device);
-            // Verify that previous format still exists so we may reuse it.
-            assert!(formats.iter().any(|fs| fs.contains(&format)));
-
-            let swap_config = SwapchainConfig::from_caps(&caps, format, resize_dims);
-            println!("{:?}", swap_config);
-            let extent = swap_config.extent.to_extent();
-
-            let (new_swap_chain, new_backbuffer) =
-                unsafe { device.create_swapchain(&mut surface, swap_config, Some(swap_chain)) }
-                    .expect("Can't create swapchain");
-
-            unsafe {
-                // Clean up the old framebuffers, images and swapchain
-                for framebuffer in framebuffers {
-                    device.destroy_framebuffer(framebuffer);
-                }
-                for (_, rtv) in frame_images {
-                    device.destroy_image_view(rtv);
-                }
+            winit::event::Event::EventsCleared => {
+                renderer.render();
             }
+            _ => { }
+        }
+    });
+}
 
-            backbuffer = new_backbuffer;
-            swap_chain = new_swap_chain;
+struct Renderer<B: hal::Backend> {
+    device: B::Device,
+    queue_group: hal::QueueGroup<B, hal::Graphics>,
+    desc_pool: ManuallyDrop<B::DescriptorPool>,
+    surface: B::Surface,
+    adapter: hal::adapter::Adapter<B>,
+    format: hal::format::Format,
+    swap_chain: Option<B::Swapchain>,
+    dimensions: Extent2D,
+    framebuffers: Vec<B::Framebuffer>,
+    frame_images: Vec<(B::Image, B::ImageView)>,
+    viewport: hal::pso::Viewport,
+    render_pass: ManuallyDrop<B::RenderPass>,
+    pipeline: ManuallyDrop<B::GraphicsPipeline>,
+    pipeline_layout: ManuallyDrop<B::PipelineLayout>,
+    desc_set: B::DescriptorSet,
+    set_layout: ManuallyDrop<B::DescriptorSetLayout>,
+    submission_complete_semaphores: Vec<B::Semaphore>,
+    image_acquire_semaphores: Vec<B::Semaphore>,
+    free_acquire_semaphore: Option<B::Semaphore>,
+    submission_complete_fences: Vec<B::Fence>,
+    cmd_pools: Vec<hal::CommandPool<B, hal::Graphics>>,
+    cmd_buffers: Vec<hal::command::CommandBuffer<B, hal::Graphics, hal::command::MultiShot>>,
+    vertex_buffer: ManuallyDrop<B::Buffer>,
+    image_upload_buffer: ManuallyDrop<B::Buffer>,
+    image_logo: ManuallyDrop<B::Image>,
+    image_srv: ManuallyDrop<B::ImageView>,
+    buffer_memory: ManuallyDrop<B::Memory>,
+    image_memory: ManuallyDrop<B::Memory>,
+    image_upload_memory: ManuallyDrop<B::Memory>,
+    sampler: ManuallyDrop<B::Sampler>,
+    frames_in_flight: usize,
+    frame: u64,
+}
 
-            let (new_frame_images, new_framebuffers) = {
-                let pairs = backbuffer
-                    .into_iter()
-                    .map(|image| unsafe {
-                        let rtv = device
-                            .create_image_view(
-                                &image,
-                                i::ViewKind::D2,
-                                format,
-                                Swizzle::NO,
-                                COLOR_RANGE.clone(),
-                            )
-                            .unwrap();
-                        (image, rtv)
-                    })
-                    .collect::<Vec<_>>();
-                let fbos = pairs
-                    .iter()
-                    .map(|&(_, ref rtv)| unsafe {
-                        device
-                            .create_framebuffer(&render_pass, Some(rtv), extent)
-                            .unwrap()
-                    })
-                    .collect();
-                (pairs, fbos)
-            };
+impl<B> Renderer<B> where B: hal::Backend {
+    fn new(mut surface: B::Surface, mut adapter: hal::adapter::Adapter<B>) -> Renderer<B> {
+        let memory_types = adapter.physical_device.memory_properties().memory_types;
+        let limits = adapter.physical_device.limits();
 
-            framebuffers = new_framebuffers;
-            frame_images = new_frame_images;
-            viewport.rect.w = extent.width as _;
-            viewport.rect.h = extent.height as _;
-            recreate_swapchain = false;
+        // Build a new device and associated command queues
+        let (device, mut queue_group) = adapter
+            .open_with::<_, hal::Graphics>(1, |family| surface.supports_queue_family(family))
+            .unwrap();
+
+        let mut command_pool = unsafe {
+            device.create_command_pool_typed(&queue_group, pool::CommandPoolCreateFlags::empty())
+        }
+        .expect("Can't create command pool");
+
+        // Setup renderpass and pipeline
+        let set_layout = ManuallyDrop::new(unsafe {
+            device.create_descriptor_set_layout(
+                &[
+                    pso::DescriptorSetLayoutBinding {
+                        binding: 0,
+                        ty: pso::DescriptorType::SampledImage,
+                        count: 1,
+                        stage_flags: ShaderStageFlags::FRAGMENT,
+                        immutable_samplers: false,
+                    },
+                    pso::DescriptorSetLayoutBinding {
+                        binding: 1,
+                        ty: pso::DescriptorType::Sampler,
+                        count: 1,
+                        stage_flags: ShaderStageFlags::FRAGMENT,
+                        immutable_samplers: false,
+                    },
+                ],
+                &[],
+            )
+        }
+        .expect("Can't create descriptor set layout"));
+
+        // Descriptors
+        let mut desc_pool = ManuallyDrop::new(unsafe {
+            device.create_descriptor_pool(
+                1, // sets
+                &[
+                    pso::DescriptorRangeDesc {
+                        ty: pso::DescriptorType::SampledImage,
+                        count: 1,
+                    },
+                    pso::DescriptorRangeDesc {
+                        ty: pso::DescriptorType::Sampler,
+                        count: 1,
+                    },
+                ],
+                pso::DescriptorPoolCreateFlags::empty(),
+            )
+        }
+        .expect("Can't create descriptor pool"));
+        let desc_set = unsafe { desc_pool.allocate_set(&set_layout) }.unwrap();
+
+        // Buffer allocations
+        println!("Memory types: {:?}", memory_types);
+
+        let buffer_stride = std::mem::size_of::<Vertex>() as u64;
+        let buffer_len = QUAD.len() as u64 * buffer_stride;
+
+        assert_ne!(buffer_len, 0);
+        let mut vertex_buffer =
+            ManuallyDrop::new(unsafe { device.create_buffer(buffer_len, buffer::Usage::VERTEX) }.unwrap());
+
+        let buffer_req = unsafe { device.get_buffer_requirements(&vertex_buffer) };
+
+        let upload_type = memory_types
+            .iter()
+            .enumerate()
+            .position(|(id, mem_type)| {
+                // type_mask is a bit field where each bit represents a memory type. If the bit is set
+                // to 1 it means we can use that type for our buffer. So this code finds the first
+                // memory type that has a `1` (or, is allowed), and is visible to the CPU.
+                buffer_req.type_mask & (1 << id) != 0
+                    && mem_type.properties.contains(m::Properties::CPU_VISIBLE)
+            })
+            .unwrap()
+            .into();
+
+        let buffer_memory = ManuallyDrop::new(unsafe { device.allocate_memory(upload_type, buffer_req.size) }.unwrap());
+
+        unsafe { device.bind_buffer_memory(&buffer_memory, 0, &mut vertex_buffer) }.unwrap();
+
+        // TODO: check transitions: read/write mapping and vertex buffer read
+        unsafe {
+            let mut vertices = device
+                .acquire_mapping_writer::<Vertex>(&buffer_memory, 0 .. buffer_req.size)
+                .unwrap();
+            vertices[0 .. QUAD.len()].copy_from_slice(&QUAD);
+            device.release_mapping_writer(vertices).unwrap();
         }
 
+        // Image
+        let img_data = include_bytes!("data/logo.png");
+
+        let img = image::load(Cursor::new(&img_data[..]), image::PNG)
+            .unwrap()
+            .to_rgba();
+        let (width, height) = img.dimensions();
+        let kind = i::Kind::D2(width as i::Size, height as i::Size, 1, 1);
+        let row_alignment_mask = limits.optimal_buffer_copy_pitch_alignment as u32 - 1;
+        let image_stride = 4usize;
+        let row_pitch = (width * image_stride as u32 + row_alignment_mask) & !row_alignment_mask;
+        let upload_size = (height * row_pitch) as u64;
+
+        let mut image_upload_buffer =
+            ManuallyDrop::new(unsafe { device.create_buffer(upload_size, buffer::Usage::TRANSFER_SRC) }.unwrap());
+        let image_mem_reqs = unsafe { device.get_buffer_requirements(&image_upload_buffer) };
+        let image_upload_memory =
+            ManuallyDrop::new(unsafe { device.allocate_memory(upload_type, image_mem_reqs.size) }.unwrap());
+
+        unsafe { device.bind_buffer_memory(&image_upload_memory, 0, &mut image_upload_buffer) }
+            .unwrap();
+
+        // copy image data into staging buffer
+        unsafe {
+            let mut data = device
+                .acquire_mapping_writer::<u8>(&image_upload_memory, 0 .. image_mem_reqs.size)
+                .unwrap();
+            for y in 0 .. height as usize {
+                let row = &(*img)
+                    [y * (width as usize) * image_stride .. (y + 1) * (width as usize) * image_stride];
+                let dest_base = y * row_pitch as usize;
+                data[dest_base .. dest_base + row.len()].copy_from_slice(row);
+            }
+            device.release_mapping_writer(data).unwrap();
+        }
+
+        let mut image_logo = ManuallyDrop::new(unsafe {
+            device.create_image(
+                kind,
+                1,
+                ColorFormat::SELF,
+                i::Tiling::Optimal,
+                i::Usage::TRANSFER_DST | i::Usage::SAMPLED,
+                i::ViewCapabilities::empty(),
+            )
+        }
+        .unwrap());
+        let image_req = unsafe { device.get_image_requirements(&image_logo) };
+
+        let device_type = memory_types
+            .iter()
+            .enumerate()
+            .position(|(id, memory_type)| {
+                image_req.type_mask & (1 << id) != 0
+                    && memory_type.properties.contains(m::Properties::DEVICE_LOCAL)
+            })
+            .unwrap()
+            .into();
+        let image_memory = ManuallyDrop::new(unsafe { device.allocate_memory(device_type, image_req.size) }.unwrap());
+
+        unsafe { device.bind_image_memory(&image_memory, 0, &mut image_logo) }.unwrap();
+        let image_srv = ManuallyDrop::new(unsafe {
+            device.create_image_view(
+                &image_logo,
+                i::ViewKind::D2,
+                ColorFormat::SELF,
+                Swizzle::NO,
+                COLOR_RANGE.clone(),
+            )
+        }
+        .unwrap());
+
+        let sampler = ManuallyDrop::new(unsafe {
+            device.create_sampler(i::SamplerInfo::new(i::Filter::Linear, i::WrapMode::Clamp))
+        }
+        .expect("Can't create sampler"));;
+
+        unsafe {
+            device.write_descriptor_sets(vec![
+                pso::DescriptorSetWrite {
+                    set: &desc_set,
+                    binding: 0,
+                    array_offset: 0,
+                    descriptors: Some(pso::Descriptor::Image(&*image_srv, i::Layout::Undefined)),
+                },
+                pso::DescriptorSetWrite {
+                    set: &desc_set,
+                    binding: 1,
+                    array_offset: 0,
+                    descriptors: Some(pso::Descriptor::Sampler(&*sampler)),
+                },
+            ]);
+        }
+
+        // copy buffer to texture
+        let mut copy_fence = device.create_fence(false).expect("Could not create fence");
+        unsafe {
+            let mut cmd_buffer = command_pool.acquire_command_buffer::<command::OneShot>();
+            cmd_buffer.begin();
+
+            let image_barrier = m::Barrier::Image {
+                states: (i::Access::empty(), i::Layout::Undefined)
+                    .. (i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal),
+                target: &*image_logo,
+                families: None,
+                range: COLOR_RANGE.clone(),
+            };
+
+            cmd_buffer.pipeline_barrier(
+                PipelineStage::TOP_OF_PIPE .. PipelineStage::TRANSFER,
+                m::Dependencies::empty(),
+                &[image_barrier],
+            );
+
+            cmd_buffer.copy_buffer_to_image(
+                &image_upload_buffer,
+                &image_logo,
+                i::Layout::TransferDstOptimal,
+                &[command::BufferImageCopy {
+                    buffer_offset: 0,
+                    buffer_width: row_pitch / (image_stride as u32),
+                    buffer_height: height as u32,
+                    image_layers: i::SubresourceLayers {
+                        aspects: f::Aspects::COLOR,
+                        level: 0,
+                        layers: 0 .. 1,
+                    },
+                    image_offset: i::Offset { x: 0, y: 0, z: 0 },
+                    image_extent: i::Extent {
+                        width,
+                        height,
+                        depth: 1,
+                    },
+                }],
+            );
+
+            let image_barrier = m::Barrier::Image {
+                states: (i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal)
+                    .. (i::Access::SHADER_READ, i::Layout::ShaderReadOnlyOptimal),
+                target: &*image_logo,
+                families: None,
+                range: COLOR_RANGE.clone(),
+            };
+            cmd_buffer.pipeline_barrier(
+                PipelineStage::TRANSFER .. PipelineStage::FRAGMENT_SHADER,
+                m::Dependencies::empty(),
+                &[image_barrier],
+            );
+
+            cmd_buffer.finish();
+
+            queue_group.queues[0].submit_without_semaphores(Some(&cmd_buffer), Some(&mut copy_fence));
+
+            device
+                .wait_for_fence(&copy_fence, !0)
+                .expect("Can't wait for fence");
+        }
+
+        unsafe {
+            device.destroy_fence(copy_fence);
+        }
+
+        let (caps, formats, _present_modes) = surface.compatibility(&mut adapter.physical_device);
+        println!("formats: {:?}", formats);
+        let format = formats.map_or(f::Format::Rgba8Srgb, |formats| {
+            formats
+                .iter()
+                .find(|format| format.base_format().1 == ChannelType::Srgb)
+                .map(|format| *format)
+                .unwrap_or(formats[0])
+        });
+
+        let swap_config = SwapchainConfig::from_caps(&caps, format, DIMS);
+        println!("{:?}", swap_config);
+        let extent = swap_config.extent.to_extent();
+
+        let (swap_chain, backbuffer) =
+            unsafe { device.create_swapchain(&mut surface, swap_config, None) }
+                .expect("Can't create swapchain");
+        let swap_chain = Some(swap_chain);
+
+        let render_pass = {
+            let attachment = pass::Attachment {
+                format: Some(format),
+                samples: 1,
+                ops: pass::AttachmentOps::new(
+                    pass::AttachmentLoadOp::Clear,
+                    pass::AttachmentStoreOp::Store,
+                ),
+                stencil_ops: pass::AttachmentOps::DONT_CARE,
+                layouts: i::Layout::Undefined .. i::Layout::Present,
+            };
+
+            let subpass = pass::SubpassDesc {
+                colors: &[(0, i::Layout::ColorAttachmentOptimal)],
+                depth_stencil: None,
+                inputs: &[],
+                resolves: &[],
+                preserves: &[],
+            };
+
+            let dependency = pass::SubpassDependency {
+                passes: pass::SubpassRef::External .. pass::SubpassRef::Pass(0),
+                stages: PipelineStage::COLOR_ATTACHMENT_OUTPUT
+                    .. PipelineStage::COLOR_ATTACHMENT_OUTPUT,
+                accesses: i::Access::empty()
+                    .. (i::Access::COLOR_ATTACHMENT_READ | i::Access::COLOR_ATTACHMENT_WRITE),
+            };
+
+            ManuallyDrop::new(unsafe { device.create_render_pass(&[attachment], &[subpass], &[dependency]) }
+                .expect("Can't create render pass"))
+        };
+
+        let (frame_images, framebuffers) = {
+            let pairs = backbuffer
+                .into_iter()
+                .map(|image| unsafe {
+                    let rtv = device
+                        .create_image_view(
+                            &image,
+                            i::ViewKind::D2,
+                            format,
+                            Swizzle::NO,
+                            COLOR_RANGE.clone(),
+                        )
+                        .unwrap();
+                    (image, rtv)
+                })
+                .collect::<Vec<_>>();
+            let fbos = pairs
+                .iter()
+                .map(|&(_, ref rtv)| unsafe {
+                    device
+                        .create_framebuffer(&render_pass, Some(rtv), extent)
+                        .unwrap()
+                })
+                .collect::<Vec<_>>();
+            (pairs, fbos)
+        };
+
+        // Define maximum number of frames we want to be able to be "in flight" (being computed
+        // simultaneously) at once
+        let frames_in_flight = 3;
+
+        // Number of image acquisition semaphores is based on the number of swapchain images, not frames in flight,
+        // plus one extra which we can guarantee is unused at any given time by swapping it out with the ones
+        // in the rest of the queue.
+        let mut image_acquire_semaphores = Vec::with_capacity(frame_images.len());
+        let free_acquire_semaphore = Option::Some(device
+            .create_semaphore()
+            .expect("Could not create semaphore"));
+
+        // The number of the rest of the resources is based on the frames in flight.
+        let mut submission_complete_semaphores = Vec::with_capacity(frames_in_flight);
+        let mut submission_complete_fences = Vec::with_capacity(frames_in_flight);
+        // Note: We don't really need a different command pool per frame in such a simple demo like this,
+        // but in a more 'real' application, it's generally seen as optimal to have one command pool per
+        // thread per frame. There is a flag that lets a command pool reset individual command buffers
+        // which are created from it, but by default the whole pool (and therefore all buffers in it)
+        // must be reset at once. Furthermore, it is often the case that resetting a whole pool is actually
+        // faster and more efficient for the hardware than resetting individual command buffers, so it's
+        // usually best to just make a command pool for each set of buffers which need to be reset at the
+        // same time (each frame). In our case, each pool will only have one command buffer created from it,
+        // though.
+        let mut cmd_pools = Vec::with_capacity(frames_in_flight);
+        let mut cmd_buffers = Vec::with_capacity(frames_in_flight);
+
+        cmd_pools.push(command_pool);
+        for _ in 1 .. frames_in_flight {
+            unsafe {
+                cmd_pools.push(
+                    device
+                        .create_command_pool_typed(&queue_group, pool::CommandPoolCreateFlags::empty())
+                        .expect("Can't create command pool"),
+                );
+            }
+        }
+
+        for _ in 0 .. frame_images.len() {
+            image_acquire_semaphores.push(
+                device
+                    .create_semaphore()
+                    .expect("Could not create semaphore"),
+            );
+        }
+
+        for i in 0 .. frames_in_flight {
+            submission_complete_semaphores.push(
+                device
+                    .create_semaphore()
+                    .expect("Could not create semaphore"),
+            );
+            submission_complete_fences.push(
+                device
+                    .create_fence(true)
+                    .expect("Could not create semaphore"),
+            );
+            cmd_buffers.push(cmd_pools[i].acquire_command_buffer::<command::MultiShot>());
+        }
+
+        let pipeline_layout = ManuallyDrop::new(unsafe {
+            device.create_pipeline_layout(
+                std::iter::once(&*set_layout),
+                &[(pso::ShaderStageFlags::VERTEX, 0 .. 8)],
+            )
+        }
+        .expect("Can't create pipeline layout"));
+        let pipeline = {
+            let vs_module = {
+                let spirv =
+                    hal::read_spirv(Cursor::new(&include_bytes!("data/quad.vert.spv")[..])).unwrap();
+                unsafe { device.create_shader_module(&spirv) }.unwrap()
+            };
+            let fs_module = {
+                let spirv =
+                    hal::read_spirv(Cursor::new(&include_bytes!("./data/quad.frag.spv")[..])).unwrap();
+                unsafe { device.create_shader_module(&spirv) }.unwrap()
+            };
+
+            let pipeline = {
+                let (vs_entry, fs_entry) = (
+                    pso::EntryPoint {
+                        entry: ENTRY_NAME,
+                        module: &vs_module,
+                        specialization: hal::spec_const_list![0.8f32],
+                    },
+                    pso::EntryPoint {
+                        entry: ENTRY_NAME,
+                        module: &fs_module,
+                        specialization: pso::Specialization::default(),
+                    },
+                );
+
+                let shader_entries = pso::GraphicsShaderSet {
+                    vertex: vs_entry,
+                    hull: None,
+                    domain: None,
+                    geometry: None,
+                    fragment: Some(fs_entry),
+                };
+
+                let subpass = Subpass {
+                    index: 0,
+                    main_pass: &*render_pass,
+                };
+
+                let mut pipeline_desc = pso::GraphicsPipelineDesc::new(
+                    shader_entries,
+                    Primitive::TriangleList,
+                    pso::Rasterizer::FILL,
+                    &*pipeline_layout,
+                    subpass,
+                );
+                pipeline_desc.blender.targets.push(pso::ColorBlendDesc {
+                    mask: pso::ColorMask::ALL,
+                    blend: Some(pso::BlendState::ALPHA),
+                });
+                pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
+                    binding: 0,
+                    stride: std::mem::size_of::<Vertex>() as u32,
+                    rate: VertexInputRate::Vertex,
+                });
+
+                pipeline_desc.attributes.push(pso::AttributeDesc {
+                    location: 0,
+                    binding: 0,
+                    element: pso::Element {
+                        format: f::Format::Rg32Sfloat,
+                        offset: 0,
+                    },
+                });
+                pipeline_desc.attributes.push(pso::AttributeDesc {
+                    location: 1,
+                    binding: 0,
+                    element: pso::Element {
+                        format: f::Format::Rg32Sfloat,
+                        offset: 8,
+                    },
+                });
+
+                unsafe { device.create_graphics_pipeline(&pipeline_desc, None) }
+            };
+
+            unsafe {
+                device.destroy_shader_module(vs_module);
+            }
+            unsafe {
+                device.destroy_shader_module(fs_module);
+            }
+
+            ManuallyDrop::new(pipeline.unwrap())
+        };
+
+        // Rendering setup
+        let viewport = pso::Viewport {
+            rect: pso::Rect {
+                x: 0,
+                y: 0,
+                w: extent.width as _,
+                h: extent.height as _,
+            },
+            depth: 0.0 .. 1.0,
+        };
+
+        let dimensions = Extent2D {
+            width: 0,
+            height: 0,
+        };
+
+        Renderer {
+            device,
+            queue_group,
+            desc_pool,
+            surface,
+            adapter,
+            format,
+            dimensions,
+            swap_chain,
+            framebuffers,
+            frame_images,
+            viewport,
+            render_pass,
+            pipeline,
+            pipeline_layout,
+            desc_set,
+            set_layout,
+            submission_complete_semaphores,
+            image_acquire_semaphores,
+            free_acquire_semaphore,
+            submission_complete_fences,
+            cmd_pools,
+            cmd_buffers,
+            vertex_buffer,
+            image_upload_buffer,
+            image_logo,
+            image_srv,
+            buffer_memory,
+            image_memory,
+            image_upload_memory,
+            sampler,
+            frames_in_flight,
+            frame: 0,
+        }
+    }
+
+    fn recreate_swapchain(&mut self) {
+        self.device.wait_idle().unwrap();
+
+        let (caps, formats, _present_modes) =
+            self.surface.compatibility(&mut self.adapter.physical_device);
+        // Verify that previous format still exists so we may reuse it.
+        assert!(formats.iter().any(|fs| fs.contains(&self.format)));
+
+        let swap_config = SwapchainConfig::from_caps(&caps, self.format, self.dimensions);
+        println!("{:?}", swap_config);
+        let extent = swap_config.extent.to_extent();
+
+        let (new_swap_chain, new_backbuffer) =
+            unsafe { self.device.create_swapchain(&mut self.surface, swap_config, self.swap_chain.take()) }
+                .expect("Can't create swapchain");
+
+        unsafe {
+            // Clean up the old framebuffers and images
+            for framebuffer in self.framebuffers.drain(..) {
+                self.device.destroy_framebuffer(framebuffer);
+            }
+            for (_, rtv) in self.frame_images.drain(..) {
+                self.device.destroy_image_view(rtv);
+            }
+        }
+
+        self.swap_chain = Some(new_swap_chain);
+
+        let (new_frame_images, new_framebuffers) = {
+            let pairs = new_backbuffer
+                .into_iter()
+                .map(|image| unsafe {
+                    let rtv = self.device
+                        .create_image_view(
+                            &image,
+                            i::ViewKind::D2,
+                            self.format,
+                            Swizzle::NO,
+                            COLOR_RANGE.clone(),
+                        )
+                        .unwrap();
+                    (image, rtv)
+                })
+                .collect::<Vec<_>>();
+            let fbos = pairs
+                .iter()
+                .map(|&(_, ref rtv)| unsafe {
+                    self.device
+                        .create_framebuffer(&self.render_pass, Some(rtv), extent)
+                        .unwrap()
+                })
+                .collect();
+            (pairs, fbos)
+        };
+
+        self.framebuffers = new_framebuffers;
+        self.frame_images = new_frame_images;
+        self.viewport.rect.w = extent.width as _;
+        self.viewport.rect.h = extent.height as _;
+    }
+
+    fn render(&mut self) {
         // Use guaranteed unused acquire semaphore to get the index of the next frame we will render to
         // by using acquire_image
         let swap_image = unsafe {
-            match swap_chain.acquire_image(!0, Some(&free_acquire_semaphore), None) {
+            match self.swap_chain.as_mut().unwrap().acquire_image(!0, self.free_acquire_semaphore.as_ref(), None) {
                 Ok((i, _)) => i as usize,
                 Err(_) => {
-                    recreate_swapchain = true;
-                    continue;
+                    self.recreate_swapchain();
+                    return;
                 }
             }
         };
 
         // Swap the acquire semaphore with the one previously associated with the image we are acquiring
         core::mem::swap(
-            &mut free_acquire_semaphore,
-            &mut image_acquire_semaphores[swap_image],
+            self.free_acquire_semaphore.as_mut().unwrap(),
+            &mut self.image_acquire_semaphores[swap_image],
         );
 
         // Compute index into our resource ring buffers based on the frame number
         // and number of frames in flight. Pay close attention to where this index is needed
         // versus when the swapchain image index we got from acquire_image is needed.
-        let frame_idx = frame as usize % frames_in_flight;
+        let frame_idx = self.frame as usize % self.frames_in_flight;
 
         // Wait for the fence of the previous submission of this frame and reset it; ensures we are
         // submitting only up to maximum number of frames_in_flight if we are submitting faster than
@@ -774,31 +861,31 @@ fn main() {
         // updated with a CPU->GPU data copy are not in use by the GPU, so we can perform those updates.
         // In this case there are none to be done, however.
         unsafe {
-            device
-                .wait_for_fence(&submission_complete_fences[frame_idx], !0)
+            self.device
+                .wait_for_fence(&self.submission_complete_fences[frame_idx], !0)
                 .expect("Failed to wait for fence");
-            device
-                .reset_fence(&submission_complete_fences[frame_idx])
+            self.device
+                .reset_fence(&self.submission_complete_fences[frame_idx])
                 .expect("Failed to reset fence");
-            cmd_pools[frame_idx].reset(false);
+            self.cmd_pools[frame_idx].reset(false);
         }
 
         // Rendering
-        let cmd_buffer = &mut cmd_buffers[frame_idx];
+        let cmd_buffer = &mut self.cmd_buffers[frame_idx];
         unsafe {
             cmd_buffer.begin(false);
 
-            cmd_buffer.set_viewports(0, &[viewport.clone()]);
-            cmd_buffer.set_scissors(0, &[viewport.rect]);
-            cmd_buffer.bind_graphics_pipeline(&pipeline);
-            cmd_buffer.bind_vertex_buffers(0, Some((&vertex_buffer, 0)));
-            cmd_buffer.bind_graphics_descriptor_sets(&pipeline_layout, 0, Some(&desc_set), &[]);
+            cmd_buffer.set_viewports(0, &[self.viewport.clone()]);
+            cmd_buffer.set_scissors(0, &[self.viewport.rect]);
+            cmd_buffer.bind_graphics_pipeline(&self.pipeline);
+            cmd_buffer.bind_vertex_buffers(0, Some((&*self.vertex_buffer, 0)));
+            cmd_buffer.bind_graphics_descriptor_sets(&self.pipeline_layout, 0, Some(&self.desc_set), &[]);
 
             {
                 let mut encoder = cmd_buffer.begin_render_pass_inline(
-                    &render_pass,
-                    &framebuffers[swap_image],
-                    viewport.rect,
+                    &self.render_pass,
+                    &self.framebuffers[swap_image],
+                    self.viewport.rect,
                     &[command::ClearValue::Color(command::ClearColor::Sfloat([
                         0.8, 0.8, 0.8, 1.0,
                     ]))],
@@ -811,64 +898,71 @@ fn main() {
             let submission = Submission {
                 command_buffers: Some(&*cmd_buffer),
                 wait_semaphores: Some((
-                    &image_acquire_semaphores[swap_image],
+                    &self.image_acquire_semaphores[swap_image],
                     PipelineStage::COLOR_ATTACHMENT_OUTPUT,
                 )),
-                signal_semaphores: Some(&submission_complete_semaphores[frame_idx]),
+                signal_semaphores: Some(&self.submission_complete_semaphores[frame_idx]),
             };
-            queue_group.queues[0].submit(submission, Some(&submission_complete_fences[frame_idx]));
+            self.queue_group.queues[0].submit(submission, Some(&self.submission_complete_fences[frame_idx]));
 
             // present frame
-            if let Err(_) = swap_chain.present(
-                &mut queue_group.queues[0],
+            if let Err(_) = self.swap_chain.as_ref().unwrap().present(
+                &mut self.queue_group.queues[0],
                 swap_image as hal::SwapImageIndex,
-                Some(&submission_complete_semaphores[frame_idx]),
+                Some(&self.submission_complete_semaphores[frame_idx]),
             ) {
-                recreate_swapchain = true;
+                self.recreate_swapchain();
+                return
             }
         }
+
         // Increment our frame
-        frame += 1;
+        self.frame += 1;
     }
+}
 
-    // cleanup!
-    device.wait_idle().unwrap();
-    unsafe {
-        device.destroy_descriptor_pool(desc_pool);
-        device.destroy_descriptor_set_layout(set_layout);
+impl<B> Drop for Renderer<B> where B: hal::Backend {
+    fn drop(&mut self) {
+        self.device.wait_idle().unwrap();
+        unsafe {
+            // TODO: When ManuallyDrop::take (soon to be renamed to ManuallyDrop::read) is stabilized we should use that instead.
+            self.device.destroy_descriptor_pool(ManuallyDrop::into_inner(std::ptr::read(&self.desc_pool)));
+            self.device.destroy_descriptor_set_layout(ManuallyDrop::into_inner(std::ptr::read(&self.set_layout)));
 
-        device.destroy_buffer(vertex_buffer);
-        device.destroy_buffer(image_upload_buffer);
-        device.destroy_image(image_logo);
-        device.destroy_image_view(image_srv);
-        device.destroy_sampler(sampler);
-        device.destroy_semaphore(free_acquire_semaphore);
-        for p in cmd_pools {
-            device.destroy_command_pool(p.into_raw());
-        }
-        for s in image_acquire_semaphores {
-            device.destroy_semaphore(s);
-        }
-        for s in submission_complete_semaphores {
-            device.destroy_semaphore(s);
-        }
-        for f in submission_complete_fences {
-            device.destroy_fence(f);
-        }
-        device.destroy_render_pass(render_pass);
-        device.free_memory(buffer_memory);
-        device.free_memory(image_memory);
-        device.free_memory(image_upload_memory);
-        device.destroy_graphics_pipeline(pipeline);
-        device.destroy_pipeline_layout(pipeline_layout);
-        for framebuffer in framebuffers {
-            device.destroy_framebuffer(framebuffer);
-        }
-        for (_, rtv) in frame_images {
-            device.destroy_image_view(rtv);
-        }
+            self.device.destroy_buffer(ManuallyDrop::into_inner(std::ptr::read(&self.vertex_buffer)));
+            self.device.destroy_buffer(ManuallyDrop::into_inner(std::ptr::read(&self.image_upload_buffer)));
+            self.device.destroy_image(ManuallyDrop::into_inner(std::ptr::read(&self.image_logo)));
+            self.device.destroy_image_view(ManuallyDrop::into_inner(std::ptr::read(&self.image_srv)));
+            self.device.destroy_sampler(ManuallyDrop::into_inner(std::ptr::read(&self.sampler)));
+            self.device.destroy_semaphore(self.free_acquire_semaphore.take().unwrap());
+            for p in self.cmd_pools.drain(..) {
+                self.device.destroy_command_pool(p.into_raw());
+            }
+            for s in self.image_acquire_semaphores.drain(..) {
+                self.device.destroy_semaphore(s);
+            }
+            for s in self.submission_complete_semaphores.drain(..) {
+                self.device.destroy_semaphore(s);
+            }
+            for f in self.submission_complete_fences.drain(..) {
+                self.device.destroy_fence(f);
+            }
+            self.device.destroy_render_pass(ManuallyDrop::into_inner(std::ptr::read(&self.render_pass)));
+            self.device.free_memory(ManuallyDrop::into_inner(std::ptr::read(&self.buffer_memory)));
+            self.device.free_memory(ManuallyDrop::into_inner(std::ptr::read(&self.image_memory)));
+            self.device.free_memory(ManuallyDrop::into_inner(std::ptr::read(&self.image_upload_memory)));
+            self.device.destroy_graphics_pipeline(ManuallyDrop::into_inner(std::ptr::read(&self.pipeline)));
+            self.device.destroy_pipeline_layout(ManuallyDrop::into_inner(std::ptr::read(&self.pipeline_layout)));
+            for framebuffer in self.framebuffers.drain(..) {
+                self.device.destroy_framebuffer(framebuffer);
+            }
+            for (_, rtv) in self.frame_images.drain(..) {
+                self.device.destroy_image_view(rtv);
+            }
 
-        device.destroy_swapchain(swap_chain);
+            self.device.destroy_swapchain(self.swap_chain.take().unwrap());
+        }
+        println!("DROPPED!");
     }
 }
 
@@ -881,5 +975,5 @@ fn main() {
     feature = "wgl"
 )))]
 fn main() {
-    println!("You need to enable the native API feature (vulkan/metal/dx11/dx12/gl/wgl) in order to test the LL");
+    println!("You need to enable the native API feature (vulkan/metal/dx11/dx12/gl/wgl) in order to run the example");
 }

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -27,7 +27,7 @@ smallvec = "0.6"
 spirv_cross = { version = "0.14.0", features = ["hlsl"] }
 parking_lot = "0.7"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
-winit = { version = "0.19", optional = true }
+winit = { version = "0.20.0-alpha2", optional = true }
 wio = "0.2"
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -154,9 +154,9 @@ impl Instance {
     }
 
     #[cfg(feature = "winit")]
-    pub fn create_surface(&self, window: &winit::Window) -> Surface {
-        use winit::os::windows::WindowExt;
-        self.create_surface_from_hwnd(window.get_hwnd() as *mut _)
+    pub fn create_surface(&self, window: &winit::window::Window) -> Surface {
+        use winit::platform::windows::WindowExtWindows;
+        self.create_surface_from_hwnd(window.hwnd() as *mut _)
     }
 }
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -27,7 +27,7 @@ log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = { version = "0.14.0", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
-winit = { version = "0.19", optional = true }
+winit = { version = "0.20.0-alpha2", optional = true }
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -22,9 +22,9 @@ impl Instance {
     }
 
     #[cfg(feature = "winit")]
-    pub fn create_surface(&self, window: &winit::Window) -> Surface {
-        use winit::os::windows::WindowExt;
-        self.create_surface_from_hwnd(window.get_hwnd() as *mut _)
+    pub fn create_surface(&self, window: &winit::window::Window) -> Surface {
+        use winit::platform::windows::WindowExtWindows;
+        self.create_surface_from_hwnd(window.hwnd() as *mut _)
     }
 }
 

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -13,4 +13,4 @@ name = "gfx_backend_empty"
 
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.3" }
-winit = { version = "0.19", optional = true }
+winit = { version = "0.20.0-alpha2", optional = true }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -928,7 +928,7 @@ impl Instance {
     }
 
     #[cfg(feature = "winit")]
-    pub fn create_surface(&self, _: &winit::Window) -> Surface {
+    pub fn create_surface(&self, _: &winit::window::Window) -> Surface {
         unimplemented!()
     }
 }

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -30,8 +30,9 @@ spirv_cross = { version = "0.14.0", features = ["glsl"] }
 lazy_static = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-glutin = { version = "0.21", optional = true }
-winit = { version = "0.19", optional = true }
+#glutin = { version = "0.22.0-alpha1", optional = true }
+glutin = { git = "https://github.com/rust-windowing/glutin", rev = "3b7e5f8adbd8c831e7f6af4a44a9a5896e6c2112", optional = true }
+winit = { version = "0.20.0-alpha2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -732,7 +732,7 @@ impl Instance {
     /// TODO: Update portability to make this more flexible
     #[cfg(target_os = "linux")]
     pub fn create(_: &str, _: u32) -> Instance {
-        use glutin::os::unix::HeadlessContextExt;
+        use glutin::platform::unix::HeadlessContextExt;
         let size = glutin::dpi::PhysicalSize::from((800, 600));
         let builder = glutin::ContextBuilder::new().with_hardware_acceleration(Some(false));
         let context: glutin::Context<glutin::NotCurrent> =

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -10,10 +10,12 @@
 //!
 //! fn main() {
 //!     use gfx_backend_gl::Surface;
-//!     use glutin::{EventsLoop, WindowBuilder, ContextBuilder, WindowedContext};
+//!     use glutin::{ContextBuilder, WindowedContext};
+//!     use glutin::window::WindowBuilder;
+//!     use glutin::event_loop::EventLoop;
 //!
 //!     // First create a window using glutin.
-//!     let mut events_loop = EventsLoop::new();
+//!     let mut events_loop = EventLoop::new();
 //!     let wb = WindowBuilder::new();
 //!     let glutin_window = ContextBuilder::new().with_vsync(true).build_windowed(wb, &events_loop).unwrap();
 //!     let (glutin_context, glutin_window) = unsafe { glutin_window.make_current().expect("Failed to make the context current").split() };
@@ -32,10 +34,11 @@
 //!
 //! use gfx_hal::Instance;
 //! use gfx_backend_gl::Headless;
-//! use glutin::{Context, ContextBuilder, EventsLoop};
+//! use glutin::{Context, ContextBuilder};
+//! use glutin::event_loop::EventLoop;
 //!
 //! fn main() {
-//!     let events_loop = EventsLoop::new();
+//!     let events_loop = EventLoop::new();
 //!     let context = ContextBuilder::new().build_headless(&events_loop, glutin::dpi::PhysicalSize::new(0.0, 0.0))
 //!         .expect("Failed to build headless context");
 //!     let context = unsafe { context.make_current() }.expect("Failed to make the context current");
@@ -52,11 +55,10 @@ use glow::Context;
 
 use glutin;
 
-fn get_window_extent(window: &glutin::Window) -> image::Extent {
+fn get_window_extent(window: &glutin::window::Window) -> image::Extent {
     let px = window
-        .get_inner_size()
-        .unwrap()
-        .to_physical(window.get_hidpi_factor());
+        .inner_size()
+        .to_physical(window.hidpi_factor());
     image::Extent {
         width: px.width as image::Size,
         height: px.height as image::Size,

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -184,10 +184,10 @@ impl Instance {
     }
 
     #[cfg(feature = "winit")]
-    pub fn create_surface(&self, window: &winit::Window) -> Surface {
-        use winit::os::windows::WindowExt;
+    pub fn create_surface(&self, window: &winit::window::Window) -> Surface {
+        use winit::platform::windows::WindowExtWindows;
 
-        let hwnd = window.get_hwnd();
+        let hwnd = window.hwnd();
         self.create_surface_from_hwnd(hwnd as *mut _)
     }
 }

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -27,7 +27,7 @@ arrayvec = "0.4"
 bitflags = "1.0"
 copyless = "0.1.4"
 log = { version = "0.4" }
-winit = { version = "0.19", optional = true }
+winit = { version = "0.20.0-alpha2", optional = true }
 dispatch = { version = "0.1", optional = true }
 metal = { version = "0.15", features = ["private"] }
 foreign-types = "0.3"

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -253,16 +253,16 @@ impl Instance {
     }
 
     #[cfg(feature = "winit")]
-    pub fn create_surface(&self, window: &winit::Window) -> Surface {
+    pub fn create_surface(&self, window: &winit::window::Window) -> Surface {
         #[cfg(target_os = "ios")]
         {
-            use winit::os::ios::WindowExt;
-            self.create_surface_from_uiview(window.get_uiview(), false)
+            use winit::platform::ios::WindowExtIOS;
+            self.create_surface_from_uiview(window.ui_view(), false)
         }
         #[cfg(target_os = "macos")]
         {
-            use winit::os::macos::WindowExt;
-            self.create_surface_from_nsview(window.get_nsview(), false)
+            use winit::platform::macos::WindowExtMacOS;
+            self.create_surface_from_nsview(window.ns_view(), false)
         }
     }
 

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -28,7 +28,7 @@ shared_library = { version = "0.1.9", optional = true }
 ash = "0.29.0"
 gfx-hal = { path = "../../hal", version = "0.3" }
 smallvec = "0.6"
-winit = { version = "0.19", optional = true }
+winit = { version = "0.20.0-alpha2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -190,7 +190,7 @@ impl Instance {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn create_surface_from_nsview(&self, view: *mut c_void) -> Surface {
+    pub fn create_surface_from_ns_view(&self, view: *mut c_void) -> Surface {
         use ash::extensions::mvk;
         use core_graphics::{base::CGFloat, geometry::CGRect};
         use objc::runtime::{Object, BOOL, YES};
@@ -251,7 +251,7 @@ impl Instance {
 
     #[cfg(feature = "winit")]
     #[allow(unreachable_code)]
-    pub fn create_surface(&self, window: &winit::Window) -> Surface {
+    pub fn create_surface(&self, window: &winit::window::Window) -> Surface {
         #[cfg(all(
             feature = "x11",
             unix,
@@ -259,12 +259,12 @@ impl Instance {
             not(target_os = "macos")
         ))]
         {
-            use winit::os::unix::WindowExt;
+            use winit::platform::unix::WindowExtUnix;
 
             if self.extensions.contains(&khr::WaylandSurface::name()) {
-                if let Some(display) = window.get_wayland_display() {
+                if let Some(display) = window.wayland_display() {
                     let display: *mut c_void = display as *mut _;
-                    let surface: *mut c_void = window.get_wayland_surface().unwrap() as *mut _;
+                    let surface: *mut c_void = window.wayland_surface().unwrap() as *mut _;
                     return self.create_surface_from_wayland(
                         display,
                         surface,
@@ -272,8 +272,8 @@ impl Instance {
                 }
             }
             if self.extensions.contains(&khr::XlibSurface::name()) {
-                if let Some(display) = window.get_xlib_display() {
-                    let window = window.get_xlib_window().unwrap();
+                if let Some(display) = window.xlib_display() {
+                    let window = window.xlib_window().unwrap();
                     return self.create_surface_from_xlib(display as _, window);
                 }
             }
@@ -281,7 +281,7 @@ impl Instance {
         }
         #[cfg(target_os = "android")]
         {
-            use winit::os::android::WindowExt;
+            use winit::platform::android::WindowExtAndroid;
             return self.create_surface_android(
                 window.get_native_window(),
             );
@@ -289,17 +289,17 @@ impl Instance {
         #[cfg(windows)]
         {
             use winapi::um::libloaderapi::GetModuleHandleW;
-            use winit::os::windows::WindowExt;
+            use winit::platform::windows::WindowExtWindows;
 
             let hinstance = unsafe { GetModuleHandleW(ptr::null()) };
-            let hwnd = window.get_hwnd();
+            let hwnd = window.hwnd();
             return self.create_surface_from_hwnd(hinstance as *mut _, hwnd as *mut _);
         }
         #[cfg(target_os = "macos")]
         {
-            use winit::os::macos::WindowExt;
+            use winit::platform::macos::WindowExtMacOS;
 
-            return self.create_surface_from_nsview(window.get_nsview());
+            return self.create_surface_from_ns_view(window.ns_view());
         }
         let _ = window;
         panic!("No suitable WSI enabled!");

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -218,10 +218,10 @@ fn main() {
     {
         use gfx_backend_gl::glutin;
         println!("Warding GL:");
-        let events_loop = glutin::EventsLoop::new();
+        let events_loop = glutin::event_loop::EventLoop::new();
         let windowed_context = glutin::ContextBuilder::new()
             .with_gl_profile(glutin::GlProfile::Core)
-            .build_windowed(glutin::WindowBuilder::new(), &events_loop)
+            .build_windowed(glutin::window::WindowBuilder::new(), &events_loop)
             .unwrap();
         let (context, window) = unsafe { windowed_context.make_current().expect("Unable to make window current").split() };
         let instance = gfx_backend_gl::Surface::from_context(context);
@@ -231,7 +231,7 @@ fn main() {
     {
         use gfx_backend_gl::glutin;
         println!("Warding GL headless:");
-        let events_loop = glutin::EventsLoop::new();
+        let events_loop = glutin::event_loop::EventLoop::new();
         let context = glutin::ContextBuilder::new()
             .build_headless(&events_loop, glutin::dpi::PhysicalSize::new(0.0, 0.0))
             .unwrap();


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/gfx/issues/2874
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following:
*   Backends: vulkan and opengl
*   OS: Arch Linux
*   GPU: GTX 960
*   Driver: Nvidia proprietary driver
- [] `rustfmt` run on changed code - its panicking and changing things outside of my commit :/ I'll look into this later

Concerns:
*   I had to comment out some opengl specific resize handling code, I dont seem to be able to call the needed functions on a `B::Surface` and I dont understand the rules behind how the `back::surface` becomes a `B::Surface` But it seems to still handle resize without this code?
*   The other backends I haven't tested can be assumed to not work.
*    I have copied the code from the unstabilized ManuallyDrop::take implementation in order to cleanup the resources.
*   For now the colour-uniform example is just commented out. The plan is to implement it once we are happy with the state of winit 0.20 and want to progress further. I don't want to implement it yet as this PR could sit around for a while and I don't want to deal with merge conflicts.
