### PR TITLE
Implement Error for pso::CreationError

### DIFF
--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -105,6 +105,24 @@ impl From<DeviceLost> for OomOrDeviceLost {
     }
 }
 
+impl std::fmt::Display for OomOrDeviceLost {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OomOrDeviceLost::DeviceLost(err) => write!(fmt, "Failed querying device: {}", err),
+            OomOrDeviceLost::OutOfMemory(err) => write!(fmt, "Failed querying device: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for OomOrDeviceLost {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            OomOrDeviceLost::DeviceLost(err) => Some(err),
+            OomOrDeviceLost::OutOfMemory(err) => Some(err),
+        }
+    }
+}
+
 /// Possible cause of allocation failure.
 #[derive(Clone, Debug, PartialEq)]
 pub enum AllocationError {

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -51,6 +51,17 @@ impl std::fmt::Display for CreationError {
     }
 }
 
+impl std::error::Error for CreationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            CreationError::OutOfMemory(err) => Some(err),
+            CreationError::Shader(err) => Some(err),
+            CreationError::InvalidSubpass(_) => None,
+            CreationError::Other => None,
+        }
+    }
+}
+
 bitflags!(
     /// Stages of the logical pipeline.
     ///


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [x] `rustfmt` run on changed code
