### PR TITLE
[0.4/hal] Error derives and ShaderStageFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Change Log
 
+### hal-0.4.1 (04-11-2019)
+  - `Error` implementations
+  - fix `ShaderStageFlags::ALL`
+
 ### backend-dx12-0.4.1, backend-dx11-0.4.2 (01-11-2019)
   - switch to explicit linking of "d3d12.dll", "d3d11.dll" and "dxgi.dll"
+
+### backend-dx12-0.4.1 (01-11-2019)
+  - switch to explicit linking of "d3d12.dll" and "dxgi.dll"
 
 ## hal-0.4.0 (23-10-2019)
   - all strongly typed HAL wrappers are removed

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-hal"
-version = "0.4.0"
+version = "0.4.1"
 description = "gfx-rs hardware abstraction layer"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -76,8 +76,8 @@ impl std::fmt::Display for ViewCreationError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ViewCreationError::OutOfMemory(err) => write!(fmt, "Failed to create buffer view: {}", err),
-            ViewCreationError::UnsupportedFormat { format: Some(format) } => write!(fmt, "Failed to create buffer: Unsupported format {:?}", format),
-            ViewCreationError::UnsupportedFormat { format: None } => write!(fmt, "Failed to create buffer: Unspecified format"),
+            ViewCreationError::UnsupportedFormat { format: Some(format) } => write!(fmt, "Failed to create buffer view: Unsupported format {:?}", format),
+            ViewCreationError::UnsupportedFormat { format: None } => write!(fmt, "Failed to create buffer view: Unspecified format"),
         }
     }
 }

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -35,6 +35,24 @@ impl From<device::OutOfMemory> for CreationError {
     }
 }
 
+impl std::fmt::Display for CreationError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreationError::OutOfMemory(err) => write!(fmt, "Failed to create buffer: {}", err),
+            CreationError::UnsupportedUsage { usage } => write!(fmt, "Failed to create buffer: Unsupported usage: {:?}", usage),
+        }
+    }
+}
+
+impl std::error::Error for CreationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CreationError::OutOfMemory(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 /// Error creating a buffer view.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ViewCreationError {
@@ -51,6 +69,25 @@ pub enum ViewCreationError {
 impl From<device::OutOfMemory> for ViewCreationError {
     fn from(error: device::OutOfMemory) -> Self {
         ViewCreationError::OutOfMemory(error)
+    }
+}
+
+impl std::fmt::Display for ViewCreationError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ViewCreationError::OutOfMemory(err) => write!(fmt, "Failed to create buffer view: {}", err),
+            ViewCreationError::UnsupportedFormat { format: Some(format) } => write!(fmt, "Failed to create buffer: Unsupported format {:?}", format),
+            ViewCreationError::UnsupportedFormat { format: None } => write!(fmt, "Failed to create buffer: Unspecified format"),
+        }
+    }
+}
+
+impl std::error::Error for ViewCreationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ViewCreationError::OutOfMemory(err) => Some(err),
+            _ => None,
+        }
     }
 }
 

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -31,13 +31,37 @@ use crate::{
 #[derive(Clone, Debug, PartialEq)]
 pub struct DeviceLost;
 
+impl std::fmt::Display for DeviceLost {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.write_str("Device lost")
+    }
+}
+
+impl std::error::Error for DeviceLost {}
+
 /// Error occurred caused surface to be lost.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SurfaceLost;
 
+impl std::fmt::Display for SurfaceLost {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.write_str("Surface lost")
+    }
+}
+
+impl std::error::Error for SurfaceLost {}
+
 /// Native window is already in use by graphics API.
 #[derive(Clone, Debug, PartialEq)]
 pub struct WindowInUse;
+
+impl std::fmt::Display for WindowInUse {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.write_str("Window is in use")
+    }
+}
+
+impl std::error::Error for WindowInUse {}
 
 /// Error allocating memory.
 #[derive(Clone, Debug, PartialEq)]
@@ -47,6 +71,17 @@ pub enum OutOfMemory {
     /// Device memory exhausted.
     Device,
 }
+
+impl std::fmt::Display for OutOfMemory {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OutOfMemory::Host => write!(fmt, "Out of host memory"),
+            OutOfMemory::Device => write!(fmt, "Out of device memory"),
+        }
+    }
+}
+
+impl std::error::Error for OutOfMemory {}
 
 /// Error occurred caused device to be lost
 /// or out of memory error.
@@ -86,6 +121,24 @@ impl From<OutOfMemory> for AllocationError {
     }
 }
 
+impl std::fmt::Display for AllocationError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AllocationError::OutOfMemory(err) => write!(fmt, "Failed to allocate object: {}", err),
+            AllocationError::TooManyObjects => write!(fmt, "Failed to allocate object: Too many objects"),
+        }
+    }
+}
+
+impl std::error::Error for AllocationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            AllocationError::OutOfMemory(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 /// Device creation errors during `open`.
 #[derive(Clone, Debug, PartialEq)]
 pub enum CreationError {
@@ -115,6 +168,28 @@ pub enum CreationError {
     DeviceLost,
 }
 
+impl std::fmt::Display for CreationError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreationError::OutOfMemory(err) => write!(fmt, "Failed to create device: {}", err),
+            CreationError::InitializationFailed => write!(fmt, "Failed to create device: Implementation specific error ocurred"),
+            CreationError::MissingExtension => write!(fmt, "Failed to create device: Requested extension is missing"),
+            CreationError::MissingFeature => write!(fmt, "Failed to create device: Requested feature is missing"),
+            CreationError::TooManyObjects => write!(fmt, "Failed to create device: Too many objects"),
+            CreationError::DeviceLost => write!(fmt, "Failed to create device: Logical or Physical device was lost during creation"),
+        }
+    }
+}
+
+impl std::error::Error for CreationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CreationError::OutOfMemory(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 /// Error accessing a mapping.
 #[derive(Clone, Debug, PartialEq)]
 pub enum MapError {
@@ -122,13 +197,32 @@ pub enum MapError {
     OutOfMemory(OutOfMemory),
     /// The requested mapping range is outside of the resource.
     OutOfBounds,
-    /// Failed to map memory range.
+    /// Failed to allocate an appropriately sized contiguous virtual address range
     MappingFailed,
 }
 
 impl From<OutOfMemory> for MapError {
     fn from(error: OutOfMemory) -> Self {
         MapError::OutOfMemory(error)
+    }
+}
+
+impl std::fmt::Display for MapError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MapError::OutOfMemory(err) => write!(fmt, "Failed to map memory: {}", err),
+            MapError::OutOfBounds => write!(fmt, "Failed to map memory: Requested range is outside the resource"),
+            MapError::MappingFailed => write!(fmt, "Failed to map memory: Unable to allocate an appropriately sized contiguous virtual address range"),
+        }
+    }
+}
+
+impl std::error::Error for MapError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            MapError::OutOfMemory(err) => Some(err),
+            _ => None,
+        }
     }
 }
 
@@ -146,6 +240,25 @@ pub enum BindError {
 impl From<OutOfMemory> for BindError {
     fn from(error: OutOfMemory) -> Self {
         BindError::OutOfMemory(error)
+    }
+}
+
+impl std::fmt::Display for BindError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BindError::OutOfMemory(err) => write!(fmt, "Failed to bind object to memory range: {}", err),
+            BindError::OutOfBounds => write!(fmt, "Failed to bind object to memory range: Requested range is outside the resource"),
+            BindError::WrongMemory => write!(fmt, "Failed to bind object to memory range: Wrong memory"),
+        }
+    }
+}
+
+impl std::error::Error for BindError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            BindError::OutOfMemory(err) => Some(err),
+            _ => None,
+        }
     }
 }
 
@@ -177,6 +290,27 @@ pub enum ShaderError {
 impl From<OutOfMemory> for ShaderError {
     fn from(error: OutOfMemory) -> Self {
         ShaderError::OutOfMemory(error)
+    }
+}
+
+impl std::fmt::Display for ShaderError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShaderError::OutOfMemory(err) => write!(fmt, "Shader error: {}", err),
+            ShaderError::CompilationFailed(string) => write!(fmt, "Shader error: Compilation failed: {}", string),
+            ShaderError::MissingEntryPoint(string) => write!(fmt, "Shader error: Missing entry point: {}", string),
+            ShaderError::InterfaceMismatch(string) => write!(fmt, "Shader error: Interface mismatch: {}", string),
+            ShaderError::UnsupportedStage(stage) => write!(fmt, "Shader error: Unsupported stage: {:?}", stage),
+        }
+    }
+}
+
+impl std::error::Error for ShaderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ShaderError::OutOfMemory(err) => Some(err),
+            _ => None,
+        }
     }
 }
 

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -172,7 +172,7 @@ impl std::fmt::Display for CreationError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CreationError::OutOfMemory(err) => write!(fmt, "Failed to create device: {}", err),
-            CreationError::InitializationFailed => write!(fmt, "Failed to create device: Implementation specific error ocurred"),
+            CreationError::InitializationFailed => write!(fmt, "Failed to create device: Implementation specific error occurred"),
             CreationError::MissingExtension => write!(fmt, "Failed to create device: Requested extension is missing"),
             CreationError::MissingFeature => write!(fmt, "Failed to create device: Requested feature is missing"),
             CreationError::TooManyObjects => write!(fmt, "Failed to create device: Too many objects"),

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -128,9 +128,32 @@ impl From<device::OutOfMemory> for CreationError {
     }
 }
 
+impl std::fmt::Display for CreationError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreationError::OutOfMemory(err) => write!(fmt, "Failed to create image: {}", err),
+            CreationError::Format(format) => write!(fmt, "Failed to create image: Unsupported format: {:?}", format),
+            CreationError::Kind => write!(fmt, "Failed to create image: Specified kind doesn't support particular operation"), // Room for impruvement.
+            CreationError::Samples(samples) => write!(fmt, "Failed to create image: Specified format doesn't support specified sampling {}", samples),
+            CreationError::Size(size) => write!(fmt, "Failed to create image: Unsupported size in one of the dimensions {}", size),
+            CreationError::Data(data) => write!(fmt, "Failed to create image: The given data has a different size {{{}}} than the target image slice", data), // Actually nothing emits this.
+            CreationError::Usage(usage) => write!(fmt, "Failed to create image: Unsupported usage: {:?}", usage),
+        }
+    }
+}
+
+impl std::error::Error for CreationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CreationError::OutOfMemory(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 /// Error creating an `ImageView`.
 #[derive(Clone, Debug, PartialEq)]
-pub enum ViewError {
+pub enum ViewError { // TODO: Rename this or `buffer::ViewCreationError`
     /// The required usage flag is not present in the image.
     Usage(Usage),
     /// Selected mip level doesn't exist.
@@ -153,6 +176,29 @@ impl From<device::OutOfMemory> for ViewError {
     }
 }
 
+impl std::fmt::Display for ViewError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ViewError::Usage(usage) => write!(fmt, "Failed to create image view: Specified usage flags are not present in the image {:?}", usage),
+            ViewError::Level(level) => write!(fmt, "Failed to create image view: Selected level doesn't exist in the image {}", level),
+            ViewError::Layer(err) => write!(fmt, "Failed to create image view: {}", err),
+            ViewError::BadFormat(format) => write!(fmt, "Failed to create image view: Incompatible format {:?}", format),
+            ViewError::BadKind(kind) => write!(fmt, "Failed to create image view: Incompatible kind {:?}", kind),
+            ViewError::OutOfMemory(err) => write!(fmt, "Failed to create image view: {}", err),
+            ViewError::Unsupported => write!(fmt, "Failed to create image view: Implementation specific error ocurred"),
+        }
+    }
+}
+
+impl std::error::Error for ViewError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ViewError::OutOfMemory(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 /// An error associated with selected image layer.
 #[derive(Clone, Debug, PartialEq)]
 pub enum LayerError {
@@ -160,6 +206,15 @@ pub enum LayerError {
     NotExpected(Kind),
     /// Selected layers are outside of the provided range.
     OutOfBounds(Range<Layer>),
+}
+
+impl std::fmt::Display for LayerError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LayerError::NotExpected(kind) => write!(fmt, "Kind {{{:?}}} does not support arrays", kind),
+            LayerError::OutOfBounds(layers) => write!(fmt, "Out of bounds layers {} .. {}", layers.start, layers.end),
+        }
+    }
 }
 
 /// How to [filter](https://en.wikipedia.org/wiki/Texture_filtering) the

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -133,7 +133,7 @@ impl std::fmt::Display for CreationError {
         match self {
             CreationError::OutOfMemory(err) => write!(fmt, "Failed to create image: {}", err),
             CreationError::Format(format) => write!(fmt, "Failed to create image: Unsupported format: {:?}", format),
-            CreationError::Kind => write!(fmt, "Failed to create image: Specified kind doesn't support particular operation"), // Room for impruvement.
+            CreationError::Kind => write!(fmt, "Failed to create image: Specified kind doesn't support particular operation"), // Room for improvement.
             CreationError::Samples(samples) => write!(fmt, "Failed to create image: Specified format doesn't support specified sampling {}", samples),
             CreationError::Size(size) => write!(fmt, "Failed to create image: Unsupported size in one of the dimensions {}", size),
             CreationError::Data(data) => write!(fmt, "Failed to create image: The given data has a different size {{{}}} than the target image slice", data), // Actually nothing emits this.
@@ -185,7 +185,7 @@ impl std::fmt::Display for ViewError {
             ViewError::BadFormat(format) => write!(fmt, "Failed to create image view: Incompatible format {:?}", format),
             ViewError::BadKind(kind) => write!(fmt, "Failed to create image view: Incompatible kind {:?}", kind),
             ViewError::OutOfMemory(err) => write!(fmt, "Failed to create image view: {}", err),
-            ViewError::Unsupported => write!(fmt, "Failed to create image view: Implementation specific error ocurred"),
+            ViewError::Unsupported => write!(fmt, "Failed to create image view: Implementation specific error occurred"),
         }
     }
 }

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -125,6 +125,20 @@ pub enum AllocationError {
     IncompatibleLayout,
 }
 
+impl std::fmt::Display for AllocationError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AllocationError::Host => write!(fmt, "Failed to allocate descriptor set: Out of host memory"),
+            AllocationError::Device => write!(fmt, "Failed to allocate descriptor set: Out of device memory"),
+            AllocationError::OutOfPoolMemory => write!(fmt, "Failed to allocate descriptor set: Out of pool memory"),
+            AllocationError::FragmentedPool => write!(fmt, "Failed to allocate descriptor set: Pool is fragmented"),
+            AllocationError::IncompatibleLayout => write!(fmt, "Failed to allocate descriptor set: Incompatible layout"),
+        }
+    }
+}
+
+impl std::error::Error for AllocationError {}
+
 /// A descriptor pool is a collection of memory from which descriptor sets are allocated.
 pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
     /// Allocate a descriptor set from the pool.

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -40,6 +40,17 @@ impl From<device::OutOfMemory> for CreationError {
     }
 }
 
+impl std::fmt::Display for CreationError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreationError::OutOfMemory(err) => write!(fmt, "Failed to create pipeline: {}", err),
+            CreationError::Other => write!(fmt, "Failed to create pipeline: Unsupported usage: Implementation specific error ocurred"),
+            CreationError::InvalidSubpass(subpass) => write!(fmt, "Failed to create pipeline: Invalid subpass: {}", subpass),
+            CreationError::Shader(err) => write!(fmt, "Failed to create pipeline: {}", err),
+        }
+    }
+}
+
 bitflags!(
     /// Stages of the logical pipeline.
     ///

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -44,7 +44,7 @@ impl std::fmt::Display for CreationError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CreationError::OutOfMemory(err) => write!(fmt, "Failed to create pipeline: {}", err),
-            CreationError::Other => write!(fmt, "Failed to create pipeline: Unsupported usage: Implementation specific error ocurred"),
+            CreationError::Other => write!(fmt, "Failed to create pipeline: Unsupported usage: Implementation specific error occurred"),
             CreationError::InvalidSubpass(subpass) => write!(fmt, "Failed to create pipeline: Invalid subpass: {}", subpass),
             CreationError::Shader(err) => write!(fmt, "Failed to create pipeline: {}", err),
         }

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -111,8 +111,8 @@ bitflags!(
         /// All graphics pipeline shader stages.
         const GRAPHICS = Self::VERTEX.bits | Self::HULL.bits |
             Self::DOMAIN.bits | Self::GEOMETRY.bits | Self::FRAGMENT.bits;
-        /// All shader stages.
-        const ALL      = Self::GRAPHICS.bits | Self::COMPUTE.bits;
+        /// All shader stages (matches Vulkan).
+        const ALL      = 0x7FFFFFFF;
     }
 );
 

--- a/src/hal/src/query.rs
+++ b/src/hal/src/query.rs
@@ -25,6 +25,15 @@ impl From<OutOfMemory> for CreationError {
     }
 }
 
+impl std::fmt::Display for CreationError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreationError::OutOfMemory(err) => write!(fmt, "Failed to create query: {}", err),
+            CreationError::Unsupported(ty) => write!(fmt, "Failed to create query: Unsupported type: {:?}", ty),
+        }
+    }
+}
+
 /// A `Query` object has a particular identifier and saves its results to a given `QueryPool`.
 /// It is passed as a parameter to the command buffer's query methods.
 #[derive(Debug)]

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -99,6 +99,28 @@ impl From<device::WindowInUse> for CreationError {
     }
 }
 
+impl std::fmt::Display for CreationError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CreationError::OutOfMemory(err) => write!(fmt, "Failed to create or configure swapchain: {}", err),
+            CreationError::DeviceLost(err) => write!(fmt, "Failed to create or configure swapchain: {}", err),
+            CreationError::SurfaceLost(err) => write!(fmt, "Failed to create or configure swapchain: {}", err),
+            CreationError::WindowInUse(err) => write!(fmt, "Failed to create or configure swapchain: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for CreationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CreationError::OutOfMemory(err) => Some(err),
+            CreationError::DeviceLost(err) => Some(err),
+            CreationError::SurfaceLost(err) => Some(err),
+            CreationError::WindowInUse(err) => Some(err),
+        }
+    }
+}
+
 /// An extent describes the size of a rectangle, such as
 /// a window or texture. It is not used for referring to a
 /// sub-rectangle; for that see `command::Rect`.
@@ -441,6 +463,30 @@ pub enum AcquireError {
     DeviceLost(device::DeviceLost),
 }
 
+impl std::fmt::Display for AcquireError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcquireError::OutOfMemory(err) => write!(fmt, "Failed to acqure image: {}", err),
+            AcquireError::NotReady => write!(fmt, "Failed to acqure image: No image ready (timeout wasn't specified)"),
+            AcquireError::Timeout => write!(fmt, "Failed to acqure image: No image ready (timeout)"),
+            AcquireError::OutOfDate => write!(fmt, "Failed to acqure image: Swapchain is out of date and needs to be re-created"),
+            AcquireError::SurfaceLost(err) => write!(fmt, "Failed to acqure image: {}", err),
+            AcquireError::DeviceLost(err) => write!(fmt, "Failed to acqure image: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for AcquireError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            AcquireError::OutOfMemory(err) => Some(err),
+            AcquireError::SurfaceLost(err) => Some(err),
+            AcquireError::DeviceLost(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 /// Error on acquiring the next image from a swapchain.
 #[derive(Clone, Debug, PartialEq)]
 pub enum PresentError {
@@ -452,6 +498,28 @@ pub enum PresentError {
     SurfaceLost(device::SurfaceLost),
     /// Device is lost
     DeviceLost(device::DeviceLost),
+}
+
+impl std::fmt::Display for PresentError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PresentError::OutOfMemory(err) => write!(fmt, "Failed to present image: {}", err),
+            PresentError::OutOfDate => write!(fmt, "Failed to present image: Swapchain is out of date and needs to be re-created"),
+            PresentError::SurfaceLost(err) => write!(fmt, "Failed to present image: {}", err),
+            PresentError::DeviceLost(err) => write!(fmt, "Failed to present image: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for PresentError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            PresentError::OutOfMemory(err) => Some(err),
+            PresentError::SurfaceLost(err) => Some(err),
+            PresentError::DeviceLost(err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 /// The `Swapchain` is the backend representation of the surface.
@@ -524,3 +592,14 @@ pub enum InitError {
     /// Window handle is not supported by the backend.
     UnsupportedWindowHandle,
 }
+
+
+impl std::fmt::Display for InitError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InitError::UnsupportedWindowHandle => write!(fmt, "Failed to create surface: Specified window handle is unsupported"),
+        }
+    }
+}
+
+impl std::error::Error for InitError {}


### PR DESCRIPTION
Has #3078 for 0.4, also has a fix for #3079 (still need to follow-up on `master`).
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

Reviewers - how do you feel about the flag change? Can we actually publish it as a patch?