### PR TITLE
Deduplicate spec const code shared between backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "src/auxil/auxil",
     "src/auxil/range-alloc",
     "src/backend/dx11",
     "src/backend/dx12",

--- a/src/auxil/auxil/Cargo.toml
+++ b/src/auxil/auxil/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gfx-auxil"
+version = "0.1.0"
+description = "Implementation details shared between gfx-rs backends"
+homepage = "https://github.com/gfx-rs/gfx"
+repository = "https://github.com/gfx-rs/gfx"
+keywords = ["graphics", "gamedev"]
+license = "MIT OR Apache-2.0"
+authors = ["The Gfx-rs Developers"]
+documentation = "https://docs.rs/gfx-auxil"
+workspace = "../../../"
+edition = "2018"
+
+[dependencies]
+hal = { path = "../../hal", version = "0.3", package = "gfx-hal" }
+spirv_cross = "0.16"
+
+[lib]
+name = "gfx_auxil"

--- a/src/auxil/auxil/src/lib.rs
+++ b/src/auxil/auxil/src/lib.rs
@@ -1,0 +1,47 @@
+use {
+    hal::{device::ShaderError, pso},
+    spirv_cross::spirv,
+};
+
+pub fn spirv_cross_specialize_ast<T>(
+    ast: &mut spirv::Ast<T>,
+    specialization: &pso::Specialization,
+) -> Result<(), ShaderError>
+where
+    T: spirv::Target,
+    spirv::Ast<T>: spirv::Compile<T> + spirv::Parse<T>,
+{
+    let spec_constants = ast.get_specialization_constants().map_err(|err| {
+        ShaderError::CompilationFailed(match err {
+            spirv_cross::ErrorCode::CompilationError(msg) => msg,
+            spirv_cross::ErrorCode::Unhandled => "Unexpected specialization constant error".into(),
+        })
+    })?;
+
+    for spec_constant in spec_constants {
+        if let Some(constant) = specialization
+            .constants
+            .iter()
+            .find(|c| c.id == spec_constant.constant_id)
+        {
+            // Override specialization constant values
+            let value = specialization.data
+                [constant.range.start as usize .. constant.range.end as usize]
+                .iter()
+                .rev()
+                .fold(0u64, |u, &b| (u << 8) + b as u64);
+
+            ast.set_scalar_constant(spec_constant.id, value)
+                .map_err(|err| {
+                    ShaderError::CompilationFailed(match err {
+                        spirv_cross::ErrorCode::CompilationError(msg) => msg,
+                        spirv_cross::ErrorCode::Unhandled => {
+                            "Unexpected specialization constant error".into()
+                        }
+                    })
+                })?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -19,11 +19,12 @@ name = "gfx_backend_dx11"
 
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.3" }
+auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
 log = { version = "0.4" }
 smallvec = "0.6"
-spirv_cross = { version = "0.15", features = ["hlsl"] }
+spirv_cross = { version = "0.16", features = ["hlsl"] }
 parking_lot = "0.9"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.20.0-alpha3", optional = true }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1,6 +1,7 @@
 //#[deny(missing_docs)]
 
 extern crate gfx_hal as hal;
+extern crate auxil;
 extern crate range_alloc;
 #[macro_use]
 extern crate bitflags;

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -19,12 +19,13 @@ name = "gfx_backend_dx12"
 
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.3", features = ["fxhash"] }
+auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
 d3d12 = "0.1"
 log = { version = "0.4" }
 smallvec = "0.6"
-spirv_cross = { version = "0.15", features = ["hlsl"] }
+spirv_cross = { version = "0.16", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.20.0-alpha3", optional = true }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate gfx_hal as hal;
+extern crate auxil;
 extern crate range_alloc;
 #[macro_use]
 extern crate bitflags;

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -25,10 +25,11 @@ arrayvec = "0.4"
 bitflags = "1"
 log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.3", features = ["fxhash"] }
+auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
 smallvec = "0.6"
 glow = "0.2.3"
 parking_lot = "0.9"
-spirv_cross = { version = "0.15", features = ["glsl"] }
+spirv_cross = { version = "0.16", features = ["glsl"] }
 lazy_static = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -22,6 +22,7 @@ name = "gfx_backend_metal"
 
 [dependencies]
 hal = { path = "../../hal", version = "0.3", package = "gfx-hal", features = ["fxhash"] }
+auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 arrayvec = "0.4"
 bitflags = "1.0"


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: mtl dx11 dx12 gl
- [ ] `rustfmt` run on changed code
