### PR TITLE
[0.3/mtl] update metal-rs and wrap RP switch into an ARP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-backend-metal-0.3.1 (21-08-2019)
+  - fix memory leaks in render pass and labels creation
+
 ## hal-0.3.0 (08-08-2019)
   - graphics pipeline state refactor
   - no `winit` feature by default
@@ -20,7 +23,7 @@
   - fix image view creation panics
 
 ### backend-backend-metal-0.2.3 (10-07-2019)
-  - fixed depth clip mode support, updates spirv-cross
+  - fix depth clip mode support, updates spirv-cross
 
 ### backend-dx11-0.2.1, backend-dx12-0.2.1, backend-metal-0.2.2, backend-empty-0.2.1 (28-06-2019)
   - `Debug` implementations for `Instance`

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-metal"
-version = "0.3.0"
+version = "0.3.1"
 description = "Metal API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -29,11 +29,11 @@ copyless = "0.1.4"
 log = { version = "0.4" }
 winit = { version = "0.19", optional = true }
 dispatch = { version = "0.1", optional = true }
-metal = { version = "0.15", features = ["private"] }
+metal = { version = "0.16", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"
-cocoa = "0.18"
+cocoa = "0.19"
 core-graphics = "0.17"
 smallvec = "0.6"
 spirv_cross = { version = "0.15", features = ["msl"] }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -3486,11 +3486,13 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
             .make_render_commands(sin.combined_aspects)
             .chain(com_ds);
 
-        self.inner
-            .borrow_mut()
-            .sink()
-            .switch_render(sin.descriptor)
-            .issue_many(init_commands);
+        autoreleasepool(|| {
+            self.inner
+                .borrow_mut()
+                .sink()
+                .switch_render(sin.descriptor)
+                .issue_many(init_commands);
+        });
     }
 
     unsafe fn end_render_pass(&mut self) {


### PR DESCRIPTION
Sibling of #2972 for hal-0.3 with a version bump