### PR TITLE
Make Limits sample_counts field naming consistent with vulkan

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -383,9 +383,9 @@ impl hal::Instance for Instance {
                 min_texel_buffer_offset_alignment: 1,                                     // TODO
                 min_uniform_buffer_offset_alignment: 16, // TODO: verify
                 min_storage_buffer_offset_alignment: 1,  // TODO
-                framebuffer_color_samples_count: 1,      // TODO
-                framebuffer_depth_samples_count: 1,      // TODO
-                framebuffer_stencil_samples_count: 1,    // TODO
+                framebuffer_color_sample_counts: 1,      // TODO
+                framebuffer_depth_sample_counts: 1,      // TODO
+                framebuffer_stencil_sample_counts: 1,    // TODO
                 max_color_attachments: d3d11::D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT as _,
                 buffer_image_granularity: 1,
                 non_coherent_atom_size: 1, // TODO

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1089,9 +1089,9 @@ impl hal::Instance for Instance {
                     min_storage_buffer_offset_alignment: 1, // TODO
                     // TODO: query supported sample count for all framebuffer formats and increase the limit
                     //       if possible.
-                    framebuffer_color_samples_count: 0b101,
-                    framebuffer_depth_samples_count: 0b101,
-                    framebuffer_stencil_samples_count: 0b101,
+                    framebuffer_color_sample_counts: 0b101,
+                    framebuffer_depth_sample_counts: 0b101,
+                    framebuffer_stencil_sample_counts: 0b101,
                     max_color_attachments: d3d12::D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT as _,
                     buffer_image_granularity: 1,
                     non_coherent_atom_size: 1, //TODO: confirm

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -359,7 +359,7 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
         min_texel_buffer_offset_alignment: 1,
         min_uniform_buffer_offset_alignment: get_u64(gl, glow::UNIFORM_BUFFER_OFFSET_ALIGNMENT).unwrap_or(1024),
         min_storage_buffer_offset_alignment: get_u64(gl, glow::SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT).unwrap_or(1024),
-        framebuffer_color_samples_count: max_samples_mask,
+        framebuffer_color_sample_counts: max_samples_mask,
         non_coherent_atom_size: 1,
         max_color_attachments: get_usize(gl, glow::MAX_COLOR_ATTACHMENTS).unwrap_or(1),
         ..Limits::default()

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -489,9 +489,9 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             max_vertex_input_binding_stride: 256,   // TODO
             max_vertex_output_components: 16,       // TODO
 
-            framebuffer_color_samples_count: 0b101,   // TODO
-            framebuffer_depth_samples_count: 0b101,   // TODO
-            framebuffer_stencil_samples_count: 0b101, // TODO
+            framebuffer_color_sample_counts: 0b101,   // TODO
+            framebuffer_depth_sample_counts: 0b101,   // TODO
+            framebuffer_stencil_sample_counts: 0b101, // TODO
             max_color_attachments: MAX_COLOR_ATTACHMENTS,
 
             buffer_image_granularity: 1,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -878,9 +878,9 @@ impl hal::PhysicalDevice<Backend> for PhysicalDevice {
             min_texel_buffer_offset_alignment: limits.min_texel_buffer_offset_alignment as _,
             min_uniform_buffer_offset_alignment: limits.min_uniform_buffer_offset_alignment as _,
             min_storage_buffer_offset_alignment: limits.min_storage_buffer_offset_alignment as _,
-            framebuffer_color_samples_count: limits.framebuffer_color_sample_counts.as_raw() as _,
-            framebuffer_depth_samples_count: limits.framebuffer_depth_sample_counts.as_raw() as _,
-            framebuffer_stencil_samples_count: limits.framebuffer_stencil_sample_counts.as_raw()
+            framebuffer_color_sample_counts: limits.framebuffer_color_sample_counts.as_raw() as _,
+            framebuffer_depth_sample_counts: limits.framebuffer_depth_sample_counts.as_raw() as _,
+            framebuffer_stencil_sample_counts: limits.framebuffer_stencil_sample_counts.as_raw()
                 as _,
             max_color_attachments: limits.max_color_attachments as _,
             buffer_image_granularity: limits.buffer_image_granularity,

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -378,11 +378,11 @@ pub struct Limits {
     /// The alignment of the start of buffer used as a storage buffer, in bytes, non-zero.
     pub min_storage_buffer_offset_alignment: buffer::Offset,
     /// Number of samples supported for color attachments of framebuffers (floating/fixed point).
-    pub framebuffer_color_samples_count: image::NumSamples,
+    pub framebuffer_color_sample_counts: image::NumSamples,
     /// Number of samples supported for depth attachments of framebuffers.
-    pub framebuffer_depth_samples_count: image::NumSamples,
+    pub framebuffer_depth_sample_counts: image::NumSamples,
     /// Number of samples supported for stencil attachments of framebuffers.
-    pub framebuffer_stencil_samples_count: image::NumSamples,
+    pub framebuffer_stencil_sample_counts: image::NumSamples,
     /// Maximum number of color attachments that can be used by a subpass in a render pass.
     pub max_color_attachments: usize,
     ///


### PR DESCRIPTION
closes https://github.com/gfx-rs/gfx/issues/2859
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
    - vulkan
    - gl

~~- [ ] `rustfmt` run on changed code~~

