### PR TITLE
Cleanup dependencies

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -24,7 +24,7 @@ bitflags = "1"
 derivative = "1"
 log = { version = "0.4" }
 smallvec = "0.6"
-spirv_cross = { version = "0.14.0", features = ["hlsl"] }
+spirv_cross = { version = "0.15", features = ["hlsl"] }
 parking_lot = "0.7"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.20.0-alpha3", optional = true }

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -21,7 +21,6 @@ name = "gfx_backend_dx11"
 gfx-hal = { path = "../../hal", version = "0.3" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
-derivative = "1"
 log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = { version = "0.15", features = ["hlsl"] }

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -20,9 +20,8 @@ use wio::com::ComPtr;
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
-use std::mem;
+use std::{fmt, mem, ptr};
 use std::ops::Range;
-use std::ptr;
 use std::sync::Arc;
 
 use parking_lot::{Condvar, Mutex};
@@ -71,16 +70,18 @@ struct InputLayout {
     vertex_strides: Vec<u32>,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Device {
-    #[derivative(Debug = "ignore")]
     raw: ComPtr<d3d11::ID3D11Device>,
-    #[derivative(Debug = "ignore")]
     pub(crate) context: ComPtr<d3d11::ID3D11DeviceContext>,
     memory_properties: MemoryProperties,
     memory_heap_flags: [MemoryHeapFlags; 3],
     pub(crate) internal: internal::Internal,
+}
+
+impl fmt::Debug for Device {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Device")
+    }
 }
 
 impl Drop for Device {

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -5,8 +5,6 @@ extern crate range_alloc;
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
-extern crate derivative;
-#[macro_use]
 extern crate log;
 extern crate parking_lot;
 extern crate smallvec;
@@ -56,6 +54,7 @@ use parking_lot::{Condvar, Mutex};
 
 use std::borrow::Borrow;
 use std::cell::RefCell;
+use std::fmt;
 use std::mem;
 use std::ops::Range;
 use std::ptr;
@@ -99,16 +98,20 @@ mod dxgi;
 mod internal;
 mod shader;
 
-#[derive(Derivative)]
-#[derivative(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct ViewInfo {
-    #[derivative(Debug = "ignore")]
     resource: *mut d3d11::ID3D11Resource,
     kind: image::Kind,
     caps: image::ViewCapabilities,
     view_kind: image::ViewKind,
     format: dxgiformat::DXGI_FORMAT,
     range: image::SubresourceRange,
+}
+
+impl fmt::Debug for ViewInfo {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("ViewInfo")
+    }
 }
 
 #[derive(Debug)]
@@ -405,16 +408,18 @@ impl hal::Instance for Instance {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct PhysicalDevice {
-    #[derivative(Debug = "ignore")]
     adapter: ComPtr<IDXGIAdapter>,
     features: hal::Features,
     limits: hal::Limits,
     memory_properties: adapter::MemoryProperties,
-    #[derivative(Debug = "ignore")]
     format_properties: [format::Properties; format::NUM_FORMATS],
+}
+
+impl fmt::Debug for PhysicalDevice {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("PhysicalDevice")
+    }
 }
 
 unsafe impl Send for PhysicalDevice {}
@@ -676,14 +681,17 @@ struct Presentation {
     size: window::Extent2D,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Surface {
-    #[derivative(Debug = "ignore")]
     pub(crate) factory: ComPtr<IDXGIFactory>,
     wnd_handle: HWND,
-    #[derivative(Debug = "ignore")]
     presentation: Option<Presentation>,
+}
+
+
+impl fmt::Debug for Surface {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Surface")
+    }
 }
 
 unsafe impl Send for Surface {}
@@ -847,11 +855,15 @@ impl window::PresentationSurface<Backend> for Surface {
 }
 
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Swapchain {
-    #[derivative(Debug = "ignore")]
     dxgi_swapchain: ComPtr<IDXGISwapChain>,
+}
+
+
+impl fmt::Debug for Swapchain {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Swapchain")
+    }
 }
 
 unsafe impl Send for Swapchain {}
@@ -886,11 +898,15 @@ impl queue::QueueFamily for QueueFamily {
     }
 }
 
-#[derive(Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Clone)]
 pub struct CommandQueue {
-    #[derivative(Debug = "ignore")]
     context: ComPtr<d3d11::ID3D11DeviceContext>,
+}
+
+impl fmt::Debug for CommandQueue {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("CommandQueue")
+    }
 }
 
 unsafe impl Send for CommandQueue {}
@@ -980,8 +996,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct AttachmentClear {
     subpass_id: Option<pass::SubpassId>,
     attachment_id: usize,
@@ -1065,8 +1080,6 @@ bitflags! {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct CommandBufferState {
     dirty_flag: DirtyStateFlag,
 
@@ -1083,7 +1096,6 @@ pub struct CommandBufferState {
     required_bindings: Option<u32>,
     // the highest binding number in currently bound pipeline
     max_bindings: Option<u32>,
-    #[derivative(Debug = "ignore")]
     viewports: Vec<d3d11::D3D11_VIEWPORT>,
     vertex_buffers: Vec<*mut d3d11::ID3D11Buffer>,
     vertex_offsets: Vec<u32>,
@@ -1094,6 +1106,13 @@ pub struct CommandBufferState {
     stencil_read_mask: Option<pso::StencilValue>,
     stencil_write_mask: Option<pso::StencilValue>,
     current_blend: Option<*mut d3d11::ID3D11BlendState>,
+}
+
+
+impl fmt::Debug for CommandBufferState {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("CommandBufferState")
+    }
 }
 
 impl CommandBufferState {
@@ -1342,15 +1361,10 @@ impl CommandBufferState {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct CommandBuffer {
     // TODO: better way of sharing
-    #[derivative(Debug = "ignore")]
     internal: internal::Internal,
-    #[derivative(Debug = "ignore")]
     context: ComPtr<d3d11::ID3D11DeviceContext>,
-    #[derivative(Debug = "ignore")]
     list: RefCell<Option<ComPtr<d3d11::ID3D11CommandList>>>,
 
     // since coherent memory needs to be synchronized at submission, we need to gather up all
@@ -1365,6 +1379,12 @@ pub struct CommandBuffer {
     cache: CommandBufferState,
 
     one_time_submit: bool,
+}
+
+impl fmt::Debug for CommandBuffer {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("CommandBuffer")
+    }
 }
 
 unsafe impl Send for CommandBuffer {}
@@ -2333,15 +2353,18 @@ pub struct MemoryFlush {
     buffer: *mut d3d11::ID3D11Buffer,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct MemoryInvalidate {
-    #[derivative(Debug = "ignore")]
     working_buffer: Option<ComPtr<d3d11::ID3D11Buffer>>,
     working_buffer_size: u64,
     host_memory: *mut u8,
     sync_range: Range<u64>,
     buffer: *mut d3d11::ID3D11Buffer,
+}
+
+impl fmt::Debug for MemoryInvalidate {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("MemoryInvalidate")
+    }
 }
 
 fn intersection(a: &Range<u64>, b: &Range<u64>) -> Option<Range<u64>> {
@@ -2478,8 +2501,6 @@ impl MemoryInvalidate {
 // range. This forces us to only expose non-coherent memory, as this
 // abstraction acts as a "cache" since the "staging buffer" vec is disjoint
 // from all the dx11 resources we store in the struct.
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Memory {
     ty: MemoryHeapFlags,
     properties: memory::Properties,
@@ -2491,12 +2512,16 @@ pub struct Memory {
     host_visible: Option<RefCell<Vec<u8>>>,
 
     // list of all buffers bound to this memory
-    #[derivative(Debug = "ignore")]
     local_buffers: RefCell<Vec<(Range<u64>, InternalBuffer)>>,
 
     // list of all images bound to this memory
-    #[derivative(Debug = "ignore")]
     local_images: RefCell<Vec<(Range<u64>, InternalImage)>>,
+}
+
+impl fmt::Debug for Memory {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Memory")
+    }
 }
 
 unsafe impl Send for Memory {}
@@ -2619,16 +2644,13 @@ impl hal::pool::CommandPool<Backend> for CommandPool {
 }
 
 /// Similarily to dx12 backend, we can handle either precompiled dxbc or spirv
-// TODO: derivative doesn't work on enum variants?
-//#[derive(Derivative)]
-//#[derivative(Debug)]
 pub enum ShaderModule {
     Dxbc(Vec<u8>),
     Spirv(Vec<u32>),
 }
 
 // TODO: temporary
-impl ::std::fmt::Debug for ShaderModule {
+impl ::fmt::Debug for ShaderModule {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "{}", "ShaderModule { ... }")
     }
@@ -2679,8 +2701,6 @@ pub struct InternalBuffer {
     usage: buffer::Usage,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Buffer {
     internal: InternalBuffer,
     ty: MemoryHeapFlags,     // empty if unbound
@@ -2690,14 +2710,18 @@ pub struct Buffer {
     bind: d3d11::D3D11_BIND_FLAG,
 }
 
+impl fmt::Debug for Buffer {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Buffer")
+    }
+}
+
 unsafe impl Send for Buffer {}
 unsafe impl Sync for Buffer {}
 
 #[derive(Debug)]
 pub struct BufferView;
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Image {
     kind: image::Kind,
     usage: image::Usage,
@@ -2711,27 +2735,31 @@ pub struct Image {
     requirements: memory::Requirements,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+impl fmt::Debug for Image {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Image")
+    }
+}
+
 pub struct InternalImage {
-    #[derivative(Debug = "ignore")]
     raw: *mut d3d11::ID3D11Resource,
-    #[derivative(Debug = "ignore")]
     copy_srv: Option<ComPtr<d3d11::ID3D11ShaderResourceView>>,
-    #[derivative(Debug = "ignore")]
     srv: Option<ComPtr<d3d11::ID3D11ShaderResourceView>>,
 
     /// Contains UAVs for all subresources
-    #[derivative(Debug = "ignore")]
     unordered_access_views: Vec<ComPtr<d3d11::ID3D11UnorderedAccessView>>,
 
     /// Contains DSVs for all subresources
-    #[derivative(Debug = "ignore")]
     depth_stencil_views: Vec<ComPtr<d3d11::ID3D11DepthStencilView>>,
 
     /// Contains RTVs for all subresources
-    #[derivative(Debug = "ignore")]
     render_target_views: Vec<ComPtr<d3d11::ID3D11RenderTargetView>>,
+}
+
+impl fmt::Debug for InternalImage {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("InternalImage")
+    }
 }
 
 unsafe impl Send for Image {}
@@ -2773,38 +2801,45 @@ impl Image {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Clone, Debug)]
+#[derive(Clone)]
 pub struct ImageView {
     format: format::Format,
-    #[derivative(Debug = "ignore")]
     rtv_handle: Option<ComPtr<d3d11::ID3D11RenderTargetView>>,
-    #[derivative(Debug = "ignore")]
     srv_handle: Option<ComPtr<d3d11::ID3D11ShaderResourceView>>,
-    #[derivative(Debug = "ignore")]
     dsv_handle: Option<ComPtr<d3d11::ID3D11DepthStencilView>>,
-    #[derivative(Debug = "ignore")]
     uav_handle: Option<ComPtr<d3d11::ID3D11UnorderedAccessView>>,
+}
+
+impl fmt::Debug for ImageView {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("ImageView")
+    }
 }
 
 unsafe impl Send for ImageView {}
 unsafe impl Sync for ImageView {}
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Sampler {
-    #[derivative(Debug = "ignore")]
     sampler_handle: ComPtr<d3d11::ID3D11SamplerState>,
+}
+
+impl fmt::Debug for Sampler {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Sampler")
+    }
 }
 
 unsafe impl Send for Sampler {}
 unsafe impl Sync for Sampler {}
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct ComputePipeline {
-    #[derivative(Debug = "ignore")]
     cs: ComPtr<d3d11::ID3D11ComputeShader>,
+}
+
+impl fmt::Debug for ComputePipeline {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("ComputePipeline")
+    }
 }
 
 unsafe impl Send for ComputePipeline {}
@@ -2815,28 +2850,17 @@ unsafe impl Sync for ComputePipeline {}
 ///       to.
 ///
 /// [0]: https://msdn.microsoft.com/en-us/library/windows/desktop/ff476500(v=vs.85).aspx
-#[derive(Derivative)]
-#[derivative(Clone, Debug)]
+#[derive(Clone)]
 pub struct GraphicsPipeline {
-    #[derivative(Debug = "ignore")]
     vs: ComPtr<d3d11::ID3D11VertexShader>,
-    #[derivative(Debug = "ignore")]
     gs: Option<ComPtr<d3d11::ID3D11GeometryShader>>,
-    #[derivative(Debug = "ignore")]
     hs: Option<ComPtr<d3d11::ID3D11HullShader>>,
-    #[derivative(Debug = "ignore")]
     ds: Option<ComPtr<d3d11::ID3D11DomainShader>>,
-    #[derivative(Debug = "ignore")]
     ps: Option<ComPtr<d3d11::ID3D11PixelShader>>,
-    #[derivative(Debug = "ignore")]
     topology: d3d11::D3D11_PRIMITIVE_TOPOLOGY,
-    #[derivative(Debug = "ignore")]
     input_layout: ComPtr<d3d11::ID3D11InputLayout>,
-    #[derivative(Debug = "ignore")]
     rasterizer_state: ComPtr<d3d11::ID3D11RasterizerState>,
-    #[derivative(Debug = "ignore")]
     blend_state: ComPtr<d3d11::ID3D11BlendState>,
-    #[derivative(Debug = "ignore")]
     depth_stencil_state: Option<(
         ComPtr<d3d11::ID3D11DepthStencilState>,
         pso::State<pso::StencilValue>,
@@ -2845,6 +2869,12 @@ pub struct GraphicsPipeline {
     required_bindings: u32,
     max_vertex_bindings: u32,
     strides: Vec<u32>,
+}
+
+impl fmt::Debug for GraphicsPipeline {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("GraphicsPipeline")
+    }
 }
 
 unsafe impl Send for GraphicsPipeline {}
@@ -2984,14 +3014,18 @@ impl CoherentBuffers {
 #[repr(C)]
 struct Descriptor(*mut d3d11::ID3D11DeviceChild);
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct DescriptorSet {
     offset: usize,
     len: usize,
     handles: *mut Descriptor,
     register_remap: RegisterRemapping,
     coherent_buffers: Mutex<CoherentBuffers>,
+}
+
+impl fmt::Debug for DescriptorSet {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("DescriptorSet")
+    }
 }
 
 unsafe impl Send for DescriptorSet {}

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -25,7 +25,7 @@ derivative = "1"
 d3d12 = "0.1"
 log = { version = "0.4" }
 smallvec = "0.6"
-spirv_cross = { version = "0.14.0", features = ["hlsl"] }
+spirv_cross = { version = "0.15", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.20.0-alpha3", optional = true }
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -21,7 +21,6 @@ name = "gfx_backend_dx12"
 gfx-hal = { path = "../../hal", version = "0.3" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
-derivative = "1"
 d3d12 = "0.1"
 log = { version = "0.4" }
 smallvec = "0.6"

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -15,7 +15,7 @@ use hal::{
 use std::borrow::Borrow;
 use std::ops::Range;
 use std::sync::Arc;
-use std::{cmp, iter, mem, ptr};
+use std::{cmp, fmt, iter, mem, ptr};
 
 use winapi::shared::minwindef::{FALSE, TRUE, UINT};
 use winapi::shared::{dxgiformat, winerror};
@@ -74,14 +74,17 @@ struct AttachmentClear {
     stencil_value: Option<u32>,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct RenderPassCache {
     render_pass: r::RenderPass,
     framebuffer: r::Framebuffer,
-    #[derivative(Debug = "ignore")]
     target_rect: d3d12::D3D12_RECT,
     attachment_clears: Vec<AttachmentClear>,
+}
+
+impl fmt::Debug for RenderPassCache {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("RenderPassCache")
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -111,8 +114,8 @@ struct UserData {
     dirty_mask: u64,
 }
 
-impl std::fmt::Debug for UserData {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for UserData {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("UserData")
             .field("data", &&self.data[..])
             .field("dirty_mask", &self.dirty_mask)
@@ -292,8 +295,6 @@ struct Copy {
     copy_extent: image::Extent,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct CommandBuffer {
     raw: native::GraphicsCommandList,
     allocator: native::CommandAllocator,
@@ -331,7 +332,6 @@ pub struct CommandBuffer {
     // inside the pipeline state.
     vertex_bindings_remap: [Option<r::VertexBinding>; MAX_VERTEX_BUFFERS],
 
-    #[derivative(Debug = "ignore")]
     vertex_buffer_views: [d3d12::D3D12_VERTEX_BUFFER_VIEW; MAX_VERTEX_BUFFERS],
 
     // Re-using allocation for the image-buffer copies.
@@ -339,12 +339,10 @@ pub struct CommandBuffer {
 
     // D3D12 only allows setting all viewports or all scissors at once, not partial updates.
     // So we must cache the implied state for these partial updates.
-    #[derivative(Debug = "ignore")]
     viewport_cache: SmallVec<
         [d3d12::D3D12_VIEWPORT;
             d3d12::D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE as usize],
     >,
-    #[derivative(Debug = "ignore")]
     scissor_cache: SmallVec<
         [d3d12::D3D12_RECT;
             d3d12::D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE as usize],
@@ -360,6 +358,12 @@ pub struct CommandBuffer {
     //
     // Required for reset behavior.
     pool_create_flags: pool::CommandPoolCreateFlags,
+}
+
+impl fmt::Debug for CommandBuffer {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("CommandBuffer")
+    }
 }
 
 unsafe impl Send for CommandBuffer {}

--- a/src/backend/dx12/src/descriptors_cpu.rs
+++ b/src/backend/dx12/src/descriptors_cpu.rs
@@ -1,18 +1,21 @@
 use native;
 use native::descriptor::{CpuDescriptor, HeapFlags, HeapType};
+use std::fmt;
 use std::collections::HashSet;
 
 // Linear stack allocator for CPU descriptor heaps.
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct HeapLinear {
     handle_size: usize,
     num: usize,
     size: usize,
-    #[derivative(Debug = "ignore")]
     start: CpuDescriptor,
-    #[derivative(Debug = "ignore")]
     raw: native::DescriptorHeap,
+}
+
+impl fmt::Debug for HeapLinear {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("HeapLinear")
+    }
 }
 
 impl HeapLinear {
@@ -55,8 +58,6 @@ impl HeapLinear {
 const HEAP_SIZE_FIXED: usize = 64;
 
 // Fixed-size free-list allocator for CPU descriptors.
-#[derive(Derivative)]
-#[derivative(Debug)]
 struct Heap {
     // Bit flag representation of available handles in the heap.
     //
@@ -64,10 +65,14 @@ struct Heap {
     //  1 - free
     availability: u64,
     handle_size: usize,
-    #[derivative(Debug = "ignore")]
     start: CpuDescriptor,
-    #[derivative(Debug = "ignore")]
     raw: native::DescriptorHeap,
+}
+
+impl fmt::Debug for Heap {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Heap")
+    }
 }
 
 impl Heap {
@@ -104,15 +109,17 @@ impl Heap {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct DescriptorCpuPool {
     device: native::Device,
-
-    #[derivative(Debug = "ignore")]
     ty: HeapType,
     heaps: Vec<Heap>,
     free_list: HashSet<usize>,
+}
+
+impl fmt::Debug for DescriptorCpuPool {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("DescriptorCpuPool")
+    }
 }
 
 impl DescriptorCpuPool {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -2,8 +2,6 @@ extern crate gfx_hal as hal;
 extern crate range_alloc;
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate derivative;
 extern crate d3d12 as native;
 #[macro_use]
 extern crate log;
@@ -36,7 +34,7 @@ use std::borrow::Borrow;
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use std::sync::{Arc, Mutex};
-use std::{mem, ptr};
+use std::{fmt, mem, ptr};
 
 use native::descriptor;
 
@@ -177,14 +175,10 @@ static QUEUE_FAMILIES: [QueueFamily; 4] = [
     QueueFamily::Normal(q::QueueType::Transfer),
 ];
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct PhysicalDevice {
-    #[derivative(Debug = "ignore")]
     adapter: native::WeakPtr<dxgi1_2::IDXGIAdapter2>,
     features: Features,
     limits: Limits,
-    #[derivative(Debug = "ignore")]
     format_properties: Arc<FormatProperties>,
     private_caps: Capabilities,
     heap_properties: &'static [HeapProperties; NUM_HEAP_PROPERTIES],
@@ -192,6 +186,12 @@ pub struct PhysicalDevice {
     // Indicates that there is currently an active logical device.
     // Opening the same adapter multiple times will return the same D3D12Device again.
     is_open: Arc<Mutex<bool>>,
+}
+
+impl fmt::Debug for PhysicalDevice {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("PhysicalDevice")
+    }
 }
 
 unsafe impl Send for PhysicalDevice {}
@@ -405,13 +405,17 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
     }
 }
 
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone)]
 pub struct CommandQueue {
     pub(crate) raw: native::CommandQueue,
     idle_fence: native::Fence,
-    #[derivative(Debug = "ignore")]
     idle_event: native::sync::Event,
+}
+
+impl fmt::Debug for CommandQueue {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("CommandQueue")
+    }
 }
 
 impl CommandQueue {
@@ -542,8 +546,6 @@ impl Shared {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Device {
     raw: native::Device,
     private_caps: Capabilities,
@@ -558,9 +560,7 @@ pub struct Device {
     // CPU/GPU descriptor heaps
     heap_srv_cbv_uav: Mutex<resource::DescriptorHeap>,
     heap_sampler: Mutex<resource::DescriptorHeap>,
-    #[derivative(Debug = "ignore")]
     events: Mutex<Vec<native::Event>>,
-    #[derivative(Debug = "ignore")]
     shared: Arc<Shared>,
     // Present queue exposed by the `Present` queue family.
     // Required for swapchain creation. Only a single queue supports presentation.
@@ -571,6 +571,13 @@ pub struct Device {
     // Indicates that there is currently an active device.
     open: Arc<Mutex<bool>>,
 }
+
+impl fmt::Debug for Device {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Device")
+    }
+}
+
 unsafe impl Send for Device {} //blocked by ComPtr
 unsafe impl Sync for Device {} //blocked by ComPtr
 

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::fmt;
 
 use winapi::shared::winerror::SUCCEEDED;
 
@@ -13,16 +14,18 @@ pub enum CommandPoolAllocator {
     Individual(Vec<native::CommandAllocator>),
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct CommandPool {
     pub(crate) allocator: CommandPoolAllocator,
     pub(crate) device: native::Device,
-
-    #[derivative(Debug = "ignore")]
     pub(crate) list_type: CmdListType,
     pub(crate) shared: Arc<Shared>,
     pub(crate) create_flags: pool::CommandPoolCreateFlags,
+}
+
+impl fmt::Debug for CommandPool {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("CommandPool")
+    }
 }
 
 impl CommandPool {

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -10,6 +10,7 @@ use crate::{root_constants::RootConstant, Backend, MAX_VERTEX_BUFFERS};
 
 use std::collections::BTreeMap;
 use std::ops::Range;
+use std::fmt;
 
 // ShaderModule is either a precompiled if the source comes from HLSL or
 // the SPIR-V module doesn't contain specialization constants or push constants
@@ -157,23 +158,30 @@ pub struct BufferUnbound {
     pub(crate) usage: buffer::Usage,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct BufferBound {
     pub(crate) resource: native::Resource,
     pub(crate) requirements: memory::Requirements,
-    #[derivative(Debug = "ignore")]
     pub(crate) clear_uav: Option<native::CpuDescriptor>,
+}
+
+impl fmt::Debug for BufferBound {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("BufferBound")
+    }
 }
 
 unsafe impl Send for BufferBound {}
 unsafe impl Sync for BufferBound {}
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub enum Buffer {
     Unbound(BufferUnbound),
     Bound(BufferBound),
+}
+
+impl fmt::Debug for Buffer {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Buffer")
+    }
 }
 
 impl Buffer {
@@ -192,16 +200,20 @@ impl Buffer {
     }
 }
 
-#[derive(Copy, Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Copy, Clone)]
 pub struct BufferView {
     // Descriptor handle for uniform texel buffers.
-    #[derivative(Debug = "ignore")]
     pub(crate) handle_srv: native::CpuDescriptor,
     // Descriptor handle for storage texel buffers.
-    #[derivative(Debug = "ignore")]
     pub(crate) handle_uav: native::CpuDescriptor,
 }
+
+impl fmt::Debug for BufferView {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("BufferView")
+    }
+}
+
 unsafe impl Send for BufferView {}
 unsafe impl Sync for BufferView {}
 
@@ -211,29 +223,29 @@ pub enum Place {
     Heap { raw: native::Heap, offset: u64 },
 }
 
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone)]
 pub struct ImageBound {
     pub(crate) resource: native::Resource,
-    #[derivative(Debug = "ignore")]
     pub(crate) place: Place,
     pub(crate) surface_type: format::SurfaceType,
     pub(crate) kind: image::Kind,
     pub(crate) usage: image::Usage,
     pub(crate) default_view_format: Option<DXGI_FORMAT>,
     pub(crate) view_caps: image::ViewCapabilities,
-    #[derivative(Debug = "ignore")]
     pub(crate) descriptor: d3d12::D3D12_RESOURCE_DESC,
     pub(crate) bytes_per_block: u8,
     // Dimension of a texel block (compressed formats).
     pub(crate) block_dim: (u8, u8),
-    #[derivative(Debug = "ignore")]
     pub(crate) clear_cv: Vec<native::CpuDescriptor>,
-    #[derivative(Debug = "ignore")]
     pub(crate) clear_dv: Vec<native::CpuDescriptor>,
-    #[derivative(Debug = "ignore")]
     pub(crate) clear_sv: Vec<native::CpuDescriptor>,
     pub(crate) requirements: memory::Requirements,
+}
+
+impl fmt::Debug for ImageBound {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("ImageBound")
+    }
 }
 
 unsafe impl Send for ImageBound {}
@@ -256,10 +268,8 @@ impl ImageBound {
     }
 }
 
-#[derive(Copy, Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Copy, Clone)]
 pub struct ImageUnbound {
-    #[derivative(Debug = "ignore")]
     pub(crate) desc: d3d12::D3D12_RESOURCE_DESC,
     pub(crate) view_format: Option<DXGI_FORMAT>,
     pub(crate) dsv_format: Option<DXGI_FORMAT>,
@@ -276,6 +286,12 @@ pub struct ImageUnbound {
     pub(crate) num_levels: image::Level,
 }
 
+impl fmt::Debug for ImageUnbound {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("ImageUnbound")
+    }
+}
+
 impl ImageUnbound {
     pub fn calc_subresource(&self, mip_level: UINT, layer: UINT, plane: UINT) -> UINT {
         mip_level
@@ -284,11 +300,16 @@ impl ImageUnbound {
     }
 }
 
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone)]
 pub enum Image {
     Unbound(ImageUnbound),
     Bound(ImageBound),
+}
+
+impl fmt::Debug for Image {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Image")
+    }
 }
 
 impl Image {
@@ -321,18 +342,12 @@ impl Image {
     }
 }
 
-#[derive(Copy, Derivative, Clone)]
-#[derivative(Debug)]
+#[derive(Copy, Clone)]
 pub struct ImageView {
-    #[derivative(Debug = "ignore")]
     pub(crate) resource: native::Resource, // weak-ptr owned by image.
-    #[derivative(Debug = "ignore")]
     pub(crate) handle_srv: Option<native::CpuDescriptor>,
-    #[derivative(Debug = "ignore")]
     pub(crate) handle_rtv: Option<native::CpuDescriptor>,
-    #[derivative(Debug = "ignore")]
     pub(crate) handle_dsv: Option<native::CpuDescriptor>,
-    #[derivative(Debug = "ignore")]
     pub(crate) handle_uav: Option<native::CpuDescriptor>,
     // Required for attachment resolves.
     pub(crate) dxgi_format: DXGI_FORMAT,
@@ -341,6 +356,13 @@ pub struct ImageView {
     pub(crate) layers: (image::Layer, image::Layer),
     pub(crate) kind: image::Kind,
 }
+
+impl fmt::Debug for ImageView {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("ImageView")
+    }
+}
+
 unsafe impl Send for ImageView {}
 unsafe impl Sync for ImageView {}
 
@@ -350,11 +372,14 @@ impl ImageView {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Sampler {
-    #[derivative(Debug = "ignore")]
     pub(crate) handle: native::CpuDescriptor,
+}
+
+impl fmt::Debug for Sampler {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Sampler")
+    }
 }
 
 #[derive(Debug)]
@@ -444,21 +469,19 @@ pub struct DescriptorBindingInfo {
     pub(crate) content: DescriptorContent,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct DescriptorSet {
     // Required for binding at command buffer
-    #[derivative(Debug = "ignore")]
     pub(crate) heap_srv_cbv_uav: native::DescriptorHeap,
-    #[derivative(Debug = "ignore")]
     pub(crate) heap_samplers: native::DescriptorHeap,
-
     pub(crate) binding_infos: Vec<DescriptorBindingInfo>,
-
-    #[derivative(Debug = "ignore")]
     pub(crate) first_gpu_sampler: Option<native::GpuDescriptor>,
-    #[derivative(Debug = "ignore")]
     pub(crate) first_gpu_view: Option<native::GpuDescriptor>,
+}
+
+impl fmt::Debug for DescriptorSet {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("DescriptorSet")
+    }
 }
 
 // TODO: is this really safe?
@@ -475,26 +498,32 @@ impl DescriptorSet {
     }
 }
 
-#[derive(Copy, Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Copy, Clone)]
 pub struct DualHandle {
-    #[derivative(Debug = "ignore")]
     pub(crate) cpu: native::CpuDescriptor,
-    #[derivative(Debug = "ignore")]
     pub(crate) gpu: native::GpuDescriptor,
     /// How large the block allocated to this handle is.
     pub(crate) size: u64,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
+impl fmt::Debug for DualHandle {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("DualHandle")
+    }
+}
+
 pub struct DescriptorHeap {
-    #[derivative(Debug = "ignore")]
     pub(crate) raw: native::DescriptorHeap,
     pub(crate) handle_size: u64,
     pub(crate) total_handles: u64,
     pub(crate) start: DualHandle,
     pub(crate) range_allocator: RangeAllocator<u64>,
+}
+
+impl fmt::Debug for DescriptorHeap {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("DescriptorHeap")
+    }
 }
 
 impl DescriptorHeap {

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use std::mem;
+use std::{fmt, mem};
 
 #[cfg(feature = "winit")]
 use winit;
@@ -39,13 +39,16 @@ struct Presentation {
     size: w::Extent2D,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Surface {
-    #[derivative(Debug = "ignore")]
     pub(crate) factory: native::WeakPtr<dxgi1_4::IDXGIFactory4>,
     pub(crate) wnd_handle: HWND,
     presentation: Option<Presentation>,
+}
+
+impl fmt::Debug for Surface {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Surface")
+    }
 }
 
 unsafe impl Send for Surface {}

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -27,7 +27,7 @@ log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.3" }
 smallvec = "0.6"
 glow = "0.2.3"
-spirv_cross = { version = "0.14.0", features = ["glsl"] }
+spirv_cross = { version = "0.15", features = ["glsl"] }
 lazy_static = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -21,7 +21,6 @@ name = "gfx_backend_vulkan"
 
 [dependencies]
 byteorder = "1"
-derivative = "1.0"
 log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -5,8 +5,6 @@ extern crate log;
 #[macro_use]
 extern crate ash;
 #[macro_use]
-extern crate derivative;
-#[macro_use]
 extern crate lazy_static;
 
 #[cfg(target_os = "macos")]
@@ -127,14 +125,17 @@ impl Drop for RawInstance {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Instance {
-    #[derivative(Debug = "ignore")]
     pub raw: Arc<RawInstance>,
 
     /// Supported extensions of this instance.
     pub extensions: Vec<&'static CStr>,
+}
+
+impl fmt::Debug for Instance {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Instance")
+    }
 }
 
 fn map_queue_type(flags: vk::QueueFlags) -> queue::QueueType {
@@ -497,13 +498,16 @@ impl queue::QueueFamily for QueueFamily {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct PhysicalDevice {
-    #[derivative(Debug = "ignore")]
     instance: Arc<RawInstance>,
     handle: vk::PhysicalDevice,
     properties: vk::PhysicalDeviceProperties,
+}
+
+impl fmt::Debug for PhysicalDevice {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("PhysicalDevice")
+    }
 }
 
 impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
@@ -1076,13 +1080,16 @@ impl Drop for RawDevice {
 // Need to explicitly synchronize on submission and present.
 pub type RawCommandQueue = Arc<vk::Queue>;
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct CommandQueue {
     raw: RawCommandQueue,
     device: Arc<RawDevice>,
-    #[derivative(Debug = "ignore")]
     swapchain_fn: vk::KhrSwapchainFn,
+}
+
+impl fmt::Debug for CommandQueue {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("CommandQueue")
+    }
 }
 
 impl queue::CommandQueue<Backend> for CommandQueue {

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Borrow,
+    fmt,
     hash,
     os::raw::c_void,
     ptr,
@@ -76,15 +77,17 @@ impl SurfaceSwapchain {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Surface {
     // Vk (EXT) specs [29.2.7 Platform-Independent Information]
     // For vkDestroySurfaceKHR: Host access to surface must be externally synchronized
-    #[derivative(Debug = "ignore")]
     pub(crate) raw: Arc<RawSurface>,
-
     pub(crate) swapchain: Option<SurfaceSwapchain>,
+}
+
+impl fmt::Debug for Surface {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Surface")
+    }
 }
 
 pub struct RawSurface {
@@ -611,13 +614,15 @@ impl w::PresentationSurface<Backend> for Surface {
     }
 }
 
-
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub struct Swapchain {
     pub(crate) raw: vk::SwapchainKHR,
-    #[derivative(Debug = "ignore")]
     pub(crate) functor: khr::Swapchain,
+}
+
+impl fmt::Debug for Swapchain {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("Swapchain")
+    }
 }
 
 impl w::Swapchain<Backend> for Swapchain {

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -21,7 +21,6 @@ path = "src/lib.rs"
 [dependencies]
 bitflags = "1.0"
 mint = { version = "0.5", optional = true }
-failure = "0.1"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 fxhash = "0.2.1"
 

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -15,16 +15,14 @@ pub type Offset = u64;
 pub type State = Access;
 
 /// Error creating a buffer.
-#[derive(Fail, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CreationError {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(device::OutOfMemory),
 
     /// Requested buffer usage is not supported.
     ///
     /// Older GL version don't support constant buffers or multiple usage flags.
-    #[fail(display = "Buffer usage unsupported ({:?}).", usage)]
     UnsupportedUsage {
         /// Unsupported usage passed on buffer creation.
         usage: Usage,
@@ -38,14 +36,12 @@ impl From<device::OutOfMemory> for CreationError {
 }
 
 /// Error creating a buffer view.
-#[derive(Fail, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ViewCreationError {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(device::OutOfMemory),
 
     /// Buffer view format is not supported.
-    #[fail(display = "Buffer view format unsupported ({:?}).", format)]
     UnsupportedFormat {
         /// Unsupported format passed on view creation.
         format: Option<format::Format>,

--- a/src/hal/src/command/clear.rs
+++ b/src/hal/src/command/clear.rs
@@ -13,8 +13,8 @@ pub union ClearColor {
     pub uint32: [u32; 4],
 }
 
-impl std::fmt::Debug for ClearColor {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for ClearColor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln![f, "ClearColor"]
     }
 }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -28,41 +28,34 @@ use crate::range::RangeArg;
 use crate::window::{self, SwapchainConfig};
 
 /// Error occurred caused device to be lost.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
-#[fail(display = "Device is lost")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DeviceLost;
 
 /// Error occurred caused surface to be lost.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
-#[fail(display = "Surface is lost")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SurfaceLost;
 
 /// Native window is already in use by graphics API.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
-#[fail(display = "Native window in use")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WindowInUse;
 
 /// Error allocating memory.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OutOfMemory {
     /// Host memory exhausted.
-    #[fail(display = "Out of host memory")]
     OutOfHostMemory,
 
     /// Device memory exhausted.
-    #[fail(display = "Out of device memory")]
     OutOfDeviceMemory,
 }
 
 /// Error occurred caused device to be lost
 /// or out of memory error.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OomOrDeviceLost {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(OutOfMemory),
     /// Device is lost
-    #[fail(display = "{}", _0)]
     DeviceLost(DeviceLost),
 }
 
@@ -79,14 +72,12 @@ impl From<DeviceLost> for OomOrDeviceLost {
 }
 
 /// Possible cause of allocation failure.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AllocationError {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(OutOfMemory),
 
-    /// Vulkan implementation doesn't allow to create too many objects.
-    #[fail(display = "Can't allocate more memory objects")]
+    /// Cannot create any more objects.
     TooManyObjects,
 }
 
@@ -97,16 +88,13 @@ impl From<OutOfMemory> for AllocationError {
 }
 
 /// Error binding a resource to memory allocation.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BindError {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(OutOfMemory),
     /// Requested binding to memory that doesn't support the required operations.
-    #[fail(display = "Unsupported memory allocation for the requirements")]
     WrongMemory,
     /// Requested binding to an invalid memory.
-    #[fail(display = "Not enough space in the memory allocation")]
     OutOfBounds,
 }
 
@@ -127,22 +115,17 @@ pub enum WaitFor {
 }
 
 /// An error from creating a shader module.
-#[derive(Clone, Debug, Fail, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ShaderError {
     /// The shader failed to compile.
-    #[fail(display = "shader compilation failed: {}", _0)]
     CompilationFailed(String),
-    /// Missing entry point.
-    #[fail(display = "shader is missing an entry point: {}", _0)]
+    /// The shader is missing an entry point.
     MissingEntryPoint(String),
-    /// Mismatch of interface (e.g missing push constants).
-    #[fail(display = "shader interface mismatch: {}", _0)]
+    /// The shader has a mismatch of interface (e.g missing push constants).
     InterfaceMismatch(String),
-    /// Shader stage is not supported.
-    #[fail(display = "shader stage \"{}\" is unsupported", _0)]
+    /// The shader stage is not supported.
     UnsupportedStage(pso::Stage),
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(OutOfMemory),
 }
 

--- a/src/hal/src/error.rs
+++ b/src/hal/src/error.rs
@@ -1,61 +1,51 @@
 //! Return values from function calls.
 
 /// Device creation errors during `open`.
-#[derive(Fail, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeviceCreationError {
     /// Memory allocation on the host side failed.
     /// This could be caused by a lack of memory.
-    #[fail(display = "Host memory allocation failed.")]
     OutOfHostMemory,
     /// Memory allocation on the device side failed.
     /// This could be caused by a lack of memory.
-    #[fail(display = "Device memory allocation failed.")]
     OutOfDeviceMemory,
     /// Device initialization failed due to implementation specific errors.
-    #[fail(display = "Device initialization failed.")]
     InitializationFailed,
     /// At least one of the user requested extensions if not supported by the
     /// physical device.
-    #[fail(display = "One or multiple extensions are not supported.")]
     MissingExtension,
     /// At least one of the user requested features if not supported by the
     /// physical device.
     ///
     /// Use [`features`](trait.PhysicalDevice.html#tymethod.features)
     /// for checking the supported features.
-    #[fail(display = "One or multiple features are not supported.")]
     MissingFeature,
     /// Too many logical devices have been created from this physical device.
     ///
     /// The implementation may only support one logical device for each physical
     /// device or lacks resources to allocate a new device.
-    #[fail(display = "Too many device objects have been created.")]
     TooManyObjects,
     /// The logical or physical device are lost during the device creation
     /// process.
     ///
     /// This may be caused by hardware failure, physical device removal,
     /// power outage, etc.
-    #[fail(display = "Physical or logical device lost.")]
     DeviceLost,
 }
 
 /// Errors during execution of operations on the host side.
-#[derive(Fail, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HostExecutionError {
     /// Memory allocation on the host side failed.
     /// This could be caused by a lack of memory.
-    #[fail(display = "Host memory allocation failed.")]
     OutOfHostMemory,
     /// Memory allocation on the device side failed.
     /// This could be caused by a lack of memory.
-    #[fail(display = "Device memory allocation failed.")]
     OutOfDeviceMemory,
     /// The logical or physical device are lost during the device creation
     /// process.
     ///
     /// This may be caused by hardware failure, physical device removal,
     /// power outage, etc.
-    #[fail(display = "Physical or logical device lost.")]
     DeviceLost,
 }

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -104,37 +104,21 @@ pub enum Tiling {
 }
 
 /// Pure image object creation error.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Fail)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, )]
 pub enum CreationError {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(device::OutOfMemory),
     /// The format is not supported by the device.
-    #[fail(display = "Failed to map a given format ({:?}) to the device", _0)]
     Format(format::Format),
     /// The kind doesn't support a particular operation.
-    #[fail(display = "The kind doesn't support a particular operation")]
     Kind,
     /// Failed to map a given multisampled kind to the device.
-    #[fail(
-        display = "Failed to map a given multisampled kind ({}) to the device",
-        _0
-    )]
     Samples(NumSamples),
     /// Unsupported size in one of the dimensions.
-    #[fail(display = "Unsupported size ({}) in one of the dimensions", _0)]
     Size(Size),
     /// The given data has a different size than the target image slice.
-    #[fail(
-        display = "The given data has a different size ({}) than the target image slice",
-        _0
-    )]
     Data(usize),
-    /// The mentioned usage mode is not supported
-    #[fail(
-        display = "The expected image usage mode ({:?}) is not supported by a graphic API",
-        _0
-    )]
+    /// The specified image usage mode is not supported.
     Usage(Usage),
 }
 
@@ -145,34 +129,21 @@ impl From<device::OutOfMemory> for CreationError {
 }
 
 /// Error creating an `ImageView`.
-#[derive(Clone, Debug, PartialEq, Eq, Fail)]
+#[derive(Clone, Debug, PartialEq, Eq, )]
 pub enum ViewError {
     /// The required usage flag is not present in the image.
-    #[fail(
-        display = "The required usage flag ({:?}) is not present in the image",
-        _0
-    )]
     Usage(Usage),
-    /// Selected mip levels doesn't exist.
-    #[fail(display = "Selected mip level ({}) doesn't exist", _0)]
+    /// Selected mip level doesn't exist.
     Level(Level),
     /// Selected array layer doesn't exist.
-    #[fail(display = "Selected mip layer ({}) doesn't exist", _0)]
     Layer(LayerError),
     /// An incompatible format was requested for the view.
-    #[fail(
-        display = "An incompatible format ({:?}) was requested for the view",
-        _0
-    )]
     BadFormat(format::Format),
-    /// Unsupported view kind.
-    #[fail(display = "An incompatible kind ({:?}) was requested for the view", _0)]
+    /// An incompatible view kind was requested for the view.
     BadKind(ViewKind),
     /// Out of either Host or Device memory
-    #[fail(display = "{}", _0)]
     OutOfMemory(device::OutOfMemory),
     /// The backend refused for some reason.
-    #[fail(display = "The backend refused for some reason")]
     Unsupported,
 }
 
@@ -183,19 +154,11 @@ impl From<device::OutOfMemory> for ViewError {
 }
 
 /// An error associated with selected image layer.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Fail)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, )]
 pub enum LayerError {
     /// The source image kind doesn't support array slices.
-    #[fail(
-        display = "The source image kind ({:?}) doesn't support array slices",
-        _0
-    )]
     NotExpected(Kind),
-    /// Selected layer is outside of the provided range.
-    #[fail(
-        display = "Selected layers ({:?}) are outside of the provided range",
-        _0
-    )]
+    /// Selected layers are outside of the provided range.
     OutOfBounds(Range<Layer>),
 }
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -5,15 +5,12 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate failure;
 
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
 
 use std::any::Any;
-use std::error::Error;
 use std::fmt;
 use std::hash::Hash;
 
@@ -516,18 +513,6 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SubmissionError {}
-
-impl fmt::Display for SubmissionError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-
-impl Error for SubmissionError {
-    fn description(&self) -> &str {
-        "Submission error"
-    }
-}
 
 /// Submission result for DX11 backend.  Currently mostly unused.
 pub type SubmissionResult<T> = Result<T, SubmissionError>;

--- a/src/hal/src/mapping.rs
+++ b/src/hal/src/mapping.rs
@@ -7,19 +7,15 @@ use std::ops::{self, Range};
 
 // TODO
 /// Error accessing a mapping.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Fail)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, )]
 pub enum Error {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(device::OutOfMemory),
     /// The requested mapping access did not match the expected usage.
-    #[fail(display = "The requested mapping access did not match the expected usage")]
     InvalidAccess,
     /// The requested mapping range is outside of the resource.
-    #[fail(display = "The requested mapping range is outside of the resource")]
     OutOfBounds,
     /// Failed to map memory range.
-    #[fail(display = "Unable to allocate an appropriately sized contiguous virtual address")]
     MappingFailed,
 }
 

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -107,25 +107,20 @@ pub struct DescriptorRangeDesc {
 }
 
 /// An error allocating descriptor sets from a pool.
-#[derive(Fail, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AllocationError {
     /// Memory allocation on the host side failed.
     /// This could be caused by a lack of memory or pool fragmentation.
-    #[fail(display = "Host memory allocation failed.")]
     OutOfHostMemory,
     /// Memory allocation on the host side failed.
     /// This could be caused by a lack of memory or pool fragmentation.
-    #[fail(display = "Device memory allocation failed.")]
     OutOfDeviceMemory,
     /// Memory allocation failed as there is not enough in the pool.
     /// This could be caused by too many descriptor sets being created.
-    #[fail(display = "Descriptor pool memory allocation failed.")]
     OutOfPoolMemory,
     /// Memory allocation failed due to pool fragmentation.
-    #[fail(display = "Descriptor pool is fragmented.")]
     FragmentedPool,
     /// Descriptor set allocation failed as the layout is incompatible with the pool.
-    #[fail(display = "Descriptor layout incompatible with pool.")]
     IncompatibleLayout,
 }
 

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -14,20 +14,15 @@ mod output_merger;
 pub use self::{compute::*, descriptor::*, graphics::*, input_assembler::*, output_merger::*};
 
 /// Error types happening upon PSO creation on the device side.
-#[derive(Clone, Debug, PartialEq, Fail)]
+#[derive(Clone, Debug, PartialEq, )]
 pub enum CreationError {
     /// Unknown other error.
-    #[fail(display = "Unknown other error")]
     Other,
     /// Invalid subpass (not part of renderpass).
-    #[fail(display = "Invalid subpass index: {}", _0)]
     InvalidSubpass(pass::SubpassId),
     /// Shader compilation error.
-    #[fail(display = "Shader compilation error: {}", _0)]
     Shader(device::ShaderError),
-
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(device::OutOfMemory),
 }
 

--- a/src/hal/src/query.rs
+++ b/src/hal/src/query.rs
@@ -10,14 +10,12 @@ use crate::Backend;
 pub type Id = u32;
 
 /// Query creation error.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CreationError {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(OutOfMemory),
 
     /// Query type unsupported.
-    #[fail(display = "Query type ({:?}) unsupported", _0)]
     Unsupported(Type),
 }
 

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -63,19 +63,15 @@ use std::iter;
 use std::ops::RangeInclusive;
 
 /// Error occurred during swapchain creation.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CreationError {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(device::OutOfMemory),
     /// Device is lost
-    #[fail(display = "{}", _0)]
     DeviceLost(device::DeviceLost),
     /// Surface is lost
-    #[fail(display = "{}", _0)]
     SurfaceLost(device::SurfaceLost),
     /// Window in use
-    #[fail(display = "{}", _0)]
     WindowInUse(device::WindowInUse),
 }
 
@@ -414,42 +410,32 @@ impl SwapchainConfig {
 pub struct Suboptimal;
 
 /// Error on acquiring the next image from a swapchain.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AcquireError {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(device::OutOfMemory),
     /// No image was ready and no timeout was specified.
-    #[fail(display = "No images ready")]
     NotReady,
     /// No image was ready after the specified timeout expired.
-    #[fail(display = "No images ready after the specified timeout expired")]
     Timeout,
     /// The swapchain is no longer in sync with the surface, needs to be re-created.
-    #[fail(display = "Swapchain is out of date")]
     OutOfDate,
     /// The surface was lost, and the swapchain is no longer usable.
-    #[fail(display = "{}", _0)]
     SurfaceLost(device::SurfaceLost),
     /// Device is lost
-    #[fail(display = "{}", _0)]
     DeviceLost(device::DeviceLost),
 }
 
 /// Error on acquiring the next image from a swapchain.
-#[derive(Clone, Copy, Debug, Fail, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PresentError {
     /// Out of either host or device memory.
-    #[fail(display = "{}", _0)]
     OutOfMemory(device::OutOfMemory),
     /// The swapchain is no longer in sync with the surface, needs to be re-created.
-    #[fail(display = "Swapchain is out of date")]
     OutOfDate,
     /// The surface was lost, and the swapchain is no longer usable.
-    #[fail(display = "{}", _0)]
     SurfaceLost(device::SurfaceLost),
     /// Device is lost
-    #[fail(display = "{}", _0)]
     DeviceLost(device::DeviceLost),
 }
 

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -29,7 +29,6 @@ gl-headless = ["gfx-backend-gl"] # "glsl-to-spirv"
 #TODO: keep Warden backend-agnostic?
 
 [dependencies]
-failure = "0.1"
 hal = { path = "../hal", version = "0.3", package = "gfx-hal", features = ["serde"] }
 log = "0.4"
 ron = "0.5"

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -1,4 +1,3 @@
-use failure::Error;
 #[cfg(feature = "glsl-to-spirv")]
 use glsl_to_spirv;
 
@@ -196,7 +195,7 @@ impl<B: hal::Backend> Scene<B> {
         adapter: adapter::Adapter<B>,
         raw: &raw::Scene,
         data_path: PathBuf,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, ()> {
         info!("creating Scene from {:?}", data_path);
         let memory_types = adapter.physical_device.memory_properties().memory_types;
         let limits = adapter.physical_device.limits();
@@ -206,7 +205,7 @@ impl<B: hal::Backend> Scene<B> {
             adapter.physical_device.open(
                 &[(&adapter.queue_families[0], &[1.0])],
                 hal::Features::empty(),
-            )?
+            ).unwrap()
         };
         let device = gpu.device;
         let queue_group = gpu.queue_groups.pop().unwrap();
@@ -236,13 +235,13 @@ impl<B: hal::Backend> Scene<B> {
             device.create_command_pool(
                 queue_group.family,
                 hal::pool::CommandPoolCreateFlags::empty(),
-            )?
+            ).unwrap()
         };
         let query_pool = unsafe {
             device.create_query_pool(
                 query::Type::Timestamp,
                 2,
-            )?
+            ).unwrap()
         };
 
         // create resources


### PR DESCRIPTION
This cleans up our dependencies slightly through version matching or dependency removal.

Fixes #2436

- Removes `failure`
  - `failure`'s README describes that it's in a bit of flux as improvements are being made to Rust's stdlib upstream, so we might want to avoid relying on it too greatly in its current state
  - we aren't really using `failure` consistently throughout, and many of the messages are just taken directly from doc comments anyway. While we could make usage more consistent, it's not clear that this effort will be very useful if it's incompatible with upstream changes in Rust itself.
- Matches spirv_cross version across all backends
- Removes `derivative`
  - most existing usages seem like they could be treated as opaque types because they don't provide much debug information, so we could just write custom debug implementations wherever it's noticeably useful

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Metal
- [ ] `rustfmt` run on changed code