### PR TITLE
[v0.18] Remove derivative usage & release

### DIFF
--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -30,7 +30,6 @@ path = "src/lib.rs"
 [dependencies]
 bitflags = "1"
 mint = { version = "0.5", optional = true }
-derivative = "1"
 draw_state = "0.8"
 log = "0.4"
 serde = { version = "1", features = ["serde_derive"], optional = true }

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx_core"
-version = "0.9.1"
+version = "0.9.2"
 description = "Core library of Gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/core/src/factory.rs
+++ b/src/core/src/factory.rs
@@ -57,7 +57,7 @@ impl Error for ResourceViewError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         if let ResourceViewError::Layer(ref e) = *self {
             Some(e)
         } else {
@@ -113,7 +113,7 @@ impl Error for TargetViewError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         if let TargetViewError::Layer(ref e) = *self {
             Some(e)
         } else {
@@ -152,7 +152,7 @@ impl Error for CombinedError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             CombinedError::Texture(ref e) => Some(e),
             CombinedError::Resource(ref e) => Some(e),

--- a/src/core/src/handle.rs
+++ b/src/core/src/handle.rs
@@ -32,13 +32,35 @@ impl<R: Resources> Deref for RawBuffer<R> {
 }
 
 /// Type-safe buffer handle
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Buffer<R: Resources, T>(
-    RawBuffer<R>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct Buffer<R: Resources, T>(RawBuffer<R>, PhantomData<T>);
+
+impl<R: Resources, T> PartialEq for Buffer<R, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<R: Resources, T> Eq for Buffer<R, T> {}
+
+impl<R: Resources, T> std::hash::Hash for Buffer<R, T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<R: Resources, T> Clone for Buffer<R, T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<R: Resources, T> std::fmt::Debug for Buffer<R, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Buffer")
+            .field(&self.0)
+            .finish()
+    }
+}
 
 impl<R: Resources, T> Typed for Buffer<R, T> {
     type Raw = RawBuffer<R>;
@@ -88,13 +110,35 @@ impl<R: Resources> Deref for RawTexture<R> {
 }
 
 /// Typed texture object
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Texture<R: Resources, S>(
-    RawTexture<R>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<S>
-);
+pub struct Texture<R: Resources, S>(RawTexture<R>, PhantomData<S>);
+
+impl<R: Resources, T> PartialEq for Texture<R, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<R: Resources, T> Eq for Texture<R, T> {}
+
+impl<R: Resources, T> std::hash::Hash for Texture<R, T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<R: Resources, T> Clone for Texture<R, T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<R: Resources, T> std::fmt::Debug for Texture<R, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Texture")
+            .field(&self.0)
+            .finish()
+    }
+}
 
 impl<R: Resources, S> Typed for Texture<R, S> {
     type Raw = RawTexture<R>;
@@ -121,13 +165,35 @@ enum ViewSource<R: Resources> {
 pub struct RawShaderResourceView<R: Resources>(Arc<R::ShaderResourceView>, ViewSource<R>);
 
 /// Type-safe Shader Resource View Handle
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct ShaderResourceView<R: Resources, T>(
-    RawShaderResourceView<R>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct ShaderResourceView<R: Resources, T>(RawShaderResourceView<R>, PhantomData<T>);
+
+impl<R: Resources, T> PartialEq for ShaderResourceView<R, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<R: Resources, T> Eq for ShaderResourceView<R, T> {}
+
+impl<R: Resources, T> std::hash::Hash for ShaderResourceView<R, T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<R: Resources, T> Clone for ShaderResourceView<R, T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<R: Resources, T> std::fmt::Debug for ShaderResourceView<R, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ShaderResourceView")
+            .field(&self.0)
+            .finish()
+    }
+}
 
 impl<R: Resources, T> ShaderResourceView<R, T> {
     /// Gets the raw view
@@ -148,13 +214,35 @@ impl<R: Resources, T> Typed for ShaderResourceView<R, T> {
 pub struct RawUnorderedAccessView<R: Resources>(Arc<R::UnorderedAccessView>, ViewSource<R>);
 
 /// Type-safe Unordered Access View Handle
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct UnorderedAccessView<R: Resources, T>(
-    RawUnorderedAccessView<R>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct UnorderedAccessView<R: Resources, T>(RawUnorderedAccessView<R>, PhantomData<T>);
+
+impl<R: Resources, T> PartialEq for UnorderedAccessView<R, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<R: Resources, T> Eq for UnorderedAccessView<R, T> {}
+
+impl<R: Resources, T> std::hash::Hash for UnorderedAccessView<R, T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<R: Resources, T> Clone for UnorderedAccessView<R, T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<R: Resources, T> std::fmt::Debug for UnorderedAccessView<R, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("UnorderedAccessView")
+            .field(&self.0)
+            .finish()
+    }
+}
 
 impl<R: Resources, T> Typed for UnorderedAccessView<R, T> {
     type Raw = RawUnorderedAccessView<R>;
@@ -192,13 +280,35 @@ impl<R: Resources> RawDepthStencilView<R> {
 }
 
 /// Typed RTV
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct RenderTargetView<R: Resources, T>(
-    RawRenderTargetView<R>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct RenderTargetView<R: Resources, T>(RawRenderTargetView<R>, PhantomData<T>);
+
+impl<R: Resources, T> PartialEq for RenderTargetView<R, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<R: Resources, T> Eq for RenderTargetView<R, T> {}
+
+impl<R: Resources, T> std::hash::Hash for RenderTargetView<R, T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<R: Resources, T> Clone for RenderTargetView<R, T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<R: Resources, T> std::fmt::Debug for RenderTargetView<R, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("RenderTargetView")
+            .field(&self.0)
+            .finish()
+    }
+}
 
 impl<R: Resources, T> RenderTargetView<R, T> {
     /// Get target dimensions
@@ -215,13 +325,35 @@ impl<R: Resources, T> Typed for RenderTargetView<R, T> {
 }
 
 /// Typed DSV
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct DepthStencilView<R: Resources, T>(
-    RawDepthStencilView<R>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct DepthStencilView<R: Resources, T>(RawDepthStencilView<R>, PhantomData<T>);
+
+impl<R: Resources, T> PartialEq for DepthStencilView<R, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<R: Resources, T> Eq for DepthStencilView<R, T> {}
+
+impl<R: Resources, T> std::hash::Hash for DepthStencilView<R, T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<R: Resources, T> Clone for DepthStencilView<R, T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<R: Resources, T> std::fmt::Debug for DepthStencilView<R, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("DepthStencilView")
+            .field(&self.0)
+            .finish()
+    }
+}
 
 impl<R: Resources, T> DepthStencilView<R, T> {
     /// Get target dimensions

--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -19,8 +19,6 @@
 
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate derivative;
 extern crate draw_state;
 extern crate log;
 

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.18.1"
+version = "0.18.2"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -35,7 +35,6 @@ unstable = []
 
 [dependencies]
 mint = { version = "0.5", optional = true }
-derivative = "1.0"
 draw_state = "0.8"
 gfx_core = { path = "../core", version = "0.9.1" }
 log = "0.4"

--- a/src/render/src/factory.rs
+++ b/src/render/src/factory.rs
@@ -70,7 +70,7 @@ impl<S: fmt::Debug + fmt::Display> Error for PipelineStateError<S> {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             PipelineStateError::Program(ref program_error) => Some(program_error),
             PipelineStateError::DescriptorInit(ref init_error) => Some(init_error),

--- a/src/render/src/lib.rs
+++ b/src/render/src/lib.rs
@@ -92,8 +92,6 @@
 extern crate mint;
 
 extern crate log;
-#[macro_use]
-extern crate derivative;
 extern crate draw_state;
 extern crate gfx_core as core;
 

--- a/src/render/src/pso/buffer.rs
+++ b/src/render/src/pso/buffer.rs
@@ -34,13 +34,33 @@ pub trait Structure<F> {
 type AttributeSlotSet = usize;
 
 /// Service struct to simplify the implementations of `VertexBuffer` and `InstanceBuffer`.
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct VertexBufferCommon<T, I=InstanceRate>(
-    RawVertexBuffer,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<(T, I)>
-);
+pub struct VertexBufferCommon<T, I=InstanceRate>(RawVertexBuffer, PhantomData<(T, I)>);
+
+impl<T, I> PartialEq for VertexBufferCommon<T, I> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T, I> Eq for VertexBufferCommon<T, I> {}
+
+impl<T, I> std::hash::Hash for VertexBufferCommon<T, I> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T, I> Clone for VertexBufferCommon<T, I> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<T, I> std::fmt::Debug for VertexBufferCommon<T, I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("VertexBufferCommon").field(&self.0).finish()
+    }
+}
 
 /// Helper trait for `VertexBufferCommon` to support variable instance rate.
 pub trait ToInstanceRate {
@@ -89,13 +109,33 @@ pub struct RawVertexBuffer(Option<BufferIndex>, AttributeSlotSet);
 ///
 /// - init: `&str` = name of the buffer
 /// - data: `Buffer<T>`
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct ConstantBuffer<T: Structure<shade::ConstFormat>>(
-    RawConstantBuffer,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct ConstantBuffer<T: Structure<shade::ConstFormat>>(RawConstantBuffer, PhantomData<T>);
+
+impl<T: Structure<shade::ConstFormat>> PartialEq for ConstantBuffer<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T: Structure<shade::ConstFormat>> Eq for ConstantBuffer<T> {}
+
+impl<T: Structure<shade::ConstFormat>> std::hash::Hash for ConstantBuffer<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T: Structure<shade::ConstFormat>> Clone for ConstantBuffer<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<T: Structure<shade::ConstFormat>> std::fmt::Debug for ConstantBuffer<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ConstantBuffer").field(&self.0).finish()
+    }
+}
 
 /// Raw constant buffer component.
 ///
@@ -109,13 +149,33 @@ pub struct RawConstantBuffer(Option<(Usage, ConstantBufferSlot)>);
 ///
 /// - init: `&str` = name of the constant
 /// - data: `T` = value
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Global<T: ToUniform>(
-    RawGlobal,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct Global<T: ToUniform>(RawGlobal, PhantomData<T>);
+
+impl<T: ToUniform> PartialEq for Global<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T: ToUniform> Eq for Global<T> {}
+
+impl<T: ToUniform> std::hash::Hash for Global<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T: ToUniform> Clone for Global<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<T: ToUniform> std::fmt::Debug for Global<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Global").field(&self.0).finish()
+    }
+}
 
 /// Raw global (uniform) constant component. Describes a free-standing value
 /// passed into the shader, which is not enclosed in any constant buffer.

--- a/src/render/src/pso/mod.rs
+++ b/src/render/src/pso/mod.rs
@@ -236,7 +236,7 @@ impl<S: fmt::Debug + fmt::Display> Error for InitError<S> {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         if let InitError::ConstantBuffer(_, Some(ref e)) = *self {
             Some(e)
         } else {

--- a/src/render/src/pso/resource.rs
+++ b/src/render/src/pso/resource.rs
@@ -26,13 +26,33 @@ use super::{DataLink, DataBind, RawDataSet, AccessInfo};
 ///
 /// - init: `&str` = name of the resource
 /// - data: `ShaderResourceView<T>`
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct ShaderResource<T>(
-    RawShaderResource,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct ShaderResource<T>(RawShaderResource, PhantomData<T>);
+
+impl<T> PartialEq for ShaderResource<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T> Eq for ShaderResource<T> {}
+
+impl<T> std::hash::Hash for ShaderResource<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T> Clone for ShaderResource<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<T> std::fmt::Debug for ShaderResource<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ShaderResource").field(&self.0).finish()
+    }
+}
 
 /// Raw (untyped) shader resource (SRV).
 ///
@@ -47,13 +67,33 @@ pub struct RawShaderResource(Option<(ResourceViewSlot, shade::Usage)>);
 ///
 /// - init: `&str` = name of the resource
 /// - data: `UnorderedAccessView<T>`
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct UnorderedAccess<T>(
-    Option<(UnorderedViewSlot, shade::Usage)>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct UnorderedAccess<T>(Option<(UnorderedViewSlot, shade::Usage)>, PhantomData<T>);
+
+impl<T> PartialEq for UnorderedAccess<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T> Eq for UnorderedAccess<T> {}
+
+impl<T> std::hash::Hash for UnorderedAccess<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T> Clone for UnorderedAccess<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<T> std::fmt::Debug for UnorderedAccess<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("UnorderedAccess").field(&self.0).finish()
+    }
+}
 
 /// Sampler component.
 ///
@@ -69,9 +109,34 @@ pub struct Sampler(Option<(SamplerSlot, shade::Usage)>);
 ///
 /// - init: `&str` = name of the sampler/texture (assuming they match)
 /// - data: (`ShaderResourceView<T>`, `Sampler`)
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash(bound=""), PartialEq)]
 pub struct TextureSampler<T>(ShaderResource<T>, Sampler);
+
+impl<T> PartialEq for TextureSampler<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0 && self.1 == other.1
+    }
+}
+
+impl<T> Eq for TextureSampler<T> {}
+
+impl<T> std::hash::Hash for TextureSampler<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+        self.1.hash(state);
+    }
+}
+
+impl<T> Clone for TextureSampler<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone())
+    }
+}
+
+impl<T> std::fmt::Debug for TextureSampler<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("TextureSampler").field(&self.0).field(&self.1).finish()
+    }
+}
 
 impl<'a, T> DataLink<'a> for ShaderResource<T> {
     type Init = &'a str;

--- a/src/render/src/pso/target.rs
+++ b/src/render/src/pso/target.rs
@@ -25,25 +25,65 @@ use super::{DataLink, DataBind, RawDataSet, AccessInfo};
 ///
 /// - init: `&str` = name of the target
 /// - data: `RenderTargetView<T>`
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct RenderTarget<T>(
-    Option<ColorSlot>,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct RenderTarget<T>(Option<ColorSlot>, PhantomData<T>);
+
+impl<T> PartialEq for RenderTarget<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T> Eq for RenderTarget<T> {}
+
+impl<T> std::hash::Hash for RenderTarget<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T> Clone for RenderTarget<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<T> std::fmt::Debug for RenderTarget<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("RenderTarget").field(&self.0).finish()
+    }
+}
 
 /// Render target component with active blending mode.
 ///
 /// - init: (`&str`, `ColorMask`, `Blend` = blending state)
 /// - data: `RenderTargetView<T>`
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct BlendTarget<T>(
-    RawRenderTarget,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct BlendTarget<T>(RawRenderTarget, PhantomData<T>);
+
+impl<T> PartialEq for BlendTarget<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T> Eq for BlendTarget<T> {}
+
+impl<T> std::hash::Hash for BlendTarget<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T> Clone for BlendTarget<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<T> std::fmt::Debug for BlendTarget<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("BlendTarget").field(&self.0).finish()
+    }
+}
 
 /// Raw (untyped) render target component with optional blending.
 ///
@@ -56,34 +96,85 @@ pub struct RawRenderTarget(Option<ColorSlot>);
 ///
 /// - init: `Depth` = depth state
 /// - data: `DepthStencilView<T>`
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct DepthTarget<T>(
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct DepthTarget<T>(PhantomData<T>);
+
+impl<T> PartialEq for DepthTarget<T> {
+    fn eq(&self, _: &Self) -> bool { true }
+}
+
+impl<T> Eq for DepthTarget<T> {}
+
+impl<T> std::hash::Hash for DepthTarget<T> {
+    fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+}
+
+impl<T> Clone for DepthTarget<T> {
+    fn clone(&self) -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> std::fmt::Debug for DepthTarget<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DepthTarget")
+    }
+}
 
 /// Stencil target component.
 ///
 /// - init: `Stencil` = stencil state
 /// - data: (`DepthStencilView<T>`, `(front, back)` = stencil reference values)
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct StencilTarget<T>(
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct StencilTarget<T>(PhantomData<T>);
+
+impl<T> PartialEq for StencilTarget<T> {
+    fn eq(&self, _: &Self) -> bool { true }
+}
+
+impl<T> Eq for StencilTarget<T> {}
+
+impl<T> std::hash::Hash for StencilTarget<T> {
+    fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+}
+
+impl<T> Clone for StencilTarget<T> {
+    fn clone(&self) -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> std::fmt::Debug for StencilTarget<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "StencilTarget")
+    }
+}
 
 /// Depth + stencil target component.
 ///
 /// - init: (`Depth` = depth state, `Stencil` = stencil state)
 /// - data: (`DepthStencilView<T>`, `(front, back)` = stencil reference values)
-#[derive(Derivative)]
-#[derivative(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct DepthStencilTarget<T>(
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
-    PhantomData<T>
-);
+pub struct DepthStencilTarget<T>(PhantomData<T>);
+
+impl<T> PartialEq for DepthStencilTarget<T> {
+    fn eq(&self, _: &Self) -> bool { true }
+}
+
+impl<T> Eq for DepthStencilTarget<T> {}
+
+impl<T> std::hash::Hash for DepthStencilTarget<T> {
+    fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+}
+
+impl<T> Clone for DepthStencilTarget<T> {
+    fn clone(&self) -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> std::fmt::Debug for DepthStencilTarget<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DepthStencilTarget")
+    }
+}
 
 /// Scissor component. Sets up the scissor test for rendering.
 ///

--- a/src/render/src/shade.rs
+++ b/src/render/src/shade.rs
@@ -110,7 +110,7 @@ impl Error for ProgramError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             ProgramError::Vertex(ref e) => Some(e),
             ProgramError::Hull(ref e) => Some(e),


### PR DESCRIPTION
Cherry-pick #3029 into `v0.18` as a non-breaking improvement to compile speed.

Bumped versions:
* gfx_core -> `0.9.2`
* gfx -> `0.18.2`
