### PR TITLE
ShaderStageFlags fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Change Log
 
+### hal-0.4.1 (04-11-2019)
+  - `Error` implementations
+  - fix `ShaderStageFlags::ALL`
+
 ### backend-dx12-0.4.1, backend-dx11-0.4.2 (01-11-2019)
   - switch to explicit linking of "d3d12.dll", "d3d11.dll" and "dxgi.dll"
+
+### backend-dx12-0.4.1 (01-11-2019)
+  - switch to explicit linking of "d3d12.dll" and "dxgi.dll"
 
 ## hal-0.4.0 (23-10-2019)
   - all strongly typed HAL wrappers are removed

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-hal"
-version = "0.4.0"
+version = "0.4.1"
 description = "gfx-rs hardware abstraction layer"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -76,8 +76,8 @@ impl std::fmt::Display for ViewCreationError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ViewCreationError::OutOfMemory(err) => write!(fmt, "Failed to create buffer view: {}", err),
-            ViewCreationError::UnsupportedFormat { format: Some(format) } => write!(fmt, "Failed to create buffer: Unsupported format {:?}", format),
-            ViewCreationError::UnsupportedFormat { format: None } => write!(fmt, "Failed to create buffer: Unspecified format"),
+            ViewCreationError::UnsupportedFormat { format: Some(format) } => write!(fmt, "Failed to create buffer view: Unsupported format {:?}", format),
+            ViewCreationError::UnsupportedFormat { format: None } => write!(fmt, "Failed to create buffer view: Unspecified format"),
         }
     }
 }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -172,7 +172,7 @@ impl std::fmt::Display for CreationError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CreationError::OutOfMemory(err) => write!(fmt, "Failed to create device: {}", err),
-            CreationError::InitializationFailed => write!(fmt, "Failed to create device: Implementation specific error ocurred"),
+            CreationError::InitializationFailed => write!(fmt, "Failed to create device: Implementation specific error occurred"),
             CreationError::MissingExtension => write!(fmt, "Failed to create device: Requested extension is missing"),
             CreationError::MissingFeature => write!(fmt, "Failed to create device: Requested feature is missing"),
             CreationError::TooManyObjects => write!(fmt, "Failed to create device: Too many objects"),

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -133,7 +133,7 @@ impl std::fmt::Display for CreationError {
         match self {
             CreationError::OutOfMemory(err) => write!(fmt, "Failed to create image: {}", err),
             CreationError::Format(format) => write!(fmt, "Failed to create image: Unsupported format: {:?}", format),
-            CreationError::Kind => write!(fmt, "Failed to create image: Specified kind doesn't support particular operation"), // Room for impruvement.
+            CreationError::Kind => write!(fmt, "Failed to create image: Specified kind doesn't support particular operation"), // Room for improvement.
             CreationError::Samples(samples) => write!(fmt, "Failed to create image: Specified format doesn't support specified sampling {}", samples),
             CreationError::Size(size) => write!(fmt, "Failed to create image: Unsupported size in one of the dimensions {}", size),
             CreationError::Data(data) => write!(fmt, "Failed to create image: The given data has a different size {{{}}} than the target image slice", data), // Actually nothing emits this.
@@ -185,7 +185,7 @@ impl std::fmt::Display for ViewError {
             ViewError::BadFormat(format) => write!(fmt, "Failed to create image view: Incompatible format {:?}", format),
             ViewError::BadKind(kind) => write!(fmt, "Failed to create image view: Incompatible kind {:?}", kind),
             ViewError::OutOfMemory(err) => write!(fmt, "Failed to create image view: {}", err),
-            ViewError::Unsupported => write!(fmt, "Failed to create image view: Implementation specific error ocurred"),
+            ViewError::Unsupported => write!(fmt, "Failed to create image view: Implementation specific error occurred"),
         }
     }
 }

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -44,7 +44,7 @@ impl std::fmt::Display for CreationError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CreationError::OutOfMemory(err) => write!(fmt, "Failed to create pipeline: {}", err),
-            CreationError::Other => write!(fmt, "Failed to create pipeline: Unsupported usage: Implementation specific error ocurred"),
+            CreationError::Other => write!(fmt, "Failed to create pipeline: Unsupported usage: Implementation specific error occurred"),
             CreationError::InvalidSubpass(subpass) => write!(fmt, "Failed to create pipeline: Invalid subpass: {}", subpass),
             CreationError::Shader(err) => write!(fmt, "Failed to create pipeline: {}", err),
         }

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -111,8 +111,8 @@ bitflags!(
         /// All graphics pipeline shader stages.
         const GRAPHICS = Self::VERTEX.bits | Self::HULL.bits |
             Self::DOMAIN.bits | Self::GEOMETRY.bits | Self::FRAGMENT.bits;
-        /// All shader stages.
-        const ALL      = Self::GRAPHICS.bits | Self::COMPUTE.bits;
+        /// All shader stages (matches Vulkan).
+        const ALL      = 0x7FFFFFFF;
     }
 );
 


### PR DESCRIPTION
Follow-up to #3078 with pieces from #3080
Fixes #3079
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
