### PR TITLE
Vulkan: fix setting up primitive restart enable flag while creating graphics pipeline

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -519,7 +519,11 @@ impl d::Device<B> for Device {
                     p_next: ptr::null(),
                     flags: vk::PipelineInputAssemblyStateCreateFlags::empty(),
                     topology: conv::map_topology(desc.input_assembler.primitive),
-                    primitive_restart_enable: vk::FALSE,
+                    primitive_restart_enable: match desc.input_assembler.primitive_restart {
+                        pso::PrimitiveRestart::U16|pso::PrimitiveRestart::U32 => vk::TRUE,
+                        pso::PrimitiveRestart::Disabled => vk::FALSE
+                    }
+
                 });
 
                 let depth_bias = match desc.rasterizer.depth_bias {


### PR DESCRIPTION
Related to #1510
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

Hello!
The fix is obvious, the: `primitiveRestartEnable` property of the [VkPipelineInputAssemblyStateCreateInfo](https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#VkPipelineInputAssemblyStateCreateInfo) should be `VK_TRUE` for `primitive_restart` == `pso::PrimitiveRestart::U16` or `pso::PrimitiveRestart::U32`. It doesn't matter which `IndexType` you later bind the index buffer with.
