### PR TITLE
[mtl] Properly set store operation for depth attachment

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1014,8 +1014,8 @@ impl hal::device::Device<Backend> for Device {
                 }
             }
             if let Some((id, ref mut ops)) = sub.depth_stencil {
-                if use_mask & 1 << id == 0 {
-                    *ops |= n::SubpassOps::LOAD;
+                if use_mask & 1 << id != 0 {
+                    *ops |= n::SubpassOps::STORE;
                     use_mask ^= 1 << id;
                 }
             }


### PR DESCRIPTION
Found this while looking into gfx-rs/wgpu#103. Looks like this was a copy-paste mistake, this partially fixes the wgpu shadow example on mac.

PR checklist:
- [x] `make` succeeds (on macOS)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [x] `rustfmt` run on changed code
