### PR TITLE
[mtl] update `CAMetalLayer` contents scale automatically on macOS

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -40,6 +40,7 @@ smallvec = "0.6"
 spirv_cross = { version = "0.16", features = ["msl"] }
 parking_lot = "0.9"
 storage-map = "0.2"
+lazy_static = "1"
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails
 # and we get no docs at all.


### PR DESCRIPTION
When a `CAMetalLayer` is created by the Metal backend, the contents scale factor is set to match the window scale factor. However, we weren't updating this scale factor if the window scale factor changed later on (such as when moved to a screen with a different scale factor, or when entering exclusive fullscreen mode)!

AppKit updates the contents scale factor automatically for layers that it manages, but for layers created and managed by us, we must implement [`NSViewLayerContentScaleDelegate`](https://developer.apple.com/documentation/appkit/nsviewlayercontentscaledelegate?language=objc) and explicitly opt-in to this behaviour.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: mtl
- [ ] `rustfmt` run on changed code
