### PR TITLE
Issue #3003: Rename constant CONSTANT_BUFFER_READ to UNIFORM_READ

### DIFF
--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -473,7 +473,7 @@ pub fn map_buffer_resource_state(access: buffer::Access) -> D3D12_RESOURCE_STATE
     if access.contains(Access::INDEX_BUFFER_READ) {
         state |= D3D12_RESOURCE_STATE_INDEX_BUFFER;
     }
-    if access.contains(Access::VERTEX_BUFFER_READ) || access.contains(Access::CONSTANT_BUFFER_READ)
+    if access.contains(Access::VERTEX_BUFFER_READ) || access.contains(Access::UNIFORM_READ)
     {
         state |= D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
     }

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -103,7 +103,7 @@ bitflags!(
         /// ../pso/struct.PipelineStage.html#associatedconstant.VERTEX_INPUT) stage.
         const VERTEX_BUFFER_READ = 0x4;
         ///
-        const CONSTANT_BUFFER_READ = 0x8;
+        const UNIFORM_READ = 0x8;
         ///
         const SHADER_READ = 0x20;
         ///


### PR DESCRIPTION
Fixes #3003 
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
