### PR TITLE
[mtl] add explicit return types for `msg_send!` calls

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2213,7 +2213,7 @@ impl RawCommandQueue<Backend> for CommandQueue {
                     self.record_empty(cmd_buffer);
                     cmd_buffer
                 });
-                msg_send![cmd_buffer, addCompletedHandler: block.deref() as *const _];
+                let () = msg_send![cmd_buffer, addCompletedHandler: block.deref() as *const _];
                 blocker.submit_impl(cmd_buffer);
 
                 if let Some(fence) = fence {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -284,9 +284,9 @@ impl Instance {
             let new_layer: CAMetalLayer = msg_send![class, new];
 
             let bounds: CGRect = msg_send![main_layer, bounds];
-            msg_send![new_layer, setFrame: bounds];
+            let () = msg_send![new_layer, setFrame: bounds];
 
-            msg_send![main_layer, addSublayer: new_layer];
+            let () = msg_send![main_layer, addSublayer: new_layer];
             new_layer
         };
 
@@ -296,10 +296,10 @@ impl Instance {
             assert!(!screen.is_null(), "window is not attached to a screen");
 
             let scale_factor: CGFloat = msg_send![screen, nativeScale];
-            msg_send![view, setContentScaleFactor: scale_factor];
+            let () = msg_send![view, setContentScaleFactor: scale_factor];
         }
 
-        msg_send![view, retain];
+        let _: *mut c_void = msg_send![view, retain];
         window::SurfaceInner::new(NonNull::new(view), render_layer)
     }
 
@@ -329,19 +329,19 @@ impl Instance {
             existing
         } else {
             let layer: CAMetalLayer = msg_send![class, new];
-            msg_send![view, setLayer: layer];
+            let () = msg_send![view, setLayer: layer];
             let bounds: CGRect = msg_send![view, bounds];
-            msg_send![layer, setBounds: bounds];
+            let () = msg_send![layer, setBounds: bounds];
 
             let window: cocoa::base::id = msg_send![view, window];
             if !window.is_null() {
                 let scale_factor: CGFloat = msg_send![window, backingScaleFactor];
-                msg_send![layer, setContentsScale: scale_factor];
+                let() = msg_send![layer, setContentsScale: scale_factor];
             }
             layer
         };
 
-        msg_send![view, retain];
+        let _: *mut c_void = msg_send![view, retain];
         window::SurfaceInner::new(NonNull::new(view), render_layer)
     }
 
@@ -349,7 +349,7 @@ impl Instance {
         let class = class!(CAMetalLayer);
         let proper_kind: BOOL = msg_send![layer, isKindOfClass: class];
         assert_eq!(proper_kind, YES);
-        msg_send![layer, retain];
+        let _: *mut c_void = msg_send![layer, retain];
         window::SurfaceInner::new(None, layer)
     }
 

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -59,7 +59,7 @@ impl Drop for SurfaceInner {
             None => *self.render_layer.lock(),
         };
         unsafe {
-            msg_send![object, release];
+            let () = msg_send![object, release];
         }
     }
 }
@@ -413,24 +413,24 @@ impl Device {
                 if let Some(view) = surface.inner.view {
                     let main_layer: *mut Object = msg_send![view.as_ptr(), layer];
                     let bounds: CGRect = msg_send![main_layer, bounds];
-                    msg_send![render_layer, setFrame: bounds];
+                    let () = msg_send![render_layer, setFrame: bounds];
                 }
             }
 
             let device_raw = self.shared.device.lock().as_ptr();
-            msg_send![render_layer, setDevice: device_raw];
-            msg_send![render_layer, setPixelFormat: mtl_format];
-            msg_send![render_layer, setFramebufferOnly: framebuffer_only];
+            let () = msg_send![render_layer, setDevice: device_raw];
+            let () = msg_send![render_layer, setPixelFormat: mtl_format];
+            let () = msg_send![render_layer, setFramebufferOnly: framebuffer_only];
 
             // this gets ignored on iOS for certain OS/device combinations (iphone5s iOS 10.3)
-            msg_send![render_layer, setMaximumDrawableCount: config.image_count as u64];
+            let () = msg_send![render_layer, setMaximumDrawableCount: config.image_count as u64];
 
-            msg_send![render_layer, setDrawableSize: drawable_size];
+            let () = msg_send![render_layer, setDrawableSize: drawable_size];
             if can_set_next_drawable_timeout {
-                msg_send![render_layer, setAllowsNextDrawableTimeout:false];
+                let () = msg_send![render_layer, setAllowsNextDrawableTimeout:false];
             }
             if can_set_display_sync {
-                msg_send![render_layer, setDisplaySyncEnabled: display_sync];
+                let () = msg_send![render_layer, setDisplaySyncEnabled: display_sync];
             }
         };
 


### PR DESCRIPTION
Fixes #2939
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: mtl
- [ ] `rustfmt` run on changed code