### PR TITLE
Backport of #3096 to hal-0.4 branch; bump gfx-backend-dx11 to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - `Error` implementations
   - fix `ShaderStageFlags::ALL`
 
-### backend-dx12-0.4.1, backend-dx11-0.4.2 (01-11-2019)
+### backend-dx12-0.4.1, backend-dx11-0.4.3 (01-11-2019)
   - switch to explicit linking of "d3d12.dll", "d3d11.dll" and "dxgi.dll"
 
 ### backend-dx12-0.4.1 (01-11-2019)

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.4.2"
+version = "0.4.3"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/dxgi.rs
+++ b/src/backend/dx11/src/dxgi.rs
@@ -1,9 +1,18 @@
 use hal::adapter::{AdapterInfo, DeviceType};
 
-use winapi::shared::guiddef::{GUID, REFIID};
-use winapi::shared::{dxgi, dxgi1_2, dxgi1_3, dxgi1_4, dxgi1_5, winerror};
-use winapi::um::unknwnbase::IUnknown;
-use winapi::Interface;
+use winapi::{
+    shared::{
+        dxgi,
+        dxgi1_2,
+        dxgi1_3,
+        dxgi1_4,
+        dxgi1_5,
+        guiddef::{GUID, REFIID},
+        winerror,
+    },
+    um::unknwnbase::IUnknown,
+    Interface,
+};
 
 use wio::com::ComPtr;
 
@@ -67,14 +76,16 @@ pub(crate) enum DxgiVersion {
     Dxgi1_5,
 }
 
-type DxgiFun = extern "system" fn(REFIID, *mut *mut winapi::ctypes::c_void) -> winerror::HRESULT;
+type DxgiFun =
+    unsafe extern "system" fn(REFIID, *mut *mut winapi::ctypes::c_void) -> winerror::HRESULT;
 
 fn create_dxgi_factory1(
-    func: &DxgiFun, guid: &GUID
+    func: &DxgiFun,
+    guid: &GUID,
 ) -> Result<ComPtr<dxgi::IDXGIFactory>, winerror::HRESULT> {
     let mut factory: *mut IUnknown = ptr::null_mut();
 
-    let hr = func(guid, &mut factory as *mut *mut _ as *mut *mut _);
+    let hr = unsafe { func(guid, &mut factory as *mut *mut _ as *mut *mut _) };
 
     if winerror::SUCCEEDED(hr) {
         Ok(unsafe { ComPtr::from_raw(factory as *mut _) })
@@ -84,37 +95,36 @@ fn create_dxgi_factory1(
 }
 
 pub(crate) fn get_dxgi_factory(
-) -> Result<(ComPtr<dxgi::IDXGIFactory>, DxgiVersion), winerror::HRESULT> {
-    let library = libloading::Library::new("dxgi.dll")
-        .map_err(|_| -1)?;
-    let func: libloading::Symbol<DxgiFun> = unsafe {
-        library.get(b"CreateDXGIFactory1")
-    }.map_err(|_| -1)?;
+) -> Result<(libloading::Library, ComPtr<dxgi::IDXGIFactory>, DxgiVersion), winerror::HRESULT> {
+    // The returned Com-pointer is only safe to use for the lifetime of the Library.
+    let library = libloading::Library::new("dxgi.dll").map_err(|_| -1)?;
+    let func: libloading::Symbol<DxgiFun> =
+        unsafe { library.get(b"CreateDXGIFactory1") }.map_err(|_| -1)?;
 
     // TODO: do we even need `create_dxgi_factory2`?
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi1_5::IDXGIFactory5::uuidof()) {
-        return Ok((factory, DxgiVersion::Dxgi1_5));
+        return Ok((library, factory, DxgiVersion::Dxgi1_5));
     }
 
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi1_4::IDXGIFactory4::uuidof()) {
-        return Ok((factory, DxgiVersion::Dxgi1_4));
+        return Ok((library, factory, DxgiVersion::Dxgi1_4));
     }
 
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi1_3::IDXGIFactory3::uuidof()) {
-        return Ok((factory, DxgiVersion::Dxgi1_3));
+        return Ok((library, factory, DxgiVersion::Dxgi1_3));
     }
 
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi1_2::IDXGIFactory2::uuidof()) {
-        return Ok((factory, DxgiVersion::Dxgi1_2));
+        return Ok((library, factory, DxgiVersion::Dxgi1_2));
     }
 
     if let Ok(factory) = create_dxgi_factory1(&func, &dxgi::IDXGIFactory1::uuidof()) {
-        return Ok((factory, DxgiVersion::Dxgi1_0));
+        return Ok((library, factory, DxgiVersion::Dxgi1_0));
     }
 
     // TODO: any reason why above would fail and this wouldnt?
     match create_dxgi_factory1(&func, &dxgi::IDXGIFactory::uuidof()) {
-        Ok(factory) => Ok((factory, DxgiVersion::Dxgi1_0)),
+        Ok(factory) => Ok((library, factory, DxgiVersion::Dxgi1_0)),
         Err(hr) => Err(hr),
     }
 }


### PR DESCRIPTION
Fixes #3092
PR checklist:
- [Yes] `make` succeeds (on ~~*nix~~ Win)
- [No; don't have access to dx12 ] `make reftests` succeeds
- [Yes] tested examples with the following backends: dx11
- [Yes] `rustfmt` run on changed code

This is a backport of #3096. 
Technically, this is a cherry-pick of c43d2b4b1cad00ca1f2ccecf7766e365b06aa9e5 + rustfmt + patch version bump
