### PR TITLE
[mtl] update parking_lot dependency to 0.9.0

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -37,8 +37,8 @@ cocoa = "0.18"
 core-graphics = "0.17"
 smallvec = "0.6"
 spirv_cross = { version = "0.15", features = ["msl"] }
-parking_lot = "0.6.3"
-storage-map = "0.1.2"
+parking_lot = "0.9.0"
+storage-map = "0.2"
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails
 # and we get no docs at all.


### PR DESCRIPTION
Depends on kvark/storage-map#2 and needs a new version published of storage-map
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: mtl
- [ ] `rustfmt` run on changed code
