### PR TITLE
[mtl][vk] add object debug labels

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -30,6 +30,7 @@ use {
     Backend,
     Buffer,
     BufferView,
+    CommandBuffer,
     CommandPool,
     ComputePipeline,
     Descriptor,
@@ -2623,5 +2624,33 @@ impl device::Device<Backend> for Device {
     fn wait_idle(&self) -> Result<(), device::OutOfMemory> {
         Ok(())
         // unimplemented!()
+    }
+
+    unsafe fn set_image_name(&self, _image: &mut Image, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_buffer_name(&self, _buffer: &mut Buffer, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_command_buffer_name(&self, _command_buffer: &mut CommandBuffer, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_semaphore_name(&self, _semaphore: &mut Semaphore, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_fence_name(&self, _fence: &mut Fence, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_framebuffer_name(&self, _framebuffer: &mut Framebuffer, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_render_pass_name(&self, _render_pass: &mut RenderPass, _name: &str) {
+        // TODO
     }
 }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -38,6 +38,7 @@ use range_alloc::RangeAllocator;
 use root_constants::RootConstant;
 use {
     conv,
+    command as cmd,
     descriptors_cpu,
     native,
     resource as r,
@@ -3360,6 +3361,38 @@ impl d::Device<B> for Device {
             queue.wait_idle()?;
         }
         Ok(())
+    }
+
+    unsafe fn set_image_name(&self, _image: &mut r::Image, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_buffer_name(&self, _buffer: &mut r::Buffer, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_command_buffer_name(
+        &self,
+        _command_buffer: &mut cmd::CommandBuffer,
+        _name: &str
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_semaphore_name(&self, _semaphore: &mut r::Semaphore, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_fence_name(&self, _fence: &mut r::Fence, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_framebuffer_name(&self, _framebuffer: &mut r::Framebuffer, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_render_pass_name(&self, _render_pass: &mut r::RenderPass, _name: &str) {
+        // TODO
     }
 }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -528,6 +528,34 @@ impl device::Device<Backend> for Device {
     fn wait_idle(&self) -> Result<(), device::OutOfMemory> {
         unimplemented!()
     }
+
+    unsafe fn set_image_name(&self, _: &mut (), _: &str) {
+        unimplemented!()
+    }
+
+    unsafe fn set_buffer_name(&self, _: &mut (), _: &str) {
+        unimplemented!()
+    }
+
+    unsafe fn set_command_buffer_name(&self, _: &mut CommandBuffer, _: &str) {
+        unimplemented!()
+    }
+
+    unsafe fn set_semaphore_name(&self, _: &mut (), _: &str) {
+        unimplemented!()
+    }
+
+    unsafe fn set_fence_name(&self, _: &mut (), _: &str) {
+        unimplemented!()
+    }
+
+    unsafe fn set_framebuffer_name(&self, _: &mut (), _: &str) {
+        unimplemented!()
+    }
+
+    unsafe fn set_render_pass_name(&self, _: &mut (), _: &str) {
+        unimplemented!()
+    }
 }
 
 #[derive(Debug)]

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -27,6 +27,7 @@ use spirv_cross::{glsl, spirv, ErrorCode as SpirvErrorCode};
 
 use crate::{
     conv,
+    command as cmd,
     info::LegacyFeatures,
     native as n,
     pool::{BufferMemory, CommandPool, OwnedBuffer},
@@ -1973,5 +1974,37 @@ impl d::Device<B> for Device {
             self.share.context.finish();
         }
         Ok(())
+    }
+
+    unsafe fn set_image_name(&self, _image: &mut n::Image, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_buffer_name(&self, _buffer: &mut n::Buffer, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_command_buffer_name(
+        &self,
+        _command_buffer: &mut cmd::CommandBuffer,
+        _name: &str
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_semaphore_name(&self, _semaphore: &mut n::Semaphore, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_fence_name(&self, _fence: &mut n::Fence, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_framebuffer_name(&self, _framebuffer: &mut n::FrameBuffer, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_render_pass_name(&self, _render_pass: &mut n::RenderPass, _name: &str) {
+        // TODO
     }
 }

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -29,14 +29,14 @@ copyless = "0.1.4"
 log = { version = "0.4" }
 winit = { version = "0.20.0-alpha3", optional = true }
 dispatch = { version = "0.1", optional = true }
-metal = { version = "0.16", features = ["private"] }
+metal = { version = "0.17", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"
 cocoa = "0.19"
 core-graphics = "0.17"
 smallvec = "0.6"
-spirv_cross = { version = "0.15", features = ["msl"] }
+spirv_cross = { version = "0.16", features = ["msl"] }
 parking_lot = "0.9"
 storage-map = "0.2"
 

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1527,7 +1527,7 @@ where
             }
         }
         Cmd::SetVisibilityResult(mode, offset) => {
-            encoder.set_visibility_result_mode(offset, mode);
+            encoder.set_visibility_result_mode(mode, offset);
         }
         Cmd::BindBuffer {
             stage,

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -243,6 +243,7 @@ pub struct CommandBuffer {
     inner: CommandBufferInnerPtr,
     state: State,
     temp: Temp,
+    pub name: String,
 }
 
 unsafe impl Send for CommandBuffer {}
@@ -767,9 +768,10 @@ enum EncodePass {
         Vec<soft::RenderCommand<soft::Own>>,
         soft::Own,
         metal::RenderPassDescriptor,
+        String,
     ),
-    Compute(Vec<soft::ComputeCommand<soft::Own>>, soft::Own),
-    Blit(Vec<soft::BlitCommand>),
+    Compute(Vec<soft::ComputeCommand<soft::Own>>, soft::Own, String),
+    Blit(Vec<soft::BlitCommand>, String),
 }
 #[cfg(feature = "dispatch")]
 unsafe impl Send for EncodePass {}
@@ -784,26 +786,29 @@ impl EncodePass {
     fn schedule(self, queue: &dispatch::Queue, cmd_buffer_arc: &Arc<Mutex<metal::CommandBuffer>>) {
         let cmd_buffer = SharedCommandBuffer(Arc::clone(cmd_buffer_arc));
         queue.r#async(move || match self {
-            EncodePass::Render(list, resources, desc) => {
+            EncodePass::Render(list, resources, desc, label) => {
                 let encoder = cmd_buffer
                     .0
                     .lock()
                     .new_render_command_encoder(&desc)
                     .to_owned();
+                encoder.set_label(&label);
                 for command in list {
                     exec_render(&encoder, command, &resources);
                 }
                 encoder.end_encoding();
             }
-            EncodePass::Compute(list, resources) => {
+            EncodePass::Compute(list, resources, label) => {
                 let encoder = cmd_buffer.0.lock().new_compute_command_encoder().to_owned();
+                encoder.set_label(&label);
                 for command in list {
                     exec_compute(&encoder, command, &resources);
                 }
                 encoder.end_encoding();
             }
-            EncodePass::Blit(list) => {
+            EncodePass::Blit(list, label) => {
                 let encoder = cmd_buffer.0.lock().new_blit_command_encoder().to_owned();
+                encoder.set_label(&label);
                 for command in list {
                     exec_blit(&encoder, command);
                 }
@@ -814,9 +819,9 @@ impl EncodePass {
 
     fn update(&self, capacity: &mut Capacity) {
         match &self {
-            EncodePass::Render(ref list, _, _) => capacity.render = capacity.render.max(list.len()),
-            EncodePass::Compute(ref list, _) => capacity.compute = capacity.compute.max(list.len()),
-            EncodePass::Blit(ref list) => capacity.blit = capacity.blit.max(list.len()),
+            EncodePass::Render(ref list, _, _, _) => capacity.render = capacity.render.max(list.len()),
+            EncodePass::Compute(ref list, _, _) => capacity.compute = capacity.compute.max(list.len()),
+            EncodePass::Blit(ref list, _) => capacity.blit = capacity.blit.max(list.len()),
         }
     }
 }
@@ -824,7 +829,7 @@ impl EncodePass {
 #[derive(Debug, Default)]
 struct Journal {
     resources: soft::Own,
-    passes: Vec<(soft::Pass, Range<usize>)>,
+    passes: Vec<(soft::Pass, Range<usize>, String)>,
     render_commands: Vec<soft::RenderCommand<soft::Own>>,
     compute_commands: Vec<soft::ComputeCommand<soft::Own>>,
     blit_commands: Vec<soft::BlitCommand>,
@@ -842,23 +847,24 @@ impl Journal {
     fn stop(&mut self) {
         match self.passes.last_mut() {
             None => {}
-            Some(&mut (soft::Pass::Render(_), ref mut range)) => {
+            Some(&mut (soft::Pass::Render(_), ref mut range, _)) => {
                 range.end = self.render_commands.len();
             }
-            Some(&mut (soft::Pass::Compute, ref mut range)) => {
+            Some(&mut (soft::Pass::Compute, ref mut range, _)) => {
                 range.end = self.compute_commands.len();
             }
-            Some(&mut (soft::Pass::Blit, ref mut range)) => {
+            Some(&mut (soft::Pass::Blit, ref mut range, _)) => {
                 range.end = self.blit_commands.len();
             }
         };
     }
 
     fn record(&self, command_buf: &metal::CommandBufferRef) {
-        for (ref pass, ref range) in &self.passes {
+        for (ref pass, ref range, ref label) in &self.passes {
             match *pass {
                 soft::Pass::Render(ref desc) => {
                     let encoder = command_buf.new_render_command_encoder(desc);
+                    encoder.set_label(label);
                     for command in &self.render_commands[range.clone()] {
                         exec_render(&encoder, command, &self.resources);
                     }
@@ -866,6 +872,7 @@ impl Journal {
                 }
                 soft::Pass::Blit => {
                     let encoder = command_buf.new_blit_command_encoder();
+                    encoder.set_label(label);
                     for command in &self.blit_commands[range.clone()] {
                         exec_blit(&encoder, command);
                     }
@@ -873,6 +880,7 @@ impl Journal {
                 }
                 soft::Pass::Compute => {
                     let encoder = command_buf.new_compute_command_encoder();
+                    encoder.set_label(label);
                     for command in &self.compute_commands[range.clone()] {
                         exec_compute(&encoder, command, &self.resources);
                     }
@@ -886,15 +894,15 @@ impl Journal {
         if inherit_pass {
             assert_eq!(other.passes.len(), 1);
             match *self.passes.last_mut().unwrap() {
-                (soft::Pass::Render(_), ref mut range) => {
+                (soft::Pass::Render(_), ref mut range, _) => {
                     range.end += other.render_commands.len();
                 }
-                (soft::Pass::Compute, _) | (soft::Pass::Blit, _) => {
+                (soft::Pass::Compute, _, _) | (soft::Pass::Blit, _, _) => {
                     panic!("Only render passes can inherit")
                 }
             }
         } else {
-            for (ref pass, ref range) in &other.passes {
+            for (pass, range, label) in &other.passes {
                 let offset = match *pass {
                     soft::Pass::Render(_) => self.render_commands.len(),
                     soft::Pass::Compute => self.compute_commands.len(),
@@ -902,7 +910,7 @@ impl Journal {
                 };
                 self.passes
                     .alloc()
-                    .init((pass.clone(), range.start + offset .. range.end + offset));
+                    .init((pass.clone(), range.start + offset .. range.end + offset, label.clone()));
             }
         }
 
@@ -933,11 +941,13 @@ enum CommandSink {
         token: Token,
         encoder_state: EncoderState,
         num_passes: usize,
+        label: String,
     },
     Deferred {
         is_encoding: bool,
         is_inheriting: bool,
         journal: Journal,
+        label: String,
     },
     #[cfg(feature = "dispatch")]
     Remote {
@@ -946,6 +956,7 @@ enum CommandSink {
         token: Token,
         pass: Option<EncodePass>,
         capacity: Capacity,
+        label: String,
     },
 }
 
@@ -1037,6 +1048,15 @@ impl<'a> PreCompute<'a> {
 }
 
 impl CommandSink {
+    fn label(&mut self, label: &str) -> &Self {
+        match self {
+            CommandSink::Immediate { label: l, .. } | CommandSink::Deferred { label: l, .. } => *l = label.to_string(),
+            #[cfg(feature = "dispatch")]
+            CommandSink::Remote { label: l, .. } => *l = label.to_string(),
+        }
+        self
+    }
+
     fn stop_encoding(&mut self) {
         match *self {
             CommandSink::Immediate {
@@ -1082,14 +1102,14 @@ impl CommandSink {
                 ref mut journal,
                 ..
             } => match journal.passes.last() {
-                Some(&(soft::Pass::Render(_), _)) => {
+                Some(&(soft::Pass::Render(_), _, _)) => {
                     PreRender::Deferred(&mut journal.resources, &mut journal.render_commands)
                 }
                 _ => PreRender::Void,
             },
             #[cfg(feature = "dispatch")]
             CommandSink::Remote {
-                pass: Some(EncodePass::Render(ref mut list, ref mut resources, _)),
+                pass: Some(EncodePass::Render(ref mut list, ref mut resources, _, _)),
                 ..
             } => PreRender::Deferred(resources, list),
             _ => PreRender::Void,
@@ -1106,10 +1126,12 @@ impl CommandSink {
                 ref cmd_buffer,
                 ref mut encoder_state,
                 ref mut num_passes,
+                ref label,
                 ..
             } => {
                 *num_passes += 1;
                 let encoder = cmd_buffer.new_render_command_encoder(&descriptor);
+                encoder.set_label(label);
                 *encoder_state = EncoderState::Render(encoder.to_owned());
                 PreRender::Immediate(encoder)
             }
@@ -1117,12 +1139,15 @@ impl CommandSink {
                 ref mut is_encoding,
                 ref mut journal,
                 is_inheriting,
+                ref label,
+                ..
             } => {
                 assert!(!is_inheriting);
                 *is_encoding = true;
                 journal.passes.alloc().init((
                     soft::Pass::Render(descriptor),
                     journal.render_commands.len() .. 0,
+                    label.clone(),
                 ));
                 PreRender::Deferred(&mut journal.resources, &mut journal.render_commands)
             }
@@ -1130,12 +1155,13 @@ impl CommandSink {
             CommandSink::Remote {
                 ref mut pass,
                 ref capacity,
+                ref label,
                 ..
             } => {
                 let list = Vec::with_capacity(capacity.render);
-                *pass = Some(EncodePass::Render(list, soft::Own::default(), descriptor));
+                *pass = Some(EncodePass::Render(list, soft::Own::default(), descriptor, label.clone()));
                 match *pass {
-                    Some(EncodePass::Render(ref mut list, ref mut resources, _)) => {
+                    Some(EncodePass::Render(ref mut list, ref mut resources, _, _)) => {
                         PreRender::Deferred(resources, list)
                     }
                     _ => unreachable!(),
@@ -1194,22 +1220,24 @@ impl CommandSink {
                 ref mut is_encoding,
                 is_inheriting,
                 ref mut journal,
+                ref label,
+                ..
             } => {
                 assert!(!is_inheriting);
                 *is_encoding = true;
-                if let Some(&(soft::Pass::Blit, _)) = journal.passes.last() {
+                if let Some(&(soft::Pass::Blit, _, _)) = journal.passes.last() {
                 } else {
                     journal.stop();
                     journal
                         .passes
                         .alloc()
-                        .init((soft::Pass::Blit, journal.blit_commands.len() .. 0));
+                        .init((soft::Pass::Blit, journal.blit_commands.len() .. 0, label.clone()));
                 }
                 PreBlit::Deferred(&mut journal.blit_commands)
             }
             #[cfg(feature = "dispatch")]
             CommandSink::Remote {
-                pass: Some(EncodePass::Blit(ref mut list)),
+                pass: Some(EncodePass::Blit(ref mut list, _)),
                 ..
             } => PreBlit::Deferred(list),
             #[cfg(feature = "dispatch")]
@@ -1218,6 +1246,7 @@ impl CommandSink {
                 ref cmd_buffer,
                 ref mut pass,
                 ref mut capacity,
+                ref label,
                 ..
             } => {
                 if let Some(pass) = pass.take() {
@@ -1225,9 +1254,9 @@ impl CommandSink {
                     pass.schedule(queue, cmd_buffer);
                 }
                 let list = Vec::with_capacity(capacity.blit);
-                *pass = Some(EncodePass::Blit(list));
+                *pass = Some(EncodePass::Blit(list, label.clone()));
                 match *pass {
-                    Some(EncodePass::Blit(ref mut list)) => PreBlit::Deferred(list),
+                    Some(EncodePass::Blit(ref mut list, _)) => PreBlit::Deferred(list),
                     _ => unreachable!(),
                 }
             }
@@ -1257,15 +1286,16 @@ impl CommandSink {
                 is_encoding: true,
                 is_inheriting: false,
                 ref mut journal,
+                ..
             } => match journal.passes.last() {
-                Some(&(soft::Pass::Compute, _)) => {
+                Some(&(soft::Pass::Compute, _, _)) => {
                     PreCompute::Deferred(&mut journal.resources, &mut journal.compute_commands)
                 }
                 _ => PreCompute::Void,
             },
             #[cfg(feature = "dispatch")]
             CommandSink::Remote {
-                pass: Some(EncodePass::Compute(ref mut list, ref mut resources)),
+                pass: Some(EncodePass::Compute(ref mut list, ref mut resources, _)),
                 ..
             } => PreCompute::Deferred(resources, list),
             _ => PreCompute::Void,
@@ -1296,17 +1326,19 @@ impl CommandSink {
                 ref mut is_encoding,
                 is_inheriting,
                 ref mut journal,
+                ref label,
+                ..
             } => {
                 assert!(!is_inheriting);
                 *is_encoding = true;
-                let switch = if let Some(&(soft::Pass::Compute, _)) = journal.passes.last() {
+                let switch = if let Some(&(soft::Pass::Compute, _, _)) = journal.passes.last() {
                     false
                 } else {
                     journal.stop();
                     journal
                         .passes
                         .alloc()
-                        .init((soft::Pass::Compute, journal.compute_commands.len() .. 0));
+                        .init((soft::Pass::Compute, journal.compute_commands.len() .. 0, label.clone()));
                     true
                 };
                 (
@@ -1316,7 +1348,7 @@ impl CommandSink {
             }
             #[cfg(feature = "dispatch")]
             CommandSink::Remote {
-                pass: Some(EncodePass::Compute(ref mut list, ref mut resources)),
+                pass: Some(EncodePass::Compute(ref mut list, ref mut resources, _)),
                 ..
             } => (PreCompute::Deferred(resources, list), false),
             #[cfg(feature = "dispatch")]
@@ -1325,6 +1357,7 @@ impl CommandSink {
                 ref cmd_buffer,
                 ref mut pass,
                 ref mut capacity,
+                ref label,
                 ..
             } => {
                 if let Some(pass) = pass.take() {
@@ -1332,9 +1365,9 @@ impl CommandSink {
                     pass.schedule(queue, cmd_buffer);
                 }
                 let list = Vec::with_capacity(capacity.compute);
-                *pass = Some(EncodePass::Compute(list, soft::Own::default()));
+                *pass = Some(EncodePass::Compute(list, soft::Own::default(), label.clone()));
                 match *pass {
-                    Some(EncodePass::Compute(ref mut list, ref mut resources)) => {
+                    Some(EncodePass::Compute(ref mut list, ref mut resources, _)) => {
                         (PreCompute::Deferred(resources, list), true)
                     }
                     _ => unreachable!(),
@@ -2399,6 +2432,7 @@ impl hal::pool::CommandPool<Backend> for CommandPool {
                 blit_vertices: FastHashMap::default(),
                 clear_values: Vec::new(),
             },
+            name: String::new(),
         }
     }
 
@@ -2452,16 +2486,19 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         let sink = match self.pool_shared.borrow_mut().online_recording {
             OnlineRecording::Immediate if can_immediate => {
                 let (cmd_buffer, token) = self.shared.queue.lock().spawn();
+                cmd_buffer.set_label(&self.name);
                 CommandSink::Immediate {
                     cmd_buffer,
                     token,
                     encoder_state: EncoderState::None,
                     num_passes: 0,
+                    label: String::new(),
                 }
             }
             #[cfg(feature = "dispatch")]
             OnlineRecording::Remote(_) if can_immediate => {
                 let (cmd_buffer, token) = self.shared.queue.lock().spawn();
+                cmd_buffer.set_label(&self.name);
                 CommandSink::Remote {
                     queue: NoDebug(dispatch::Queue::with_target_queue(
                         "gfx-metal",
@@ -2478,12 +2515,14 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                     token,
                     pass: None,
                     capacity: inner.backup_capacity.take().unwrap_or_default(),
+                    label: String::new(),
                 }
             }
             _ => CommandSink::Deferred {
                 is_encoding: false,
                 is_inheriting: info.subpass.is_some(),
                 journal: inner.backup_journal.take().unwrap_or_default(),
+                label: String::new(),
             },
         };
         inner.sink = Some(sink);
@@ -2509,6 +2548,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                 Some(CommandSink::Deferred {
                     ref mut is_encoding,
                     ref mut journal,
+                    ref label,
                     ..
                 }) => {
                     *is_encoding = true;
@@ -2516,7 +2556,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                     journal
                         .passes
                         .alloc()
-                        .init((soft::Pass::Render(pass_desc), 0 .. 0));
+                        .init((soft::Pass::Render(pass_desc), 0 .. 0, label.clone()));
                 }
                 _ => {
                     warn!("Unexpected inheritance info on a primary command buffer");
@@ -3472,6 +3512,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             });
         }
 
+        self.inner.borrow_mut().sink().label(&render_pass.name);
         self.next_subpass(first_subpass_contents);
     }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -308,7 +308,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             let shared_capture_manager = CaptureManager::shared();
             let default_capture_scope =
                 shared_capture_manager.new_capture_scope_with_device(&*device);
-            shared_capture_manager.set_default_capture_scope(default_capture_scope);
+            shared_capture_manager.set_default_capture_scope(&default_capture_scope);
             shared_capture_manager.start_capture_with_scope(&default_capture_scope);
             default_capture_scope.begin_scope();
         }
@@ -1230,6 +1230,7 @@ impl hal::device::Device<Backend> for Device {
             MTLLanguageVersion::V1_2 => msl::Version::V1_2,
             MTLLanguageVersion::V2_0 => msl::Version::V2_0,
             MTLLanguageVersion::V2_1 => msl::Version::V2_1,
+            MTLLanguageVersion::V2_2 => msl::Version::V2_2,
         };
         shader_compiler_options.enable_point_size_builtin = false;
         shader_compiler_options.vertex.invert_y = true;

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -96,6 +96,7 @@ pub struct Subpass {
 pub struct RenderPass {
     pub(crate) attachments: Vec<Attachment>,
     pub(crate) subpasses: Vec<Subpass>,
+    pub(crate) name: String,
 }
 
 #[derive(Debug)]
@@ -294,6 +295,7 @@ pub enum ImageLike {
         descriptor: metal::TextureDescriptor,
         mip_sizes: Vec<buffer::Offset>,
         host_visible: bool,
+        name: String,
     },
     /// This is a linearly tiled HOST-visible image, which is represented by a buffer.
     Buffer(Buffer),
@@ -413,6 +415,7 @@ pub enum Buffer {
     Unbound {
         size: u64,
         usage: buffer::Usage,
+        name: String,
     },
     Bound {
         raw: metal::Buffer,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -582,7 +582,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         });
 
         let device = Device {
-            raw: Arc::new(RawDevice(device_raw, requested_features)),
+            raw: Arc::new(RawDevice(device_raw, requested_features, self.instance.clone())),
         };
 
         let device_arc = device.raw.clone();
@@ -1073,7 +1073,12 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 }
 
 #[doc(hidden)]
-pub struct RawDevice(pub ash::Device, Features);
+pub struct RawDevice(
+    pub ash::Device,
+    Features,
+    Arc<RawInstance>,
+);
+
 impl fmt::Debug for RawDevice {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "RawDevice") // TODO: Real Debug impl

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -758,4 +758,26 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     ///
     /// Host access to all queues needs to be **externally** sycnhronized!
     fn wait_idle(&self) -> Result<(), OutOfMemory>;
+
+    /// Associate a name with an image, for easier debugging in external tools or with validation
+    /// layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_image_name(&self, image: &mut B::Image, name: &str);
+    /// Associate a name with a buffer, for easier debugging in external tools or with validation
+    /// layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_buffer_name(&self, buffer: &mut B::Buffer, name: &str);
+    /// Associate a name with a command buffer, for easier debugging in external tools or with
+    /// validation layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_command_buffer_name(&self, command_buffer: &mut B::CommandBuffer, name: &str);
+    /// Associate a name with a semaphore, for easier debugging in external tools or with validation
+    /// layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_semaphore_name(&self, semaphore: &mut B::Semaphore, name: &str);
+    /// Associate a name with a fence, for easier debugging in external tools or with validation
+    /// layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_fence_name(&self, fence: &mut B::Fence, name: &str);
+    /// Associate a name with a framebuffer, for easier debugging in external tools or with
+    /// validation layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_framebuffer_name(&self, framebuffer: &mut B::Framebuffer, name: &str);
+    /// Associate a name with a render pass, for easier debugging in external tools or with
+    /// validation layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_render_pass_name(&self, render_pass: &mut B::RenderPass, name: &str);
 }


### PR DESCRIPTION
Resolves a part of #1508
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: mtl vk
- [ ] `rustfmt` run on changed code
