### PR TITLE
[hal-0.3] Upgrade to raw-window-handle v0.3.0

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -29,7 +29,7 @@ parking_lot = "0.7"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.19", optional = true }
 wio = "0.2"
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -28,7 +28,7 @@ smallvec = "0.6"
 spirv_cross = { version = "0.14.0", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 winit = { version = "0.19", optional = true }
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -14,4 +14,4 @@ name = "gfx_backend_empty"
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.3.1" }
 winit = { version = "0.19", optional = true }
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -32,7 +32,7 @@ lazy_static = "1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.21", optional = true }
 winit = { version = "0.19", optional = true }
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -39,7 +39,7 @@ smallvec = "0.6"
 spirv_cross = { version = "0.15", features = ["msl"] }
 parking_lot = "0.9"
 storage-map = "0.2"
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -29,7 +29,7 @@ ash = "0.29.0"
 gfx-hal = { path = "../../hal", version = "0.3.1" }
 smallvec = "0.6"
 winit = { version = "0.19", optional = true }
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -336,6 +336,16 @@ impl Instance {
             {
                 Ok(self.create_surface_from_xlib(handle.display as *mut _, handle.window))
             }
+            #[cfg(all(
+                feature = "xcb",
+                unix,
+                not(target_os = "android"),
+                not(target_os = "macos"),
+                not(target_os = "ios")
+            ))]
+            RawWindowHandle::Xcb(handle) if self.extensions.contains(&khr::XcbSurface::name()) => {
+                Ok(self.create_surface_from_xcb(handle.connection as *mut _, handle.window))
+            }
             // #[cfg(target_os = "android")]
             // RawWindowHandle::ANativeWindowHandle(handle) => {
             //     let native_window = unimplemented!();

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -331,7 +331,7 @@ impl Instance {
                 not(target_os = "macos"),
                 not(target_os = "ios")
             ))]
-            RawWindowHandle::X11(handle)
+            RawWindowHandle::Xlib(handle)
                 if self.extensions.contains(&khr::XlibSurface::name()) =>
             {
                 Ok(self.create_surface_from_xlib(handle.display as *mut _, handle.window))


### PR DESCRIPTION
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: `vulkan`
- [x] `rustfmt` run on changed code

In the process, I've also added support for building a Vulkan surface using a raw XCB handle.