### PR TITLE
Flush on `submit` in GL when there are no sync capabilities

### DIFF
--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1011,18 +1011,19 @@ impl hal::queue::RawCommandQueue<Backend> for CommandQueue {
         }
 
         if let Some(fence) = fence {
-            fence.0.set(native::FenceInner::Pending(
-                if self.share.private_caps.sync {
+            if self.share.private_caps.sync {
+                fence.0.set(native::FenceInner::Pending(
                     Some(
                         self.share
                             .context
                             .fence_sync(glow::SYNC_GPU_COMMANDS_COMPLETE, 0)
                             .unwrap(),
                     )
-                } else {
-                    None
-                },
-            ));
+                ));
+            } else {
+                self.share.context.flush();
+                fence.0.set(native::FenceInner::Idle { signaled: true });
+            }
         }
     }
 


### PR DESCRIPTION
Currently, when there are no sync capabilites, the GL backend returns an unsignaled fence on `submit` which only changes to signaled if `wait_for_fence` is called. This behavior causes memory to _never_ be freed when using WebGL2 on `wgpu`.

The changes here flush immediately on `submit` in this case, and return an already signaled fence. I am not sure if this is the correct way to fix this. Let me know how to proceed.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code