### PR TITLE
[dx11] explicit library loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx12-0.4.1, backend-dx11-0.4.1 (01-11-2019)
+  - switch to explicit linking of "d3d12.dll", "d3d11.dll" and "dxgi.dll"
+
 ## hal-0.4.0 (23-10-2019)
   - all strongly typed HAL wrappers are removed
   - all use of `failure` is removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-### backend-dx12-0.4.1, backend-dx11-0.4.1 (01-11-2019)
+### backend-dx12-0.4.1, backend-dx11-0.4.2 (01-11-2019)
   - switch to explicit linking of "d3d12.dll", "d3d11.dll" and "dxgi.dll"
 
 ## hal-0.4.0 (23-10-2019)

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.4.0"
+version = "0.4.1"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -23,6 +23,7 @@ auxil = { path = "../../auxil/auxil", version = "0.2", package = "gfx-auxil", fe
 hal = { path = "../../hal", version = "0.4", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
+libloading = "0.5"
 log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = { version = "0.16", features = ["hlsl"] }


### PR DESCRIPTION
Sibling of #3076 but for `master`.
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx11
- [ ] `rustfmt` run on changed code
