### PR TITLE
[mtl] fix incorrect `image_count` caps

### DIFF
--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -328,14 +328,16 @@ impl hal::Surface<Backend> for Surface {
         let device_caps = &device.shared.private_caps;
 
         let can_set_maximum_drawables_count =
-            device_caps.os_is_mac || device_caps.has_version_at_least(11, 2);
+            (device_caps.os_is_mac && device_caps.has_version_at_least(10, 13)) // macOS 10.13.2+
+            || (!device_caps.os_is_mac && device_caps.has_version_at_least(11, 2)); // iOS 11.2+
 
         let image_count = if can_set_maximum_drawables_count {
-            2 .. 4
+            // You can set this value to 2 or 3 only; other values are ignored
+            // and an exception is thrown
+            2 .. 3
         } else {
-            // 3 is the default in `CAMetalLayer` documentation
-            // iOS 10.3 was tested to use 3 on iphone5s
-            3 .. 4
+            // The default value is 3
+            3 .. 3
         };
 
         let caps = hal::SurfaceCapabilities {


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: mtl
- [ ] `rustfmt` run on changed code
