### PR TITLE
gl: Check for debug extension support

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "1"
 log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.3" }
 smallvec = "0.6"
-glow = "0.2.2"
+glow = "0.2.3"
 spirv_cross = { version = "0.14.0", features = ["glsl"] }
 lazy_static = "1"
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -582,7 +582,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         }
         self.0.open.set(true);
 
-        // TODO: Check for support in the LeagcyFeatures struct too
+        // TODO: Check for support in the LegacyFeatures struct too
         if !self.features().contains(requested_features) {
             return Err(error::DeviceCreationError::MissingFeature);
         }
@@ -592,7 +592,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            if cfg!(debug_assertions) {
+            if cfg!(debug_assertions) && gl.supports_debug() {
                 gl.enable(glow::DEBUG_OUTPUT);
                 gl.debug_message_callback(debug_message_callback);
             }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -318,7 +318,7 @@ impl Instance {
             .enumerate_instance_layer_properties()
             .expect("Unable to enumerate instance layers");
 
-        // Check our xtensions against the available extensions
+        // Check our extensions against the available extensions
         let extensions = SURFACE_EXTENSIONS
             .iter()
             .chain(EXTENSIONS.iter())


### PR DESCRIPTION
This fixes the quad example on native GL.

We were unwrapping an invalid enum error when getting the `VENDOR` string, but the invalid enum was actually caused by trying to unconditionally use a constant from the KHR_debug extension.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code
