### PR TITLE
Metal: update metal-rs and wrap RP switch into an ARP

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -29,11 +29,11 @@ copyless = "0.1.4"
 log = { version = "0.4" }
 winit = { version = "0.20.0-alpha3", optional = true }
 dispatch = { version = "0.1", optional = true }
-metal = { version = "0.15", features = ["private"] }
+metal = { version = "0.16", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"
-cocoa = "0.18"
+cocoa = "0.19"
 core-graphics = "0.17"
 smallvec = "0.6"
 spirv_cross = { version = "0.15", features = ["msl"] }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -3507,11 +3507,13 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             .make_render_commands(sin.combined_aspects)
             .chain(com_ds);
 
-        self.inner
-            .borrow_mut()
-            .sink()
-            .switch_render(sin.descriptor)
-            .issue_many(init_commands);
+        autoreleasepool(|| {
+            self.inner
+                .borrow_mut()
+                .sink()
+                .switch_render(sin.descriptor)
+                .issue_many(init_commands);
+        });
     }
 
     unsafe fn end_render_pass(&mut self) {


### PR DESCRIPTION
Fixes the leak of render command encoders
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Metal
- [ ] `rustfmt` run on changed code
