### PR TITLE
Upgrade to raw-window-handle v0.3

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -37,7 +37,7 @@ gfx-backend-empty = { path = "../src/backend/empty", version = "0.3" }
 env_logger = "0.6"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-winit = "0.20.0-alpha3"
+winit = "0.20.0-alpha4"
 glsl-to-spirv = "0.1.4"
 
 [dependencies.gfx-backend-gl]

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -28,7 +28,7 @@ spirv_cross = { version = "0.16", features = ["hlsl"] }
 parking_lot = "0.9"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 wio = "0.2"
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -27,7 +27,7 @@ log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = { version = "0.16", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -13,4 +13,4 @@ name = "gfx_backend_empty"
 
 [dependencies]
 gfx-hal = { path = "../../hal", version = "0.3" }
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -31,10 +31,11 @@ glow = "0.3.0-alpha3"
 parking_lot = "0.9"
 spirv_cross = { version = "0.16", features = ["glsl"] }
 lazy_static = "1"
-raw-window-handle = { version = "0.1", optional = true }
+raw-window-handle = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.22.0-alpha3", optional = true }
+raw-window-handle = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -40,7 +40,7 @@ spirv_cross = { version = "0.16", features = ["msl"] }
 parking_lot = "0.9"
 storage-map = "0.2"
 lazy_static = "1"
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -28,7 +28,7 @@ shared_library = { version = "0.1.9", optional = true }
 ash = "0.29.0"
 hal = { path = "../../hal", version = "0.3", package = "gfx-hal" }
 smallvec = "0.6"
-raw-window-handle = "0.1"
+raw-window-handle = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -274,14 +274,14 @@ impl Instance {
 
             if !use_current {
                 let layer: *mut Object = msg_send![class, new];
-                msg_send![view, setLayer: layer];
+                let () = msg_send![view, setLayer: layer];
                 let bounds: CGRect = msg_send![view, bounds];
-                msg_send![layer, setBounds: bounds];
+                let () = msg_send![layer, setBounds: bounds];
 
                 let window: *mut Object = msg_send![view, window];
                 if !window.is_null() {
                     let scale_factor: CGFloat = msg_send![window, backingScaleFactor];
-                    msg_send![layer, setContentsScale: scale_factor];
+                    let () = msg_send![layer, setContentsScale: scale_factor];
                 }
             }
         }
@@ -336,10 +336,20 @@ impl Instance {
                 not(target_os = "android"),
                 not(target_os = "macos")
             ))]
-            RawWindowHandle::X11(handle)
+            RawWindowHandle::Xlib(handle)
                 if self.extensions.contains(&khr::XlibSurface::name()) =>
             {
                 Ok(self.create_surface_from_xlib(handle.display as *mut _, handle.window))
+            }
+            #[cfg(all(
+                feature = "xcb",
+                unix,
+                not(target_os = "android"),
+                not(target_os = "macos"),
+                not(target_os = "ios")
+            ))]
+            RawWindowHandle::Xcb(handle) if self.extensions.contains(&khr::XcbSurface::name()) => {
+                Ok(self.create_surface_from_xcb(handle.connection as *mut _, handle.window))
             }
             // #[cfg(target_os = "android")]
             // RawWindowHandle::ANativeWindowHandle(handle) => {


### PR DESCRIPTION
Reopening #3037 against `master`, for merge whenever ready.

Note that compiling examples currently doesn't work because `winit` still imports the old version of `raw-window-handle`; the two versions of the traits are incompatible.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: `vulkan`
- [x] `rustfmt` run on changed code
