### PR TITLE
[vk] add debug labels for descriptor sets

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -35,6 +35,7 @@ use {
     ComputePipeline,
     Descriptor,
     DescriptorPool,
+    DescriptorSet,
     DescriptorSetLayout,
     Fence,
     Framebuffer,
@@ -2610,6 +2611,18 @@ impl device::Device<Backend> for Device {
     }
 
     unsafe fn set_render_pass_name(&self, _render_pass: &mut RenderPass, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_descriptor_set_name(&self, _descriptor_set: &mut DescriptorSet, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_descriptor_set_layout_name(
+        &self,
+        _descriptor_set_layout: &mut DescriptorSetLayout,
+        _name: &str,
+    ) {
         // TODO
     }
 }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3373,6 +3373,18 @@ impl d::Device<B> for Device {
     unsafe fn set_render_pass_name(&self, _render_pass: &mut r::RenderPass, _name: &str) {
         // TODO
     }
+
+    unsafe fn set_descriptor_set_name(&self, _descriptor_set: &mut r::DescriptorSet, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_descriptor_set_layout_name(
+        &self,
+        _descriptor_set_layout: &mut r::DescriptorSetLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
 }
 
 #[test]

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -556,6 +556,14 @@ impl device::Device<Backend> for Device {
     unsafe fn set_render_pass_name(&self, _: &mut (), _: &str) {
         unimplemented!()
     }
+
+    unsafe fn set_descriptor_set_name(&self, _: &mut (), _: &str) {
+        unimplemented!()
+    }
+
+    unsafe fn set_descriptor_set_layout_name(&self, _: &mut (), _: &str) {
+        unimplemented!()
+    }
 }
 
 #[derive(Debug)]

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1978,4 +1978,16 @@ impl d::Device<B> for Device {
     unsafe fn set_render_pass_name(&self, _render_pass: &mut n::RenderPass, _name: &str) {
         // TODO
     }
+
+    unsafe fn set_descriptor_set_name(&self, _descriptor_set: &mut n::DescriptorSet, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_descriptor_set_layout_name(
+        &self,
+        _descriptor_set_layout: &mut n::DescriptorSetLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -3018,6 +3018,18 @@ impl hal::device::Device<Backend> for Device {
     unsafe fn set_render_pass_name(&self, render_pass: &mut n::RenderPass, name: &str) {
         render_pass.name = name.to_string();
     }
+
+    unsafe fn set_descriptor_set_name(&self, _descriptor_set: &mut n::DescriptorSet, _name: &str) {
+        // TODO
+    }
+
+    unsafe fn set_descriptor_set_layout_name(
+        &self,
+        _descriptor_set_layout: &mut n::DescriptorSetLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
 }
 
 #[test]

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -2265,6 +2265,14 @@ impl d::Device<B> for Device {
     unsafe fn set_render_pass_name(&self, render_pass: &mut n::RenderPass, name: &str) {
         self.set_object_name(vk::ObjectType::RENDER_PASS, render_pass.raw.as_raw(), name)
     }
+
+    unsafe fn set_descriptor_set_name(&self, descriptor_set: &mut n::DescriptorSet, name: &str) {
+        self.set_object_name(vk::ObjectType::DESCRIPTOR_SET, descriptor_set.raw.as_raw(), name)
+    }
+
+    unsafe fn set_descriptor_set_layout_name(&self, descriptor_set_layout: &mut n::DescriptorSetLayout, name: &str) {
+        self.set_object_name(vk::ObjectType::DESCRIPTOR_SET_LAYOUT, descriptor_set_layout.raw.as_raw(), name)
+    }
 }
 
 impl Device {

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -780,4 +780,15 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Associate a name with a render pass, for easier debugging in external tools or with
     /// validation layers that can print a friendly name when referring to objects in error messages
     unsafe fn set_render_pass_name(&self, render_pass: &mut B::RenderPass, name: &str);
+    /// Associate a name with a descriptor set, for easier debugging in external tools or with
+    /// validation layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_descriptor_set_name(&self, descriptor_set: &mut B::DescriptorSet, name: &str);
+    /// Associate a name with a descriptor set layout, for easier debugging in external tools or
+    /// with validation layers that can print a friendly name when referring to objects in error
+    /// messages
+    unsafe fn set_descriptor_set_layout_name(
+        &self,
+        descriptor_set_layout: &mut B::DescriptorSetLayout,
+        name: &str,
+    );
 }


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
