### PR TITLE
Refactor DescriptorType

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -157,7 +157,9 @@ impl<B: Backend> RendererState<B> {
             vec![
                 pso::DescriptorSetLayoutBinding {
                     binding: 0,
-                    ty: pso::DescriptorType::SampledImage,
+                    ty: pso::DescriptorType::Image {
+                        ty: pso::ImageDescriptorType::Sampled,
+                    },
                     count: 1,
                     stage_flags: pso::ShaderStageFlags::FRAGMENT,
                     immutable_samplers: false,
@@ -176,7 +178,10 @@ impl<B: Backend> RendererState<B> {
             Rc::clone(&device),
             vec![pso::DescriptorSetLayoutBinding {
                 binding: 0,
-                ty: pso::DescriptorType::UniformBuffer,
+                ty: pso::DescriptorType::Buffer {
+                    access: pso::BufferDescriptorAccess::Uniform,
+                    format: pso::BufferDescriptorFormat::Structured,
+                },
                 count: 1,
                 stage_flags: pso::ShaderStageFlags::FRAGMENT,
                 immutable_samplers: false,
@@ -190,7 +195,9 @@ impl<B: Backend> RendererState<B> {
                 1, // # of sets
                 &[
                     pso::DescriptorRangeDesc {
-                        ty: pso::DescriptorType::SampledImage,
+                        ty: pso::DescriptorType::Image {
+                            ty: pso::ImageDescriptorType::Sampled,
+                        },
                         count: 1,
                     },
                     pso::DescriptorRangeDesc {
@@ -208,7 +215,10 @@ impl<B: Backend> RendererState<B> {
             .create_descriptor_pool(
                 1, // # of sets
                 &[pso::DescriptorRangeDesc {
-                    ty: pso::DescriptorType::UniformBuffer,
+                    ty: pso::DescriptorType::Buffer {
+                        access: pso::BufferDescriptorAccess::Uniform,
+                        format: pso::BufferDescriptorFormat::Structured,
+                    },
                     count: 1,
                 }],
                 pso::DescriptorPoolCreateFlags::empty(),

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -158,7 +158,7 @@ impl<B: Backend> RendererState<B> {
                 pso::DescriptorSetLayoutBinding {
                     binding: 0,
                     ty: pso::DescriptorType::Image {
-                        ty: pso::ImageDescriptorType::Sampled,
+                        ty: pso::ImageDescriptorType::Sampled { with_sampler: false },
                     },
                     count: 1,
                     stage_flags: pso::ShaderStageFlags::FRAGMENT,
@@ -196,7 +196,7 @@ impl<B: Backend> RendererState<B> {
                 &[
                     pso::DescriptorRangeDesc {
                         ty: pso::DescriptorType::Image {
-                            ty: pso::ImageDescriptorType::Sampled,
+                            ty: pso::ImageDescriptorType::Sampled { with_sampler: false },
                         },
                         count: 1,
                     },

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -179,8 +179,8 @@ impl<B: Backend> RendererState<B> {
             vec![pso::DescriptorSetLayoutBinding {
                 binding: 0,
                 ty: pso::DescriptorType::Buffer {
-                    access: pso::BufferDescriptorAccess::Uniform,
-                    format: pso::BufferDescriptorFormat::Structured,
+                    ty: pso::BufferDescriptorType::Uniform,
+                    format: pso::BufferDescriptorFormat::Structured { dynamic_offset: false },
                 },
                 count: 1,
                 stage_flags: pso::ShaderStageFlags::FRAGMENT,
@@ -216,8 +216,8 @@ impl<B: Backend> RendererState<B> {
                 1, // # of sets
                 &[pso::DescriptorRangeDesc {
                     ty: pso::DescriptorType::Buffer {
-                        access: pso::BufferDescriptorAccess::Uniform,
-                        format: pso::BufferDescriptorFormat::Structured,
+                        ty: pso::BufferDescriptorType::Uniform,
+                        format: pso::BufferDescriptorFormat::Structured { dynamic_offset: false },
                     },
                     count: 1,
                 }],

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -81,8 +81,8 @@ fn main() {
                 &[pso::DescriptorSetLayoutBinding {
                     binding: 0,
                     ty: pso::DescriptorType::Buffer {
-                        access: pso::BufferDescriptorAccess::Storage,
-                        format: pso::BufferDescriptorFormat::Structured,
+                        ty: pso::BufferDescriptorType::Storage { read_only: false },
+                        format: pso::BufferDescriptorFormat::Structured { dynamic_offset: false },
                     },
                     count: 1,
                     stage_flags: pso::ShaderStageFlags::COMPUTE,
@@ -113,8 +113,8 @@ fn main() {
                 1,
                 &[pso::DescriptorRangeDesc {
                     ty: pso::DescriptorType::Buffer {
-                        access: pso::BufferDescriptorAccess::Storage,
-                        format: pso::BufferDescriptorFormat::Structured,
+                        ty: pso::BufferDescriptorType::Storage { read_only: false },
+                        format: pso::BufferDescriptorFormat::Structured { dynamic_offset: false },
                     },
                     count: 1,
                 }],

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -80,7 +80,10 @@ fn main() {
             device.create_descriptor_set_layout(
                 &[pso::DescriptorSetLayoutBinding {
                     binding: 0,
-                    ty: pso::DescriptorType::StorageBuffer,
+                    ty: pso::DescriptorType::Buffer {
+                        access: pso::BufferDescriptorAccess::Storage,
+                        format: pso::BufferDescriptorFormat::Structured,
+                    },
                     count: 1,
                     stage_flags: pso::ShaderStageFlags::COMPUTE,
                     immutable_samplers: false,
@@ -109,7 +112,10 @@ fn main() {
             device.create_descriptor_pool(
                 1,
                 &[pso::DescriptorRangeDesc {
-                    ty: pso::DescriptorType::StorageBuffer,
+                    ty: pso::DescriptorType::Buffer {
+                        access: pso::BufferDescriptorAccess::Storage,
+                        format: pso::BufferDescriptorFormat::Structured,
+                    },
                     count: 1,
                 }],
                 pso::DescriptorPoolCreateFlags::empty(),

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -276,7 +276,7 @@ where
                         pso::DescriptorSetLayoutBinding {
                             binding: 0,
                             ty: pso::DescriptorType::Image {
-                                ty: pso::ImageDescriptorType::Sampled,
+                                ty: pso::ImageDescriptorType::Sampled { with_sampler: false },
                             },
                             count: 1,
                             stage_flags: ShaderStageFlags::FRAGMENT,
@@ -304,7 +304,7 @@ where
                     &[
                         pso::DescriptorRangeDesc {
                             ty: pso::DescriptorType::Image {
-                                ty: pso::ImageDescriptorType::Sampled,
+                                ty: pso::ImageDescriptorType::Sampled { with_sampler: false },
                             },
                             count: 1,
                         },

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -275,7 +275,9 @@ where
                     &[
                         pso::DescriptorSetLayoutBinding {
                             binding: 0,
-                            ty: pso::DescriptorType::SampledImage,
+                            ty: pso::DescriptorType::Image {
+                                ty: pso::ImageDescriptorType::Sampled,
+                            },
                             count: 1,
                             stage_flags: ShaderStageFlags::FRAGMENT,
                             immutable_samplers: false,
@@ -301,7 +303,9 @@ where
                     1, // sets
                     &[
                         pso::DescriptorRangeDesc {
-                            ty: pso::DescriptorType::SampledImage,
+                            ty: pso::DescriptorType::Image {
+                                ty: pso::ImageDescriptorType::Sampled,
+                            },
                             count: 1,
                         },
                         pso::DescriptorRangeDesc {

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -467,10 +467,12 @@ impl From<pso::DescriptorType> for DescriptorContent {
 
         match ty {
             Dt::Sampler => Dc::SAMPLER,
-            Dt::CombinedImageSampler => Dc::SRV | Dc::SAMPLER,
             Dt::Image { ty } => match ty {
                 Idt::Storage => Dc::SRV | Dc::UAV,
-                Idt::Sampled => Dc::SRV,
+                Idt::Sampled { with_sampler } => match with_sampler {
+                    true => Dc::SRV | Dc::SAMPLER,
+                    false => Dc::SRV,
+                }
             }
             Dt::Buffer { ty, format } => match ty {
                 Bdt::Storage { .. } => match format {

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -459,7 +459,7 @@ impl From<pso::DescriptorType> for DescriptorContent {
         use hal::pso::{
             DescriptorType as Dt,
             ImageDescriptorType as Idt,
-            BufferDescriptorAccess as Bda,
+            BufferDescriptorType as Bdt,
             BufferDescriptorFormat as Bdf
         };
 
@@ -472,14 +472,14 @@ impl From<pso::DescriptorType> for DescriptorContent {
                 Idt::Storage => Dc::SRV | Dc::UAV,
                 Idt::Sampled => Dc::SRV,
             }
-            Dt::Buffer { access, format } => match access {
-                Bda::Storage => match format {
-                    Bdf::Dynamic => Dc::SRV | Dc::UAV | Dc::DYNAMIC,
-                    Bdf::Structured | Bdf::Texel => Dc::SRV | Dc::UAV,
+            Dt::Buffer { ty, format } => match ty {
+                Bdt::Storage { .. } => match format {
+                    Bdf::Structured { dynamic_offset: true } => Dc::SRV | Dc::UAV | Dc::DYNAMIC,
+                    Bdf::Structured { dynamic_offset: false } | Bdf::Texel => Dc::SRV | Dc::UAV,
                 }
-                Bda::Uniform => match format {
-                    Bdf::Dynamic => Dc::CBV | Dc::DYNAMIC,
-                    Bdf::Structured => Dc::CBV,
+                Bdt::Uniform => match format {
+                    Bdf::Structured { dynamic_offset: true } => Dc::CBV | Dc::DYNAMIC,
+                    Bdf::Structured { dynamic_offset: false } => Dc::CBV,
                     Bdf::Texel => Dc::SRV,
                 }
             }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -685,16 +685,19 @@ impl d::Device<B> for Device {
                         // We need to figure out combos once we get the shaders, until then we
                         // do nothing
                     }
-                    Buffer { access, format: pso::BufferDescriptorFormat::Structured } => {
-                        match access {
-                            pso::BufferDescriptorAccess::Uniform => {
+                    Buffer {
+                        ty,
+                        format: pso::BufferDescriptorFormat::Structured { dynamic_offset: false },
+                    } => {
+                        match ty {
+                            pso::BufferDescriptorType::Uniform => {
                                 drd.insert_missing_binding_into_spare(
                                     n::BindingTypes::UniformBuffers,
                                     set as _,
                                     binding.binding,
                                 );
                             }
-                            pso::BufferDescriptorAccess::Storage => {
+                            pso::BufferDescriptorType::Storage { .. } => {
                                 drd.insert_missing_binding_into_spare(
                                     n::BindingTypes::StorageBuffers,
                                     set as _,
@@ -1547,11 +1550,11 @@ impl d::Device<B> for Device {
 
                         let ty = set.layout[binding as usize].ty;
                         let ty = match ty {
-                            pso::DescriptorType::Buffer { access, .. } => match access {
-                                pso::BufferDescriptorAccess::Uniform => {
+                            pso::DescriptorType::Buffer { ty, .. } => match ty {
+                                pso::BufferDescriptorType::Uniform => {
                                     n::BindingTypes::UniformBuffers
                                 }
-                                pso::BufferDescriptorAccess::Storage => {
+                                pso::BufferDescriptorType::Storage { .. } => {
                                     n::BindingTypes::StorageBuffers
                                 }
                             }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -674,16 +674,16 @@ impl d::Device<B> for Device {
                 assert!(!binding.immutable_samplers); //TODO: Implement immutable_samplers
                 use crate::pso::DescriptorType::*;
                 match binding.ty {
-                    CombinedImageSampler => {
+                    Sampler | Image { ty: pso::ImageDescriptorType::Sampled { with_sampler: false }} => {
+                        // We need to figure out combos once we get the shaders, until then we
+                        // do nothing
+                    }
+                    Image { ty: pso::ImageDescriptorType::Sampled { with_sampler: true }} => {
                         drd.insert_missing_binding_into_spare(
                             n::BindingTypes::Images,
                             set as _,
                             binding.binding,
                         );
-                    }
-                    Sampler | Image { ty: pso::ImageDescriptorType::Sampled } => {
-                        // We need to figure out combos once we get the shaders, until then we
-                        // do nothing
                     }
                     Buffer {
                         ty,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1908,14 +1908,14 @@ impl hal::device::Device<Backend> for Device {
                 // for textures in an argument buffer
                 match desc.ty {
                     pso::DescriptorType::Buffer {
-                        format: pso::BufferDescriptorFormat::Dynamic, ..
+                        format: pso::BufferDescriptorFormat::Structured { dynamic_offset: true }, ..
                     } => {
                         //TODO: apply the offsets somehow at the binding time
                         error!("Dynamic offsets are not yet supported in argument buffers!");
                     }
                     pso::DescriptorType::Image { ty: pso::ImageDescriptorType::Storage }
                     | pso::DescriptorType::Buffer {
-                        access: pso::BufferDescriptorAccess::Storage,
+                        ty: pso::BufferDescriptorType::Storage { .. },
                         format: pso::BufferDescriptorFormat::Texel,
                     } => {
                         //TODO: bind storage images separately

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1907,12 +1907,17 @@ impl hal::device::Device<Backend> for Device {
                 //TODO: have the API providing the dimensions and MSAA flag
                 // for textures in an argument buffer
                 match desc.ty {
-                    pso::DescriptorType::UniformBufferDynamic
-                    | pso::DescriptorType::StorageBufferDynamic => {
+                    pso::DescriptorType::Buffer {
+                        format: pso::BufferDescriptorFormat::Dynamic, ..
+                    } => {
                         //TODO: apply the offsets somehow at the binding time
                         error!("Dynamic offsets are not yet supported in argument buffers!");
                     }
-                    pso::DescriptorType::StorageImage | pso::DescriptorType::StorageTexelBuffer => {
+                    pso::DescriptorType::Image { ty: pso::ImageDescriptorType::Storage }
+                    | pso::DescriptorType::Buffer {
+                        access: pso::BufferDescriptorAccess::Storage,
+                        format: pso::BufferDescriptorFormat::Texel,
+                    } => {
                         //TODO: bind storage images separately
                         error!("Storage images are not yet supported in argument buffers!");
                     }

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -819,10 +819,10 @@ impl From<pso::DescriptorType> for DescriptorContent {
             }
             pso::DescriptorType::Image { .. } => DescriptorContent::TEXTURE,
             pso::DescriptorType::Buffer { format, .. } => match format {
-                pso::BufferDescriptorFormat::Dynamic => {
-                    DescriptorContent::BUFFER | DescriptorContent::DYNAMIC_BUFFER
+                pso::BufferDescriptorFormat::Structured { dynamic_offset } => match dynamic_offset {
+                    true => DescriptorContent::BUFFER | DescriptorContent::DYNAMIC_BUFFER,
+                    false => DescriptorContent::BUFFER,
                 }
-                pso::BufferDescriptorFormat::Structured => DescriptorContent::BUFFER,
                 pso::BufferDescriptorFormat::Texel => DescriptorContent::TEXTURE,
             }
             pso::DescriptorType::InputAttachment => DescriptorContent::TEXTURE,
@@ -934,11 +934,10 @@ impl ArgumentArray {
                 pso::ImageDescriptorType::Sampled => MTLResourceUsage::Sample,
                 pso::ImageDescriptorType::Storage => MTLResourceUsage::Write,
             }
-            Dt::Buffer { access, format } => match access {
-                pso::BufferDescriptorAccess::Storage => MTLResourceUsage::Write,
-                pso::BufferDescriptorAccess::Uniform => match format {
-                    pso::BufferDescriptorFormat::Dynamic
-                        | pso::BufferDescriptorFormat::Structured => MTLResourceUsage::Read,
+            Dt::Buffer { ty, format } => match ty {
+                pso::BufferDescriptorType::Storage { .. } => MTLResourceUsage::Write,
+                pso::BufferDescriptorType::Uniform => match format {
+                    pso::BufferDescriptorFormat::Structured { .. } => MTLResourceUsage::Read,
                     pso::BufferDescriptorFormat::Texel => MTLResourceUsage::Sample,
                 }
             }

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -170,9 +170,11 @@ pub fn map_vk_image_usage(usage: vk::ImageUsageFlags) -> image::Usage {
 pub fn map_descriptor_type(ty: pso::DescriptorType) -> vk::DescriptorType {
     match ty {
         pso::DescriptorType::Sampler => vk::DescriptorType::SAMPLER,
-        pso::DescriptorType::CombinedImageSampler => vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
         pso::DescriptorType::Image { ty } => match ty {
-            pso::ImageDescriptorType::Sampled => vk::DescriptorType::SAMPLED_IMAGE,
+            pso::ImageDescriptorType::Sampled { with_sampler } => match with_sampler {
+                true => vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
+                false => vk::DescriptorType::SAMPLED_IMAGE,
+            }
             pso::ImageDescriptorType::Storage => vk::DescriptorType::STORAGE_IMAGE,
         }
         pso::DescriptorType::Buffer { ty, format } => match ty {

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -168,7 +168,7 @@ pub fn map_vk_image_usage(usage: vk::ImageUsageFlags) -> image::Usage {
 }
 
 pub fn map_descriptor_type(ty: pso::DescriptorType) -> vk::DescriptorType {
-    vk::DescriptorType::from_raw(ty as i32)
+    vk::DescriptorType::from_raw(pso::RawDescriptorType::from(ty) as i32)
 }
 
 pub fn map_stage_flags(stages: pso::ShaderStageFlags) -> vk::ShaderStageFlags {

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -168,7 +168,31 @@ pub fn map_vk_image_usage(usage: vk::ImageUsageFlags) -> image::Usage {
 }
 
 pub fn map_descriptor_type(ty: pso::DescriptorType) -> vk::DescriptorType {
-    vk::DescriptorType::from_raw(pso::RawDescriptorType::from(ty) as i32)
+    match ty {
+        pso::DescriptorType::Sampler => vk::DescriptorType::SAMPLER,
+        pso::DescriptorType::CombinedImageSampler => vk::DescriptorType::COMBINED_IMAGE_SAMPLER,
+        pso::DescriptorType::Image { ty } => match ty {
+            pso::ImageDescriptorType::Sampled => vk::DescriptorType::SAMPLED_IMAGE,
+            pso::ImageDescriptorType::Storage => vk::DescriptorType::STORAGE_IMAGE,
+        }
+        pso::DescriptorType::Buffer { ty, format } => match ty {
+            pso::BufferDescriptorType::Storage { .. } => match format {
+                pso::BufferDescriptorFormat::Structured { dynamic_offset } => match dynamic_offset {
+                    true => vk::DescriptorType::STORAGE_BUFFER_DYNAMIC,
+                    false => vk::DescriptorType::STORAGE_BUFFER,
+                }
+                pso::BufferDescriptorFormat::Texel => vk::DescriptorType::STORAGE_TEXEL_BUFFER,
+            }
+            pso::BufferDescriptorType::Uniform => match format {
+                pso::BufferDescriptorFormat::Structured { dynamic_offset } => match dynamic_offset {
+                    true => vk::DescriptorType::UNIFORM_BUFFER_DYNAMIC,
+                    false => vk::DescriptorType::UNIFORM_BUFFER,
+                }
+                pso::BufferDescriptorFormat::Texel => vk::DescriptorType::UNIFORM_TEXEL_BUFFER,
+            }
+        }
+        pso::DescriptorType::InputAttachment => vk::DescriptorType::INPUT_ATTACHMENT,
+    }
 }
 
 pub fn map_stage_flags(stages: pso::ShaderStageFlags) -> vk::ShaderStageFlags {

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -66,20 +66,21 @@ pub enum BufferDescriptorFormat {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ImageDescriptorType {
     /// A sampled image allows sampling operations.
-    Sampled,
+    Sampled {
+        /// If true, this descriptor corresponds to both a sampled image and a
+        /// sampler to be used with that image.
+        with_sampler: bool,
+    },
     /// A storage image allows load, store and atomic operations.
     Storage,
 }
 
-/// The type of a descriptor. TODO: more specific doc
+/// The type of a descriptor.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DescriptorType {
     /// A descriptor associated with sampler.
     Sampler,
-    /// A single descriptor associated with both a sampler and an image to be
-    /// used together.
-    CombinedImageSampler,
     /// A descriptor associated with an image.
     Image {
         /// The specific type of this image descriptor.

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -95,6 +95,7 @@ impl std::convert::From<RichDescriptorType> for DescriptorType {
 
 /// Access type of a buffer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum BufferDescriptorAccess {
     /// Storage buffers allow load, store, and atomic operations.
     Storage,
@@ -104,6 +105,7 @@ pub enum BufferDescriptorAccess {
 
 /// Format of a buffer.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum BufferDescriptorFormat {
     // TODO: seems to have no effect in hal, ask about removing or documenting that it's a no-op
     /// TODO
@@ -117,6 +119,7 @@ pub enum BufferDescriptorFormat {
 
 /// Specific type of an image descriptor.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ImageDescriptorType {
     /// A storage image allows load, store and atomic operations.
     Storage,
@@ -127,6 +130,7 @@ pub enum ImageDescriptorType {
 
 /// The type of a descriptor. TODO: more specific doc
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum RichDescriptorType {
     /// A descriptor associated with sampler.
     Sampler,

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -39,7 +39,7 @@ pub type DescriptorArrayIndex = usize;
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum DescriptorType {
+pub enum RawDescriptorType {
     /// Controls filtering parameters for sampling from images.
     Sampler = 0,
     ///
@@ -67,28 +67,28 @@ pub enum DescriptorType {
     InputAttachment = 10,
 }
 
-impl std::convert::From<RichDescriptorType> for DescriptorType {
-    fn from(ty: RichDescriptorType) -> Self {
+impl std::convert::From<DescriptorType> for RawDescriptorType {
+    fn from(ty: DescriptorType) -> Self {
         match ty {
-            RichDescriptorType::Sampler => DescriptorType::Sampler,
-            RichDescriptorType::CombinedImageSampler => DescriptorType::CombinedImageSampler,
-            RichDescriptorType::Image { ty } => match ty {
-                ImageDescriptorType::Storage => DescriptorType::StorageImage,
-                ImageDescriptorType::Sampled => DescriptorType::SampledImage,
+            DescriptorType::Sampler => RawDescriptorType::Sampler,
+            DescriptorType::CombinedImageSampler => RawDescriptorType::CombinedImageSampler,
+            DescriptorType::Image { ty } => match ty {
+                ImageDescriptorType::Storage => RawDescriptorType::StorageImage,
+                ImageDescriptorType::Sampled => RawDescriptorType::SampledImage,
             }
-            RichDescriptorType::Buffer { access, format } => match access {
+            DescriptorType::Buffer { access, format } => match access {
                 BufferDescriptorAccess::Storage => match format {
-                    BufferDescriptorFormat::Dynamic => DescriptorType::StorageBufferDynamic,
-                    BufferDescriptorFormat::Structured => DescriptorType::StorageBuffer,
-                    BufferDescriptorFormat::Texel => DescriptorType::StorageTexelBuffer,
+                    BufferDescriptorFormat::Dynamic => RawDescriptorType::StorageBufferDynamic,
+                    BufferDescriptorFormat::Structured => RawDescriptorType::StorageBuffer,
+                    BufferDescriptorFormat::Texel => RawDescriptorType::StorageTexelBuffer,
                 },
                 BufferDescriptorAccess::Uniform => match format {
-                    BufferDescriptorFormat::Dynamic => DescriptorType::UniformBufferDynamic,
-                    BufferDescriptorFormat::Structured => DescriptorType::UniformBuffer,
-                    BufferDescriptorFormat::Texel => DescriptorType::UniformTexelBuffer,
+                    BufferDescriptorFormat::Dynamic => RawDescriptorType::UniformBufferDynamic,
+                    BufferDescriptorFormat::Structured => RawDescriptorType::UniformBuffer,
+                    BufferDescriptorFormat::Texel => RawDescriptorType::UniformTexelBuffer,
                 },
             }
-            RichDescriptorType::InputAttachment => DescriptorType::InputAttachment,
+            DescriptorType::InputAttachment => RawDescriptorType::InputAttachment,
         }
     }
 }
@@ -121,17 +121,16 @@ pub enum BufferDescriptorFormat {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ImageDescriptorType {
-    /// A storage image allows load, store and atomic operations.
-    Storage,
-
     /// A sampled image allows sampling operations.
     Sampled,
+    /// A storage image allows load, store and atomic operations.
+    Storage,
 }
 
 /// The type of a descriptor. TODO: more specific doc
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum RichDescriptorType {
+pub enum DescriptorType {
     /// A descriptor associated with sampler.
     Sampler,
     /// A single descriptor associated with both a sampler and an image to be

--- a/work/scenes/compute.ron
+++ b/work/scenes/compute.ron
@@ -9,9 +9,9 @@
 				(
 					binding: 0,
 					ty: Buffer(
-            access: Storage,
-            format: Structured,
-          ),
+						ty: Storage(read_only: false),
+						format: Structured(dynamic_offset: false),
+					),
 					count: 1,
 					stage_flags: (bits: 0x20), //COMPUTE
 					immutable_samplers: false,
@@ -23,9 +23,9 @@
 			ranges: [
 				(
 					ty: Buffer(
-              access: Storage,
-              format: Structured,
-          ),
+							ty: Storage(read_only: false),
+							format: Structured(dynamic_offset: false),
+					),
 					count: 1,
 				),
 			],

--- a/work/scenes/compute.ron
+++ b/work/scenes/compute.ron
@@ -8,7 +8,10 @@
 			bindings: [
 				(
 					binding: 0,
-					ty: StorageBuffer,
+					ty: Buffer(
+            access: Storage,
+            format: Structured,
+          ),
 					count: 1,
 					stage_flags: (bits: 0x20), //COMPUTE
 					immutable_samplers: false,
@@ -19,7 +22,10 @@
 			capacity: 1,
 			ranges: [
 				(
-					ty: StorageBuffer,
+					ty: Buffer(
+              access: Storage,
+              format: Structured,
+          ),
 					count: 1,
 				),
 			],

--- a/work/scenes/compute.ron
+++ b/work/scenes/compute.ron
@@ -23,8 +23,8 @@
 			ranges: [
 				(
 					ty: Buffer(
-							ty: Storage(read_only: false),
-							format: Structured(dynamic_offset: false),
+						ty: Storage(read_only: false),
+						format: Structured(dynamic_offset: false),
 					),
 					count: 1,
 				),


### PR DESCRIPTION
Fixes #3055 
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds (seems broken for DX12 on master?)
- [x] tested examples with the following backends: vulkan, dx11, dx12, gl
- [x] `rustfmt` run on changed code

This PR refactors `DescriptorType`:

```rust
pub enum DescriptorType {
    /// A descriptor associated with sampler.
    Sampler,
    /// A single descriptor associated with both a sampler and an image to be
    /// used together.
    CombinedImageSampler,
    /// A descriptor associated with an image.
    Image {
        /// The specific type of this image descriptor.
        ty: ImageDescriptorType,
    },
    /// A descriptor associated with a buffer.
    Buffer {
        /// The access type of this buffer descriptor.
        access: BufferDescriptorAccess,
        /// The format of this buffer descriptor.
        format: BufferDescriptorFormat,
    },
    /// A descriptor associated with an input attachment.
    InputAttachment,
}
```

The number of top-level variants is reduced from 11 to 5 by turning `Image` and `Buffer` into struct variants, which allows e.g.:
```rust
DescriptorType::Buffer {
    access: Storage,
    format: Texel,
}
```
for what was previously `StorageTexelBuffer`.

One other note: `gfx-backend-dx11` relies on the conversion from `DescriptorType` to `u32` for sorting descriptors, so I've kept the old `DescriptorType` as `RawDescriptorType` for that purpose.