### PR TITLE
Remove usages of range that dont describe linear values

### DIFF
--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -173,11 +173,12 @@ fn main() {
             }],
         );
         command_buffer.pipeline_barrier(
-            pso::PipelineStage::TRANSFER .. pso::PipelineStage::COMPUTE_SHADER,
+            pso::PipelineStage::TRANSFER,
+            pso::PipelineStage::COMPUTE_SHADER,
             memory::Dependencies::empty(),
             Some(memory::Barrier::Buffer {
-                states: buffer::Access::TRANSFER_WRITE
-                    .. buffer::Access::SHADER_READ | buffer::Access::SHADER_WRITE,
+                src_access: buffer::Access::TRANSFER_WRITE,
+                dst_access: buffer::Access::SHADER_READ | buffer::Access::SHADER_WRITE,
                 families: None,
                 target: &device_buffer,
                 range: None .. None,
@@ -187,11 +188,12 @@ fn main() {
         command_buffer.bind_compute_descriptor_sets(&pipeline_layout, 0, &[desc_set], &[]);
         command_buffer.dispatch([numbers.len() as u32, 1, 1]);
         command_buffer.pipeline_barrier(
-            pso::PipelineStage::COMPUTE_SHADER .. pso::PipelineStage::TRANSFER,
+            pso::PipelineStage::COMPUTE_SHADER,
+            pso::PipelineStage::TRANSFER,
             memory::Dependencies::empty(),
             Some(memory::Barrier::Buffer {
-                states: buffer::Access::SHADER_READ | buffer::Access::SHADER_WRITE
-                    .. buffer::Access::TRANSFER_READ,
+                src_access: buffer::Access::SHADER_READ | buffer::Access::SHADER_WRITE,
+                dst_access: buffer::Access::TRANSFER_READ,
                 families: None,
                 target: &device_buffer,
                 range: None .. None,

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -339,15 +339,18 @@ fn main() {
         cmd_buffer.begin();
 
         let image_barrier = m::Barrier::Image {
-            states: (i::Access::empty(), i::Layout::Undefined)
-                .. (i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal),
+            src_access: i::Access::empty(),
+            dst_access: i::Access::TRANSFER_WRITE,
+            src_layout: i::Layout::Undefined,
+            dst_layout: i::Layout::TransferDstOptimal,
             target: &image_logo,
             families: None,
             range: COLOR_RANGE.clone(),
         };
 
         cmd_buffer.pipeline_barrier(
-            PipelineStage::TOP_OF_PIPE .. PipelineStage::TRANSFER,
+            PipelineStage::TOP_OF_PIPE,
+            PipelineStage::TRANSFER,
             m::Dependencies::empty(),
             &[image_barrier],
         );
@@ -375,14 +378,17 @@ fn main() {
         );
 
         let image_barrier = m::Barrier::Image {
-            states: (i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal)
-                .. (i::Access::SHADER_READ, i::Layout::ShaderReadOnlyOptimal),
+            src_access: i::Access::TRANSFER_WRITE,
+            dst_access: i::Access::SHADER_READ,
+            src_layout: i::Layout::TransferDstOptimal,
+            dst_layout: i::Layout::ShaderReadOnlyOptimal,
             target: &image_logo,
             families: None,
             range: COLOR_RANGE.clone(),
         };
         cmd_buffer.pipeline_barrier(
-            PipelineStage::TRANSFER .. PipelineStage::FRAGMENT_SHADER,
+            PipelineStage::TRANSFER,
+            PipelineStage::FRAGMENT_SHADER,
             m::Dependencies::empty(),
             &[image_barrier],
         );
@@ -427,7 +433,8 @@ fn main() {
                 pass::AttachmentStoreOp::Store,
             ),
             stencil_ops: pass::AttachmentOps::DONT_CARE,
-            layouts: i::Layout::Undefined .. i::Layout::Present,
+            initial_layout: i::Layout::Undefined,
+            final_layout: i::Layout::Present,
         };
 
         let subpass = pass::SubpassDesc {
@@ -439,11 +446,12 @@ fn main() {
         };
 
         let dependency = pass::SubpassDependency {
-            passes: pass::SubpassRef::External .. pass::SubpassRef::Pass(0),
-            stages: PipelineStage::COLOR_ATTACHMENT_OUTPUT
-                .. PipelineStage::COLOR_ATTACHMENT_OUTPUT,
-            accesses: i::Access::empty()
-                .. (i::Access::COLOR_ATTACHMENT_READ | i::Access::COLOR_ATTACHMENT_WRITE),
+            src_subpass: pass::SubpassRef::External,
+            dst_subpass: pass::SubpassRef::Pass(0),
+            src_stage: PipelineStage::COLOR_ATTACHMENT_OUTPUT,
+            dst_stage: PipelineStage::COLOR_ATTACHMENT_OUTPUT,
+            src_access: i::Access::empty(),
+            dst_access: i::Access::COLOR_ATTACHMENT_READ | i::Access::COLOR_ATTACHMENT_WRITE,
         };
 
         unsafe { device.create_render_pass(&[attachment], &[subpass], &[dependency]) }

--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -12,7 +12,8 @@
 					format: Some(Rgba8Unorm),
 					samples: 1,
 					ops: (load: Clear, store: Store),
-					layouts: (start: General, end: General),
+					initial_layout: General,
+					final_layout: General,
 				),
 			},
 			subpasses: {

--- a/reftests/scenes/vertex-offset.ron
+++ b/reftests/scenes/vertex-offset.ron
@@ -17,7 +17,8 @@
                     format: Some(Rgba32Uint),
                     samples: 1,
                     ops: (load: Clear, store: Store),
-                    layouts: (start: General, end: General),
+                    initial_layout: General,
+                    final_layout: General,
                 ),
             },
             subpasses: {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -558,7 +558,8 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
     unsafe fn pipeline_barrier<'a, T>(
         &mut self,
-        _: Range<pso::PipelineStage>,
+        _: pso::PipelineStage,
+        _: pso::PipelineStage,
         _: memory::Dependencies,
         _: T,
     ) where
@@ -807,7 +808,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    unsafe fn wait_events<'a, I, J>(&mut self, _: I, _: Range<pso::PipelineStage>, _: J)
+    unsafe fn wait_events<'a, I, J>(&mut self, _: I, _: pso::PipelineStage, _: pso::PipelineStage, _: J)
     where
         I: IntoIterator,
         I::Item: Borrow<()>,

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -591,7 +591,8 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
 
     unsafe fn pipeline_barrier<'a, T>(
         &mut self,
-        _stages: Range<hal::pso::PipelineStage>,
+        _src_stage: hal::pso::PipelineStage,
+        _dst_stage: hal::pso::PipelineStage,
         _dependencies: memory::Dependencies,
         _barriers: T,
     ) where
@@ -1357,7 +1358,7 @@ impl command::RawCommandBuffer<Backend> for RawCommandBuffer {
         unimplemented!()
     }
 
-    unsafe fn wait_events<'a, I, J>(&mut self, _: I, _: Range<pso::PipelineStage>, _: J)
+    unsafe fn wait_events<'a, I, J>(&mut self, _: I, _: pso::PipelineStage, _: pso::PipelineStage, _: J)
     where
         I: IntoIterator,
         I::Item: Borrow<()>,

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2522,7 +2522,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn pipeline_barrier<'a, T>(
         &mut self,
-        _stages: Range<pso::PipelineStage>,
+        _src_stage: pso::PipelineStage,
+        _dst_stage: pso::PipelineStage,
         _dependencies: memory::Dependencies,
         _barriers: T,
     ) where
@@ -4399,7 +4400,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
     unsafe fn wait_events<'a, I, J>(
         &mut self,
         events: I,
-        stages: Range<pso::PipelineStage>,
+        src_stage: pso::PipelineStage,
+        dst_stage: pso::PipelineStage,
         barriers: J,
     ) where
         I: IntoIterator,
@@ -4425,7 +4427,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
 
         if need_barrier {
-            self.pipeline_barrier(stages, memory::Dependencies::empty(), barriers);
+            self.pipeline_barrier(src_stage, dst_stage, memory::Dependencies::empty(), barriers);
         }
     }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -122,8 +122,8 @@ impl d::Device<B> for Device {
                     store_op: conv::map_attachment_store_op(attachment.ops.store),
                     stencil_load_op: conv::map_attachment_load_op(attachment.stencil_ops.load),
                     stencil_store_op: conv::map_attachment_store_op(attachment.stencil_ops.store),
-                    initial_layout: conv::map_image_layout(attachment.layouts.start),
-                    final_layout: conv::map_image_layout(attachment.layouts.end),
+                    initial_layout: conv::map_image_layout(attachment.initial_layout),
+                    final_layout: conv::map_image_layout(attachment.final_layout),
                 }
             })
             .collect::<Vec<_>>();
@@ -197,12 +197,12 @@ impl d::Device<B> for Device {
                 let dependency = dependency.borrow();
                 // TODO: checks
                 vk::SubpassDependency {
-                    src_subpass: map_subpass_ref(dependency.passes.start),
-                    dst_subpass: map_subpass_ref(dependency.passes.end),
-                    src_stage_mask: conv::map_pipeline_stage(dependency.stages.start),
-                    dst_stage_mask: conv::map_pipeline_stage(dependency.stages.end),
-                    src_access_mask: conv::map_image_access(dependency.accesses.start),
-                    dst_access_mask: conv::map_image_access(dependency.accesses.end),
+                    src_subpass: map_subpass_ref(dependency.src_subpass),
+                    dst_subpass: map_subpass_ref(dependency.dst_subpass),
+                    src_stage_mask: conv::map_pipeline_stage(dependency.src_stage),
+                    dst_stage_mask: conv::map_pipeline_stage(dependency.dst_stage),
+                    src_access_mask: conv::map_image_access(dependency.src_access),
+                    dst_access_mask: conv::map_image_access(dependency.dst_access),
                     dependency_flags: vk::DependencyFlags::empty(), // TODO
                 }
             })

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -11,9 +11,6 @@ use crate::{device, format, Backend, IndexType};
 /// An offset inside a buffer, in bytes.
 pub type Offset = u64;
 
-/// Buffer state.
-pub type State = Access;
-
 /// Error creating a buffer.
 #[derive(Fail, Debug, Clone, PartialEq, Eq)]
 pub enum CreationError {

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -157,7 +157,8 @@ pub trait RawCommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// in the command buffer.
     unsafe fn pipeline_barrier<'a, T>(
         &mut self,
-        stages: Range<pso::PipelineStage>,
+        src_stage: pso::PipelineStage,
+        dst_stage: pso::PipelineStage,
         dependencies: Dependencies,
         barriers: T,
     ) where
@@ -512,14 +513,15 @@ pub trait RawCommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
 
     /// Waits at some shader stage(s) until all events have been signalled.
     ///
-    /// - `src_stages` specifies the shader pipeline stages in which the events were signalled.
-    /// - `dst_stages` specifies the shader pipeline stages at which execution should wait.
+    /// - `src_stage` specifies the shader pipeline stages in which the events were signalled.
+    /// - `dst_stage` specifies the shader pipeline stages at which execution should wait.
     /// - `barriers` specifies a series of memory barriers to be executed before pipeline execution
     ///   resumes.
     unsafe fn wait_events<'a, I, J>(
         &mut self,
         events: I,
-        stages: Range<pso::PipelineStage>,
+        src_stage: pso::PipelineStage,
+        dst_stage: pso::PipelineStage,
         barriers: J,
     ) where
         I: IntoIterator,

--- a/src/hal/src/command/transfer.rs
+++ b/src/hal/src/command/transfer.rs
@@ -1,6 +1,5 @@
 //! `CommandBuffer` methods for transfer operations.
 use std::borrow::Borrow;
-use std::ops::Range;
 
 use super::{CommandBuffer, Level, RawCommandBuffer, Shot};
 use crate::memory::{Barrier, Dependencies};
@@ -63,14 +62,15 @@ impl<B: Backend, C: Supports<Transfer>, S: Shot, L: Level> CommandBuffer<B, C, S
     /// Identical to the `RawCommandBuffer` method of the same name.
     pub unsafe fn pipeline_barrier<'i, T>(
         &mut self,
-        stages: Range<PipelineStage>,
+        src_stage: PipelineStage,
+        dst_stage: PipelineStage,
         dependencies: Dependencies,
         barriers: T,
     ) where
         T: IntoIterator,
         T::Item: Borrow<Barrier<'i, B>>,
     {
-        self.raw.pipeline_barrier(stages, dependencies, barriers)
+        self.raw.pipeline_barrier(src_stage, dst_stage, dependencies, barriers)
     }
 
     /// Identical to the `RawCommandBuffer` method of the same name.

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -83,8 +83,10 @@ pub enum Barrier<'a, B: Backend> {
     AllImages(Range<image::Access>),
     /// A memory barrier that defines access to a buffer.
     Buffer {
-        /// The access flags controlling the buffer.
-        states: Range<buffer::State>,
+        /// The source access flags controlling the buffer.
+        src_access: buffer::Access,
+        /// The destination access flags controlling the buffer.
+        dst_access: buffer::Access,
         /// The buffer the barrier controls.
         target: &'a B::Buffer,
         /// The source and destination Queue family IDs, for a [queue family ownership transfer](https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#synchronization-queue-transfers)
@@ -95,8 +97,14 @@ pub enum Barrier<'a, B: Backend> {
     },
     /// A memory barrier that defines access to (a subset of) an image.
     Image {
-        /// The access flags controlling the image.
-        states: Range<image::State>,
+        /// The source access flags controlling the image.
+        src_access: image::Access,
+        /// The destination access flags controlling the image.
+        dst_access: image::Access,
+        /// The source layout controlling the image.
+        src_layout: image::Layout,
+        /// The destination layout controlling the image.
+        dst_layout: image::Layout,
         /// The image the barrier controls.
         target: &'a B::Image,
         /// The source and destination Queue family IDs, for a [queue family ownership transfer](https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#synchronization-queue-transfers)
@@ -109,9 +117,10 @@ pub enum Barrier<'a, B: Backend> {
 
 impl<'a, B: Backend> Barrier<'a, B> {
     /// Create a barrier for the whole buffer between the given states.
-    pub fn whole_buffer(target: &'a B::Buffer, states: Range<buffer::State>) -> Self {
+    pub fn whole_buffer(target: &'a B::Buffer, src_access: buffer::Access, dst_access: buffer::Access) -> Self {
         Barrier::Buffer {
-            states,
+            src_access,
+            dst_access,
             target,
             families: None,
             range: None .. None,

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -1,7 +1,6 @@
 //! RenderPass handling.
 
 use crate::{format::Format, image, pso::PipelineStage, Backend};
-use std::ops::Range;
 
 /// Specifies the operation which will be applied at the beginning of a subpass.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
@@ -84,8 +83,10 @@ pub struct Attachment {
     /// Load and store operations of the stencil aspect, if any
     #[cfg_attr(feature = "serde", serde(default = "AttachmentOps::whatever"))]
     pub stencil_ops: AttachmentOps,
-    /// Initial and final image layouts of the renderpass.
-    pub layouts: Range<AttachmentLayout>,
+    /// Initial image layout of the renderpass.
+    pub initial_layout: AttachmentLayout,
+    /// Final image layouts of the renderpass.
+    pub final_layout: AttachmentLayout,
 }
 
 impl Attachment {
@@ -124,12 +125,18 @@ pub enum SubpassRef {
 #[derive(Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SubpassDependency {
-    /// Other subpasses this one depends on.
-    pub passes: Range<SubpassRef>,
-    /// Other pipeline stages this subpass depends on.
-    pub stages: Range<PipelineStage>,
-    /// Resource accesses this subpass depends on.
-    pub accesses: Range<image::Access>,
+    /// Source subpass this one depends on.
+    pub src_subpass: SubpassRef,
+    /// Destination subpass this one depends on.
+    pub dst_subpass: SubpassRef,
+    /// Source pipeline stage this subpass depends on.
+    pub src_stage: PipelineStage,
+    /// Destination pipeline stage this subpass depends on.
+    pub dst_stage: PipelineStage,
+    /// Resource source access this subpass depends on.
+    pub src_access: image::Access,
+    /// Resource destination access this subpass depends on.
+    pub dst_access: image::Access,
 }
 
 /// Description of a subpass for renderpass creation.

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -20,9 +20,12 @@ pub struct Subpass {
 
 #[derive(Debug, Deserialize)]
 pub struct SubpassDependency {
-    pub passes: Range<String>,
-    pub stages: Range<hal::pso::PipelineStage>,
-    pub accesses: Range<hal::image::Access>,
+    pub src_subpass: String,
+    pub dst_subpass: String,
+    pub src_stage: hal::pso::PipelineStage,
+    pub dst_stage: hal::pso::PipelineStage,
+    pub src_access: hal::image::Access,
+    pub dst_access: hal::image::Access,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/gfx/issues/2571
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
   - linux opengl + vulkan

~~- [ ] `rustfmt` run on changed code~~

I haven't fully checked that this covers every case, I just went through the examples and changed every case that pops up there. Can thoroughly replace everything in this PR or a followup.