### PR TITLE
[gl] add SwiftShader to list of CPU renderers

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -516,7 +516,10 @@ impl PhysicalDevice {
             "mali",
             "intel",
         ];
-        let strings_that_imply_cpu = ["mesa offscreen"];
+        let strings_that_imply_cpu = [
+            "mesa offscreen",
+            "swiftshader",
+        ];
         // todo: Intel will release a discrete gpu soon, and we will need to update this logic when they do
         let inferred_device_type = if vendor_lower.contains("qualcomm")
             || vendor_lower.contains("intel")


### PR DESCRIPTION
Fixes #2962

I'm not %100 sure this is the correct solution. Since the checks are only for string containment, I'm fairly sure SwiftShader would apply for any string that contains "swiftshader".

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
