### PR TITLE
hal: dedicated buffer/image memory

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -29,6 +29,7 @@ ash = "0.29.0"
 gfx-hal = { path = "../../hal", version = "0.2" }
 smallvec = "0.6"
 winit = { version = "0.19", optional = true }
+#vk-mem = { version = "0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }


### PR DESCRIPTION
Fixes #2511 
Closes #2513

The idea is that backends can implement this more efficiently than the default implementation.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
