### PR TITLE
Fix: Vulkan validation for examples using ShaderReadOnlyOptimal

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1209,7 +1209,7 @@ impl<B: Backend> ImageState<B> {
                 DescSetWrite {
                     binding: 0,
                     array_offset: 0,
-                    descriptors: Some(pso::Descriptor::Image(&image_view, i::Layout::Undefined)),
+                    descriptors: Some(pso::Descriptor::Image(&image_view, i::Layout::ShaderReadOnlyOptimal)),
                 },
                 DescSetWrite {
                     binding: 1,

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -321,7 +321,7 @@ fn main() {
                 set: &desc_set,
                 binding: 0,
                 array_offset: 0,
-                descriptors: Some(pso::Descriptor::Image(&image_srv, i::Layout::Undefined)),
+                descriptors: Some(pso::Descriptor::Image(&image_srv, i::Layout::ShaderReadOnlyOptimal)),
             },
             pso::DescriptorSetWrite {
                 set: &desc_set,


### PR DESCRIPTION
Fixes Validation error
> [2019-07-27T02:28:11Z ERROR gfx_backend_vulkan]
> VALIDATION [VUID-VkWriteDescriptorSet-descriptorType-01403 (0)] : vkUpdateDescriptorSets() failed write update validation for Descriptor Set 0x6 with error: Write update to VkDescriptorSet 0x6 allocated with VkDescriptorSetLayout 0x4 binding #0 failed with error message: Attempted write update to image descriptor failed due to: Descriptor update with descriptorType VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE is being updated with invalid imageLayout VK_IMAGE_LAYOUT_UNDEFINED. Allowed layouts are: VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL. The Vulkan spec states: If descriptorType is VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE or VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, the imageLayout member of each element of pImageInfo must be a member of the list given in Sampled Image or Combined Image Sampler, corresponding to its type (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-VkWriteDescriptorSet-descriptorType-01403)
object info: (type: DESCRIPTOR_SET, hndl: 6)

Vulkan version 1.1.108

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds: (on *nix)
- [ ] tested examples with the following backends: dx12, vulkan
  (sorry I don't have a Mac right now, currently between jobs)
- [ ] `rustfmt` run on changed code
  (warnings about imports_layout, spaces_around_ranges, and blank_lines_upper_bound available only in nightly, also `rustfmt` for is not available for nightly on pc-windows-msvc nor unkown-linux-gnu)