### PR TITLE
Add type Instance to trait Backend

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -3166,6 +3166,7 @@ pub struct QueryPool;
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Backend {}
 impl hal::Backend for Backend {
+    type Instance = Instance;
     type PhysicalDevice = PhysicalDevice;
     type Device = device::Device;
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1144,6 +1144,7 @@ impl hal::Instance for Instance {
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Backend {}
 impl hal::Backend for Backend {
+    type Instance = Instance;
     type PhysicalDevice = PhysicalDevice;
     type Device = Device;
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -28,6 +28,7 @@ use std::ops::Range;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Backend {}
 impl hal::Backend for Backend {
+    type Instance = Instance;
     type PhysicalDevice = PhysicalDevice;
     type Device = Device;
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -437,6 +437,7 @@ impl Instance {
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Backend {}
 impl hal::Backend for Backend {
+    type Instance = Instance;
     type PhysicalDevice = device::PhysicalDevice;
     type Device = device::Device;
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1338,6 +1338,7 @@ pub struct Device {
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Backend {}
 impl hal::Backend for Backend {
+    type Instance = Instance;
     type PhysicalDevice = PhysicalDevice;
     type Device = Device;
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -474,7 +474,7 @@ impl From<usize> for MemoryTypeId {
 /// or Metal, will implement this trait with its own concrete types.
 #[allow(missing_docs)]
 pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send + Sync {
-    //type Instance:          Instance<Self>;
+    type Instance: Instance;
     type PhysicalDevice: adapter::PhysicalDevice<Self>;
     type Device: device::Device<Self>;
 


### PR DESCRIPTION
Fixes #2963 

Much simpler than #3034, but still had to add the cfgs to the gl backend.

PR checklist:
- [X] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds (panics on macOS, but same for `master` branch, didn't have enough time on the windows machine to test)
- [X] tested examples with the following backends:
  - macOS: metal ✅ , vulkan (moltenvk) ✅ , gl 🔴 (panics)
  - windows: vulkan ✅ , dx12 ✅ , dx11 ✅ , gl ✅ 
- [X] `rustfmt` run on changed code
