### PR TITLE
[0.3/dx12] use explicit external pass barrier access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx12-0.3.3 (12-09-2019)
+  - improve external render pass barriers
+
 ### backend-metal-0.3.3 (05-09-2019)
   - fix immutable samplers in combined image-samplers
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.3.2"
+version = "0.3.3"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
Improves (but doesn't fix yet) #3009 
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

The basic thing it does is just using the access flags provided in the explicit external barriers, if any, instead of `empty()`.
@zakorgy - please check it out and tell if it's helping or not