### PR TITLE
Take the push constant range as bytes in `create_pipeline_layout`

### DIFF
--- a/src/backend/dx12/src/root_constants.rs
+++ b/src/backend/dx12/src/root_constants.rs
@@ -129,9 +129,11 @@ where
         .into_iter()
         .map(|borrowable| {
             let &(stages, ref range) = borrowable.borrow();
+            debug_assert_eq!(range.start % 4, 0);
+            debug_assert_eq!(range.end % 4, 0);
             RootConstant {
                 stages,
-                range: range.clone(),
+                range: range.start / 4 .. range.end / 4,
             }
         })
         .collect()
@@ -143,7 +145,7 @@ mod tests {
 
     #[test]
     fn test_single() {
-        let range = &[(pso::ShaderStageFlags::VERTEX, 0 .. 3)];
+        let range = &[(pso::ShaderStageFlags::VERTEX, 0 .. 12)];
         assert_eq!(into_vec(range), split(range));
     }
 
@@ -153,8 +155,8 @@ mod tests {
         //      |----------|
         //          |------------|
         let ranges = &[
-            (pso::ShaderStageFlags::VERTEX, 0 .. 3),
-            (pso::ShaderStageFlags::FRAGMENT, 2 .. 4),
+            (pso::ShaderStageFlags::VERTEX, 0 .. 12),
+            (pso::ShaderStageFlags::FRAGMENT, 8 .. 16),
         ];
 
         let reference = vec![
@@ -180,8 +182,8 @@ mod tests {
         //      |-------------------|
         //          |------------|
         let ranges = &[
-            (pso::ShaderStageFlags::VERTEX, 0 .. 5),
-            (pso::ShaderStageFlags::FRAGMENT, 2 .. 4),
+            (pso::ShaderStageFlags::VERTEX, 0 .. 20),
+            (pso::ShaderStageFlags::FRAGMENT, 8 .. 16),
         ];
 
         let reference = vec![
@@ -207,8 +209,8 @@ mod tests {
         //      |--------------|
         //      |------------|
         let ranges = &[
-            (pso::ShaderStageFlags::VERTEX, 0 .. 5),
-            (pso::ShaderStageFlags::FRAGMENT, 0 .. 4),
+            (pso::ShaderStageFlags::VERTEX, 0 .. 20),
+            (pso::ShaderStageFlags::FRAGMENT, 0 .. 16),
         ];
 
         let reference = vec![
@@ -230,8 +232,8 @@ mod tests {
         //      |-----|
         //      |-----|
         let ranges = &[
-            (pso::ShaderStageFlags::VERTEX, 0 .. 4),
-            (pso::ShaderStageFlags::FRAGMENT, 0 .. 4),
+            (pso::ShaderStageFlags::VERTEX, 0 .. 16),
+            (pso::ShaderStageFlags::FRAGMENT, 0 .. 16),
         ];
 
         let reference = vec![RootConstant {
@@ -247,8 +249,8 @@ mod tests {
         //      |------|
         //               |------------|
         let ranges = &[
-            (pso::ShaderStageFlags::VERTEX, 0 .. 3),
-            (pso::ShaderStageFlags::FRAGMENT, 3 .. 4),
+            (pso::ShaderStageFlags::VERTEX, 0 .. 12),
+            (pso::ShaderStageFlags::FRAGMENT, 12 .. 16),
         ];
         assert_eq!(into_vec(ranges), split(ranges));
     }
@@ -256,10 +258,10 @@ mod tests {
     #[test]
     fn test_complex() {
         let ranges = &[
-            (pso::ShaderStageFlags::VERTEX, 2 .. 10),
-            (pso::ShaderStageFlags::FRAGMENT, 0 .. 5),
-            (pso::ShaderStageFlags::GEOMETRY, 6 .. 10),
-            (pso::ShaderStageFlags::HULL, 4 .. 7),
+            (pso::ShaderStageFlags::VERTEX, 8 .. 40),
+            (pso::ShaderStageFlags::FRAGMENT, 0 .. 20),
+            (pso::ShaderStageFlags::GEOMETRY, 24 .. 40),
+            (pso::ShaderStageFlags::HULL, 16 .. 28),
         ];
 
         let reference = vec![

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1063,7 +1063,8 @@ impl hal::device::Device<Backend> for Device {
             let (flags, range) = pcr.borrow();
             for (limit, &(stage_bit, _, _)) in pc_limits.iter_mut().zip(&stage_infos) {
                 if flags.contains(stage_bit) {
-                    *limit = range.end.max(*limit);
+                    debug_assert_eq!(range.end % 4, 0);
+                    *limit = (range.end / 4).max(*limit);
                 }
             }
         }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -689,8 +689,8 @@ impl d::Device<B> for Device {
                 let &(s, ref r) = range.borrow();
                 vk::PushConstantRange {
                     stage_flags: conv::map_stage_flags(s),
-                    offset: r.start * 4,
-                    size: (r.end - r.start) * 4,
+                    offset: r.start,
+                    size: r.end - r.start,
                 }
             })
             .collect::<Vec<_>>();

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -531,9 +531,11 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Requests a timestamp to be written.
     unsafe fn write_timestamp(&mut self, stage: pso::PipelineStage, query: query::Query<B>);
 
-    /// Modify constant data in a graphics pipeline.
-    /// Push constants are intended to modify data in a pipeline more
-    /// quickly than a updating the values inside a descriptor set.
+    /// Modify constant data in a graphics pipeline. Push constants are intended to modify data in a
+    /// pipeline more quickly than a updating the values inside a descriptor set.
+    ///
+    /// Push constants must be aligned to 4 bytes, and to guarantee alignment, this function takes a
+    /// `&[u32]` instead of a `&[u8]`. Note that the offset is still specified in units of bytes.
     unsafe fn push_graphics_constants(
         &mut self,
         layout: &B::PipelineLayout,
@@ -542,9 +544,11 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         constants: &[u32],
     );
 
-    /// Modify constant data in a compute pipeline.
-    /// Push constants are intended to modify data in a pipeline more
-    /// quickly than a updating the values inside a descriptor set.
+    /// Modify constant data in a compute pipeline. Push constants are intended to modify data in a
+    /// pipeline more quickly than a updating the values inside a descriptor set.
+    ///
+    /// Push constants must be aligned to 4 bytes, and to guarantee alignment, this function takes a
+    /// `&[u32]` instead of a `&[u8]`. Note that the offset is still specified in units of bytes.
     unsafe fn push_compute_constants(
         &mut self,
         layout: &B::PipelineLayout,

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -258,8 +258,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     ///
     /// * `set_layouts` - Descriptor set layouts
     /// * `push_constants` - Ranges of push constants. A shader stage may only contain one push
-    ///     constant block. The length of the range indicates the number of u32 constants occupied
-    ///     by the push constant block.
+    ///     constant block. The range is defined in units of bytes.
     ///
     /// # PipelineLayout
     ///


### PR DESCRIPTION
Fixes #3021
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12 mtl vk
- [ ] `rustfmt` run on changed code
