### PR TITLE
Update DirectX backends to Rust2018

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["The Gfx-rs Developers"]
 readme = "README.md"
 documentation = "https://docs.rs/gfx-backend-dx11"
 workspace = "../../.."
+edition = "2018"
 
 [features]
 default = []
@@ -18,7 +19,7 @@ default = []
 name = "gfx_backend_dx11"
 
 [dependencies]
-gfx-hal = { path = "../../hal", version = "0.4" }
+hal = { path = "../../hal", version = "0.4", package = "gfx-hal" }
 auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"

--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -1,36 +1,40 @@
-use hal::format::Format;
-use hal::image::{Anisotropic, Filter, WrapMode};
-use hal::pso::{
-    BlendDesc,
-    BlendOp,
-    ColorBlendDesc,
-    Comparison,
-    DepthBias,
-    DepthStencilDesc,
-    Face,
-    Factor,
-    FrontFace,
-    InputAssemblerDesc,
-    PolygonMode,
-    Rasterizer,
-    Rect,
-    Sided,
-    Stage,
-    State,
-    StencilFace,
-    StencilOp,
-    StencilValue,
-    Viewport,
+use hal::{
+    format::Format,
+    image::{Anisotropic, Filter, WrapMode},
+    pso::{
+        BlendDesc,
+        BlendOp,
+        ColorBlendDesc,
+        Comparison,
+        DepthBias,
+        DepthStencilDesc,
+        Face,
+        Factor,
+        FrontFace,
+        InputAssemblerDesc,
+        PolygonMode,
+        Rasterizer,
+        Rect,
+        Sided,
+        Stage,
+        State,
+        StencilFace,
+        StencilOp,
+        StencilValue,
+        Viewport,
+    },
+    IndexType,
 };
-use hal::IndexType;
 
 use spirv_cross::spirv;
 
-use winapi::shared::dxgiformat::*;
-use winapi::shared::minwindef::{FALSE, INT, TRUE};
-
-use winapi::um::d3d11::*;
-use winapi::um::d3dcommon::*;
+use winapi::{
+    shared::{
+        dxgiformat::*,
+        minwindef::{FALSE, INT, TRUE},
+    },
+    um::{d3d11::*, d3dcommon::*},
+};
 
 use std::mem;
 

--- a/src/backend/dx11/src/debug.rs
+++ b/src/backend/dx11/src/debug.rs
@@ -1,17 +1,19 @@
 use winapi::um::d3d11;
 
-use wio::com::ComPtr;
-use wio::wide::ToWide;
+use wio::{com::ComPtr, wide::ToWide};
 
-use std::ffi::OsStr;
-use std::{env, fmt};
+use std::{env, ffi::OsStr, fmt};
 
 // TODO: replace with new winapi version when available
 #[allow(bad_style, unused)]
 mod temp {
-    use winapi::shared::minwindef::{BOOL, INT};
-    use winapi::um::unknwnbase::{IUnknown, IUnknownVtbl};
-    use winapi::um::winnt::LPCWSTR;
+    use winapi::{
+        shared::minwindef::{BOOL, INT},
+        um::{
+            unknwnbase::{IUnknown, IUnknownVtbl},
+            winnt::LPCWSTR,
+        },
+    };
 
     RIDL! {#[uuid(0xb2daad8b, 0x03d4, 0x4dbf, 0x95, 0xeb, 0x32, 0xab, 0x4b, 0x63, 0xd0, 0xab)]
     interface ID3DUserDefinedAnnotation(ID3DUserDefinedAnnotationVtbl):

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1,32 +1,43 @@
-use hal::adapter::MemoryProperties;
-use hal::pso::VertexInputRate;
-use hal::queue::QueueFamilyId;
-use hal::range::RangeArg;
-use hal::{buffer, device, format, image, memory, pass, pool, pso, query, window};
-
-use winapi::shared::dxgi::{
-    IDXGIFactory,
-    IDXGISwapChain,
-    DXGI_SWAP_CHAIN_DESC,
-    DXGI_SWAP_EFFECT_DISCARD,
+use hal::{
+    adapter::MemoryProperties,
+    buffer,
+    device,
+    format,
+    image,
+    memory,
+    pass,
+    pool,
+    pso,
+    pso::VertexInputRate,
+    query,
+    queue::QueueFamilyId,
+    range::RangeArg,
+    window,
 };
-use winapi::shared::minwindef::TRUE;
-use winapi::shared::windef::HWND;
-use winapi::shared::{dxgiformat, dxgitype, winerror};
-use winapi::um::{d3d11, d3d11sdklayers, d3dcommon};
-use winapi::Interface as _;
+
+use winapi::{
+    shared::{
+        dxgi::{IDXGIFactory, IDXGISwapChain, DXGI_SWAP_CHAIN_DESC, DXGI_SWAP_EFFECT_DISCARD},
+        dxgiformat,
+        dxgitype,
+        minwindef::TRUE,
+        windef::HWND,
+        winerror,
+    },
+    um::{d3d11, d3d11sdklayers, d3dcommon},
+    Interface as _,
+};
 
 use wio::com::ComPtr;
 
-use std::borrow::Borrow;
-use std::cell::RefCell;
-use std::ops::Range;
-use std::sync::Arc;
-use std::{fmt, mem, ptr};
+use std::{borrow::Borrow, cell::RefCell, fmt, mem, ops::Range, ptr, sync::Arc};
 
 use parking_lot::{Condvar, Mutex};
 
-use {
+use crate::{
+    conv,
+    internal,
+    shader,
     Backend,
     Buffer,
     BufferView,
@@ -61,8 +72,6 @@ use {
     Swapchain,
     ViewInfo,
 };
-
-use {conv, internal, shader};
 
 struct InputLayout {
     raw: ComPtr<d3d11::ID3D11InputLayout>,

--- a/src/backend/dx11/src/dxgi.rs
+++ b/src/backend/dx11/src/dxgi.rs
@@ -1,16 +1,14 @@
 use hal::adapter::{AdapterInfo, DeviceType};
 
-use winapi::shared::guiddef::GUID;
-use winapi::shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_5, winerror};
-use winapi::um::unknwnbase::IUnknown;
-use winapi::Interface;
+use winapi::{
+    shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_5, guiddef::GUID, winerror},
+    um::unknwnbase::IUnknown,
+    Interface,
+};
 
 use wio::com::ComPtr;
 
-use std::ffi::OsString;
-use std::mem;
-use std::os::windows::ffi::OsStringExt;
-use std::ptr;
+use std::{ffi::OsString, mem, os::windows::ffi::OsStringExt, ptr};
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum DxgiVersion {

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -1,23 +1,27 @@
-use hal::pso::{Stage, Viewport};
-use hal::{command, image, pso};
+use hal::{
+    command,
+    image,
+    pso,
+    pso::{Stage, Viewport},
+};
 
-use winapi::shared::dxgiformat;
-use winapi::shared::minwindef::{FALSE, TRUE};
-use winapi::shared::winerror;
-use winapi::um::d3d11;
-use winapi::um::d3dcommon;
+use winapi::{
+    shared::{
+        dxgiformat,
+        minwindef::{FALSE, TRUE},
+        winerror,
+    },
+    um::{d3d11, d3dcommon},
+};
 
 use wio::com::ComPtr;
 
-use std::borrow::Borrow;
-use std::{mem, ptr};
+use std::{borrow::Borrow, mem, ptr};
 
 use smallvec::SmallVec;
 use spirv_cross;
 
-use {conv, shader};
-
-use {Buffer, Image, RenderPassCache};
+use crate::{conv, shader, Buffer, Image, RenderPassCache};
 
 #[repr(C)]
 struct BufferCopy {
@@ -1072,7 +1076,7 @@ impl Internal {
     }
 
     fn find_blit_shader(&self, src: &Image) -> Option<*mut d3d11::ID3D11PixelShader> {
-        use format::ChannelType as Ct;
+        use crate::format::ChannelType as Ct;
 
         match src.format.base_format().1 {
             Ct::Uint => Some(self.ps_blit_2d_uint.as_raw()),

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1,18 +1,11 @@
 //#[deny(missing_docs)]
 
-extern crate gfx_hal as hal;
-extern crate auxil;
-extern crate range_alloc;
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
 extern crate log;
-extern crate parking_lot;
-extern crate smallvec;
-extern crate spirv_cross;
 #[macro_use]
 extern crate winapi;
-extern crate wio;
 
 use hal::{
     adapter,
@@ -38,27 +31,23 @@ use hal::{
 
 use range_alloc::RangeAllocator;
 
-use winapi::shared::dxgi::{IDXGIAdapter, IDXGIFactory, IDXGISwapChain};
-use winapi::shared::minwindef::{FALSE, UINT};
-use winapi::shared::windef::{HWND, RECT};
-use winapi::shared::{dxgiformat, winerror};
-use winapi::um::winuser::GetClientRect;
-use winapi::um::{d3d11, d3dcommon};
-use winapi::Interface as _;
+use winapi::{
+    shared::{
+        dxgi::{IDXGIAdapter, IDXGIFactory, IDXGISwapChain},
+        dxgiformat,
+        minwindef::{FALSE, UINT},
+        windef::{HWND, RECT},
+        winerror,
+    },
+    um::{d3d11, d3dcommon, winuser::GetClientRect},
+    Interface as _,
+};
 
 use wio::com::ComPtr;
 
 use parking_lot::{Condvar, Mutex};
 
-use std::borrow::Borrow;
-use std::cell::RefCell;
-use std::fmt;
-use std::mem;
-use std::ops::Range;
-use std::ptr;
-use std::sync::Arc;
-
-use std::os::raw::c_void;
+use std::{borrow::Borrow, cell::RefCell, fmt, mem, ops::Range, os::raw::c_void, ptr, sync::Arc};
 
 macro_rules! debug_scope {
     ($context:expr, $($arg:tt)+) => ({
@@ -730,7 +719,7 @@ impl window::Surface<Backend> for Surface {
         window::SurfaceCapabilities {
             present_modes: window::PresentMode::FIFO, //TODO
             composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
-            image_count: 1 ..= 16, // TODO:
+            image_count: 1 ..= 16,                    // TODO:
             current_extent,
             extents: window::Extent2D {
                 width: 16,
@@ -745,7 +734,7 @@ impl window::Surface<Backend> for Surface {
     }
 
     fn supported_formats(&self, _physical_device: &PhysicalDevice) -> Option<Vec<format::Format>> {
-         Some(vec![
+        Some(vec![
             format::Format::Bgra8Srgb,
             format::Format::Bgra8Unorm,
             format::Format::Rgba8Srgb,
@@ -2635,7 +2624,7 @@ pub enum ShaderModule {
 }
 
 // TODO: temporary
-impl ::fmt::Debug for ShaderModule {
+impl fmt::Debug for ShaderModule {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "{}", "ShaderModule { ... }")
     }

--- a/src/backend/dx11/src/shader.rs
+++ b/src/backend/dx11/src/shader.rs
@@ -2,14 +2,16 @@ use std::{ffi, ptr, slice};
 
 use spirv_cross::{hlsl, spirv, ErrorCode as SpirvErrorCode};
 
-use winapi::shared::winerror;
-use winapi::um::{d3dcommon, d3dcompiler};
+use winapi::{
+    shared::winerror,
+    um::{d3dcommon, d3dcompiler},
+};
 use wio::com::ComPtr;
 
 use auxil::spirv_cross_specialize_ast;
 use hal::{device, pso};
 
-use {conv, Backend, PipelineLayout};
+use crate::{conv, Backend, PipelineLayout};
 
 /// Emit error during shader module creation. Used if we don't expect an error
 /// but might panic due to an exception in SPIRV-Cross.

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["The Gfx-rs Developers"]
 readme = "README.md"
 documentation = "https://docs.rs/gfx-backend-dx12"
 workspace = "../../.."
+edition = "2018"
 
 [features]
 default = []
@@ -19,10 +20,10 @@ name = "gfx_backend_dx12"
 
 [dependencies]
 auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
-gfx-hal = { path = "../../hal", version = "0.4" }
+hal = { path = "../../hal", version = "0.4", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
-d3d12 = "0.2.2"
+native = { version = "0.2.2", package = "d3d12" }
 log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = { version = "0.16", features = ["hlsl"] }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1,8 +1,16 @@
 use auxil::FastHashMap;
-use hal::format::Aspects;
-use hal::range::RangeArg;
-use hal::{buffer, command as com, format, image, memory, pass, pool, pso, query};
 use hal::{
+    buffer,
+    command as com,
+    format,
+    format::Aspects,
+    image,
+    memory,
+    pass,
+    pool,
+    pso,
+    query,
+    range::RangeArg,
     DrawCount,
     IndexCount,
     IndexType,
@@ -12,27 +20,29 @@ use hal::{
     WorkGroupCount,
 };
 
-use std::borrow::Borrow;
-use std::ops::Range;
-use std::sync::Arc;
-use std::{cmp, fmt, iter, mem, ptr};
+use std::{borrow::Borrow, cmp, fmt, iter, mem, ops::Range, ptr, sync::Arc};
 
-use winapi::shared::minwindef::{FALSE, TRUE, UINT};
-use winapi::shared::{dxgiformat, winerror};
-use winapi::um::{d3d12, d3dcommon};
-use winapi::Interface;
-
-use native::{self, descriptor};
+use winapi::{
+    shared::{
+        dxgiformat,
+        minwindef::{FALSE, TRUE, UINT},
+        winerror,
+    },
+    um::{d3d12, d3dcommon},
+    Interface,
+};
 
 use device::{ViewInfo, IDENTITY_MAPPING};
-use root_constants::RootConstant;
+use native::descriptor;
 use smallvec::SmallVec;
-use {
+
+use crate::{
     conv,
     descriptors_cpu,
     device,
     internal,
     resource as r,
+    root_constants::RootConstant,
     validate_line_width,
     Backend,
     Device,
@@ -294,8 +304,10 @@ impl PipelineCache {
                 let dynamic_descriptors = unsafe { &*binding.dynamic_descriptors.get() };
                 for descriptor in dynamic_descriptors {
                     let root_offset = element.descriptors[descriptor_id].offset;
-                    self.user_data
-                        .set_descriptor_cbv(root_offset, descriptor.gpu_buffer_location + offsets.next().unwrap());
+                    self.user_data.set_descriptor_cbv(
+                        root_offset,
+                        descriptor.gpu_buffer_location + offsets.next().unwrap(),
+                    );
                     descriptor_id += 1;
                 }
             }
@@ -815,18 +827,25 @@ impl CommandBuffer {
             if user_data.is_index_dirty(table_index) {
                 match user_data.data[table_index] {
                     RootElement::TableSrvCbvUav(offset) => {
-                        let gpu = d3d12::D3D12_GPU_DESCRIPTOR_HANDLE { ptr: pipeline.srv_cbv_uav_start + offset as u64 };
+                        let gpu = d3d12::D3D12_GPU_DESCRIPTOR_HANDLE {
+                            ptr: pipeline.srv_cbv_uav_start + offset as u64,
+                        };
                         table_update(i as _, gpu);
                         user_data.clear_dirty(table_index);
                     }
                     RootElement::TableSampler(offset) => {
-                        let gpu = d3d12::D3D12_GPU_DESCRIPTOR_HANDLE { ptr: pipeline.sampler_start + offset as u64 };
+                        let gpu = d3d12::D3D12_GPU_DESCRIPTOR_HANDLE {
+                            ptr: pipeline.sampler_start + offset as u64,
+                        };
                         table_update(i as _, gpu);
                         user_data.clear_dirty(table_index);
                     }
                     RootElement::DescriptorCbv { buffer } => {
                         debug_assert!(user_data.is_index_dirty(table_index + 1));
-                        debug_assert_eq!(user_data.data[table_index + 1], RootElement::DescriptorPlaceholder);
+                        debug_assert_eq!(
+                            user_data.data[table_index + 1],
+                            RootElement::DescriptorPlaceholder
+                        );
 
                         descriptor_cbv_update(i as _, buffer);
 
@@ -1109,13 +1128,12 @@ impl CommandBuffer {
         range: &image::SubresourceRange,
         list: &mut impl Extend<d3d12::D3D12_RESOURCE_BARRIER>,
     ) {
-        let mut bar =
-            Self::transition_barrier(d3d12::D3D12_RESOURCE_TRANSITION_BARRIER {
-                pResource: target.resource.as_mut_ptr(),
-                Subresource: d3d12::D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
-                StateBefore: states.start,
-                StateAfter: states.end,
-            });
+        let mut bar = Self::transition_barrier(d3d12::D3D12_RESOURCE_TRANSITION_BARRIER {
+            pResource: target.resource.as_mut_ptr(),
+            Subresource: d3d12::D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+            StateBefore: states.start,
+            StateAfter: states.end,
+        });
 
         if *range == target.to_subresource_range(range.aspects) {
             // Only one barrier if it affects the whole image.
@@ -1327,7 +1345,12 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                     }
 
                     let target = target.expect_bound();
-                    Self::fill_texture_barries(target, state_src .. state_dst, range, &mut raw_barriers);
+                    Self::fill_texture_barries(
+                        target,
+                        state_src .. state_dst,
+                        range,
+                        &mut raw_barriers,
+                    );
                 }
             }
         }

--- a/src/backend/dx12/src/descriptors_cpu.rs
+++ b/src/backend/dx12/src/descriptors_cpu.rs
@@ -1,7 +1,5 @@
-use native;
 use native::descriptor::{CpuDescriptor, HeapFlags, HeapType};
-use std::fmt;
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt};
 
 // Linear stack allocator for CPU descriptor heaps.
 pub struct HeapLinear {

--- a/src/backend/dx12/src/internal.rs
+++ b/src/backend/dx12/src/internal.rs
@@ -1,15 +1,18 @@
 use auxil::FastHashMap;
-use std::ffi::CStr;
-use std::sync::Mutex;
-use std::{mem, ptr};
+use std::{ffi::CStr, mem, ptr, sync::Mutex};
 
-use d3d12;
-use winapi::shared::minwindef::{FALSE, TRUE};
-use winapi::shared::{dxgiformat, dxgitype, winerror};
-use winapi::um::d3d12::*;
-use winapi::Interface;
+use winapi::{
+    shared::{
+        dxgiformat,
+        dxgitype,
+        minwindef::{FALSE, TRUE},
+        winerror,
+    },
+    um::d3d12::{self, *},
+    Interface,
+};
 
-use native::{self, descriptor, pso};
+use native::{descriptor, pso};
 
 #[derive(Clone, Debug)]
 pub struct BlitPipe {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1,14 +1,7 @@
-extern crate gfx_hal as hal;
-extern crate auxil;
-extern crate range_alloc;
 #[macro_use]
 extern crate bitflags;
-extern crate d3d12 as native;
 #[macro_use]
 extern crate log;
-extern crate smallvec;
-extern crate spirv_cross;
-extern crate winapi;
 
 mod command;
 mod conv;
@@ -20,21 +13,25 @@ mod resource;
 mod root_constants;
 mod window;
 
-use hal::pso::PipelineStage;
-use hal::{adapter, format as f, image, memory, queue as q, Features, Limits};
+use hal::{adapter, format as f, image, memory, pso::PipelineStage, queue as q, Features, Limits};
 
-use winapi::shared::minwindef::TRUE;
-use winapi::shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_6, winerror};
-use winapi::um::{d3d12, d3d12sdklayers, dxgidebug, handleapi, synchapi, winbase};
-use winapi::Interface;
+use winapi::{
+    shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_6, minwindef::TRUE, winerror},
+    um::{d3d12, d3d12sdklayers, dxgidebug, handleapi, synchapi, winbase},
+    Interface,
+};
 
-use std::borrow::Borrow;
-use std::ffi::OsString;
-use std::os::windows::ffi::OsStringExt;
-use std::sync::{Arc, Mutex};
-use std::{fmt, mem, ptr};
+use std::{
+    borrow::Borrow,
+    ffi::OsString,
+    fmt,
+    mem,
+    os::windows::ffi::OsStringExt,
+    ptr,
+    sync::{Arc, Mutex},
+};
 
-use descriptors_cpu::DescriptorCpuPool;
+use self::descriptors_cpu::DescriptorCpuPool;
 use native::descriptor;
 
 #[derive(Debug)]

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -1,12 +1,10 @@
-use std::sync::Arc;
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use winapi::shared::winerror::SUCCEEDED;
 
-use command::CommandBuffer;
+use crate::{command::CommandBuffer, Backend, Shared};
 use hal::{command, pool};
 use native::command_list::CmdListType;
-use {native, Backend, Shared};
 
 #[derive(Debug)]
 pub enum CommandPoolAllocator {

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -1,6 +1,7 @@
-use winapi::shared::dxgiformat::DXGI_FORMAT;
-use winapi::shared::minwindef::UINT;
-use winapi::um::d3d12;
+use winapi::{
+    shared::{dxgiformat::DXGI_FORMAT, minwindef::UINT},
+    um::d3d12,
+};
 
 use hal::{buffer, format, image, memory, pass, pso};
 use native::{self, query};
@@ -8,10 +9,7 @@ use range_alloc::RangeAllocator;
 
 use crate::{root_constants::RootConstant, Backend, MAX_VERTEX_BUFFERS};
 
-use std::collections::BTreeMap;
-use std::fmt;
-use std::ops::Range;
-use std::cell::UnsafeCell;
+use std::{cell::UnsafeCell, collections::BTreeMap, fmt, ops::Range};
 
 // ShaderModule is either a precompiled if the source comes from HLSL or
 // the SPIR-V module doesn't contain specialization constants or push constants
@@ -683,25 +681,26 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
                     None
                 };
 
-                let sampler_range = if content.intersects(DescriptorContent::SAMPLER) && !content.is_dynamic() {
-                    let count = binding.count as u64;
-                    debug!("\tsampler handles: {}", count);
-                    let handle = self
-                        .heap_sampler
-                        .alloc_handles(count)
-                        .ok_or(pso::AllocationError::OutOfPoolMemory)?;
-                    if first_gpu_sampler.is_none() {
-                        first_gpu_sampler = Some(handle.gpu);
-                    }
-                    Some(DescriptorRange {
-                        handle,
-                        ty: binding.ty,
-                        count,
-                        handle_size: self.heap_sampler.handle_size,
-                    })
-                } else {
-                    None
-                };
+                let sampler_range =
+                    if content.intersects(DescriptorContent::SAMPLER) && !content.is_dynamic() {
+                        let count = binding.count as u64;
+                        debug!("\tsampler handles: {}", count);
+                        let handle = self
+                            .heap_sampler
+                            .alloc_handles(count)
+                            .ok_or(pso::AllocationError::OutOfPoolMemory)?;
+                        if first_gpu_sampler.is_none() {
+                            first_gpu_sampler = Some(handle.gpu);
+                        }
+                        Some(DescriptorRange {
+                            handle,
+                            ty: binding.ty,
+                            count,
+                            handle_size: self.heap_sampler.handle_size,
+                        })
+                    } else {
+                        None
+                    };
 
                 (view_range, sampler_range, Vec::new())
             };

--- a/src/backend/dx12/src/root_constants.rs
+++ b/src/backend/dx12/src/root_constants.rs
@@ -6,9 +6,7 @@
 //! ranges. The disjunct ranges can be then converted into root signature entries.
 
 use hal::pso;
-use std::borrow::Borrow;
-use std::cmp::Ordering;
-use std::ops::Range;
+use std::{borrow::Borrow, cmp::Ordering, ops::Range};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct RootConstant {

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -1,17 +1,16 @@
-use std::collections::VecDeque;
-use std::{fmt, mem};
+use std::{collections::VecDeque, fmt, mem, os::raw::c_void};
 
-use winapi::shared::{
-    dxgi1_4,
-    windef::{HWND, RECT},
-    winerror,
+use winapi::{
+    shared::{
+        dxgi1_4,
+        windef::{HWND, RECT},
+        winerror,
+    },
+    um::winuser::GetClientRect,
 };
-use winapi::um::winuser::GetClientRect;
 
+use crate::{conv, resource as r, Backend, Device, Instance, PhysicalDevice, QueueFamily};
 use hal::{self, device::Device as _, format as f, image as i, window as w};
-use {conv, native, resource as r, Backend, Device, Instance, PhysicalDevice, QueueFamily};
-
-use std::os::raw::c_void;
 
 impl Instance {
     pub fn create_surface_from_hwnd(&self, hwnd: *mut c_void) -> Surface {
@@ -77,7 +76,7 @@ impl w::Surface<Backend> for Surface {
         };
 
         w::SurfaceCapabilities {
-            present_modes: w::PresentMode::FIFO, //TODO
+            present_modes: w::PresentMode::FIFO,                  //TODO
             composite_alpha_modes: w::CompositeAlphaMode::OPAQUE, //TODO
             image_count: 2 ..= 16, // we currently use a flip effect which supports 2..=16 buffers
             current_extent,
@@ -94,7 +93,7 @@ impl w::Surface<Backend> for Surface {
     }
 
     fn supported_formats(&self, _physical_device: &PhysicalDevice) -> Option<Vec<f::Format>> {
-         Some(vec![
+        Some(vec![
             f::Format::Bgra8Srgb,
             f::Format::Bgra8Unorm,
             f::Format::Rgba8Srgb,


### PR DESCRIPTION
Fixes #3052 

I also ran `rustfmt` over the files(by accident cause my setup runs it on file save) but figured this would be alright to do for this change anyways, if that's not the case I wouldn't mind reverting that.

PR checklist:
- [ ] ~~`make` succeeds (on *nix)~~
- [ ] ~~`make reftests` succeeds~~
- [x] tested examples with the following backends: dx11, dx12
- [x] `rustfmt` run on changed code
