### PR TITLE
UPDATE: The getting started readme now informs macOS users that cmake…

### DIFF
--- a/info/getting_started.md
+++ b/info/getting_started.md
@@ -2,7 +2,9 @@
 
 ## macOS Dependencies
 
-Install the newest XCode from the App Store. This installs the required `metal` developer tools.
+Install the newest XCode from the App Store. This installs the required `metal` developer tools.   
+
+Ensure [CMake is installed](https://cmake.org/install/) as it is required for `glsl-to-spirv`.   
 
 ## Vulkan Dependencies
 

--- a/info/getting_started.md
+++ b/info/getting_started.md
@@ -4,7 +4,7 @@
 
 Install the newest XCode from the App Store. This installs the required `metal` developer tools.   
 
-Ensure [CMake is installed](https://cmake.org/install/) as it is required for `glsl-to-spirv`.   
+To run the examples, ensure [CMake is installed](https://cmake.org/install/) as it is required for `glsl-to-spirv`.   
 
 ## Vulkan Dependencies
 


### PR DESCRIPTION
… is a requirement for one of the libraries. Without this information a clean clone will not work and the user will be presented with a compilation error when trying to run the examples.

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
