### PR TITLE
Implement surface-to-surface copy in GL backend

### DIFF
--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1394,7 +1394,7 @@ impl d::Device<B> for Device {
                 }
                 _ => unimplemented!(),
             };
-            n::ImageKind::Surface(name)
+            n::ImageKind::Surface { surface: name, format: iformat }
         };
 
         let surface_desc = format.base_format().0.desc();
@@ -1457,7 +1457,7 @@ impl d::Device<B> for Device {
         assert_eq!(swizzle, Swizzle::NO);
         //TODO: check format
         match image.kind {
-            n::ImageKind::Surface(surface) => {
+            n::ImageKind::Surface { surface, .. } => {
                 if range.levels.start == 0 && range.layers.start == 0 {
                     Ok(n::ImageView::Surface(surface))
                 } else if level != 0 {
@@ -1812,7 +1812,7 @@ impl d::Device<B> for Device {
     unsafe fn destroy_image(&self, image: n::Image) {
         let gl = &self.share.context;
         match image.kind {
-            n::ImageKind::Surface(rb) => gl.delete_renderbuffer(rb),
+            n::ImageKind::Surface { surface, .. } => gl.delete_renderbuffer(surface),
             n::ImageKind::Texture { texture, .. } => gl.delete_texture(texture),
         }
     }
@@ -1892,12 +1892,12 @@ impl d::Device<B> for Device {
                 .unwrap();
 
             match image.kind {
-                n::ImageKind::Surface(suf) => {
+                n::ImageKind::Surface { surface, .. } => {
                     gl.framebuffer_renderbuffer(
                         glow::FRAMEBUFFER,
                         glow::COLOR_ATTACHMENT0,
                         glow::RENDERBUFFER,
-                        Some(suf),
+                        Some(surface),
                     );
                 }
                 n::ImageKind::Texture {

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -181,7 +181,10 @@ pub struct Image {
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum ImageKind {
-    Surface(Surface),
+    Surface {
+        surface: Surface,
+        format: TextureFormat
+    },
     Texture {
         texture: Texture,
         target: TextureTarget,


### PR DESCRIPTION
This is probably incomplete (and wrong). Now, it just always copies the color attachment. I imagine we should check the subresource layers in `data`. I would appreciate some guidance, is that easily implementable from here?

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
