### PR TITLE
Fix validation errors in quad example

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -121,6 +121,7 @@ fn main() {
             .expect("Failed to create an instance!");
         let surface = instance.create_surface(&window).expect("Failed to create a surface!");
         let adapters = instance.enumerate_adapters();
+        // Return `window` so it is not dropped: dropping it invalidates `surface`.
         (window, instance, adapters, surface)
     };
     #[cfg(feature = "gl")]
@@ -619,7 +620,7 @@ where
             submission_complete_fences.push(
                 device
                     .create_fence(true)
-                    .expect("Could not create semaphore"),
+                    .expect("Could not create fence"),
             );
             cmd_buffers.push(cmd_pools[i].allocate_one(command::Level::Primary));
         }
@@ -927,6 +928,8 @@ where
             }
             self.device
                 .destroy_render_pass(ManuallyDrop::into_inner(ptr::read(&self.render_pass)));
+            self.surface
+              .unconfigure_swapchain(&self.device);
             self.device
                 .free_memory(ManuallyDrop::into_inner(ptr::read(&self.buffer_memory)));
             self.device


### PR DESCRIPTION
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan, gl (wasm)
- [x] `rustfmt` run on changed code

Fix validation errors in quad example

This commit fixes the Vulkan validation errors for the `quad` example:
- The framebuffer is destroyed without waiting for the command buffer to be executed.
- The swapchain is not destroyed.

This commit also adds a small comment explaining why `main` extends the lifetime of `window` beyond its initial scope.
