### PR TITLE
Dynamic PSO states refactor

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1399,10 +1399,10 @@ impl<B: Backend> PipelineState<B> {
                     &pipeline_layout,
                     subpass,
                 );
-                pipeline_desc.blender.targets.push(pso::ColorBlendDesc(
-                    pso::ColorMask::ALL,
-                    pso::BlendState::ALPHA,
-                ));
+                pipeline_desc.blender.targets.push(pso::ColorBlendDesc {
+                    mask: pso::ColorMask::ALL,
+                    blend: Some(pso::BlendState::ALPHA),
+                });
                 pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
                     binding: 0,
                     stride: size_of::<Vertex>() as u32,

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -590,10 +590,10 @@ fn main() {
                 &pipeline_layout,
                 subpass,
             );
-            pipeline_desc.blender.targets.push(pso::ColorBlendDesc(
-                pso::ColorMask::ALL,
-                pso::BlendState::ALPHA,
-            ));
+            pipeline_desc.blender.targets.push(pso::ColorBlendDesc {
+                mask: pso::ColorMask::ALL,
+                blend: Some(pso::BlendState::ALPHA),
+            });
             pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
                 binding: 0,
                 stride: std::mem::size_of::<Vertex>() as u32,

--- a/reftests/scenes/basic.ron
+++ b/reftests/scenes/basic.ron
@@ -4,7 +4,7 @@
 			kind: D2(1, 1, 1, 1),
 			num_levels: 1,
 			format: Rgba8Unorm,
-			usage: (bits: 0x14), //COLOR_ATTACHMENT | SAMPLED (temporary for GL)
+			usage: (bits: 0x15), //COLOR_ATTACHMENT | TRANSFER_SRC (for reading) | SAMPLED (temporary for GL)
 		),
 		"pass": RenderPass(
 			attachments: {
@@ -71,7 +71,7 @@
 				alpha_coverage: false,
 				logic_op: None,
 				targets: [
-					((bits: 15), Off),
+					(mask: (bits: 15), blend: None),
 				],
 			),
 			layout: "pipe-layout",

--- a/reftests/scenes/vertex-offset.ron
+++ b/reftests/scenes/vertex-offset.ron
@@ -9,7 +9,7 @@
             kind: D2(1, 1, 1, 1),
             num_levels: 1,
             format: Rgba32Uint,
-            usage: (bits: 0x14), //COLOR_ATTACHMENT | SAMPLED (temporary for GL)
+            usage: (bits: 0x15), //COLOR_ATTACHMENT | TRANSFER_SRC (for reading back) | SAMPLED (temporary for GL)
         ),
         "pass": RenderPass(
             attachments: {
@@ -93,7 +93,7 @@
                 alpha_coverage: false,
                 logic_op: None,
                 targets: [
-                    ((bits: 15), Off),
+                    (mask: (bits: 15), blend: None),
                 ],
             ),
             layout: "pipe-layout",
@@ -140,7 +140,7 @@
                 alpha_coverage: false,
                 logic_op: None,
                 targets: [
-                    ((bits: 15), Off),
+                    (mask: (bits: 15), blend: None),
                 ],
             ),
             layout: "pipe-layout",

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -163,15 +163,12 @@ impl Instance {
 fn get_features(
     _device: ComPtr<d3d11::ID3D11Device>,
     _feature_level: d3dcommon::D3D_FEATURE_LEVEL,
-) -> hal::Features {
-    use hal::Features;
-
+) -> Features {
     let features = Features::ROBUST_BUFFER_ACCESS
         | Features::FULL_DRAW_INDEX_U32
         | Features::FORMAT_BC
         | Features::INSTANCE_RATE
         | Features::SAMPLER_MIP_LOD_BIAS;
-
     features
 }
 

--- a/src/backend/dx11/src/shader.rs
+++ b/src/backend/dx11/src/shader.rs
@@ -1,4 +1,4 @@
-use std::{ffi, mem, ptr, slice};
+use std::{ffi, ptr, slice};
 
 use spirv_cross::{hlsl, spirv, ErrorCode as SpirvErrorCode};
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -77,7 +77,7 @@ pub enum Command {
         rasterizer: pso::Rasterizer,
     },
     BindDepth {
-        depth: pso::DepthTest,
+        depth: Option<pso::DepthTest>,
     },
     SetViewports {
         first_viewport: u32,

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -163,7 +163,7 @@ pub struct GraphicsPipeline {
     pub(crate) vertex_buffers: Vec<Option<pso::VertexBufferDesc>>,
     pub(crate) uniforms: Vec<UniformDesc>,
     pub(crate) rasterizer: pso::Rasterizer,
-    pub(crate) depth: pso::DepthTest,
+    pub(crate) depth: Option<pso::DepthTest>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -1205,8 +1205,11 @@ pub fn map_polygon_mode(mode: pso::PolygonMode) -> MTLTriangleFillMode {
             MTLTriangleFillMode::Lines
         }
         pso::PolygonMode::Line(width) => {
-            if width != 1.0 {
-                warn!("Unsupported line width: {:?}", width);
+            match width {
+                pso::State::Static(w) if w != 1.0 => {
+                    warn!("Unsupported line width: {:?}", w);
+                }
+                _ => {}
             }
             MTLTriangleFillMode::Lines
         }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1406,7 +1406,7 @@ impl hal::Device<Backend> for Device {
             .targets
             .iter()
             .chain(iter::repeat(&pso::ColorBlendDesc::EMPTY));
-        for (i, (&(mtl_format, _), &pso::ColorBlendDesc(mask, ref blend))) in subpass
+        for (i, (&(mtl_format, _), color_desc)) in subpass
             .target_formats
             .colors
             .iter()
@@ -1419,12 +1419,12 @@ impl hal::Device<Backend> for Device {
                 .expect("too many color attachments");
 
             desc.set_pixel_format(mtl_format);
-            desc.set_write_mask(conv::map_write_mask(mask));
+            desc.set_write_mask(conv::map_write_mask(color_desc.mask));
 
-            if let pso::BlendState::On { color, alpha } = *blend {
+            if let Some(ref blend) = color_desc.blend {
                 desc.set_blending_enabled(true);
-                let (color_op, color_src, color_dst) = conv::map_blend_op(color);
-                let (alpha_op, alpha_src, alpha_dst) = conv::map_blend_op(alpha);
+                let (color_op, color_src, color_dst) = conv::map_blend_op(blend.color);
+                let (alpha_op, alpha_src, alpha_dst) = conv::map_blend_op(blend.alpha);
 
                 desc.set_rgb_blend_operation(color_op);
                 desc.set_source_rgb_blend_factor(color_src);

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -245,13 +245,10 @@ impl Default for RasterizerState {
 }
 
 #[derive(Debug)]
-pub struct StencilState<T> {
-    pub front_reference: T,
-    pub back_reference: T,
-    pub front_read_mask: T,
-    pub back_read_mask: T,
-    pub front_write_mask: T,
-    pub back_write_mask: T,
+pub struct StencilState<T: Clone> {
+    pub reference_values: pso::Sided<T>,
+    pub read_masks: pso::Sided<T>,
+    pub write_masks: pso::Sided<T>,
 }
 
 pub type VertexBufferVec = Vec<(pso::VertexBufferDesc, pso::ElemOffset)>;

--- a/src/backend/metal/src/soft.rs
+++ b/src/backend/metal/src/soft.rs
@@ -65,7 +65,7 @@ pub enum RenderCommand<R: Resources> {
     SetBlendColor(hal::pso::ColorValue),
     SetDepthBias(hal::pso::DepthBias),
     SetDepthStencilState(R::DepthStencil),
-    SetStencilReferenceValues(hal::pso::StencilValue, hal::pso::StencilValue),
+    SetStencilReferenceValues(hal::pso::Sided<hal::pso::StencilValue>),
     SetRasterizerState(RasterizerState),
     SetVisibilityResult(metal::MTLVisibilityResultMode, hal::buffer::Offset),
     BindBuffer {
@@ -217,7 +217,7 @@ impl Own {
             SetBlendColor(color) => SetBlendColor(color),
             SetDepthBias(bias) => SetDepthBias(bias),
             SetDepthStencilState(state) => SetDepthStencilState(state.to_owned()),
-            SetStencilReferenceValues(front, back) => SetStencilReferenceValues(front, back),
+            SetStencilReferenceValues(sided) => SetStencilReferenceValues(sided),
             SetRasterizerState(ref state) => SetRasterizerState(state.clone()),
             SetVisibilityResult(mode, offset) => SetVisibilityResult(mode, offset),
             BindBuffer {

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -215,14 +215,6 @@ pub fn map_topology(prim: Primitive) -> vk::PrimitiveTopology {
     }
 }
 
-pub fn map_polygon_mode(rm: pso::PolygonMode) -> (vk::PolygonMode, f32) {
-    match rm {
-        pso::PolygonMode::Point => (vk::PolygonMode::POINT, 1.0),
-        pso::PolygonMode::Line(w) => (vk::PolygonMode::LINE, w),
-        pso::PolygonMode::Fill => (vk::PolygonMode::FILL, 1.0),
-    }
-}
-
 pub fn map_cull_face(cf: pso::Face) -> vk::CullModeFlags {
     match cf {
         pso::Face::NONE => vk::CullModeFlags::NONE,
@@ -273,18 +265,9 @@ pub fn map_stencil_side(side: &pso::StencilFace) -> vk::StencilOpState {
         pass_op: map_stencil_op(side.op_pass),
         depth_fail_op: map_stencil_op(side.op_depth_fail),
         compare_op: map_comparison(side.fun),
-        compare_mask: match side.mask_read {
-            pso::State::Static(mr) => mr,
-            pso::State::Dynamic => !0,
-        },
-        write_mask: match side.mask_write {
-            pso::State::Static(mw) => mw,
-            pso::State::Dynamic => !0,
-        },
-        reference: match side.reference {
-            pso::State::Static(r) => r,
-            pso::State::Dynamic => 0,
-        },
+        compare_mask: !0,
+        write_mask: !0,
+        reference: 0,
     }
 }
 

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -162,7 +162,7 @@ pub enum PolygonMode {
     /// Rasterize as a point.
     Point,
     /// Rasterize as a line with the given width.
-    Line(f32),
+    Line(State<f32>),
     /// Rasterize as a face.
     Fill,
 }

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/gfx-render"
 categories = ["rendering::graphics-api"]
 workspace = "../.."
 edition = "2018"
+publish = false
 
 [lib]
 name = "gfx_warden"
@@ -20,6 +21,7 @@ name = "gfx_warden"
 default = ["glsl-to-spirv"]
 vulkan = ["gfx-backend-vulkan"]
 dx12 = ["gfx-backend-dx12"]
+dx11 = ["gfx-backend-dx11"]
 metal = ["gfx-backend-metal"]
 gl = ["gfx-backend-gl"]
 gl-headless = ["gfx-backend-gl"] # "glsl-to-spirv"
@@ -28,7 +30,7 @@ gl-headless = ["gfx-backend-gl"] # "glsl-to-spirv"
 
 [dependencies]
 failure = "0.1"
-gfx-hal = { path = "../hal", version = "0.2", features = ["serde"] }
+hal = { path = "../hal", version = "0.2", package = "gfx-hal", features = ["serde"] }
 log = "0.4"
 ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
@@ -43,6 +45,12 @@ optional = true
 
 [target.'cfg(windows)'.dependencies.gfx-backend-dx12]
 path = "../../src/backend/dx12"
+version = "0.2"
+features = ["winit"]
+optional = true
+
+[target.'cfg(windows)'.dependencies.gfx-backend-dx11]
+path = "../../src/backend/dx11"
 version = "0.2"
 features = ["winit"]
 optional = true

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -2,28 +2,16 @@
     not(any(
         feature = "vulkan",
         feature = "dx12",
+        feature = "dx11",
         feature = "metal",
         feature = "gl"
     )),
     allow(dead_code)
 )]
 
-extern crate gfx_hal as hal;
 extern crate gfx_warden as warden;
-extern crate ron;
 #[macro_use]
 extern crate serde;
-
-#[cfg(feature = "env_logger")]
-extern crate env_logger;
-#[cfg(feature = "dx12")]
-extern crate gfx_backend_dx12;
-#[cfg(any(feature = "gl", feature = "gl-headless"))]
-extern crate gfx_backend_gl;
-#[cfg(feature = "metal")]
-extern crate gfx_backend_metal;
-#[cfg(feature = "vulkan")]
-extern crate gfx_backend_vulkan;
 
 use std::collections::HashMap;
 use std::fs::File;
@@ -92,7 +80,7 @@ impl Harness {
     }
 
     fn run<I: hal::Instance>(&self, instance: I, _disabilities: Disabilities) -> usize {
-        use crate::hal::PhysicalDevice;
+        use hal::PhysicalDevice as _;
 
         let mut results = TestResults {
             pass: 0,
@@ -207,6 +195,12 @@ fn main() {
     {
         println!("Warding DX12:");
         let instance = gfx_backend_dx12::Instance::create("warden", 1);
+        num_failures += harness.run(instance, Disabilities::default());
+    }
+    #[cfg(feature = "dx11")]
+    {
+        println!("Warding DX11:");
+        let instance = gfx_backend_dx11::Instance::create("warden", 1);
         num_failures += harness.run(instance, Disabilities::default());
     }
     #[cfg(feature = "metal")]

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -8,8 +8,8 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::{iter, slice};
 
-use crate::hal::{self, buffer as b, command as c, format as f, image as i, memory, pso};
-use crate::hal::{DescriptorPool, Device, PhysicalDevice};
+use hal::{self, buffer as b, command as c, format as f, image as i, memory, pso};
+use hal::{DescriptorPool, Device, PhysicalDevice};
 
 use crate::raw;
 

--- a/src/warden/src/lib.rs
+++ b/src/warden/src/lib.rs
@@ -1,14 +1,10 @@
 //! Data-driven reference test framework for warding
 //! against breaking changes.
 
-extern crate gfx_hal as hal;
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde;
-extern crate failure;
-#[cfg(feature = "glsl-to-spirv")]
-extern crate glsl_to_spirv;
 
 pub mod gpu;
 pub mod raw;

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::ops::Range;
 
-use crate::hal;
+use hal;
 
 #[derive(Debug, Deserialize)]
 pub struct AttachmentRef(pub String, pub hal::pass::AttachmentLayout);


### PR DESCRIPTION
Fixes #2905
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
