### PR TITLE
Refactor surface capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - all strongly typed HAL wrappers are removed
   - alternative swapchain model built into `Surface`
   - `Instance` trait is assocated by `Backend`, now includes surface creation and destruction
+  - `Surface` capabiltities queried are refactored, `PresentMode` is turned into bitflags
   - `Primitive` enum is refactored and moved to `pso` module
   - `SamplerInfo` struct is refactored and renamed to `SamplerDesc`
   - debug labels for objects

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1352,9 +1352,8 @@ struct SwapchainState<B: Backend> {
 
 impl<B: Backend> SwapchainState<B> {
     unsafe fn new(backend: &mut BackendState<B>, device: Rc<RefCell<DeviceState<B>>>) -> Self {
-        let (caps, formats, _present_modes) = backend
-            .surface
-            .compatibility(&device.borrow().physical_device);
+        let caps = backend.surface.capabilities(&device.borrow().physical_device);
+        let formats = backend.surface.supported_formats(&device.borrow().physical_device);
         println!("formats: {:?}", formats);
         let format = formats.map_or(f::Format::Rgba8Srgb, |formats| {
             formats

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -241,7 +241,7 @@ where
     fn new(
         instance: Option<B::Instance>,
         mut surface: B::Surface,
-        mut adapter: hal::adapter::Adapter<B>
+        adapter: hal::adapter::Adapter<B>
     ) -> Renderer<B> {
         let memory_types = adapter.physical_device.memory_properties().memory_types;
         let limits = adapter.physical_device.limits();
@@ -531,7 +531,8 @@ where
             device.destroy_fence(copy_fence);
         }
 
-        let (caps, formats, _present_modes) = surface.compatibility(&mut adapter.physical_device);
+        let caps = surface.capabilities(&adapter.physical_device);
+        let formats = surface.supported_formats(&adapter.physical_device);
         println!("formats: {:?}", formats);
         let format = formats.map_or(f::Format::Rgba8Srgb, |formats| {
             formats
@@ -765,12 +766,7 @@ where
     }
 
     fn recreate_swapchain(&mut self) {
-        let (caps, formats, _present_modes) = self
-            .surface
-            .compatibility(&mut self.adapter.physical_device);
-        // Verify that previous format still exists so we may reuse it.
-        assert!(formats.iter().any(|fs| fs.contains(&self.format)));
-
+        let caps = self.surface.capabilities(&self.adapter.physical_device);
         let swap_config = window::SwapchainConfig::from_caps(&caps, self.format, self.dimensions);
         println!("{:?}", swap_config);
         let extent = swap_config.extent.to_extent();

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -711,14 +711,7 @@ impl window::Surface<Backend> for Surface {
         true
     }
 
-    fn compatibility(
-        &self,
-        _: &PhysicalDevice,
-    ) -> (
-        window::SurfaceCapabilities,
-        Option<Vec<format::Format>>,
-        Vec<window::PresentMode>,
-    ) {
+    fn capabilities(&self, physical_device: &PhysicalDevice) -> window::SurfaceCapabilities {
         let current_extent = unsafe {
             let mut rect: RECT = mem::zeroed();
             assert_ne!(
@@ -734,7 +727,9 @@ impl window::Surface<Backend> for Surface {
         // TODO: flip swap effects require dx11.1/windows8
         // NOTE: some swap effects affect msaa capabilities..
         // TODO: _DISCARD swap effects can only have one image?
-        let capabilities = window::SurfaceCapabilities {
+        window::SurfaceCapabilities {
+            present_modes: window::PresentMode::FIFO, //TODO
+            composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
             image_count: 1 ..= 16, // TODO:
             current_extent,
             extents: window::Extent2D {
@@ -746,23 +741,18 @@ impl window::Surface<Backend> for Surface {
             },
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
-            composite_alpha: window::CompositeAlpha::OPAQUE, //TODO
-        };
+        }
+    }
 
-        let formats = vec![
+    fn supported_formats(&self, _physical_device: &PhysicalDevice) -> Option<Vec<format::Format>> {
+         Some(vec![
             format::Format::Bgra8Srgb,
             format::Format::Bgra8Unorm,
             format::Format::Rgba8Srgb,
             format::Format::Rgba8Unorm,
             format::Format::A2b10g10r10Unorm,
             format::Format::Rgba16Sfloat,
-        ];
-
-        let present_modes = vec![
-            window::PresentMode::Fifo, //TODO
-        ];
-
-        (capabilities, Some(formats), present_modes)
+        ])
     }
 }
 

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -64,14 +64,7 @@ impl w::Surface<Backend> for Surface {
         }
     }
 
-    fn compatibility(
-        &self,
-        _: &PhysicalDevice,
-    ) -> (
-        w::SurfaceCapabilities,
-        Option<Vec<f::Format>>,
-        Vec<w::PresentMode>,
-    ) {
+    fn capabilities(&self, _physical_device: &PhysicalDevice) -> w::SurfaceCapabilities {
         let current_extent = unsafe {
             let mut rect: RECT = mem::zeroed();
             if GetClientRect(self.wnd_handle as *mut _, &mut rect as *mut RECT) == 0 {
@@ -83,7 +76,9 @@ impl w::Surface<Backend> for Surface {
             })
         };
 
-        let capabilities = w::SurfaceCapabilities {
+        w::SurfaceCapabilities {
+            present_modes: w::PresentMode::FIFO, //TODO
+            composite_alpha_modes: w::CompositeAlphaMode::OPAQUE, //TODO
             image_count: 2 ..= 16, // we currently use a flip effect which supports 2..=16 buffers
             current_extent,
             extents: w::Extent2D {
@@ -95,26 +90,18 @@ impl w::Surface<Backend> for Surface {
             },
             max_image_layers: 1,
             usage: i::Usage::COLOR_ATTACHMENT | i::Usage::TRANSFER_SRC | i::Usage::TRANSFER_DST,
-            composite_alpha: w::CompositeAlpha::OPAQUE, //TODO
-        };
+        }
+    }
 
-        // Sticking to FLIP swap effects for the moment.
-        // We also expose sRGB buffers but they are handled internally as UNORM.
-        // Roughly ordered by popularity..
-        let formats = vec![
+    fn supported_formats(&self, _physical_device: &PhysicalDevice) -> Option<Vec<f::Format>> {
+         Some(vec![
             f::Format::Bgra8Srgb,
             f::Format::Bgra8Unorm,
             f::Format::Rgba8Srgb,
             f::Format::Rgba8Unorm,
             f::Format::A2b10g10r10Unorm,
             f::Format::Rgba16Sfloat,
-        ];
-
-        let present_modes = vec![
-            w::PresentMode::Fifo, //TODO
-        ];
-
-        (capabilities, Some(formats), present_modes)
+        ])
     }
 }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -947,18 +947,15 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
 #[derive(Debug)]
 pub struct Surface;
 impl window::Surface<Backend> for Surface {
-    fn compatibility(
-        &self,
-        _: &PhysicalDevice,
-    ) -> (
-        window::SurfaceCapabilities,
-        Option<Vec<format::Format>>,
-        Vec<window::PresentMode>,
-    ) {
+    fn supports_queue_family(&self, _: &QueueFamily) -> bool {
         panic!(DO_NOT_USE_MESSAGE)
     }
 
-    fn supports_queue_family(&self, _: &QueueFamily) -> bool {
+    fn capabilities(&self, _: &PhysicalDevice) -> window::SurfaceCapabilities {
+        panic!(DO_NOT_USE_MESSAGE)
+    }
+
+    fn supported_formats(&self, _: &PhysicalDevice) -> Option<Vec<format::Format>> {
         panic!(DO_NOT_USE_MESSAGE)
     }
 }

--- a/src/backend/gl/src/window/dummy.rs
+++ b/src/backend/gl/src/window/dummy.rs
@@ -8,18 +8,15 @@ pub struct Surface {
 }
 
 impl window::Surface<Backend> for Surface {
-    fn compatibility(
-        &self,
-        _: &PhysicalDevice,
-    ) -> (
-        window::SurfaceCapabilities,
-        Option<Vec<hal::format::Format>>,
-        Vec<window::PresentMode>,
-    ) {
+    fn supports_queue_family(&self, _: &QueueFamily) -> bool {
         unimplemented!()
     }
 
-    fn supports_queue_family(&self, _: &QueueFamily) -> bool {
+    fn capabilities(&self, _: &PhysicalDevice) -> window::SurfaceCapabilities {
+        unimplemented!()
+    }
+
+    fn supported_formats(&self, _: &PhysicalDevice) -> Option<Vec<hal::format::Format>> {
         unimplemented!()
     }
 }

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -185,15 +185,14 @@ impl window::PresentationSurface<B> for Surface {
 }
 
 impl window::Surface<B> for Surface {
-    fn compatibility(
-        &self,
-        _: &PhysicalDevice,
-    ) -> (
-        window::SurfaceCapabilities,
-        Option<Vec<f::Format>>,
-        Vec<window::PresentMode>,
-    ) {
-        let caps = window::SurfaceCapabilities {
+    fn supports_queue_family(&self, _: &QueueFamily) -> bool {
+        true
+    }
+
+    fn capabilities(&self, _physical_device: &PhysicalDevice) -> window::SurfaceCapabilities {
+        window::SurfaceCapabilities {
+            present_modes: window::PresentMode::FIFO, //TODO
+            composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
             image_count: if self.context.get_pixel_format().double_buffer {
                 2 ..= 2
             } else {
@@ -209,17 +208,11 @@ impl window::Surface<B> for Surface {
             },
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
-            composite_alpha: window::CompositeAlpha::OPAQUE, //TODO
-        };
-        let present_modes = vec![
-            window::PresentMode::Fifo, //TODO
-        ];
-
-        (caps, Some(self.swapchain_formats()), present_modes)
+        }
     }
 
-    fn supports_queue_family(&self, _: &QueueFamily) -> bool {
-        true
+    fn supported_formats(&self, _physical_device: &PhysicalDevice) -> Option<Vec<f::Format>> {
+        Some(self.swapchain_formats())
     }
 }
 
@@ -292,7 +285,7 @@ impl hal::Instance<B> for Headless {
                     info!("Headless context error {:?}", e);
                     hal::UnsupportedBackend
                 })?;
-        };
+        }
         #[cfg(not(target_os = "linux"))]
         {
             context = unimplemented!();

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -64,39 +64,29 @@ impl Surface {
 }
 
 impl window::Surface<B> for Surface {
-    fn compatibility(
-        &self,
-        _: &PhysicalDevice,
-    ) -> (
-        window::SurfaceCapabilities,
-        Option<Vec<f::Format>>,
-        Vec<window::PresentMode>,
-    ) {
+    fn supports_queue_family(&self, _: &QueueFamily) -> bool {
+        true
+    }
+
+    fn capabilities(&self, _physical_device: &PhysicalDevice) -> window::SurfaceCapabilities {
         let extent = hal::window::Extent2D {
             width: self.canvas.width(),
             height: self.canvas.height(),
         };
 
-        let caps = hal::window::SurfaceCapabilities {
+        window::SurfaceCapabilities {
+            present_modes: window::PresentMode::FIFO, //TODO
+            composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
             image_count: 1 ..= 1,
             current_extent: Some(extent),
-            extents: extent ..= hal::window::Extent2D {
-                width: extent.width,
-                height: extent.height,
-            },
+            extents: extent ..= extent,
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
-            composite_alpha: window::CompositeAlpha::OPAQUE, //TODO
-        };
-        let present_modes = vec![
-            window::PresentMode::Fifo, //TODO
-        ];
-
-        (caps, Some(self.swapchain_formats()), present_modes)
+        }
     }
 
-    fn supports_queue_family(&self, _: &QueueFamily) -> bool {
-        true
+    fn supported_formats(&self, _physical_device: &PhysicalDevice) -> Option<Vec<f::Format>> {
+        Some(self.swapchain_formats())
     }
 }
 

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -229,14 +229,11 @@ unsafe impl Send for Surface {}
 unsafe impl Sync for Surface {}
 
 impl window::Surface<Backend> for Surface {
-    fn compatibility(
-        &self,
-        physical_device: &PhysicalDevice,
-    ) -> (
-        window::SurfaceCapabilities,
-        Option<Vec<f::Format>>,
-        Vec<window::PresentMode>,
-    ) {
+    fn supports_queue_family(&self, _queue_family: &QueueFamily) -> bool {
+        true
+    }
+
+    fn capabilities(&self, _physical_device: &PhysicalDevice) -> window::SurfaceCapabilities {
         let extent = unsafe {
             let mut rect: RECT = mem::zeroed();
             GetClientRect(self.hwnd, &mut rect);
@@ -246,27 +243,19 @@ impl window::Surface<Backend> for Surface {
             }
         };
 
-        let caps = window::SurfaceCapabilities {
+        window::SurfaceCapabilities {
+            present_modes: window::PresentMode::FIFO, //TODO
+            composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
             image_count: 2 ..= 2,
             current_extent: Some(extent),
             extents: extent ..= extent,
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
-            composite_alpha: window::CompositeAlpha::OPAQUE, //TODO
-        };
-        let present_modes = vec![
-            window::PresentMode::Fifo, //TODO
-        ];
-
-        (
-            caps,
-            Some(vec![f::Format::Rgba8Srgb, f::Format::Bgra8Srgb]),
-            present_modes,
-        )
+        }
     }
 
-    fn supports_queue_family(&self, _queue_family: &QueueFamily) -> bool {
-        true
+    fn supported_formats(&self, _physical_device: &PhysicalDevice) -> Option<Vec<f::Format>> {
+        Some(vec![f::Format::Rgba8Srgb, f::Format::Bgra8Srgb])
     }
 }
 

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -9,7 +9,7 @@ use hal::{
     pso,
     query,
     range::RangeArg,
-    window::{CompositeAlpha, PresentMode},
+    window::{CompositeAlphaMode, PresentMode},
     Features,
     IndexType,
 };
@@ -544,19 +544,40 @@ pub fn map_view_capabilities(caps: image::ViewCapabilities) -> vk::ImageCreateFl
 }
 
 pub fn map_present_mode(mode: PresentMode) -> vk::PresentModeKHR {
-    vk::PresentModeKHR::from_raw(mode as i32)
+    if mode == PresentMode::IMMEDIATE {
+        vk::PresentModeKHR::IMMEDIATE
+    } else if mode == PresentMode::MAILBOX {
+        vk::PresentModeKHR::MAILBOX
+    } else if mode == PresentMode::FIFO {
+        vk::PresentModeKHR::FIFO
+    } else if mode == PresentMode::RELAXED {
+        vk::PresentModeKHR::FIFO_RELAXED
+    } else {
+        panic!("Unexpected present mode {:?}", mode)
+    }
 }
 
 pub fn map_vk_present_mode(mode: vk::PresentModeKHR) -> PresentMode {
-    unsafe { mem::transmute(mode) }
+    if mode == vk::PresentModeKHR::IMMEDIATE {
+        PresentMode::IMMEDIATE
+    } else if mode == vk::PresentModeKHR::MAILBOX {
+        PresentMode::MAILBOX
+    } else if mode == vk::PresentModeKHR::FIFO {
+        PresentMode::FIFO
+    } else if mode == vk::PresentModeKHR::FIFO_RELAXED {
+        PresentMode::RELAXED
+    } else {
+        warn!("Unrecognized present mode {:?}", mode);
+        PresentMode::IMMEDIATE
+    }
 }
 
-pub fn map_composite_alpha(composite_alpha: CompositeAlpha) -> vk::CompositeAlphaFlagsKHR {
-    vk::CompositeAlphaFlagsKHR::from_raw(composite_alpha.bits())
+pub fn map_composite_alpha_mode(composite_alpha_mode: CompositeAlphaMode) -> vk::CompositeAlphaFlagsKHR {
+    vk::CompositeAlphaFlagsKHR::from_raw(composite_alpha_mode.bits())
 }
 
-pub fn map_vk_composite_alpha(composite_alpha: vk::CompositeAlphaFlagsKHR) -> CompositeAlpha {
-    CompositeAlpha::from_bits_truncate(composite_alpha.as_raw())
+pub fn map_vk_composite_alpha(composite_alpha: vk::CompositeAlphaFlagsKHR) -> CompositeAlphaMode {
+    CompositeAlphaMode::from_bits_truncate(composite_alpha.as_raw())
 }
 
 pub fn map_descriptor_pool_create_flags(

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -2082,7 +2082,7 @@ impl d::Device<B> for Device {
             queue_family_index_count: 0,
             p_queue_family_indices: ptr::null(),
             pre_transform: vk::SurfaceTransformFlagsKHR::IDENTITY,
-            composite_alpha: conv::map_composite_alpha(config.composite_alpha),
+            composite_alpha: conv::map_composite_alpha_mode(config.composite_alpha_mode),
             present_mode: conv::map_present_mode(config.present_mode),
             clipped: 1,
             old_swapchain,


### PR DESCRIPTION
Fixes #3019
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

I tried to make present mode consistent with composite alpha modes, both in names and types.