### PR TITLE
Make spirv_cross an optional dependency of gfx-auxil

### DIFF
--- a/src/auxil/auxil/Cargo.toml
+++ b/src/auxil/auxil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-auxil"
-version = "0.1.0"
+version = "0.2.0"
 description = "Implementation details shared between gfx-rs backends"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 hal = { path = "../../hal", version = "0.4", package = "gfx-hal" }
 fxhash = "0.2.1"
-spirv_cross = "0.16"
+spirv_cross = { version = "0.16", optional = true }
 
 [lib]
 name = "gfx_auxil"

--- a/src/auxil/auxil/src/lib.rs
+++ b/src/auxil/auxil/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "spirv_cross")]
 use {
     hal::{device::ShaderError, pso},
     spirv_cross::spirv,
@@ -6,6 +7,7 @@ use {
 /// Fast hash map used internally.
 pub type FastHashMap<K, V> = std::collections::HashMap<K, V, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
 
+#[cfg(feature = "spirv_cross")]
 pub fn spirv_cross_specialize_ast<T>(
     ast: &mut spirv::Ast<T>,
     specialization: &pso::Specialization,

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -19,8 +19,8 @@ default = []
 name = "gfx_backend_dx11"
 
 [dependencies]
+auxil = { path = "../../auxil/auxil", version = "0.2", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.4", package = "gfx-hal" }
-auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
 log = { version = "0.4" }

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 name = "gfx_backend_dx12"
 
 [dependencies]
-auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
+auxil = { path = "../../auxil/auxil", version = "0.2", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.4", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -25,7 +25,7 @@ arrayvec = "0.5"
 bitflags = "1"
 log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.4" }
-auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
+auxil = { path = "../../auxil/auxil", version = "0.2", package = "gfx-auxil", features = ["spirv_cross"] }
 smallvec = "0.6"
 glow = "0.3.0-alpha3"
 parking_lot = "0.9"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -21,8 +21,8 @@ signpost = []
 name = "gfx_backend_metal"
 
 [dependencies]
+auxil = { path = "../../auxil/auxil", version = "0.2", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.4", package = "gfx-hal" }
-auxil = { path = "../../auxil/auxil", version = "0.1", package = "gfx-auxil" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 arrayvec = "0.5"
 bitflags = "1.0"


### PR DESCRIPTION
Fixes #3063
This is a breaking revision for gfx-auxil, but we can release patched backends for 0.4 if/when we want.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
