### PR TITLE
[mtl] Fixes the FeatureSet requirement for calling setDepthClipMode

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -580,7 +580,7 @@ const FUNCTION_SPECIALIZATION_SUPPORT: &[MTLFeatureSet] = &[
 ];
 
 const DEPTH_CLIP_MODE: &[MTLFeatureSet] = &[
-    MTLFeatureSet::iOS_GPUFamily2_v1,
+    MTLFeatureSet::iOS_GPUFamily4_v1,
     MTLFeatureSet::tvOS_GPUFamily1_v3,
     MTLFeatureSet::macOS_GPUFamily1_v1,
 ];


### PR DESCRIPTION
Before this PR I was getting metal validation errors on iOS sim.

According to the apple [docs](https://developer.apple.com/documentation/metal/mtlrendercommandencoder/1516267-setdepthclipmode?language=objc), setDepthClipMode requires atleast ios gpu family 4 or later. FWIW it appears that iOS simulators do not support that gpu family.

This PR also bumps the metal backend version.

Also, it looks like apple is moving away from [FeatureSets](https://developer.apple.com/documentation/metal/mtlfeatureset?language=objc) to just Metal version and GPU Families. Probly due to metal on iOS sim.
> If your app is running on Metal 3.0 or later, don't use MTLFeatureSet. Instead, search for Metal software versions (supportsVersion:) and Metal GPU families (supportsFamily:).