### PR TITLE
End render pass in colour-uniform

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -431,6 +431,7 @@ impl<B: Backend> RendererState<B> {
                 command::SubpassContents::Inline,
             );
             cmd_buffer.draw(0 .. 6, 0 .. 1);
+            cmd_buffer.end_render_pass();
             cmd_buffer.finish();
 
             let submission = Submission {


### PR DESCRIPTION
Fixes #3015
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
- [ ] `rustfmt` run on changed code

@Herschel I wasn't able to repro the validation error about Present layout, and the code looks like it should be correct, so not sure what to make of that. Is you Vulkan SDK fresh? Do you still see this error?