### PR TITLE
Fix attachments confusion

### DIFF
--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -361,6 +361,7 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
         min_storage_buffer_offset_alignment: get_u64(gl, glow::SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT).unwrap_or(1024),
         framebuffer_color_samples_count: max_samples_mask,
         non_coherent_atom_size: 1,
+        max_color_attachments: get_usize(gl, glow::MAX_COLOR_ATTACHMENTS).unwrap_or(1),
         ..Limits::default()
     };
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -140,7 +140,7 @@ impl hal::Backend for Backend {
 
     type ShaderModule = native::ShaderModule;
     type RenderPass = native::RenderPass;
-    type Framebuffer = Option<native::FrameBuffer>;
+    type Framebuffer = native::FrameBuffer;
 
     type Buffer = native::Buffer;
     type BufferView = native::BufferView;
@@ -234,7 +234,7 @@ const CPU_VISIBLE_HEAP: usize = 1;
 
 /// Memory types in the OpenGL backend are either usable for buffers and are backed by a real OpenGL
 /// buffer, or are used for images and are fake and not backed by any real raw buffer.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 enum MemoryUsage {
     Buffer(buffer::Usage),
     Image,
@@ -471,6 +471,8 @@ impl PhysicalDevice {
         ));
 
         assert!(memory_types.len() <= 64);
+
+        log::info!("Memory types: {:#?}", memory_types);
 
         // create the shared context
         let share = Share {

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -55,7 +55,7 @@ pub enum BufferMemory {
 
 #[derive(Debug)]
 pub struct RawCommandPool {
-    pub(crate) fbo: Option<n::FrameBuffer>,
+    pub(crate) fbo: Option<n::RawFrameBuffer>,
     pub(crate) limits: command::Limits,
     pub(crate) memory: Arc<Mutex<BufferMemory>>,
 }

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -32,7 +32,7 @@ struct State {
     // Currently set scissor rects.
     num_scissors: usize,
     // Currently bound fbo
-    fbo: Option<native::FrameBuffer>,
+    fbo: Option<native::RawFrameBuffer>,
 }
 
 impl State {

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -71,7 +71,7 @@ pub struct Swapchain {
     // Extent because the window lies
     pub(crate) extent: Extent2D,
     ///
-    pub(crate) fbos: Vec<native::FrameBuffer>,
+    pub(crate) fbos: Vec<native::RawFrameBuffer>,
 }
 
 impl hal::Swapchain<B> for Swapchain {

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -43,7 +43,7 @@ impl Window {
 pub struct Swapchain {
     pub(crate) window: Window,
     pub(crate) extent: Extent2D,
-    pub(crate) fbos: Vec<native::FrameBuffer>,
+    pub(crate) fbos: Vec<native::RawFrameBuffer>,
 }
 
 impl hal::Swapchain<B> for Swapchain {

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -274,7 +274,7 @@ impl hal::Surface<Backend> for Surface {
 
 #[derive(Debug)]
 pub struct Swapchain {
-    pub(crate) fbos: Vec<native::FrameBuffer>,
+    pub(crate) fbos: Vec<native::RawFrameBuffer>,
     pub(crate) context: PresentContext,
     pub(crate) extent: Extent2D,
 }


### PR DESCRIPTION
This changes attachments references confusion that led to `draw_buffers` to contain shifted indices.
Also this opens route to support multiple subpasses in one render pass by having fbo per subpass.