### PR TITLE
[dx12] read-only storage descriptors

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1199,7 +1199,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                     ref states,
                     target,
                     ref families,
-                    ref range,
+                    ..
                 } => {
                     // TODO: Implement queue family ownership transitions for dx12
                     if let Some(f) = families {
@@ -1631,7 +1631,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 MaxDepth: 1.0,
             };
 
-            let mut list = instances.entry(key).or_insert(Vec::new());
+            let list = instances.entry(key).or_insert(Vec::new());
 
             for i in 0 .. num_layers {
                 let src_layer = r.src_subresource.layers.start + i;
@@ -1726,7 +1726,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         }
         // post barriers
         for bar in &mut barriers {
-            let mut transition = bar.u.Transition_mut();
+            let transition = bar.u.Transition_mut();
             mem::swap(&mut transition.StateBefore, &mut transition.StateAfter);
         }
         self.raw
@@ -1982,7 +1982,7 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         );
     }
 
-    unsafe fn fill_buffer<R>(&mut self, buffer: &r::Buffer, range: R, data: u32)
+    unsafe fn fill_buffer<R>(&mut self, buffer: &r::Buffer, range: R, _data: u32)
     where
         R: RangeArg<buffer::Offset>,
     {

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -10,10 +10,9 @@ use winapi::um::d3d12::*;
 use winapi::um::d3dcommon::*;
 
 use hal::format::{Format, ImageFeature, SurfaceType, Swizzle};
-use hal::pso::DescriptorSetLayoutBinding;
 use hal::{buffer, image, pso, Primitive};
 
-use native::descriptor::{Binding, DescriptorRange, DescriptorRangeType, ShaderVisibility};
+use native::descriptor::ShaderVisibility;
 
 
 pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
@@ -542,51 +541,44 @@ pub fn map_image_resource_state(
     state
 }
 
-pub fn map_descriptor_range(
-    bind: &DescriptorSetLayoutBinding,
-    register_space: u32,
-) -> Option<DescriptorRange> {
-    Some(DescriptorRange::new(
-        match bind.ty {
-            pso::DescriptorType::Sampler => return None,
-            pso::DescriptorType::SampledImage
-            | pso::DescriptorType::CombinedImageSampler
-            | pso::DescriptorType::InputAttachment
-            | pso::DescriptorType::UniformTexelBuffer => DescriptorRangeType::SRV,
-            pso::DescriptorType::StorageBuffer
-            | pso::DescriptorType::StorageBufferDynamic
-            | pso::DescriptorType::StorageTexelBuffer
-            | pso::DescriptorType::StorageImage => DescriptorRangeType::UAV,
-            pso::DescriptorType::UniformBuffer | pso::DescriptorType::UniformBufferDynamic => {
-                DescriptorRangeType::CBV
-            }
-        },
-        bind.count as _,
-        Binding {
-            register: bind.binding as _,
-            space: register_space,
-        },
-        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND,
-    ))
+bitflags! {
+    /// A set of D3D12 descriptor types that need to be associated
+    /// with a single gfx-hal `DescriptorType`.
+    pub struct DescriptorContent: u8 {
+        const CBV = 0x1;
+        const SRV = 0x2;
+        const UAV = 0x4;
+        const SAMPLER = 0x8;
+    }
 }
 
-pub fn map_sampler_descriptor_range(
-    bind: &DescriptorSetLayoutBinding,
-    register_space: u32,
-) -> Option<DescriptorRange> {
-    Some(DescriptorRange::new(
-        match bind.ty {
-            pso::DescriptorType::Sampler |
-            pso::DescriptorType::CombinedImageSampler => DescriptorRangeType::Sampler,
-            _ => return None,
-        },
-        bind.count as _,
-        Binding {
-            register: bind.binding as _,
-            space: register_space,
-        },
-        D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND,
-    ))
+impl From<pso::DescriptorType> for DescriptorContent {
+    fn from(ty: pso::DescriptorType) -> Self {
+        use hal::pso::DescriptorType as Dt;
+        match ty {
+            Dt::Sampler => {
+                DescriptorContent::SAMPLER
+            }
+            Dt::CombinedImageSampler => {
+                DescriptorContent::SRV | DescriptorContent::SAMPLER
+            }
+            Dt::SampledImage |
+            Dt::InputAttachment |
+            Dt::UniformTexelBuffer => {
+                DescriptorContent::SRV
+            }
+            Dt::StorageImage |
+            Dt::StorageBuffer |
+            Dt::StorageBufferDynamic |
+            Dt::StorageTexelBuffer => {
+                DescriptorContent::SRV | DescriptorContent::UAV
+            }
+            Dt::UniformBuffer |
+            Dt::UniformBufferDynamic => {
+                DescriptorContent::CBV
+            }
+        }
+    }
 }
 
 pub fn map_shader_visibility(flags: pso::ShaderStageFlags) -> ShaderVisibility {

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -541,46 +541,6 @@ pub fn map_image_resource_state(
     state
 }
 
-bitflags! {
-    /// A set of D3D12 descriptor types that need to be associated
-    /// with a single gfx-hal `DescriptorType`.
-    pub struct DescriptorContent: u8 {
-        const CBV = 0x1;
-        const SRV = 0x2;
-        const UAV = 0x4;
-        const SAMPLER = 0x8;
-    }
-}
-
-impl From<pso::DescriptorType> for DescriptorContent {
-    fn from(ty: pso::DescriptorType) -> Self {
-        use hal::pso::DescriptorType as Dt;
-        match ty {
-            Dt::Sampler => {
-                DescriptorContent::SAMPLER
-            }
-            Dt::CombinedImageSampler => {
-                DescriptorContent::SRV | DescriptorContent::SAMPLER
-            }
-            Dt::SampledImage |
-            Dt::InputAttachment |
-            Dt::UniformTexelBuffer => {
-                DescriptorContent::SRV
-            }
-            Dt::StorageImage |
-            Dt::StorageBuffer |
-            Dt::StorageBufferDynamic |
-            Dt::StorageTexelBuffer => {
-                DescriptorContent::SRV | DescriptorContent::UAV
-            }
-            Dt::UniformBuffer |
-            Dt::UniformBufferDynamic => {
-                DescriptorContent::CBV
-            }
-        }
-    }
-}
-
 pub fn map_shader_visibility(flags: pso::ShaderStageFlags) -> ShaderVisibility {
     use hal::pso::ShaderStageFlags as Ssf;
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -760,9 +760,7 @@ impl hal::Instance for Instance {
             if winerror::SUCCEEDED(hr) {
                 // It's okay to decrement the refcount here because we
                 // have another reference to the factory already owned by `self`.
-                unsafe {
-                    f6.destroy();
-                }
+                f6.destroy();
                 (true, f6)
             } else {
                 (false, native::WeakPtr::null())

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -5,8 +5,11 @@ use winapi::um::d3d12;
 use hal::{buffer, format, image, memory, pass, pso, DescriptorPool as HalDescriptorPool};
 use native::{self, query};
 use range_alloc::RangeAllocator;
-use root_constants::RootConstant;
-use {Backend, MAX_VERTEX_BUFFERS};
+
+use crate::{
+    root_constants::RootConstant,
+    Backend, MAX_VERTEX_BUFFERS,
+};
 
 use std::collections::BTreeMap;
 use std::ops::Range;
@@ -389,6 +392,48 @@ pub struct Memory {
 unsafe impl Send for Memory {}
 unsafe impl Sync for Memory {}
 
+bitflags! {
+    /// A set of D3D12 descriptor types that need to be associated
+    /// with a single gfx-hal `DescriptorType`.
+    #[derive(Default)]
+    pub struct DescriptorContent: u8 {
+        const CBV = 0x1;
+        const SRV = 0x2;
+        const UAV = 0x4;
+        const SAMPLER = 0x8;
+        const VIEW = 0x7;
+    }
+}
+
+impl From<pso::DescriptorType> for DescriptorContent {
+    fn from(ty: pso::DescriptorType) -> Self {
+        use hal::pso::DescriptorType as Dt;
+        match ty {
+            Dt::Sampler => {
+                DescriptorContent::SAMPLER
+            }
+            Dt::CombinedImageSampler => {
+                DescriptorContent::SRV | DescriptorContent::SAMPLER
+            }
+            Dt::SampledImage |
+            Dt::InputAttachment |
+            Dt::UniformTexelBuffer => {
+                DescriptorContent::SRV
+            }
+            Dt::StorageImage |
+            Dt::StorageBuffer |
+            Dt::StorageBufferDynamic |
+            Dt::StorageTexelBuffer => {
+                DescriptorContent::SRV | DescriptorContent::UAV
+            }
+            Dt::UniformBuffer |
+            Dt::UniformBufferDynamic => {
+                DescriptorContent::CBV
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct DescriptorRange {
     pub(crate) handle: DualHandle,
@@ -410,7 +455,7 @@ pub struct DescriptorBindingInfo {
     pub(crate) count: u64,
     pub(crate) view_range: Option<DescriptorRange>,
     pub(crate) sampler_range: Option<DescriptorRange>,
-    pub(crate) is_uav: bool,
+    pub(crate) content: DescriptorContent,
 }
 
 #[derive(Derivative)]
@@ -543,20 +588,21 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
         let mut first_gpu_view = None;
 
         for binding in &layout.bindings {
-            let HeapProperties {
-                has_view,
-                has_sampler,
-                is_uav,
-            } = HeapProperties::from(binding.ty);
             while binding_infos.len() <= binding.binding as usize {
                 binding_infos.push(DescriptorBindingInfo::default());
             }
+            let content = DescriptorContent::from(binding.ty);
             binding_infos[binding.binding as usize] = DescriptorBindingInfo {
                 count: binding.count as _,
-                view_range: if has_view {
+                view_range: if content.intersects(DescriptorContent::VIEW) {
+                    let handle_count = if content.contains(DescriptorContent::SRV | DescriptorContent::UAV) {
+                        2 * binding.count as u64
+                    } else {
+                        binding.count as u64
+                    };
                     let handle = self
                         .heap_srv_cbv_uav
-                        .alloc_handles(binding.count as u64)
+                        .alloc_handles(handle_count)
                         .ok_or(pso::AllocationError::OutOfPoolMemory)?;
                     if first_gpu_view.is_none() {
                         first_gpu_view = Some(handle.gpu);
@@ -564,13 +610,13 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
                     Some(DescriptorRange {
                         handle,
                         ty: binding.ty,
-                        count: binding.count as _,
+                        count: binding.count as u64,
                         handle_size: self.heap_srv_cbv_uav.handle_size,
                     })
                 } else {
                     None
                 },
-                sampler_range: if has_sampler {
+                sampler_range: if content.intersects(DescriptorContent::SAMPLER) {
                     let handle = self
                         .heap_sampler
                         .alloc_handles(binding.count as u64)
@@ -587,7 +633,7 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
                 } else {
                     None
                 },
-                is_uav,
+                content,
             };
         }
 
@@ -607,12 +653,12 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
         for descriptor_set in descriptor_sets {
             for binding_info in &descriptor_set.binding_infos {
                 if let Some(ref view_range) = binding_info.view_range {
-                    if HeapProperties::from(view_range.ty).has_view {
+                    if binding_info.content.intersects(DescriptorContent::VIEW) {
                         self.heap_srv_cbv_uav.free_handles(view_range.handle);
                     }
                 }
                 if let Some(ref sampler_range) = binding_info.sampler_range {
-                    if HeapProperties::from(sampler_range.ty).has_sampler {
+                    if binding_info.content.intersects(DescriptorContent::SAMPLER) {
                         self.heap_sampler.free_handles(sampler_range.handle);
                     }
                 }
@@ -623,39 +669,6 @@ impl HalDescriptorPool<Backend> for DescriptorPool {
     unsafe fn reset(&mut self) {
         self.heap_srv_cbv_uav.clear();
         self.heap_sampler.clear();
-    }
-}
-
-struct HeapProperties {
-    has_view: bool,
-    has_sampler: bool,
-    is_uav: bool,
-}
-
-impl HeapProperties {
-    pub fn new(has_view: bool, has_sampler: bool, is_uav: bool) -> Self {
-        HeapProperties {
-            has_view,
-            has_sampler,
-            is_uav,
-        }
-    }
-
-    /// Returns DescriptorType properties for DX12.
-    fn from(ty: pso::DescriptorType) -> HeapProperties {
-        match ty {
-            pso::DescriptorType::Sampler => HeapProperties::new(false, true, false),
-            pso::DescriptorType::CombinedImageSampler => HeapProperties::new(true, true, false),
-            pso::DescriptorType::InputAttachment
-            | pso::DescriptorType::SampledImage
-            | pso::DescriptorType::UniformTexelBuffer
-            | pso::DescriptorType::UniformBufferDynamic
-            | pso::DescriptorType::UniformBuffer => HeapProperties::new(true, false, false),
-            pso::DescriptorType::StorageImage
-            | pso::DescriptorType::StorageTexelBuffer
-            | pso::DescriptorType::StorageBufferDynamic
-            | pso::DescriptorType::StorageBuffer => HeapProperties::new(true, false, true),
-        }
     }
 }
 


### PR DESCRIPTION
Addresses the DX12 side of #2933 
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12
- [ ] `rustfmt` run on changed code

@msiglreith please take a careful look at it. I still need to run it over CTS to see if anything regressed, but the code should be ready for the review now.