### PR TITLE
Makes gl backend use parking_lot

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -27,6 +27,7 @@ log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.3", features = ["fxhash"] }
 smallvec = "0.6"
 glow = "0.2.3"
+parking_lot = "0.9"
 spirv_cross = { version = "0.15", features = ["glsl"] }
 lazy_static = "1"
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -9,9 +9,10 @@ use hal::{self, buffer, command, image, memory, pass, pso, query, ColorSlot};
 use crate::pool::{self, BufferMemory};
 use crate::{native as n, Backend};
 
+use parking_lot::Mutex;
 use std::borrow::Borrow;
 use std::ops::Range;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::{mem, slice};
 
 // Command buffer implementation details:
@@ -1013,10 +1014,10 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         assert!(offsets.into_iter().next().is_none()); // TODO: offsets unsupported
 
         let mut set = first_set as _;
-        let drd = &*layout.desc_remap_data.read().unwrap();
+        let drd = &*layout.desc_remap_data.read();
         for desc_set in sets {
             let desc_set = desc_set.borrow();
-            let bindings = desc_set.bindings.lock().unwrap();
+            let bindings = desc_set.bindings.lock();
             for new_binding in &*bindings {
                 match new_binding {
                     n::DescSetBindings::Buffer {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1,8 +1,11 @@
+use arrayvec::ArrayVec;
+use parking_lot::{Mutex, RwLock};
+use spirv_cross::{glsl, spirv, ErrorCode as SpirvErrorCode};
 use std::borrow::Borrow;
 use std::cell::Cell;
 use std::ops::Range;
 use std::slice;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::Arc;
 
 use glow::Context as _;
 
@@ -21,9 +24,6 @@ use hal::{
     range::RangeArg,
     window::{Extent2D, SwapchainConfig},
 };
-
-use arrayvec::ArrayVec;
-use spirv_cross::{glsl, spirv, ErrorCode as SpirvErrorCode};
 
 use crate::{
     conv,
@@ -787,7 +787,7 @@ impl d::Device<B> for Device {
                         let shader_name = self.compile_shader(
                             point,
                             stage,
-                            &mut desc.layout.desc_remap_data.write().unwrap(),
+                            &mut desc.layout.desc_remap_data.write(),
                             &mut name_binding_map,
                         );
                         gl.attach_shader(name, shader_name);
@@ -922,7 +922,7 @@ impl d::Device<B> for Device {
             let shader = self.compile_shader(
                 &desc.shader,
                 pso::Stage::Compute,
-                &mut desc.layout.desc_remap_data.write().unwrap(),
+                &mut desc.layout.desc_remap_data.write(),
                 &mut name_binding_map,
             );
 
@@ -1523,7 +1523,7 @@ impl d::Device<B> for Device {
     {
         for mut write in writes {
             let set = &mut write.set;
-            let mut bindings = set.bindings.lock().unwrap();
+            let mut bindings = set.bindings.lock();
             let binding = write.binding;
             let mut offset = write.array_offset as i32;
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -1,6 +1,7 @@
+use parking_lot::{Mutex, RwLock};
 use std::cell::Cell;
 use std::ops::Range;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::Arc;
 
 use hal::backend::FastHashMap;
 use hal::memory::{Properties, Requirements};

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -3,7 +3,8 @@ use crate::native as n;
 use crate::Backend;
 use hal::backend::FastHashMap;
 
-use std::sync::{Arc, Mutex};
+use parking_lot::Mutex;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct OwnedBuffer {


### PR DESCRIPTION
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code

`make` succeeds on Windows with DX11 disabled.
Please note that `parking_lot` types do not become poisoned, so a program behaviour may be different if a locking thread panics.
