### PR TITLE
[dx12] update d3d12 to 0.3 and use explicit linking

### DIFF
--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -23,7 +23,7 @@ auxil = { path = "../../auxil/auxil", version = "0.2", package = "gfx-auxil", fe
 hal = { path = "../../hal", version = "0.4", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
-native = { version = "0.2.2", package = "d3d12" }
+native = { package = "d3d12", version = "0.3", features = ["libloading"] }
 log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = { version = "0.16", features = ["hlsl"] }

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -19,7 +19,7 @@ use hal::{
     pso,
 };
 
-use native::descriptor::ShaderVisibility;
+use native::ShaderVisibility;
 
 pub fn map_format(format: Format) -> Option<DXGI_FORMAT> {
     use hal::format::Format::*;

--- a/src/backend/dx12/src/descriptors_cpu.rs
+++ b/src/backend/dx12/src/descriptors_cpu.rs
@@ -1,4 +1,4 @@
-use native::descriptor::{CpuDescriptor, HeapFlags, HeapType};
+use native::{CpuDescriptor, DescriptorHeapFlags, DescriptorHeapType};
 use std::{collections::HashSet, fmt};
 
 // Linear stack allocator for CPU descriptor heaps.
@@ -17,8 +17,8 @@ impl fmt::Debug for HeapLinear {
 }
 
 impl HeapLinear {
-    pub fn new(device: native::Device, ty: HeapType, size: usize) -> Self {
-        let (heap, _hr) = device.create_descriptor_heap(size as _, ty, HeapFlags::empty(), 0);
+    pub fn new(device: native::Device, ty: DescriptorHeapType, size: usize) -> Self {
+        let (heap, _hr) = device.create_descriptor_heap(size as _, ty, DescriptorHeapFlags::empty(), 0);
 
         HeapLinear {
             handle_size: device.get_descriptor_increment_size(ty) as _,
@@ -74,9 +74,9 @@ impl fmt::Debug for Heap {
 }
 
 impl Heap {
-    pub fn new(device: native::Device, ty: HeapType) -> Self {
+    pub fn new(device: native::Device, ty: DescriptorHeapType) -> Self {
         let (heap, _hr) =
-            device.create_descriptor_heap(HEAP_SIZE_FIXED as _, ty, HeapFlags::empty(), 0);
+            device.create_descriptor_heap(HEAP_SIZE_FIXED as _, ty, DescriptorHeapFlags::empty(), 0);
 
         Heap {
             handle_size: device.get_descriptor_increment_size(ty) as _,
@@ -109,7 +109,7 @@ impl Heap {
 
 pub struct DescriptorCpuPool {
     device: native::Device,
-    ty: HeapType,
+    ty: DescriptorHeapType,
     heaps: Vec<Heap>,
     free_list: HashSet<usize>,
 }
@@ -121,7 +121,7 @@ impl fmt::Debug for DescriptorCpuPool {
 }
 
 impl DescriptorCpuPool {
-    pub fn new(device: native::Device, ty: HeapType) -> Self {
+    pub fn new(device: native::Device, ty: DescriptorHeapType) -> Self {
         DescriptorCpuPool {
             device,
             ty,

--- a/src/backend/dx12/src/internal.rs
+++ b/src/backend/dx12/src/internal.rs
@@ -1,5 +1,5 @@
 use auxil::FastHashMap;
-use std::{ffi::CStr, mem, ptr, sync::Mutex};
+use std::{ffi::CStr, mem, ptr, sync::{Arc, Mutex}};
 
 use winapi::{
     shared::{
@@ -12,7 +12,7 @@ use winapi::{
     Interface,
 };
 
-use native::{descriptor, pso};
+use native;
 
 #[derive(Clone, Debug)]
 pub struct BlitPipe {
@@ -43,13 +43,15 @@ type BlitMap = FastHashMap<BlitKey, BlitPipe>;
 #[derive(Debug)]
 pub(crate) struct ServicePipes {
     pub(crate) device: native::Device,
+    library: Arc<native::D3D12Lib>,
     blits_2d_color: Mutex<BlitMap>,
 }
 
 impl ServicePipes {
-    pub fn new(device: native::Device) -> Self {
+    pub fn new(device: native::Device, library: Arc<native::D3D12Lib>) -> Self {
         ServicePipes {
             device,
+            library,
             blits_2d_color: Mutex::new(FastHashMap::default()),
         }
     }
@@ -70,10 +72,10 @@ impl ServicePipes {
     }
 
     fn create_blit_2d_color(&self, (dst_format, filter): BlitKey) -> BlitPipe {
-        let descriptor_range = [descriptor::DescriptorRange::new(
-            descriptor::DescriptorRangeType::SRV,
+        let descriptor_range = [native::DescriptorRange::new(
+            native::DescriptorRangeType::SRV,
             1,
-            native::descriptor::Binding {
+            native::Binding {
                 register: 0,
                 space: 0,
             },
@@ -81,13 +83,13 @@ impl ServicePipes {
         )];
 
         let root_parameters = [
-            descriptor::RootParameter::descriptor_table(
-                descriptor::ShaderVisibility::All,
+            native::RootParameter::descriptor_table(
+                native::ShaderVisibility::All,
                 &descriptor_range,
             ),
-            descriptor::RootParameter::constants(
-                descriptor::ShaderVisibility::All,
-                native::descriptor::Binding {
+            native::RootParameter::constants(
+                native::ShaderVisibility::All,
+                native::Binding {
                     register: 0,
                     space: 0,
                 },
@@ -95,9 +97,9 @@ impl ServicePipes {
             ),
         ];
 
-        let static_samplers = [descriptor::StaticSampler::new(
-            descriptor::ShaderVisibility::PS,
-            native::descriptor::Binding {
+        let static_samplers = [native::StaticSampler::new(
+            native::ShaderVisibility::PS,
+            native::Binding {
                 register: 0,
                 space: 0,
             },
@@ -110,16 +112,20 @@ impl ServicePipes {
             0.0,
             0,
             d3d12::D3D12_COMPARISON_FUNC_ALWAYS,
-            descriptor::StaticBorderColor::TransparentBlack,
+            native::StaticBorderColor::TransparentBlack,
             0.0 .. d3d12::D3D12_FLOAT32_MAX,
         )];
 
-        let ((signature_raw, error), _hr) = native::RootSignature::serialize(
-            descriptor::RootSignatureVersion::V1_0,
+        let (signature_raw, error) = match self.library.serialize_root_signature(
+            native::RootSignatureVersion::V1_0,
             &root_parameters,
             &static_samplers,
-            descriptor::RootSignatureFlags::empty(),
-        );
+            native::RootSignatureFlags::empty(),
+        ) {
+            Ok((pair, hr)) if winerror::SUCCEEDED(hr) => pair,
+            Ok((_, hr)) => panic!("Can't serialize internal root signature: {:?}", hr),
+            Err(e) => panic!("Can't find serialization function: {:?}", e),
+        };
 
         if !error.is_null() {
             error!("D3D12SerializeRootSignature error: {:?}", unsafe {
@@ -129,21 +135,21 @@ impl ServicePipes {
         }
 
         let (signature, _hr) = self.device.create_root_signature(signature_raw, 0);
-        unsafe { signature_raw.destroy() };
+        unsafe { signature_raw.destroy(); }
 
         let shader_src = include_bytes!("../shaders/blit.hlsl");
         // TODO: check results
-        let ((vs, _), _hr_vs) = pso::Shader::compile(
+        let ((vs, _), _hr_vs) = native::Shader::compile(
             shader_src,
             unsafe { CStr::from_bytes_with_nul_unchecked(b"vs_5_0\0") },
             unsafe { CStr::from_bytes_with_nul_unchecked(b"vs_blit_2d\0") },
-            pso::ShaderCompileFlags::empty(),
+            native::ShaderCompileFlags::empty(),
         );
-        let ((ps, _), _hr_ps) = pso::Shader::compile(
+        let ((ps, _), _hr_ps) = native::Shader::compile(
             shader_src,
             unsafe { CStr::from_bytes_with_nul_unchecked(b"ps_5_0\0") },
             unsafe { CStr::from_bytes_with_nul_unchecked(b"ps_blit_2d\0") },
-            pso::ShaderCompileFlags::empty(),
+            native::ShaderCompileFlags::empty(),
         );
 
         let mut rtvs = [dxgiformat::DXGI_FORMAT_UNKNOWN; 8];
@@ -165,11 +171,11 @@ impl ServicePipes {
 
         let pso_desc = d3d12::D3D12_GRAPHICS_PIPELINE_STATE_DESC {
             pRootSignature: signature.as_mut_ptr(),
-            VS: *pso::Shader::from_blob(vs),
-            PS: *pso::Shader::from_blob(ps),
-            GS: *pso::Shader::null(),
-            DS: *pso::Shader::null(),
-            HS: *pso::Shader::null(),
+            VS: *native::Shader::from_blob(vs),
+            PS: *native::Shader::from_blob(ps),
+            GS: *native::Shader::null(),
+            DS: *native::Shader::null(),
+            HS: *native::Shader::null(),
             StreamOutput: d3d12::D3D12_STREAM_OUTPUT_DESC {
                 pSODeclaration: ptr::null(),
                 NumEntries: 0,

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -4,7 +4,6 @@ use winapi::shared::winerror::SUCCEEDED;
 
 use crate::{command::CommandBuffer, Backend, Shared};
 use hal::{command, pool};
-use native::command_list::CmdListType;
 
 #[derive(Debug)]
 pub enum CommandPoolAllocator {
@@ -15,7 +14,7 @@ pub enum CommandPoolAllocator {
 pub struct CommandPool {
     pub(crate) allocator: CommandPoolAllocator,
     pub(crate) device: native::Device,
-    pub(crate) list_type: CmdListType,
+    pub(crate) list_type: native::CmdListType,
     pub(crate) shared: Arc<Shared>,
     pub(crate) create_flags: pool::CommandPoolCreateFlags,
 }

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -4,7 +4,6 @@ use winapi::{
 };
 
 use hal::{buffer, format, image, memory, pass, pso};
-use native::{self, query};
 use range_alloc::RangeAllocator;
 
 use crate::{root_constants::RootConstant, Backend, MAX_VERTEX_BUFFERS};
@@ -752,7 +751,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
 #[derive(Debug)]
 pub struct QueryPool {
     pub(crate) raw: native::QueryHeap,
-    pub(crate) ty: query::HeapType,
+    pub(crate) ty: native::QueryHeapType,
 }
 
 unsafe impl Send for QueryPool {}


### PR DESCRIPTION
Fixes #3067 (not exactly matching the wording but addresses the real blocker)
Depends on https://github.com/gfx-rs/d3d12-rs/pull/20 merged and published, doesn't need to be updated when that happens
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: d3d12
- [ ] `rustfmt` run on changed code

Verified on a Windows 7 machine that we are gracefully failing to init DX12 now.