### PR TITLE
Change SurfaceCapabilities fields to use RangeInclusive instead of Range

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -722,9 +722,9 @@ impl hal::Surface<Backend> for Surface {
         // NOTE: some swap effects affect msaa capabilities..
         // TODO: _DISCARD swap effects can only have one image?
         let capabilities = hal::SurfaceCapabilities {
-            image_count: 1 .. 16, // TODO:
+            image_count: 1 ..= 16, // TODO:
             current_extent: Some(extent),
-            extents: extent .. extent,
+            extents: extent ..= extent,
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
             composite_alpha: CompositeAlpha::OPAQUE, //TODO

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -74,9 +74,9 @@ impl hal::Surface<Backend> for Surface {
         let extent = hal::window::Extent2D { width, height };
 
         let capabilities = hal::SurfaceCapabilities {
-            image_count: 2 .. 16, // we currently use a flip effect which supports 2..16 buffers
+            image_count: 2 ..= 16, // we currently use a flip effect which supports 2..=16 buffers
             current_extent: Some(extent),
-            extents: extent .. extent,
+            extents: extent ..= extent,
             max_image_layers: 1,
             usage: i::Usage::COLOR_ATTACHMENT | i::Usage::TRANSFER_SRC | i::Usage::TRANSFER_DST,
             composite_alpha: CompositeAlpha::OPAQUE, //TODO

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -135,15 +135,15 @@ impl hal::Surface<B> for Surface {
     ) {
         let caps = hal::SurfaceCapabilities {
             image_count: if self.context.get_pixel_format().double_buffer {
-                2 .. 3
+                2 ..= 2
             } else {
-                1 .. 2
+                1 ..= 1
             },
             current_extent: None,
             extents: hal::window::Extent2D {
                 width: 4,
                 height: 4,
-            } .. hal::window::Extent2D {
+            } ..= hal::window::Extent2D {
                 width: 4096,
                 height: 4096,
             },

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -95,15 +95,12 @@ impl hal::Surface<B> for Surface {
 
         let caps = hal::SurfaceCapabilities {
             image_count: if Window.get_pixel_format().double_buffer {
-                2 .. 3
+                2 ..= 2
             } else {
-                1 .. 2
+                1 ..= 1
             },
             current_extent: Some(extent),
-            extents: extent .. hal::window::Extent2D {
-                width: ex.width + 1,
-                height: ex.height + 1,
-            },
+            extents: extent ..= extent,
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
             composite_alpha: CompositeAlpha::OPAQUE, //TODO

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -244,12 +244,9 @@ impl hal::Surface<Backend> for Surface {
         let extent = self.get_extent();
 
         let caps = hal::SurfaceCapabilities {
-            image_count: 2 .. 3,
+            image_count: 2 ..= 2,
             current_extent: Some(extent),
-            extents: extent .. hal::window::Extent2D {
-                width: extent.width + 1,
-                height: extent.height + 1,
-            },
+            extents: extent ..= extent,
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
             composite_alpha: CompositeAlpha::OPAQUE, //TODO

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -326,11 +326,11 @@ impl hal::Surface<Backend> for Surface {
             device_caps.os_is_mac || device_caps.has_version_at_least(11, 2);
 
         let image_count = if can_set_maximum_drawables_count {
-            2 .. 4
+            2 ..= 3
         } else {
             // 3 is the default in `CAMetalLayer` documentation
             // iOS 10.3 was tested to use 3 on iphone5s
-            3 .. 4
+            3 ..= 3
         };
 
         let caps = hal::SurfaceCapabilities {
@@ -340,7 +340,7 @@ impl hal::Surface<Backend> for Surface {
             extents: Extent2D {
                 width: 4,
                 height: 4,
-            } .. Extent2D {
+            } ..= Extent2D {
                 width: 4096,
                 height: 4096,
             },

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -373,9 +373,9 @@ impl hal::Surface<Backend> for Surface {
         };
 
         let capabilities = hal::SurfaceCapabilities {
-            image_count: caps.min_image_count .. max_images,
+            image_count: caps.min_image_count ..= max_images,
             current_extent,
-            extents: min_extent .. max_extent,
+            extents: min_extent ..= max_extent,
             max_image_layers: caps.max_image_array_layers as _,
             usage: conv::map_vk_image_usage(caps.supported_usage_flags),
             composite_alpha: conv::map_vk_composite_alpha(caps.supported_composite_alpha),

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -61,7 +61,7 @@ use std::borrow::Borrow;
 use std::cmp::{max, min};
 use std::fmt;
 use std::iter;
-use std::ops::Range;
+use std::ops::RangeInclusive;
 
 /// Error occurred during swapchain creation.
 #[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
@@ -146,7 +146,7 @@ pub struct SurfaceCapabilities {
     ///
     /// - `image_count.start` must be at least 1.
     /// - `image_count.end` must be larger or equal to `image_count.start`.
-    pub image_count: Range<SwapImageIndex>,
+    pub image_count: RangeInclusive<SwapImageIndex>,
 
     /// Current extent of the surface.
     ///
@@ -156,7 +156,7 @@ pub struct SurfaceCapabilities {
     /// Range of supported extents.
     ///
     /// `current_extent` must be inside this range.
-    pub extents: Range<Extent2D>,
+    pub extents: RangeInclusive<Extent2D>,
 
     /// Maximum number of layers supported for presentable images.
     ///
@@ -311,9 +311,8 @@ impl SwapchainConfig {
         let clamped_extent = match caps.current_extent {
             Some(current) => current,
             None => {
-                let (min_width, max_width) = (caps.extents.start.width, caps.extents.end.width - 1);
-                let (min_height, max_height) =
-                    (caps.extents.start.height, caps.extents.end.height - 1);
+                let (min_width, max_width) = (caps.extents.start().width, caps.extents.end().width);
+                let (min_height, max_height) = (caps.extents.start().height, caps.extents.end().height);
 
                 // clamp the default_extent to within the allowed surface sizes
                 let width = min(max_width, max(default_extent.width, min_width));
@@ -336,7 +335,7 @@ impl SwapchainConfig {
             composite_alpha,
             format,
             extent: clamped_extent,
-            image_count: caps.image_count.start,
+            image_count: *caps.image_count.start(),
             image_layers: 1,
             image_usage: image::Usage::COLOR_ATTACHMENT,
         }


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/gfx/issues/2571
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
vulkan - linux
gl - linux

~~`rustfmt` run on changed code~~