### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -531,12 +531,12 @@ impl PhysicalDevice {
         let inferred_device_type = if vendor_lower.contains("qualcomm")
             || vendor_lower.contains("intel")
             || strings_that_imply_integrated
-                .into_iter()
+                .iter()
                 .any(|&s| renderer_lower.contains(s))
         {
             hal::adapter::DeviceType::IntegratedGpu
         } else if strings_that_imply_cpu
-            .into_iter()
+            .iter()
             .any(|&s| renderer_lower.contains(s))
         {
             hal::adapter::DeviceType::Cpu


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
