### PR TITLE
Reduces allocations on Vulkan create_*_pipeline(s), and fixes #2987

### DIFF
--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -217,6 +217,22 @@ impl device::Device<Backend> for Device {
         unimplemented!()
     }
 
+    unsafe fn create_graphics_pipeline<'a>(
+        &self,
+        _: &pso::GraphicsPipelineDesc<'a, Backend>,
+        _: Option<&()>,
+    ) -> Result<(), pso::CreationError> {
+        unimplemented!()
+    }
+
+    unsafe fn create_compute_pipeline<'a>(
+        &self,
+        _: &pso::ComputePipelineDesc<'a, Backend>,
+        _: Option<&()>,
+    ) -> Result<(), pso::CreationError> {
+        unimplemented!()
+    }
+
     unsafe fn merge_pipeline_caches<I>(&self, _: &(), _: I) -> Result<(), device::OutOfMemory>
     where
         I: IntoIterator,

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -20,6 +20,7 @@ use-rtld-next = ["shared_library"]
 name = "gfx_backend_vulkan"
 
 [dependencies]
+arrayvec = "0.4"
 byteorder = "1"
 log = { version = "0.4" }
 lazy_static = "1"

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -313,10 +313,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         &self,
         desc: &pso::GraphicsPipelineDesc<'a, B>,
         cache: Option<&B::PipelineCache>,
-    ) -> Result<B::GraphicsPipeline, pso::CreationError> {
-        self.create_graphics_pipelines(iter::once(desc), cache)
-            .remove(0)
-    }
+    ) -> Result<B::GraphicsPipeline, pso::CreationError>;
 
     /// Create graphics pipelines.
     unsafe fn create_graphics_pipelines<'a, I>(
@@ -345,10 +342,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         &self,
         desc: &pso::ComputePipelineDesc<'a, B>,
         cache: Option<&B::PipelineCache>,
-    ) -> Result<B::ComputePipeline, pso::CreationError> {
-        self.create_compute_pipelines(iter::once(desc), cache)
-            .remove(0)
-    }
+    ) -> Result<B::ComputePipeline, pso::CreationError>;
 
     /// Create compute pipelines.
     unsafe fn create_compute_pipelines<'a, I>(

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -899,8 +899,7 @@ impl<B: hal::Backend> Scene<B> {
                         flags: pso::PipelineCreationFlags::empty(),
                         parent: pso::BasePipeline::None,
                     };
-                    let pso = unsafe { device.create_graphics_pipelines(&[desc], None) }
-                        .remove(0)
+                    let pso = unsafe { device.create_graphics_pipeline(&desc, None) }
                         .unwrap();
                     resources.graphics_pipelines.insert(name.clone(), pso);
                 }
@@ -924,8 +923,7 @@ impl<B: hal::Backend> Scene<B> {
                         flags: pso::PipelineCreationFlags::empty(),
                         parent: pso::BasePipeline::None,
                     };
-                    let pso = unsafe { device.create_compute_pipelines(&[desc], None) }
-                        .remove(0)
+                    let pso = unsafe { device.create_compute_pipeline(&desc, None) }
                         .unwrap();
                     resources
                         .compute_pipelines


### PR DESCRIPTION
Fixes #2987

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: Windows Vulkan + GL + DX12
- [ ] ~`rustfmt` run on changed code~

`make` succeeds on Windows, and `make reftests` fails even on master, didn't try building on Linux.

This greatly reduces the amount of Vecs used on the Vulkan create_*_pipeline(s) by combining vectors.