### PR TITLE
[v0.18] Remove `core` alias in gfx_device_gl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ notifications:
     on_success: always
     on_failure: always
     on_start: false
+services:
+  - xvfb
 before_install:
   # Do not run bors builds against the nightly compiler.
   # We want to find out about nightly bugs, so they're done in master, but we don't block on them.
@@ -59,8 +61,6 @@ before_install:
   # Will no longer be needed when Trusty build environment goes out of beta at Travis CI
   # (assuming it will have libsdl2-dev and Rust by then)
   # see https://docs.travis-ci.com/user/trusty-ci-environment/
-  - "export DISPLAY=:99.0"
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then scripts/travis-install-sdl2.sh ; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew install sdl2; fi

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -15,15 +15,15 @@
 #![allow(missing_docs)]
 
 use gl;
-use core::{self as c, command, state as s};
-use core::target::{ColorValue, Depth, Mirror, Rect, Stencil};
-use core::texture::TextureCopyRegion;
+use gfx_core::{self as c, command, state as s};
+use gfx_core::target::{ColorValue, Depth, Mirror, Rect, Stencil};
+use gfx_core::texture::TextureCopyRegion;
 use {Buffer, BufferElement, Program, FrameBuffer, Texture,
      NewTexture, Resources, PipelineState, ResourceView, TargetView};
 
 
 fn primitive_to_gl(primitive: c::Primitive) -> gl::types::GLenum {
-    use core::Primitive::*;
+    use gfx_core::Primitive::*;
     match primitive {
         PointList => gl::POINTS,
         LineList => gl::LINES,

--- a/src/backend/gl/src/factory.rs
+++ b/src/backend/gl/src/factory.rs
@@ -16,11 +16,11 @@ use std::rc::Rc;
 use std::{slice, ptr};
 
 use {gl, tex};
-use core::{self as d, factory as f, texture as t, buffer, mapping};
-use core::memory::{Access, Bind, Typed, Usage};
-use core::format::{ChannelType, Format};
-use core::handle::{self, Producer};
-use core::target::{Layer, Level};
+use gfx_core::{self as d, factory as f, texture as t, buffer, mapping};
+use gfx_core::memory::{Access, Bind, Typed, Usage};
+use gfx_core::format::{ChannelType, Format};
+use gfx_core::handle::{self, Producer};
+use gfx_core::target::{Layer, Level};
 
 use command::CommandBuffer;
 use {Resources as R, Share, OutputMerger};
@@ -354,7 +354,7 @@ impl f::Factory<R> for Factory {
 
     fn create_pipeline_state_raw(&mut self, program: &handle::Program<R>, desc: &d::pso::Descriptor)
                                  -> Result<handle::RawPipelineState<R>, d::pso::CreationError> {
-        use core::state as s;
+        use gfx_core::state as s;
         let caps = &self.share.capabilities;
         match desc.primitive {
             d::Primitive::PatchList(num) if num == 0 || (num as usize) > caps.max_patch_size =>
@@ -416,7 +416,7 @@ impl f::Factory<R> for Factory {
 
     fn create_texture_raw(&mut self, desc: t::Info, hint: Option<ChannelType>, data_opt: Option<(&[&[u8]], t::Mipmap)>)
                           -> Result<handle::RawTexture<R>, t::CreationError> {
-        use core::texture::CreationError;
+        use gfx_core::texture::CreationError;
         let caps = &self.share.private_caps;
         if desc.levels == 0 {
             return Err(CreationError::Size(0))

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 use std::{ffi, fmt, mem, str};
 use gl;
-use core::Capabilities;
+use gfx_core::Capabilities;
 
 
 /// A version number for a specific component of an OpenGL implementation

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -20,14 +20,14 @@
 #[macro_use]
 extern crate log;
 extern crate gfx_gl as gl;
-extern crate gfx_core as core;
+extern crate gfx_core;
 
 use std::cell::RefCell;
 use std::error::Error as StdError;
 use std::fmt;
 use std::rc::Rc;
-use core::{self as c, handle, state as s, format, pso, texture, command as com, buffer};
-use core::target::{Layer, Level};
+use gfx_core::{self as c, handle, state as s, format, pso, texture, command as com, buffer};
+use gfx_core::target::{Layer, Level};
 use command::{Command, DataBuffer};
 use factory::MappingKind;
 
@@ -211,8 +211,8 @@ pub fn create<F>(fn_proc: F) -> (Device, Factory) where
 /// Not supposed to be used by the users directly.
 pub fn create_main_targets_raw(dim: texture::Dimensions, color_format: format::SurfaceType, depth_format: format::SurfaceType)
                                -> (handle::RawRenderTargetView<Resources>, handle::RawDepthStencilView<Resources>) {
-    use core::handle::Producer;
-    use core::memory::{Bind, Usage};
+    use gfx_core::handle::Producer;
+    use gfx_core::memory::{Bind, Usage};
 
     let mut temp = handle::Manager::new();
     let color_tex = temp.make_texture(
@@ -348,8 +348,8 @@ impl Device {
     }
 
     fn bind_attribute(&mut self, slot: c::AttributeSlot, buffer: Buffer, bel: BufferElement) {
-        use core::format::SurfaceType as S;
-        use core::format::ChannelType as C;
+        use gfx_core::format::SurfaceType as S;
+        use gfx_core::format::ChannelType as C;
         let (fm8, fm16, fm32) = match bel.elem.format.1 {
             C::Int | C::Inorm =>
                 (gl::BYTE, gl::SHORT, gl::INT),
@@ -907,7 +907,7 @@ impl Device {
     }
 
     fn place_fence(&mut self) -> handle::Fence<Resources> {
-        use core::handle::Producer;
+        use gfx_core::handle::Producer;
 
         let gl = &self.share.context;
         let fence = unsafe {
@@ -986,7 +986,7 @@ impl c::Device for Device {
     }
 
     fn cleanup(&mut self) {
-        use core::handle::Producer;
+        use gfx_core::handle::Producer;
         self.frame_handles.clear();
         self.share.handles.borrow_mut().clean_with(&mut &self.share.context,
             |gl, buffer| {

--- a/src/backend/gl/src/shade.rs
+++ b/src/backend/gl/src/shade.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::iter::repeat;
-use core::{self as c, shade as s};
+use gfx_core::{self as c, shade as s};
 use info::PrivateCaps;
 use gl;
 
@@ -92,11 +92,11 @@ enum StorageType {
 
 impl StorageType {
     fn new(storage: gl::types::GLenum) -> StorageType {
-        use core::shade::{BaseType, ContainerType, TextureType, SamplerType, MatrixFormat};
-        use core::shade::IsArray::*;
-        use core::shade::IsRect::*;
-        use core::shade::IsComparison::*;
-        use core::shade::IsMultiSample::*;
+        use gfx_core::shade::{BaseType, ContainerType, TextureType, SamplerType, MatrixFormat};
+        use gfx_core::shade::IsArray::*;
+        use gfx_core::shade::IsRect::*;
+        use gfx_core::shade::IsComparison::*;
+        use gfx_core::shade::IsMultiSample::*;
         use self::StorageType::*;
         match storage {
             gl::FLOAT                        => Var(BaseType::F32,  ContainerType::Single),
@@ -529,7 +529,7 @@ pub fn create_program(gl: &gl::Gl, caps: &c::Capabilities, private: &PrivateCaps
 }
 
 pub fn bind_uniform(gl: &gl::Gl, loc: gl::types::GLint, uniform: s::UniformValue) {
-    use core::shade::UniformValue;
+    use gfx_core::shade::UniformValue;
     match uniform {
         UniformValue::I32(val) => unsafe { gl.Uniform1i(loc, val) },
         UniformValue::U32(val) => unsafe { gl.Uniform1ui(loc, val) },

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::{MAX_COLOR_TARGETS, ColorSlot};
-use core::state as s;
-use core::state::{BlendValue, Comparison, CullFace, Equation,
+use gfx_core::{MAX_COLOR_TARGETS, ColorSlot};
+use gfx_core::state as s;
+use gfx_core::state::{BlendValue, Comparison, CullFace, Equation,
                   Offset, RasterMethod, StencilOp, FrontFace};
-use core::target::{ColorValue, Rect, Stencil};
+use gfx_core::target::{ColorValue, Rect, Stencil};
 use gl;
 
 
@@ -221,7 +221,7 @@ pub fn set_output_masks(gl: &gl::Gl, color: bool, depth: bool, stencil: bool) {
 }
 
 pub fn bind_blend(gl: &gl::Gl, color: s::Color) {
-    use core::state::ColorMask as Cm;
+    use gfx_core::state::ColorMask as Cm;
     match color.blend {
         Some(b) => unsafe {
             gl.Enable(gl::BLEND);
@@ -249,7 +249,7 @@ pub fn bind_blend(gl: &gl::Gl, color: s::Color) {
 }
 
 pub fn bind_blend_slot(gl: &gl::Gl, slot: ColorSlot, color: s::Color) {
-    use core::state::ColorMask as Cm;
+    use gfx_core::state::ColorMask as Cm;
     let buf = slot as gl::types::GLuint;
     match color.blend {
         Some(b) => unsafe {

--- a/src/backend/gl/src/tex.rs
+++ b/src/backend/gl/src/tex.rs
@@ -16,10 +16,10 @@ use {gl, FrameBuffer, Surface, Texture, NewTexture, Buffer, Sampler};
 use gl::types::{GLenum, GLuint, GLint, GLfloat, GLsizei, GLvoid};
 use state;
 use info::PrivateCaps;
-use core::memory::Bind;
-use core::factory::ResourceViewError;
-use core::format::{Format as NewFormat, ChannelType};
-use core::texture as t;
+use gfx_core::memory::Bind;
+use gfx_core::factory::ResourceViewError;
+use gfx_core::format::{Format as NewFormat, ChannelType};
+use gfx_core::texture as t;
 
 
 fn cube_face_to_gl(face: t::CubeFace) -> GLenum {
@@ -55,8 +55,8 @@ fn kind_face_to_gl(kind: t::Kind, face: Option<t::CubeFace>) -> GLenum {
 }
 
 fn format_to_glpixel(format: NewFormat) -> GLenum {
-    use core::format::SurfaceType as S;
-    use core::format::ChannelType as C;
+    use gfx_core::format::SurfaceType as S;
+    use gfx_core::format::ChannelType as C;
     let (r, rg, rgb, rgba, bgra) = match format.1 {
         C::Int | C::Uint => (gl::RED_INTEGER, gl::RG_INTEGER, gl::RGB_INTEGER, gl::RGBA_INTEGER, gl::BGRA_INTEGER),
         _ => (gl::RED, gl::RG, gl::RGB, gl::RGBA, gl::BGRA),
@@ -83,8 +83,8 @@ fn format_to_glpixel(format: NewFormat) -> GLenum {
 }
 
 fn format_to_gltype(format: NewFormat) -> Result<GLenum, ()> {
-    use core::format::SurfaceType as S;
-    use core::format::ChannelType as C;
+    use gfx_core::format::SurfaceType as S;
+    use gfx_core::format::ChannelType as C;
     let (fm8, fm16, fm32) = match format.1 {
         C::Int | C::Inorm =>
             (gl::BYTE, gl::SHORT, gl::INT),
@@ -116,8 +116,8 @@ fn format_to_gltype(format: NewFormat) -> Result<GLenum, ()> {
 }
 
 pub fn format_to_glfull(format: NewFormat) -> Result<GLenum, ()> {
-    use core::format::SurfaceType as S;
-    use core::format::ChannelType as C;
+    use gfx_core::format::SurfaceType as S;
+    use gfx_core::format::ChannelType as C;
     let cty = format.1;
     Ok(match format.0 {
         //S::R3_G3_B2 => gl::R3_G3_B2,
@@ -1200,9 +1200,9 @@ trait CompressionAware {
     fn is_compressed(&self) -> bool;
 }
 
-impl CompressionAware for core::format::SurfaceType {
+impl CompressionAware for gfx_core::format::SurfaceType {
     fn is_compressed(&self) -> bool {
-        use core::format::SurfaceType as S;
+        use gfx_core::format::SurfaceType as S;
         match *self {
             S::BC3_R8_G8_B8_A8 | S::BC1_R8_G8_B8 => true,
             S::R4_G4


### PR DESCRIPTION
Fixes gfx_device_gl to compile on recent nightlies, fixes #2964. Cherry picked from #2979 into `v0.18`.

PR checklist:
- [x] tested examples with the following backends: gl
