### PR TITLE
[vk] fall back to debug report when debug utils is not available

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -24,7 +24,7 @@ use std::{mem, ptr};
 
 use crate::pool::RawCommandPool;
 use crate::{conv, native as n, window as w, command as cmd};
-use crate::{Backend as B, Device};
+use crate::{Backend as B, DebugMessenger, Device};
 
 #[derive(Debug, Default)]
 struct GraphicsPipelineInfoBuf {
@@ -2270,7 +2270,7 @@ impl d::Device<B> for Device {
 impl Device {
     unsafe fn set_object_name(&self, object_type: vk::ObjectType, object_handle: u64, name: &str) {
         let instance = &self.raw.2;
-        if let Some(ref debug_utils_ext) = instance.1 {
+        if let Some(DebugMessenger::Utils(ref debug_utils_ext, _)) = instance.1 {
             // Append a null terminator to the string while avoiding allocating memory
             static mut NAME_BUF: [i8; 64] = [0_i8; 64];
             std::ptr::copy_nonoverlapping(
@@ -2279,7 +2279,7 @@ impl Device {
                 name.len().min(NAME_BUF.len())
             );
             NAME_BUF[name.len()] = 0;
-            let _result = debug_utils_ext.0.debug_utils_set_object_name(
+            let _result = debug_utils_ext.debug_utils_set_object_name(
                 self.raw.0.handle(),
                 &vk::DebugUtilsObjectNameInfoEXT {
                     s_type: vk::StructureType::DEBUG_UTILS_OBJECT_NAME_INFO_EXT,

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -2272,9 +2272,9 @@ impl Device {
         let instance = &self.raw.2;
         if let Some(DebugMessenger::Utils(ref debug_utils_ext, _)) = instance.1 {
             // Append a null terminator to the string while avoiding allocating memory
-            static mut NAME_BUF: [i8; 64] = [0_i8; 64];
+            static mut NAME_BUF: [u8; 64] = [0u8; 64];
             std::ptr::copy_nonoverlapping(
-                name.as_ptr() as *mut i8,
+                name.as_ptr(),
                 &mut NAME_BUF[0],
                 name.len().min(NAME_BUF.len())
             );
@@ -2286,7 +2286,7 @@ impl Device {
                     p_next: std::ptr::null_mut(),
                     object_type,
                     object_handle,
-                    p_object_name: NAME_BUF.as_ptr(),
+                    p_object_name: NAME_BUF.as_ptr() as *mut _,
                 }
             );
         }


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- [x] `rustfmt` run on changed code

Allows debug output again on platforms without the `VK_EXT_debug_utils` extension, such as android.
Minor fix for platforms where `c_char = u8` (also android :smile:)