### PR TITLE
gl: Fix quad example on native and web

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -46,7 +46,7 @@ version = "0.3"
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.32"
+wasm-bindgen = "0.2.51"
 console_error_panic_hook = "0.1.6"
 console_log = "0.1.2"
 

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -333,7 +333,7 @@ where
                 // to 1 it means we can use that type for our buffer. So this code finds the first
                 // memory type that has a `1` (or, is allowed), and is visible to the CPU.
                 buffer_req.type_mask & (1 << id) != 0
-                    && mem_type.properties.contains(m::Properties::CPU_VISIBLE | m::Properties::COHERENT)
+                    && mem_type.properties.contains(m::Properties::CPU_VISIBLE)
             })
             .unwrap()
             .into();
@@ -344,6 +344,7 @@ where
             device.bind_buffer_memory(&memory, 0, &mut vertex_buffer).unwrap();
             let mapping = device.map_memory(&memory, 0 .. buffer_len).unwrap();
             ptr::copy_nonoverlapping(QUAD.as_ptr() as *const u8, mapping, buffer_len as usize);
+            device.flush_mapped_memory_ranges(iter::once((&memory, 0 .. buffer_len))).unwrap();
             device.unmap_memory(&memory);
             ManuallyDrop::new(memory)
         };
@@ -380,6 +381,7 @@ where
                     width as usize * image_stride,
                 );
             }
+            device.flush_mapped_memory_ranges(iter::once((&memory, 0 .. upload_size))).unwrap();
             device.unmap_memory(&memory);
             ManuallyDrop::new(memory)
         };

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -27,7 +27,7 @@ log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.3", features = ["fxhash"] }
 auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
 smallvec = "0.6"
-glow = "0.2.3"
+glow = "0.3.0-alpha3"
 parking_lot = "0.9"
 spirv_cross = { version = "0.16", features = ["glsl"] }
 lazy_static = "1"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -38,7 +38,7 @@ glutin = { version = "0.22.0-alpha3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"
-wasm-bindgen = "0.2.39"
+wasm-bindgen = "0.2.51"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.6"

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -107,7 +107,7 @@ pub enum Command {
     BindTargetView(FrameBufferTarget, AttachmentPoint, n::ImageView),
     SetDrawColorBuffers(usize),
     SetPatchSize(i32),
-    BindProgram(<GlContext as glow::Context>::Program),
+    BindProgram(<GlContext as glow::HasContext>::Program),
     SetBlend(pso::ColorBlendDesc),
     SetBlendSlot(ColorSlot, pso::ColorBlendDesc),
     BindAttribute(n::AttributeDesc, n::RawBuffer, i32, u32),

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 use std::slice;
 use std::sync::Arc;
 
-use glow::Context as _;
+use glow::HasContext;
 
 use auxil::spirv_cross_specialize_ast;
 
@@ -54,7 +54,7 @@ fn gen_unexpected_error(err: SpirvErrorCode) -> d::ShaderError {
     d::ShaderError::CompilationFailed(msg)
 }
 
-fn create_fbo_internal(share: &Starc<Share>) -> Option<<GlContext as glow::Context>::Framebuffer> {
+fn create_fbo_internal(share: &Starc<Share>) -> Option<<GlContext as glow::HasContext>::Framebuffer> {
     if share.private_caps.framebuffer {
         let gl = &share.context;
         let name = unsafe { gl.create_framebuffer() }.unwrap();

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -3,7 +3,7 @@ use hal::{Features, Limits};
 use std::collections::HashSet;
 use std::{fmt, str};
 
-use glow::Context;
+use glow::HasContext;
 
 /// A version number for a specific component of an OpenGL implementation
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -333,9 +333,11 @@ impl Info {
     }
 
     pub fn is_webgl(&self) -> bool {
-        cfg!(target_arch = "wasm32")
+        IS_WEBGL
     }
 }
+
+const IS_WEBGL: bool = cfg!(target_arch = "wasm32");
 
 /// Load the information pertaining to the driver and the corresponding device
 /// capabilities.
@@ -345,6 +347,16 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
     let max_texture_size = get_usize(gl, glow::MAX_TEXTURE_SIZE).unwrap_or(64) as u32;
     let max_samples = get_usize(gl, glow::MAX_SAMPLES).unwrap_or(8);
     let max_samples_mask = (max_samples * 2 - 1) as u8;
+    let max_texel_elements = if IS_WEBGL {
+        0
+    } else {
+        get_usize(gl, glow::MAX_TEXTURE_BUFFER_SIZE).unwrap_or(0)
+    };
+    let min_storage_buffer_offset_alignment = if IS_WEBGL {
+        1024
+    } else {
+        get_u64(gl, glow::SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT).unwrap_or(1024)
+    };
 
     let mut limits = Limits {
         max_image_1d_size: max_texture_size,
@@ -352,18 +364,14 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Li
         max_image_3d_size: max_texture_size,
         max_image_cube_size: max_texture_size,
         max_image_array_layers: get_usize(gl, glow::MAX_ARRAY_TEXTURE_LAYERS).unwrap_or(1) as u16,
-        max_texel_elements: get_usize(gl, glow::MAX_TEXTURE_BUFFER_SIZE).unwrap_or(0),
+        max_texel_elements,
         max_viewports: 1,
         optimal_buffer_copy_offset_alignment: 1,
         optimal_buffer_copy_pitch_alignment: 1,
         min_texel_buffer_offset_alignment: 1,
         min_uniform_buffer_offset_alignment: get_u64(gl, glow::UNIFORM_BUFFER_OFFSET_ALIGNMENT)
             .unwrap_or(1024),
-        min_storage_buffer_offset_alignment: get_u64(
-            gl,
-            glow::SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT,
-        )
-        .unwrap_or(1024),
+        min_storage_buffer_offset_alignment,
         framebuffer_color_sample_counts: max_samples_mask,
         non_coherent_atom_size: 1,
         max_color_attachments: get_usize(gl, glow::MAX_COLOR_ATTACHMENTS).unwrap_or(1),

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -45,11 +45,8 @@ use window::wgl::{DeviceContext, Surface, Swapchain};
 #[cfg(not(any(target_arch = "wasm32", feature = "glutin", feature = "wgl")))]
 pub use window::dummy::{Surface, Swapchain};
 
-#[cfg(not(target_arch = "wasm32"))]
-pub use glow::native::Context as GlContext;
-#[cfg(target_arch = "wasm32")]
-pub use glow::web::Context as GlContext;
-use glow::Context;
+pub use glow::Context as GlContext;
+use glow::HasContext;
 
 
 pub(crate) struct GlContainer {
@@ -67,7 +64,7 @@ impl GlContainer {
     where
         F: FnMut(&str) -> *const std::os::raw::c_void,
     {
-        let context = glow::native::Context::from_loader_function(fn_proc);
+        let context = glow::Context::from_loader_function(fn_proc);
         GlContainer { context }
     }
 
@@ -107,7 +104,7 @@ impl GlContainer {
                 .expect("Cannot get document body")
                 .append_child(&canvas)
                 .expect("Cannot insert canvas into document body");
-            glow::web::Context::from_webgl2_context(webgl2_context)
+            glow::Context::from_webgl2_context(webgl2_context)
         };
         GlContainer { context }
     }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -14,17 +14,17 @@ pub type TextureFormat = u32;
 pub type DataType = u32;
 
 // TODO: Consider being generic over `glow::Context` instead
-pub type VertexArray = <GlContext as glow::Context>::VertexArray;
-pub type RawBuffer = <GlContext as glow::Context>::Buffer;
-pub type Shader = <GlContext as glow::Context>::Shader;
-pub type Program = <GlContext as glow::Context>::Program;
-pub type Renderbuffer = <GlContext as glow::Context>::Renderbuffer;
-pub type Texture = <GlContext as glow::Context>::Texture;
-pub type Sampler = <GlContext as glow::Context>::Sampler;
-pub type UniformLocation = <GlContext as glow::Context>::UniformLocation;
+pub type VertexArray = <GlContext as glow::HasContext>::VertexArray;
+pub type RawBuffer = <GlContext as glow::HasContext>::Buffer;
+pub type Shader = <GlContext as glow::HasContext>::Shader;
+pub type Program = <GlContext as glow::HasContext>::Program;
+pub type Renderbuffer = <GlContext as glow::HasContext>::Renderbuffer;
+pub type Texture = <GlContext as glow::HasContext>::Texture;
+pub type Sampler = <GlContext as glow::HasContext>::Sampler;
+pub type UniformLocation = <GlContext as glow::HasContext>::UniformLocation;
 pub type DescriptorSetLayout = Vec<pso::DescriptorSetLayoutBinding>;
 
-pub type RawFrameBuffer = <GlContext as glow::Context>::Framebuffer;
+pub type RawFrameBuffer = <GlContext as glow::HasContext>::Framebuffer;
 
 #[derive(Clone, Debug)]
 pub struct FrameBuffer {
@@ -59,7 +59,7 @@ pub struct BufferView;
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum FenceInner {
     Idle { signaled: bool },
-    Pending(Option<<GlContext as glow::Context>::Fence>),
+    Pending(Option<<GlContext as glow::HasContext>::Fence>),
 }
 
 #[derive(Debug)]

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 use std::{mem, slice};
 
-use glow::Context;
+use glow::HasContext;
 use smallvec::SmallVec;
 
 use crate::{

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)] //TODO: remove
 
 use crate::{GlContainer, Share};
-use glow::Context;
+use glow::HasContext;
 use hal::{pso, ColorSlot};
 use smallvec::SmallVec;
 

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -51,7 +51,7 @@ use crate::{conv, native, Backend as B, Device, GlContainer, PhysicalDevice, Que
 use hal::{adapter::Adapter, format as f, image, window};
 
 use arrayvec::ArrayVec;
-use glow::Context as _;
+use glow::HasContext;
 use glutin;
 
 use std::iter;

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -1,6 +1,6 @@
 use crate::{conv, device::Device, native, Backend as B, GlContainer, PhysicalDevice, QueueFamily};
 use arrayvec::ArrayVec;
-use glow::Context as _;
+use glow::HasContext;
 use hal::{adapter::Adapter, format as f, image, window};
 use std::iter;
 

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -8,7 +8,7 @@ use std::{
     ptr,
 };
 
-use glow::Context as _;
+use glow::HasContext;
 use hal::{adapter::Adapter, format as f, image, window};
 
 use arrayvec::ArrayVec;


### PR DESCRIPTION
Fixes #3023
Fixes #3036 

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code

Summary:
- Remove the coherent requirement and instead flush mapped memory ranges for the quad example.
  - Currently [we purposely do not provide `COHERENT` when buffer storage isn't available](https://github.com/gfx-rs/gfx/blob/da078cd6e4cc49f542310ce7a0ff12ba0a07b13a/src/backend/gl/src/lib.rs#L452) on native OpenGL (I guess we can decide later whether that's necessary or if this can be emulated). Regardless I think we need the flush for WebGL to work here.
  - Another option for the quad example is to fallback when coherent memory isn't available. I didn't do that for now because I thought it would complicate the quad example more.
- Avoid checking `MAX_TEXTURE_BUFFER_SIZE` and `SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT` on WebGL because they're not available. Later we can think of a better way to expose this restriction from glow, maybe providing the limits as `Option`s.
  - I don't think these were actually breaking anything, but they did log warnings in the console.
- The version bumps probably aren't necessary, but I did it anyway while debugging because I hit an issue with an older version of wasm-bindgen.

![Screen Shot 2019-10-10 at 10 18 49 PM](https://user-images.githubusercontent.com/2113872/66617059-f8599200-ebad-11e9-8a34-4b2f5c0f5c71.png)