### PR TITLE
Add Instance::destroy_surface and implement it for the backends

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -279,9 +279,7 @@ fn get_format_properties(
     format_properties
 }
 
-impl hal::Instance for Instance {
-    type Backend = Backend;
-
+impl hal::Instance<Backend> for Instance {
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Backend>> {
         let mut adapters = Vec::new();
         let mut idx = 0;
@@ -414,6 +412,10 @@ impl hal::Instance for Instance {
         }
 
         adapters
+    }
+
+    unsafe fn destroy_surface(&self, _surface: Surface) {
+        // TODO: Implement Surface cleanup
     }
 }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -764,9 +764,7 @@ impl Instance {
     }
 }
 
-impl hal::Instance for Instance {
-    type Backend = Backend;
-
+impl hal::Instance<Backend> for Instance {
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Backend>> {
         use self::memory::Properties;
 
@@ -1136,6 +1134,10 @@ impl hal::Instance for Instance {
             });
         }
         adapters
+    }
+
+    unsafe fn destroy_surface(&self, _surface: window::Surface) {
+        // TODO: Implement Surface cleanup
     }
 }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -1016,9 +1016,12 @@ impl Instance {
     }
 }
 
-impl hal::Instance for Instance {
-    type Backend = Backend;
+impl hal::Instance<Backend> for Instance {
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Backend>> {
         vec![]
+    }
+
+    unsafe fn destroy_surface(&self, _surface: Surface) {
+        panic!(DO_NOT_USE_MESSAGE)
     }
 }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -717,9 +717,12 @@ impl q::QueueFamily for QueueFamily {
 pub struct DummyInstance;
 
 #[cfg(not(any(target_arch = "wasm32", feature = "glutin", feature = "wgl")))]
-impl hal::Instance for DummyInstance {
-    type Backend = Backend;
+impl hal::Instance<Backend> for DummyInstance {
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Backend>> {
+        unimplemented!()
+    }
+
+    unsafe fn destroy_surface(&self, _surface: Surface) {
         unimplemented!()
     }
 }
@@ -733,13 +736,16 @@ pub enum Instance {
 }
 
 #[cfg(all(feature = "glutin", not(target_arch = "wasm32")))]
-impl hal::Instance for Instance {
-    type Backend = Backend;
+impl hal::Instance<Backend> for Instance {
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Backend>> {
         match self {
             Instance::Headless(instance) => instance.enumerate_adapters(),
             Instance::Surface(instance) => instance.enumerate_adapters(),
         }
+    }
+
+    unsafe fn destroy_surface(&self, _surface: Surface) {
+        // TODO: Implement Surface cleanup
     }
 }
 

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -223,14 +223,17 @@ impl window::Surface<B> for Surface {
     }
 }
 
-impl hal::Instance for Surface {
-    type Backend = B;
+impl hal::Instance<B> for Surface {
     fn enumerate_adapters(&self) -> Vec<Adapter<B>> {
         let adapter = PhysicalDevice::new_adapter(
             (),
             GlContainer::from_fn_proc(|s| self.context.get_proc_address(s) as *const _),
         );
         vec![adapter]
+    }
+
+    unsafe fn destroy_surface(&self, _surface: Surface) {
+        // TODO: Implement Surface cleanup
     }
 }
 
@@ -264,13 +267,16 @@ impl Headless {
     }
 }
 
-impl hal::Instance for Headless {
-    type Backend = B;
+impl hal::Instance<B> for Headless {
     fn enumerate_adapters(&self) -> Vec<Adapter<B>> {
         let adapter = PhysicalDevice::new_adapter(
             (),
             GlContainer::from_fn_proc(|s| self.0.get_proc_address(s) as *const _),
         );
         vec![adapter]
+    }
+
+    unsafe fn destroy_surface(&self, _surface: Surface) {
+        // TODO: Implement Surface cleanup
     }
 }

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -166,10 +166,13 @@ impl window::PresentationSurface<B> for Surface {
     }
 }
 
-impl hal::Instance for Surface {
-    type Backend = B;
+impl hal::Instance<B> for Surface {
     fn enumerate_adapters(&self) -> Vec<Adapter<B>> {
         let adapter = PhysicalDevice::new_adapter((), GlContainer::from_canvas(&self.canvas)); // TODO: Move to `self` like native/window
         vec![adapter]
+    }
+
+    unsafe fn destroy_surface(&self, _surface: Surface) {
+        // TODO: Implement Surface cleanup
     }
 }

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -197,9 +197,7 @@ impl Instance {
     }
 }
 
-impl hal::Instance for Instance {
-    type Backend = Backend;
-
+impl hal::Instance<Backend> for Instance {
     fn enumerate_adapters(&self) -> Vec<Adapter<Backend>> {
         let gl_container = GlContainer::from_fn_proc(|s| unsafe {
             let sym = CString::new(s.as_bytes()).unwrap();
@@ -212,6 +210,10 @@ impl hal::Instance for Instance {
         });
         let adapter = PhysicalDevice::new_adapter(self.ctxt, gl_container);
         vec![adapter]
+    }
+
+    unsafe fn destroy_surface(&self, _surface: Surface) {
+        // TODO: Implement Surface cleanup
     }
 }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -212,9 +212,7 @@ pub struct Instance {
     gfx_managed_metal_layer_delegate: GfxManagedMetalLayerDelegate,
 }
 
-impl hal::Instance for Instance {
-    type Backend = Backend;
-
+impl hal::Instance<Backend> for Instance {
     fn enumerate_adapters(&self) -> Vec<Adapter<Backend>> {
         let devices = metal::Device::all();
         let mut adapters: Vec<Adapter<Backend>> = devices
@@ -246,6 +244,10 @@ impl hal::Instance for Instance {
             )
         });
         adapters
+    }
+
+    unsafe fn destroy_surface(&self, _surface: Surface) {
+        // TODO: Implement Surface cleanup
     }
 }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -468,9 +468,7 @@ impl Instance {
     }
 }
 
-impl hal::Instance for Instance {
-    type Backend = Backend;
-
+impl hal::Instance<Backend> for Instance {
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Backend>> {
         let devices = match unsafe { self.raw.0.enumerate_physical_devices() } {
             Ok(devices) => devices,
@@ -532,6 +530,10 @@ impl hal::Instance for Instance {
                 }
             })
             .collect()
+    }
+
+    unsafe fn destroy_surface(&self, surface: window::Surface) {
+        surface.raw.functor.destroy_surface(surface.raw.handle, None);
     }
 }
 

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -92,16 +92,8 @@ impl fmt::Debug for Surface {
 
 pub struct RawSurface {
     pub(crate) handle: vk::SurfaceKHR,
-    functor: khr::Surface,
+    pub(crate) functor: khr::Surface,
     pub(crate) instance: Arc<RawInstance>,
-}
-
-impl Drop for RawSurface {
-    fn drop(&mut self) {
-        unsafe {
-            self.functor.destroy_surface(self.handle, None);
-        }
-    }
 }
 
 impl Instance {

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -446,11 +446,14 @@ pub enum IndexType {
 ///     println!("Adapter {}: {:?}", idx, adapter.info);
 /// }
 /// ```
-pub trait Instance: Any + Send + Sync {
-    /// Associated backend type of this instance.
-    type Backend: Backend;
+pub trait Instance<B: Backend>: Any + Send + Sync {
     /// Return all available adapters.
-    fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Self::Backend>>;
+    fn enumerate_adapters(&self) -> Vec<adapter::Adapter<B>>;
+    /// Destroy a surface.
+    ///
+    /// The surface shouldn't be destroyed before the attached
+    /// swapchain is destroyed.
+    unsafe fn destroy_surface(&self, surface: B::Surface);
 }
 
 /// Error creating an instance of a backend on the platform that
@@ -474,7 +477,7 @@ impl From<usize> for MemoryTypeId {
 /// or Metal, will implement this trait with its own concrete types.
 #[allow(missing_docs)]
 pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send + Sync {
-    type Instance: Instance;
+    type Instance: Instance<Self>;
     type PhysicalDevice: adapter::PhysicalDevice<Self>;
     type Device: device::Device<Self>;
 

--- a/src/warden/src/bin/bench.rs
+++ b/src/warden/src/bin/bench.rs
@@ -71,7 +71,7 @@ impl Harness {
         Harness { base_path, suite }
     }
 
-    fn run<I: hal::Instance>(&self, instance: I, _disabilities: Disabilities) {
+    fn run<I: hal::Instance<B>, B: hal::Backend>(&self, instance: I, _disabilities: Disabilities) {
         use hal::adapter::PhysicalDevice as _;
 
         for tg in &self.suite {
@@ -94,7 +94,7 @@ impl Harness {
                 }
             }
 
-            let mut scene = warden::gpu::Scene::<I::Backend>::new(
+            let mut scene = warden::gpu::Scene::<B>::new(
                 adapter,
                 &tg.scene,
                 self.base_path.join("data"),

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -79,7 +79,11 @@ impl Harness {
         Harness { base_path, suite }
     }
 
-    fn run<I: hal::Instance>(&self, instance: I, _disabilities: Disabilities) -> usize {
+    fn run<I: hal::Instance<B>, B: hal::Backend>(
+        &self,
+        instance: I,
+        _disabilities: Disabilities,
+    ) -> usize {
         use hal::adapter::PhysicalDevice as _;
 
         let mut results = TestResults {
@@ -108,7 +112,7 @@ impl Harness {
                 }
             }
 
-            let mut scene = warden::gpu::Scene::<I::Backend>::new(
+            let mut scene = warden::gpu::Scene::<B>::new(
                 adapter,
                 &tg.scene,
                 self.base_path.join("data"),


### PR DESCRIPTION
Fixes #2950 
PR checklist:
- [X] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds (doesn't currently succeed on master on macOS)
- [X] tested examples with the following backends:
    - metal on macOS ✅ 
    - vulkan on macOS ✅ 
    - gl on macOS (quad ✅ , colour-uniform 🔴 - but master doesn't work either) 
- [X] `rustfmt` run on changed code

This adds `hal::Instance::destroy_surface(&self, surface: B::Surface)` trait method, and its implementation in the vulkan backend. All other backend implementations are currently no-ops.

Apart from that, there are 2 notable changes:

- The `Drop` impl for `window::RawSurface` in the vulkan backend was removed to prevent double destroy for users of the new `destroy_surface`.
- Trait `hal::Instance` is now generic over `B: Backend` similarly to how other hal traits are, instead of having the `B: Backend` associated type. It might have been just my general rust inexperience, but I was unable to have `destroy_surface` compile without adding a fully qualified type of the surface as the type of the surface parameter. Also, some type annotations were necessary in the usage code. If this is a problem, let me know and I'll try again.

I also updated the quad and colour-uniform examples to use the new API. 