### PR TITLE
Ensure dxgi.dll is not unloaded while it's still needed (dx11)

### DIFF
--- a/src/backend/dx11/src/dxgi.rs
+++ b/src/backend/dx11/src/dxgi.rs
@@ -65,14 +65,14 @@ pub(crate) enum DxgiVersion {
     Dxgi1_5,
 }
 
-type DxgiFun = extern "system" fn(REFIID, *mut *mut winapi::ctypes::c_void) -> winerror::HRESULT;
+type DxgiFun = unsafe extern "system" fn(REFIID, *mut *mut winapi::ctypes::c_void) -> winerror::HRESULT;
 
 fn create_dxgi_factory1(
     func: &DxgiFun, guid: &GUID
 ) -> Result<ComPtr<dxgi::IDXGIFactory>, winerror::HRESULT> {
     let mut factory: *mut IUnknown = ptr::null_mut();
 
-    let hr = func(guid, &mut factory as *mut *mut _ as *mut *mut _);
+    let hr = unsafe { func(guid, &mut factory as *mut *mut _ as *mut *mut _) };
 
     if winerror::SUCCEEDED(hr) {
         Ok(unsafe { ComPtr::from_raw(factory as *mut _) })
@@ -82,7 +82,8 @@ fn create_dxgi_factory1(
 }
 
 pub(crate) fn get_dxgi_factory(
-) -> Result<(ComPtr<dxgi::IDXGIFactory>, DxgiVersion), winerror::HRESULT> {
+) -> Result<(libloading::Library, ComPtr<dxgi::IDXGIFactory>, DxgiVersion), winerror::HRESULT> {
+    // The returned Com-pointer is only safe to use for the lifetime of the Library.
     let library = libloading::Library::new("dxgi.dll")
         .map_err(|_| -1)?;
     let func: libloading::Symbol<DxgiFun> = unsafe {
@@ -91,28 +92,28 @@ pub(crate) fn get_dxgi_factory(
 
     // TODO: do we even need `create_dxgi_factory2`?
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi1_5::IDXGIFactory5::uuidof()) {
-        return Ok((factory, DxgiVersion::Dxgi1_5));
+        return Ok((library, factory, DxgiVersion::Dxgi1_5));
     }
 
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi1_4::IDXGIFactory4::uuidof()) {
-        return Ok((factory, DxgiVersion::Dxgi1_4));
+        return Ok((library, factory, DxgiVersion::Dxgi1_4));
     }
 
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi1_3::IDXGIFactory3::uuidof()) {
-        return Ok((factory, DxgiVersion::Dxgi1_3));
+        return Ok((library, factory, DxgiVersion::Dxgi1_3));
     }
 
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi1_2::IDXGIFactory2::uuidof()) {
-        return Ok((factory, DxgiVersion::Dxgi1_2));
+        return Ok((library, factory, DxgiVersion::Dxgi1_2));
     }
 
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi::IDXGIFactory1::uuidof()) {
-        return Ok((factory, DxgiVersion::Dxgi1_0));
+        return Ok((library, factory, DxgiVersion::Dxgi1_0));
     }
 
     // TODO: any reason why above would fail and this wouldnt?
     match create_dxgi_factory1(&func, &dxgi::IDXGIFactory::uuidof()) {
-        Ok(factory) => Ok((factory, DxgiVersion::Dxgi1_0)),
+        Ok(factory) => Ok((library, factory, DxgiVersion::Dxgi1_0)),
         Err(hr) => Err(hr),
     }
 }

--- a/src/backend/dx11/src/dxgi.rs
+++ b/src/backend/dx11/src/dxgi.rs
@@ -1,7 +1,15 @@
 use hal::adapter::{AdapterInfo, DeviceType};
 
 use winapi::{
-    shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_5, guiddef::{GUID, REFIID}, winerror},
+    shared::{
+        dxgi,
+        dxgi1_2,
+        dxgi1_3,
+        dxgi1_4,
+        dxgi1_5,
+        guiddef::{GUID, REFIID},
+        winerror,
+    },
     um::unknwnbase::IUnknown,
     Interface,
 };
@@ -65,10 +73,12 @@ pub(crate) enum DxgiVersion {
     Dxgi1_5,
 }
 
-type DxgiFun = unsafe extern "system" fn(REFIID, *mut *mut winapi::ctypes::c_void) -> winerror::HRESULT;
+type DxgiFun =
+    unsafe extern "system" fn(REFIID, *mut *mut winapi::ctypes::c_void) -> winerror::HRESULT;
 
 fn create_dxgi_factory1(
-    func: &DxgiFun, guid: &GUID
+    func: &DxgiFun,
+    guid: &GUID,
 ) -> Result<ComPtr<dxgi::IDXGIFactory>, winerror::HRESULT> {
     let mut factory: *mut IUnknown = ptr::null_mut();
 
@@ -84,11 +94,9 @@ fn create_dxgi_factory1(
 pub(crate) fn get_dxgi_factory(
 ) -> Result<(libloading::Library, ComPtr<dxgi::IDXGIFactory>, DxgiVersion), winerror::HRESULT> {
     // The returned Com-pointer is only safe to use for the lifetime of the Library.
-    let library = libloading::Library::new("dxgi.dll")
-        .map_err(|_| -1)?;
-    let func: libloading::Symbol<DxgiFun> = unsafe {
-        library.get(b"CreateDXGIFactory1")
-    }.map_err(|_| -1)?;
+    let library = libloading::Library::new("dxgi.dll").map_err(|_| -1)?;
+    let func: libloading::Symbol<DxgiFun> =
+        unsafe { library.get(b"CreateDXGIFactory1") }.map_err(|_| -1)?;
 
     // TODO: do we even need `create_dxgi_factory2`?
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi1_5::IDXGIFactory5::uuidof()) {

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -85,7 +85,7 @@ mod dxgi;
 mod internal;
 mod shader;
 
-type CreateFun = extern "system" fn(
+type CreateFun = unsafe extern "system" fn(
     *mut IDXGIAdapter,
     UINT,
     HMODULE,
@@ -118,7 +118,8 @@ impl fmt::Debug for ViewInfo {
 pub struct Instance {
     pub(crate) factory: ComPtr<IDXGIFactory>,
     pub(crate) dxgi_version: dxgi::DxgiVersion,
-    library: Arc<libloading::Library>,
+    library_d3d11: Arc<libloading::Library>,
+    library_dxgi: libloading::Library,
 }
 
 unsafe impl Send for Instance {}
@@ -257,16 +258,17 @@ impl hal::Instance<Backend> for Instance {
         // TODO: get the latest factory we can find
 
         match dxgi::get_dxgi_factory() {
-            Ok((factory, dxgi_version)) => {
+            Ok((library_dxgi, factory, dxgi_version)) => {
                 info!("DXGI version: {:?}", dxgi_version);
-                let library = Arc::new(
+                let library_d3d11 = Arc::new(
                     libloading::Library::new("d3d11.dll")
                         .map_err(|_| hal::UnsupportedBackend)?
                 );
                 Ok(Instance {
                     factory,
                     dxgi_version,
-                    library,
+                    library_d3d11,
+                    library_dxgi,
                 })
             }
             Err(hr) => {
@@ -281,7 +283,7 @@ impl hal::Instance<Backend> for Instance {
         let mut idx = 0;
 
         let func: libloading::Symbol<CreateFun> = match unsafe {
-            self.library.get(b"D3D11CreateDevice")
+            self.library_d3d11.get(b"D3D11CreateDevice")
         } {
             Ok(func) => func,
             Err(e) => {
@@ -302,18 +304,20 @@ impl hal::Instance<Backend> for Instance {
                 let feature_level = get_feature_level(&func, adapter.as_raw());
 
                 let mut device = ptr::null_mut();
-                let hr = func(
-                    adapter.as_raw() as *mut _,
-                    d3dcommon::D3D_DRIVER_TYPE_UNKNOWN,
-                    ptr::null_mut(),
-                    0,
-                    [feature_level].as_ptr(),
-                    1,
-                    d3d11::D3D11_SDK_VERSION,
-                    &mut device as *mut *mut _ as *mut *mut _,
-                    ptr::null_mut(),
-                    ptr::null_mut(),
-                );
+                let hr = unsafe {
+                    func(
+                        adapter.as_raw() as *mut _,
+                        d3dcommon::D3D_DRIVER_TYPE_UNKNOWN,
+                        ptr::null_mut(),
+                        0,
+                        [feature_level].as_ptr(),
+                        1,
+                        d3d11::D3D11_SDK_VERSION,
+                        &mut device as *mut *mut _ as *mut *mut _,
+                        ptr::null_mut(),
+                        ptr::null_mut(),
+                    )
+                };
 
                 if !winerror::SUCCEEDED(hr) {
                     continue;
@@ -400,7 +404,7 @@ impl hal::Instance<Backend> for Instance {
 
             let physical_device = PhysicalDevice {
                 adapter,
-                library: Arc::clone(&self.library),
+                library_d3d11: Arc::clone(&self.library_d3d11),
                 features,
                 limits,
                 memory_properties,
@@ -438,7 +442,7 @@ impl hal::Instance<Backend> for Instance {
 
 pub struct PhysicalDevice {
     adapter: ComPtr<IDXGIAdapter>,
-    library: Arc<libloading::Library>,
+    library_d3d11: Arc<libloading::Library>,
     features: hal::Features,
     limits: hal::Limits,
     memory_properties: adapter::MemoryProperties,
@@ -467,36 +471,40 @@ fn get_feature_level(func: &CreateFun, adapter: *mut IDXGIAdapter) -> d3dcommon:
     ];
 
     let mut feature_level = d3dcommon::D3D_FEATURE_LEVEL_9_1;
-    let hr = func(
-        adapter,
-        d3dcommon::D3D_DRIVER_TYPE_UNKNOWN,
-        ptr::null_mut(),
-        0,
-        requested_feature_levels[..].as_ptr(),
-        requested_feature_levels.len() as _,
-        d3d11::D3D11_SDK_VERSION,
-        ptr::null_mut(),
-        &mut feature_level as *mut _,
-        ptr::null_mut(),
-    );
+    let hr =  unsafe{
+        func(
+            adapter,
+            d3dcommon::D3D_DRIVER_TYPE_UNKNOWN,
+            ptr::null_mut(),
+            0,
+            requested_feature_levels[..].as_ptr(),
+            requested_feature_levels.len() as _,
+            d3d11::D3D11_SDK_VERSION,
+            ptr::null_mut(),
+            &mut feature_level as *mut _,
+            ptr::null_mut(),
+        )
+    };
 
     if !winerror::SUCCEEDED(hr) {
         // if there is no 11.1 runtime installed, requesting
         // `D3D_FEATURE_LEVEL_11_1` will return E_INVALIDARG so we just retry
         // without that
         if hr == winerror::E_INVALIDARG {
-            let hr = func(
-                adapter,
-                d3dcommon::D3D_DRIVER_TYPE_UNKNOWN,
-                ptr::null_mut(),
-                0,
-                requested_feature_levels[1 ..].as_ptr(),
-                (requested_feature_levels.len() - 1) as _,
-                d3d11::D3D11_SDK_VERSION,
-                ptr::null_mut(),
-                &mut feature_level as *mut _,
-                ptr::null_mut(),
-            );
+            let hr = unsafe {
+                func(
+                    adapter,
+                    d3dcommon::D3D_DRIVER_TYPE_UNKNOWN,
+                    ptr::null_mut(),
+                    0,
+                    requested_feature_levels[1 ..].as_ptr(),
+                    (requested_feature_levels.len() - 1) as _,
+                    d3d11::D3D11_SDK_VERSION,
+                    ptr::null_mut(),
+                    &mut feature_level as *mut _,
+                    ptr::null_mut(),
+                )
+            };
 
             if !winerror::SUCCEEDED(hr) {
                 // TODO: device might not support any feature levels?
@@ -515,7 +523,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         families: &[(&QueueFamily, &[queue::QueuePriority])],
         requested_features: hal::Features,
     ) -> Result<adapter::Gpu<Backend>, hal::device::CreationError> {
-        let func: libloading::Symbol<CreateFun> = self.library
+        let func: libloading::Symbol<CreateFun> = self.library_d3d11
             .get(b"D3D11CreateDevice")
             .unwrap();
 


### PR DESCRIPTION
Fixes #3092
PR checklist:
- [Yes (on Windows)] `make` succeeds (on *nix)
- [No (Win 7 does not support dx12, and those tests fail; I don't have access to other OS)] `make reftests` succeeds
- [Yes] tested examples with the following backends: dx11
- [Yes] `rustfmt` run on changed code

This PR keeps dxgi.dll around for the lifetime of `Instance`, in order to ensure that dxgi factories keep working.
This (I assumed) happened  to work before `d3d11.dll` was switched to libloading model, since linking in d3d11 statically pulled in dxdi transitively, so the lifetime issue never manifested.

Incidentally, this PR also marks the two libloaded `extern` functions as unsafe, as rust segfaulting in nominally `safe` code felt plain wrong to me.

Big thanks to @kvark for rubberducking me through this in #3092 