### PR TITLE
[hal-0.3] Add support for `raw-window-handle`

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -29,7 +29,7 @@ parking_lot = "0.7"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.19", optional = true }
 wio = "0.2"
-raw-window-handle = { version = "0.1.2", optional = true }
+raw-window-handle = "0.1.2"
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.3.0"
+version = "0.3.1"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -18,7 +18,7 @@ default = []
 name = "gfx_backend_dx11"
 
 [dependencies]
-gfx-hal = { path = "../../hal", version = "0.3" }
+gfx-hal = { path = "../../hal", version = "0.3.1" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
 derivative = "1"

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -29,6 +29,7 @@ parking_lot = "0.7"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.19", optional = true }
 wio = "0.2"
+raw-window-handle = { version = "0.1.2", optional = true }
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -29,7 +29,7 @@ parking_lot = "0.7"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.19", optional = true }
 wio = "0.2"
-raw-window-handle = "0.1.2"
+raw-window-handle = "0.1"
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -158,6 +158,19 @@ impl Instance {
         use winit::os::windows::WindowExt;
         self.create_surface_from_hwnd(window.get_hwnd() as *mut _)
     }
+
+    #[cfg(feature = "raw-window-handle")]
+    pub fn create_surface_from_raw(
+        &self,
+        has_handle: &impl raw_window_handle::HasRawWindowHandle,
+    ) -> Surface {
+        match has_handle.raw_window_handle() {
+            raw_window_handle::RawWindowHandle::Windows(handle) => {
+                self.create_surface_from_hwnd(handle.hwnd)
+            }
+            _ => panic!("DX11 is not supported for this target"),
+        }
+    }
 }
 
 fn get_features(

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -163,12 +163,12 @@ impl Instance {
     pub fn create_surface_from_raw(
         &self,
         has_handle: &impl raw_window_handle::HasRawWindowHandle,
-    ) -> Surface {
+    ) -> Result<Surface, hal::window::InitError> {
         match has_handle.raw_window_handle() {
             raw_window_handle::RawWindowHandle::Windows(handle) => {
-                self.create_surface_from_hwnd(handle.hwnd)
+                Ok(self.create_surface_from_hwnd(handle.hwnd))
             }
-            _ => panic!("DX11 is not supported for this target"),
+            _ => Err(hal::window::InitError::UnsupportedWindowHandle),
         }
     }
 }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -159,7 +159,6 @@ impl Instance {
         self.create_surface_from_hwnd(window.get_hwnd() as *mut _)
     }
 
-    #[cfg(feature = "raw-window-handle")]
     pub fn create_surface_from_raw(
         &self,
         has_handle: &impl raw_window_handle::HasRawWindowHandle,

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -28,6 +28,7 @@ smallvec = "0.6"
 spirv_cross = { version = "0.14.0", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.19", optional = true }
+raw-window-handle = { version = "0.1.2", optional = true }
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -28,7 +28,7 @@ smallvec = "0.6"
 spirv_cross = { version = "0.14.0", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.19", optional = true }
-raw-window-handle = "0.1.2"
+raw-window-handle = "0.1"
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -28,7 +28,7 @@ smallvec = "0.6"
 spirv_cross = { version = "0.14.0", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.19", optional = true }
-raw-window-handle = { version = "0.1.2", optional = true }
+raw-window-handle = "0.1.2"
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.3.0"
+version = "0.3.1"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -18,7 +18,7 @@ default = []
 name = "gfx_backend_dx12"
 
 [dependencies]
-gfx-hal = { path = "../../hal", version = "0.3" }
+gfx-hal = { path = "../../hal", version = "0.3.1" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
 derivative = "1"

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -26,6 +26,19 @@ impl Instance {
         use winit::os::windows::WindowExt;
         self.create_surface_from_hwnd(window.get_hwnd() as *mut _)
     }
+
+    #[cfg(feature = "raw-window-handle")]
+    pub fn create_surface_from_raw(
+        &self,
+        has_handle: &impl raw_window_handle::HasRawWindowHandle,
+    ) -> Surface {
+        match has_handle.raw_window_handle() {
+            raw_window_handle::RawWindowHandle::Windows(handle) => {
+                self.create_surface_from_hwnd(handle.hwnd)
+            }
+            _ => panic!("DX12 is not supported for this target"),
+        }
+    }
 }
 
 #[derive(Derivative)]

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -27,7 +27,6 @@ impl Instance {
         self.create_surface_from_hwnd(window.get_hwnd() as *mut _)
     }
 
-    #[cfg(feature = "raw-window-handle")]
     pub fn create_surface_from_raw(
         &self,
         has_handle: &impl raw_window_handle::HasRawWindowHandle,

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -31,12 +31,12 @@ impl Instance {
     pub fn create_surface_from_raw(
         &self,
         has_handle: &impl raw_window_handle::HasRawWindowHandle,
-    ) -> Surface {
+    ) -> Result<Surface, hal::window::InitError> {
         match has_handle.raw_window_handle() {
             raw_window_handle::RawWindowHandle::Windows(handle) => {
-                self.create_surface_from_hwnd(handle.hwnd)
+                Ok(self.create_surface_from_hwnd(handle.hwnd))
             }
-            _ => panic!("DX12 is not supported for this target"),
+            _ => Err(hal::window::InitError::UnsupportedWindowHandle),
         }
     }
 }

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-empty"
-version = "0.3.0"
+version = "0.3.1"
 description = "Empty backend for gfx-rs"
 license = "MIT OR Apache-2.0"
 authors = ["The Gfx-rs Developers"]
@@ -12,6 +12,6 @@ edition = "2018"
 name = "gfx_backend_empty"
 
 [dependencies]
-gfx-hal = { path = "../../hal", version = "0.3" }
+gfx-hal = { path = "../../hal", version = "0.3.1" }
 winit = { version = "0.19", optional = true }
 raw-window-handle = "0.1.2"

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -14,4 +14,4 @@ name = "gfx_backend_empty"
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.3.1" }
 winit = { version = "0.19", optional = true }
-raw-window-handle = "0.1.2"
+raw-window-handle = "0.1"

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -14,4 +14,4 @@ name = "gfx_backend_empty"
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.3" }
 winit = { version = "0.19", optional = true }
-raw-window-handle = { version = "0.1.2", optional = true }
+raw-window-handle = "0.1.2"

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -14,3 +14,4 @@ name = "gfx_backend_empty"
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.3" }
 winit = { version = "0.19", optional = true }
+raw-window-handle = { version = "0.1.2", optional = true }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -931,6 +931,14 @@ impl Instance {
     pub fn create_surface(&self, _: &winit::Window) -> Surface {
         unimplemented!()
     }
+
+    #[cfg(feature = "raw-window-handle")]
+    pub fn create_surface_from_raw(
+        &self,
+        _: &impl raw_window_handle::HasRawWindowHandle,
+    ) -> Surface {
+        unimplemented!()
+    }
 }
 
 impl hal::Instance for Instance {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -932,7 +932,6 @@ impl Instance {
         unimplemented!()
     }
 
-    #[cfg(feature = "raw-window-handle")]
     pub fn create_surface_from_raw(
         &self,
         _: &impl raw_window_handle::HasRawWindowHandle,

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -936,7 +936,7 @@ impl Instance {
     pub fn create_surface_from_raw(
         &self,
         _: &impl raw_window_handle::HasRawWindowHandle,
-    ) -> Surface {
+    ) -> Result<Surface, hal::window::InitError> {
         unimplemented!()
     }
 }

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -32,7 +32,7 @@ lazy_static = "1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.21", optional = true }
 winit = { version = "0.19", optional = true }
-raw-window-handle = { version = "0.1.2", optional = true }
+raw-window-handle = "0.1.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -32,7 +32,7 @@ lazy_static = "1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.21", optional = true }
 winit = { version = "0.19", optional = true }
-raw-window-handle = "0.1.2"
+raw-window-handle = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-gl"
-version = "0.3.0"
+version = "0.3.1"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -23,7 +23,7 @@ wgl = []
 [dependencies]
 bitflags = "1"
 log = { version = "0.4" }
-gfx-hal = { path = "../../hal", version = "0.3" }
+gfx-hal = { path = "../../hal", version = "0.3.1" }
 smallvec = "0.6"
 glow = "0.2.2"
 spirv_cross = { version = "0.14.0", features = ["glsl"] }

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -32,6 +32,7 @@ lazy_static = "1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.21", optional = true }
 winit = { version = "0.19", optional = true }
+raw-window-handle = { version = "0.1.2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -190,6 +190,19 @@ impl Instance {
         let hwnd = window.get_hwnd();
         self.create_surface_from_hwnd(hwnd as *mut _)
     }
+
+    #[cfg(feature = "raw-window-handle")]
+    pub fn create_surface_from_raw(
+        &self,
+        has_handle: &impl raw_window_handle::HasRawWindowHandle,
+    ) -> Result<Surface, hal::window::InitError> {
+        match has_handle.raw_window_handle() {
+            raw_window_handle::RawWindowHandle::Windows(handle) => {
+                Ok(self.create_surface_from_hwnd(handle.hwnd))
+            }
+            _ => Err(hal::window::InitError::UnsupportedWindowHandle),
+        }
+    }
 }
 
 impl hal::Instance for Instance {

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -191,7 +191,6 @@ impl Instance {
         self.create_surface_from_hwnd(hwnd as *mut _)
     }
 
-    #[cfg(feature = "raw-window-handle")]
     pub fn create_surface_from_raw(
         &self,
         has_handle: &impl raw_window_handle::HasRawWindowHandle,

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -39,7 +39,7 @@ smallvec = "0.6"
 spirv_cross = { version = "0.15", features = ["msl"] }
 parking_lot = "0.9.0"
 storage-map = "0.2"
-raw-window-handle = "0.1.2"
+raw-window-handle = "0.1"
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-metal"
-version = "0.3.0"
+version = "0.3.1"
 description = "Metal API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -21,7 +21,7 @@ signpost = []
 name = "gfx_backend_metal"
 
 [dependencies]
-hal = { path = "../../hal", version = "0.3", package = "gfx-hal" }
+hal = { path = "../../hal", version = "0.3.1", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 arrayvec = "0.4"
 bitflags = "1.0"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -39,7 +39,7 @@ smallvec = "0.6"
 spirv_cross = { version = "0.15", features = ["msl"] }
 parking_lot = "0.9.0"
 storage-map = "0.2"
-raw-window-handle = { version = "0.1.2", optional = true }
+raw-window-handle = "0.1.2"
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -39,6 +39,7 @@ smallvec = "0.6"
 spirv_cross = { version = "0.15", features = ["msl"] }
 parking_lot = "0.9.0"
 storage-map = "0.2"
+raw-window-handle = { version = "0.1.2", optional = true }
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -266,6 +266,24 @@ impl Instance {
         }
     }
 
+    #[cfg(feature = "raw-window-handle")]
+    pub fn create_surface_from_raw(
+        &self,
+        has_handle: &impl raw_window_handle::HasRawWindowHandle,
+    ) -> Surface {
+        match has_handle.raw_window_handle() {
+            #[cfg(target_os = "ios")]
+            raw_window_handle::RawWindowHandle::IOS(handle) => {
+                self.create_surface_from_uiview(handle.ui_view, false)
+            }
+            #[cfg(target_os = "macos")]
+            raw_window_handle::RawWindowHandle::MacOS(handle) => {
+                self.create_surface_from_nsview(handle.ns_view, false)
+            }
+            _ => panic!("Metal is not supported for this target"),
+        }
+    }
+
     #[cfg(target_os = "ios")]
     unsafe fn create_from_uiview(&self, uiview: *mut c_void) -> window::SurfaceInner {
         let view: cocoa::base::id = mem::transmute(uiview);

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -270,17 +270,17 @@ impl Instance {
     pub fn create_surface_from_raw(
         &self,
         has_handle: &impl raw_window_handle::HasRawWindowHandle,
-    ) -> Surface {
+    ) -> Result<Surface, hal::window::InitError> {
         match has_handle.raw_window_handle() {
             #[cfg(target_os = "ios")]
             raw_window_handle::RawWindowHandle::IOS(handle) => {
-                self.create_surface_from_uiview(handle.ui_view, false)
+                Ok(self.create_surface_from_uiview(handle.ui_view, false))
             }
             #[cfg(target_os = "macos")]
             raw_window_handle::RawWindowHandle::MacOS(handle) => {
-                self.create_surface_from_nsview(handle.ns_view, false)
+                Ok(self.create_surface_from_nsview(handle.ns_view, false))
             }
-            _ => panic!("Metal is not supported for this target"),
+            _ => Err(hal::window::InitError::UnsupportedWindowHandle),
         }
     }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -266,7 +266,6 @@ impl Instance {
         }
     }
 
-    #[cfg(feature = "raw-window-handle")]
     pub fn create_surface_from_raw(
         &self,
         has_handle: &impl raw_window_handle::HasRawWindowHandle,

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -29,7 +29,7 @@ ash = "0.29.0"
 gfx-hal = { path = "../../hal", version = "0.3.1" }
 smallvec = "0.6"
 winit = { version = "0.19", optional = true }
-raw-window-handle = "0.1.2"
+raw-window-handle = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -29,6 +29,7 @@ ash = "0.29.0"
 gfx-hal = { path = "../../hal", version = "0.3" }
 smallvec = "0.6"
 winit = { version = "0.19", optional = true }
+raw-window-handle = { version = "0.1.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -29,7 +29,7 @@ ash = "0.29.0"
 gfx-hal = { path = "../../hal", version = "0.3" }
 smallvec = "0.6"
 winit = { version = "0.19", optional = true }
-raw-window-handle = { version = "0.1.2", optional = true }
+raw-window-handle = "0.1.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-vulkan"
-version = "0.3.0"
+version = "0.3.1"
 description = "Vulkan API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -26,7 +26,7 @@ log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
 ash = "0.29.0"
-gfx-hal = { path = "../../hal", version = "0.3" }
+gfx-hal = { path = "../../hal", version = "0.3.1" }
 smallvec = "0.6"
 winit = { version = "0.19", optional = true }
 raw-window-handle = "0.1.2"

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -305,7 +305,6 @@ impl Instance {
         panic!("No suitable WSI enabled!");
     }
 
-    #[cfg(feature = "raw-window-handle")]
     pub fn create_surface_from_raw(
         &self,
         has_handle: &impl raw_window_handle::HasRawWindowHandle,

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-hal"
-version = "0.3.0"
+version = "0.3.1"
 description = "gfx-rs hardware abstraction layer"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -478,3 +478,11 @@ pub trait Swapchain<B: Backend>: fmt::Debug + Any + Send + Sync {
         self.present::<_, B::Semaphore, _>(present_queue, image_index, iter::empty())
     }
 }
+
+/// Error occurred during surface creation.
+#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
+pub enum InitError {
+    /// Window handle is not supported by the backend.
+    #[fail(display = "Backend does not support creating surfaces for this type of window handle")]
+    UnsupportedWindowHandle,
+}


### PR DESCRIPTION
Closes #2956.
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [x] `rustfmt` run on changed code

Non-breaking change version of #2967.

Currently Android is not supported in raw-window-handle and therefore unimplemented in gfx-backend-vulkan - waiting on https://github.com/rust-windowing/raw-window-handle/issues/12 to be resolved.