### PR TITLE
Allow instance creation to fail

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -565,7 +565,8 @@ fn create_backend(
     event_loop: &winit::event_loop::EventLoop<()>,
 ) -> (BackendState<back::Backend>, back::Instance) {
     let window = wb.build(event_loop).unwrap();
-    let instance = back::Instance::create("gfx-rs colour-uniform", 1);
+    let instance = back::Instance::create("gfx-rs colour-uniform", 1)
+        .expect("Failed to create an instance!");
     let surface = instance.create_surface(&window);
     let mut adapters = instance.enumerate_adapters();
     (

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -42,7 +42,8 @@ fn main() {
         .collect();
     let stride = std::mem::size_of::<u32>() as u64;
 
-    let instance = back::Instance::create("gfx-rs compute", 1);
+    let instance = back::Instance::create("gfx-rs compute", 1)
+        .expect("Failed to create an instance!");
 
     let adapter = instance
         .enumerate_adapters()

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -117,7 +117,8 @@ fn main() {
     #[cfg(not(feature = "gl"))]
     let (_window, _instance, mut adapters, surface) = {
         let window = wb.build(&event_loop).unwrap();
-        let instance = back::Instance::create("gfx-rs quad", 1);
+        let instance = back::Instance::create("gfx-rs quad", 1)
+            .expect("Failed to create an instance!");
         let surface = instance.create_surface(&window);
         let adapters = instance.enumerate_adapters();
         (window, instance, adapters, surface)

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -123,16 +123,21 @@ unsafe impl Send for Instance {}
 unsafe impl Sync for Instance {}
 
 impl Instance {
-    pub fn create(_: &str, _: u32) -> Self {
+    pub fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
         // TODO: get the latest factory we can find
 
-        let (factory, dxgi_version) = dxgi::get_dxgi_factory().unwrap();
-
-        info!("DXGI version: {:?}", dxgi_version);
-
-        Instance {
-            factory,
-            dxgi_version,
+        match dxgi::get_dxgi_factory() {
+            Ok((factory, dxgi_version)) => {
+                info!("DXGI version: {:?}", dxgi_version);
+                Ok(Instance {
+                    factory,
+                    dxgi_version,
+                })
+            }
+            Err(hr) => {
+                info!("Failed on factory creation: {:?}", hr);
+                Err(hal::UnsupportedBackend)
+            }
         }
     }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -702,7 +702,7 @@ unsafe impl Send for Instance {}
 unsafe impl Sync for Instance {}
 
 impl Instance {
-    pub fn create(_: &str, _: u32) -> Instance {
+    pub fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
         #[cfg(debug_assertions)]
         {
             // Enable debug layer
@@ -754,12 +754,13 @@ impl Instance {
             )
         };
 
-        if !winerror::SUCCEEDED(hr) {
-            error!("Failed on dxgi factory creation: {:?}", hr);
-        }
-
-        Instance {
-            factory: dxgi_factory,
+        if winerror::SUCCEEDED(hr) {
+            Ok(Instance {
+                factory: dxgi_factory,
+            })
+        } else {
+            info!("Failed on dxgi factory creation: {:?}", hr);
+            Err(hal::UnsupportedBackend)
         }
     }
 }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -947,8 +947,8 @@ pub struct Instance;
 
 impl Instance {
     /// Create instance.
-    pub fn create(_name: &str, _version: u32) -> Self {
-        Instance
+    pub fn create(_name: &str, _version: u32) -> Result<Self, hal::UnsupportedBackend> {
+        Ok(Instance)
     }
 
     #[cfg(feature = "winit")]

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -158,7 +158,7 @@ pub struct Instance {
 }
 
 impl Instance {
-    pub fn create(_name: &str, version: u32) -> Self {
+    pub fn create(_name: &str, version: u32) -> Result<Self, hal::UnsupportedBackend> {
         unsafe {
             let glrc = WGL_ENTRY.wgl.CreateContextAttribsARB(
                 WGL_ENTRY.hdc as *const _,
@@ -168,12 +168,12 @@ impl Instance {
 
             wglMakeCurrent(WGL_ENTRY.hdc as *mut _, glrc);
 
-            Instance {
+            Ok(Instance {
                 ctxt: DeviceContext {
                     ctxt: Context { glrc },
                     hdc: WGL_ENTRY.hdc,
                 },
-            }
+            })
         }
     }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -247,10 +247,10 @@ impl hal::Instance for Instance {
 }
 
 impl Instance {
-    pub fn create(_: &str, _: u32) -> Self {
-        Instance {
+    pub fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
+        Ok(Instance {
             experiments: Experiments::default(),
-        }
+        })
     }
 
     #[cfg(feature = "winit")]

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -453,6 +453,11 @@ pub trait Instance: Any + Send + Sync {
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Self::Backend>>;
 }
 
+/// Error creating an instance of a backend on the platform that
+/// doesn't support this backend.
+#[derive(Clone, Debug, PartialEq)]
+pub struct UnsupportedBackend;
+
 /// A strongly-typed index to a particular `MemoryType`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/warden/src/bin/bench.rs
+++ b/src/warden/src/bin/bench.rs
@@ -152,25 +152,25 @@ fn main() {
     #[cfg(feature = "vulkan")]
     {
         println!("Benching Vulkan:");
-        let instance = gfx_backend_vulkan::Instance::create("warden", 1);
+        let instance = gfx_backend_vulkan::Instance::create("warden", 1).unwrap();
         harness.run(instance, Disabilities::default());
     }
     #[cfg(feature = "dx12")]
     {
         println!("Benching DX12:");
-        let instance = gfx_backend_dx12::Instance::create("warden", 1);
+        let instance = gfx_backend_dx12::Instance::create("warden", 1).unwrap();
         harness.run(instance, Disabilities::default());
     }
     #[cfg(feature = "dx11")]
     {
         println!("Benching DX11:");
-        let instance = gfx_backend_dx11::Instance::create("warden", 1);
+        let instance = gfx_backend_dx11::Instance::create("warden", 1).unwrap();
         harness.run(instance, Disabilities::default());
     }
     #[cfg(feature = "metal")]
     {
         println!("Benching Metal:");
-        let instance = gfx_backend_metal::Instance::create("warden", 1);
+        let instance = gfx_backend_metal::Instance::create("warden", 1).unwrap();
         harness.run(
             instance,
             Disabilities {
@@ -187,7 +187,7 @@ fn main() {
             .with_gl_profile(glutin::GlProfile::Core)
             .build_windowed(glutin::window::WindowBuilder::new(), &events_loop)
             .unwrap();
-        let (context, window) = unsafe {
+        let (context, _window) = unsafe {
             windowed_context
                 .make_current()
                 .expect("Unable to make window current")

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -188,25 +188,25 @@ fn main() {
     #[cfg(feature = "vulkan")]
     {
         println!("Testing Vulkan:");
-        let instance = gfx_backend_vulkan::Instance::create("warden", 1);
+        let instance = gfx_backend_vulkan::Instance::create("warden", 1).unwrap();
         num_failures += harness.run(instance, Disabilities::default());
     }
     #[cfg(feature = "dx12")]
     {
         println!("Testing DX12:");
-        let instance = gfx_backend_dx12::Instance::create("warden", 1);
+        let instance = gfx_backend_dx12::Instance::create("warden", 1).unwrap();
         num_failures += harness.run(instance, Disabilities::default());
     }
     #[cfg(feature = "dx11")]
     {
         println!("Testing DX11:");
-        let instance = gfx_backend_dx11::Instance::create("warden", 1);
+        let instance = gfx_backend_dx11::Instance::create("warden", 1).unwrap();
         num_failures += harness.run(instance, Disabilities::default());
     }
     #[cfg(feature = "metal")]
     {
         println!("Testing Metal:");
-        let instance = gfx_backend_metal::Instance::create("warden", 1);
+        let instance = gfx_backend_metal::Instance::create("warden", 1).unwrap();
         num_failures += harness.run(
             instance,
             Disabilities {


### PR DESCRIPTION
This is required for https://github.com/gfx-rs/wgpu/pull/311 and similar things that try to do more work at run-time instead of relying on the user-selected features. (Note: still needs to be back-ported to hal-0.3 before we can use it in wgpu).

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
