### PR TITLE
[0.4/dx11] disable coherent memory, remove MemoryHeapFlags

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -32,7 +32,7 @@ image = "0.21"
 log = "0.4"
 hal = { path = "../src/hal", version = "0.4", package = "gfx-hal" }
 gfx-backend-empty = { path = "../src/backend/empty", version = "0.4" }
-winit = { version = "0.20.0-alpha4", features = ["web-sys"] }
+winit = { version = "0.20.0-alpha6", features = ["web-sys"] }
 
 [target.'cfg(debug_assertions)'.dependencies]
 env_logger = "0.6"

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1661,16 +1661,16 @@ fn main() {
                             renderer_state.input(virtual_keycode);
                         }
                     }
-                    winit::event::WindowEvent::RedrawRequested => {
-                        println!("RedrawRequested");
-                        renderer_state.draw();
-                    }
                     _ => (),
                 }
             }
-            winit::event::Event::EventsCleared => {
+            winit::event::Event::RedrawRequested(_) => {
+                println!("RedrawRequested");
+                        renderer_state.draw();
+            }
+            winit::event::Event::RedrawEventsCleared => {
                 renderer_state.backend.window.request_redraw();
-                println!("EventsCleared");
+                println!("RedrawEventsCleared");
             }
             _ => (),
         }

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -195,7 +195,7 @@ fn main() {
                 }
                 _ => {}
             },
-            winit::event::Event::EventsCleared => {
+            winit::event::Event::RedrawEventsCleared => {
                 renderer.render();
             }
             _ => {}

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.4.3"
+version = "0.4.4"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -45,7 +45,6 @@ use {
     InternalBuffer,
     InternalImage,
     Memory,
-    MemoryHeapFlags,
     PipelineBinding,
     PipelineLayout,
     QueryPool,
@@ -64,6 +63,10 @@ use {
 
 use {conv, internal, shader};
 
+
+//TODO: expose coherent type 0x2 when it's properly supported
+const BUFFER_TYPE_MASK: u64 = 0x1 | 0x4;
+
 struct InputLayout {
     raw: ComPtr<d3d11::ID3D11InputLayout>,
     required_bindings: u32,
@@ -76,7 +79,6 @@ pub struct Device {
     raw: ComPtr<d3d11::ID3D11Device>,
     pub(crate) context: ComPtr<d3d11::ID3D11DeviceContext>,
     memory_properties: MemoryProperties,
-    memory_heap_flags: [MemoryHeapFlags; 3],
     pub(crate) internal: internal::Internal,
 }
 
@@ -113,11 +115,6 @@ impl Device {
             raw: device.clone(),
             context,
             memory_properties,
-            memory_heap_flags: [
-                MemoryHeapFlags::DEVICE_LOCAL,
-                MemoryHeapFlags::HOST_COHERENT,
-                MemoryHeapFlags::HOST_VISIBLE,
-            ],
             internal: internal::Internal::new(&device),
         }
     }
@@ -770,13 +767,12 @@ impl device::Device<Backend> for Device {
     ) -> Result<Memory, device::AllocationError> {
         let vec = Vec::with_capacity(size as usize);
         Ok(Memory {
-            ty: self.memory_heap_flags[mem_type.0],
             properties: self.memory_properties.memory_types[mem_type.0].properties,
             size,
             mapped_ptr: vec.as_ptr() as *mut _,
             host_visible: Some(RefCell::new(vec)),
             local_buffers: RefCell::new(Vec::new()),
-            local_images: RefCell::new(Vec::new()),
+            _local_images: RefCell::new(Vec::new()),
         })
     }
 
@@ -1027,7 +1023,7 @@ impl device::Device<Backend> for Device {
         Ok(())
     }
 
-    unsafe fn get_pipeline_cache_data(&self, cache: &()) -> Result<Vec<u8>, device::OutOfMemory> {
+    unsafe fn get_pipeline_cache_data(&self, _cache: &()) -> Result<Vec<u8>, device::OutOfMemory> {
         //empty
         Ok(Vec::new())
     }
@@ -1223,14 +1219,14 @@ impl device::Device<Backend> for Device {
                 uav: None,
                 usage,
             },
-            ty: MemoryHeapFlags::empty(),
+            properties: memory::Properties::empty(),
             bound_range: 0 .. 0,
             host_ptr: ptr::null_mut(),
             bind,
             requirements: memory::Requirements {
                 size,
                 alignment: 1,
-                type_mask: MemoryHeapFlags::all().bits(),
+                type_mask: BUFFER_TYPE_MASK,
             },
         })
     }
@@ -1269,80 +1265,76 @@ impl device::Device<Backend> for Device {
                 SysMemSlicePitch: 0,
             });
 
-        let raw = match memory.ty {
-            MemoryHeapFlags::DEVICE_LOCAL => {
-                // device local memory
-                let desc = d3d11::D3D11_BUFFER_DESC {
-                    ByteWidth: buffer.requirements.size as _,
-                    Usage: d3d11::D3D11_USAGE_DEFAULT,
-                    BindFlags: buffer.bind,
-                    CPUAccessFlags: 0,
-                    MiscFlags,
-                    StructureByteStride: if buffer
-                        .internal
-                        .usage
-                        .contains(buffer::Usage::TRANSFER_SRC)
-                    {
-                        4
-                    } else {
-                        0
-                    },
-                };
+        let raw = if memory.properties.contains(memory::Properties::DEVICE_LOCAL) {
+            // device local memory
+            let desc = d3d11::D3D11_BUFFER_DESC {
+                ByteWidth: buffer.requirements.size as _,
+                Usage: d3d11::D3D11_USAGE_DEFAULT,
+                BindFlags: buffer.bind,
+                CPUAccessFlags: 0,
+                MiscFlags,
+                StructureByteStride: if buffer
+                    .internal
+                    .usage
+                    .contains(buffer::Usage::TRANSFER_SRC)
+                {
+                    4
+                } else {
+                    0
+                },
+            };
 
-                let mut buffer: *mut d3d11::ID3D11Buffer = ptr::null_mut();
-                let hr = self.raw.CreateBuffer(
-                    &desc,
-                    if let Some(data) = initial_data {
-                        &data
-                    } else {
-                        ptr::null_mut()
-                    },
-                    &mut buffer as *mut *mut _ as *mut *mut _,
-                );
+            let mut buffer: *mut d3d11::ID3D11Buffer = ptr::null_mut();
+            let hr = self.raw.CreateBuffer(
+                &desc,
+                if let Some(data) = initial_data {
+                    &data
+                } else {
+                    ptr::null_mut()
+                },
+                &mut buffer as *mut *mut _ as *mut *mut _,
+            );
 
-                if !winerror::SUCCEEDED(hr) {
-                    return Err(device::BindError::WrongMemory);
-                }
-
-                ComPtr::from_raw(buffer)
+            if !winerror::SUCCEEDED(hr) {
+                return Err(device::BindError::WrongMemory);
             }
-            MemoryHeapFlags::HOST_VISIBLE | MemoryHeapFlags::HOST_COHERENT => {
-                let desc = d3d11::D3D11_BUFFER_DESC {
-                    ByteWidth: buffer.requirements.size as _,
-                    // TODO: dynamic?
-                    Usage: d3d11::D3D11_USAGE_DEFAULT,
-                    BindFlags: buffer.bind,
-                    CPUAccessFlags: 0,
-                    MiscFlags,
-                    StructureByteStride: if buffer
-                        .internal
-                        .usage
-                        .contains(buffer::Usage::TRANSFER_SRC)
-                    {
-                        4
-                    } else {
-                        0
-                    },
-                };
 
-                let mut buffer: *mut d3d11::ID3D11Buffer = ptr::null_mut();
-                let hr = self.raw.CreateBuffer(
-                    &desc,
-                    if let Some(data) = initial_data {
-                        &data
-                    } else {
-                        ptr::null_mut()
-                    },
-                    &mut buffer as *mut *mut _ as *mut *mut _,
-                );
+            ComPtr::from_raw(buffer)
+        } else {
+            let desc = d3d11::D3D11_BUFFER_DESC {
+                ByteWidth: buffer.requirements.size as _,
+                // TODO: dynamic?
+                Usage: d3d11::D3D11_USAGE_DEFAULT,
+                BindFlags: buffer.bind,
+                CPUAccessFlags: 0,
+                MiscFlags,
+                StructureByteStride: if buffer
+                    .internal
+                    .usage
+                    .contains(buffer::Usage::TRANSFER_SRC)
+                {
+                    4
+                } else {
+                    0
+                },
+            };
 
-                if !winerror::SUCCEEDED(hr) {
-                    return Err(device::BindError::WrongMemory);
-                }
+            let mut buffer: *mut d3d11::ID3D11Buffer = ptr::null_mut();
+            let hr = self.raw.CreateBuffer(
+                &desc,
+                if let Some(data) = initial_data {
+                    &data
+                } else {
+                    ptr::null_mut()
+                },
+                &mut buffer as *mut *mut _ as *mut *mut _,
+            );
 
-                ComPtr::from_raw(buffer)
+            if !winerror::SUCCEEDED(hr) {
+                return Err(device::BindError::WrongMemory);
             }
-            _ => unimplemented!(),
+
+            ComPtr::from_raw(buffer)
         };
 
         let disjoint_cb = if buffer.internal.disjoint_cb.is_some() {
@@ -1439,7 +1431,7 @@ impl device::Device<Backend> for Device {
             uav,
             usage: buffer.internal.usage,
         };
-        let range = offset .. buffer.requirements.size;
+        let range = offset .. offset + buffer.requirements.size;
 
         memory.bind_buffer(range.clone(), internal.clone());
 
@@ -1450,7 +1442,7 @@ impl device::Device<Backend> for Device {
         };
 
         buffer.internal = internal;
-        buffer.ty = memory.ty;
+        buffer.properties = memory.properties;
         buffer.host_ptr = host_ptr;
         buffer.bound_range = range;
 
@@ -1471,7 +1463,7 @@ impl device::Device<Backend> for Device {
         kind: image::Kind,
         mip_levels: image::Level,
         format: format::Format,
-        tiling: image::Tiling,
+        _tiling: image::Tiling,
         usage: image::Usage,
         view_caps: image::ViewCapabilities,
     ) -> Result<Image, image::CreationError> {
@@ -1523,13 +1515,12 @@ impl device::Device<Backend> for Device {
             mip_levels,
             format,
             usage,
-            tiling,
             view_caps,
             bind,
             requirements: memory::Requirements {
                 size: size,
                 alignment: 1,
-                type_mask: MemoryHeapFlags::DEVICE_LOCAL.bits(),
+                type_mask: 0x1, // device-local only
             },
         })
     }
@@ -2177,9 +2168,8 @@ impl device::Device<Backend> for Device {
                     pso::Descriptor::Buffer(buffer, ref _range) => match ty {
                         pso::DescriptorType::UniformBuffer
                         | pso::DescriptorType::UniformBufferDynamic => {
-                            if buffer.ty == MemoryHeapFlags::HOST_COHERENT {
+                            if buffer.properties.contains(memory::Properties::COHERENT) {
                                 let old_buffer = (*handle).0 as *mut _;
-
                                 write.set.add_flush(old_buffer, buffer);
                             }
 
@@ -2190,9 +2180,8 @@ impl device::Device<Backend> for Device {
                             };
                         }
                         pso::DescriptorType::StorageBuffer => {
-                            if buffer.ty == MemoryHeapFlags::HOST_COHERENT {
+                            if buffer.properties.contains(memory::Properties::COHERENT) {
                                 let old_buffer = (*handle).0 as *mut _;
-
                                 write.set.add_flush(old_buffer, buffer);
                                 write.set.add_invalidate(old_buffer, buffer);
                             }
@@ -2397,15 +2386,15 @@ impl device::Device<Backend> for Device {
         unimplemented!()
     }
 
-    unsafe fn get_event_status(&self, event: &()) -> Result<bool, device::OomOrDeviceLost> {
+    unsafe fn get_event_status(&self, _event: &()) -> Result<bool, device::OomOrDeviceLost> {
         unimplemented!()
     }
 
-    unsafe fn set_event(&self, event: &()) -> Result<(), device::OutOfMemory> {
+    unsafe fn set_event(&self, _event: &()) -> Result<(), device::OutOfMemory> {
         unimplemented!()
     }
 
-    unsafe fn reset_event(&self, event: &()) -> Result<(), device::OutOfMemory> {
+    unsafe fn reset_event(&self, _event: &()) -> Result<(), device::OutOfMemory> {
         unimplemented!()
     }
 
@@ -2565,11 +2554,10 @@ impl device::Device<Backend> for Device {
                     bind: 0, // TODO: ?
                     requirements: memory::Requirements {
                         // values don't really matter
-                        size: 1,
-                        alignment: 1,
-                        type_mask: MemoryHeapFlags::DEVICE_LOCAL.bits(),
+                        size: 0,
+                        alignment: 0,
+                        type_mask: 0,
                     },
-                    tiling: image::Tiling::Optimal,
                 }
             })
             .collect();


### PR DESCRIPTION
The coherency isn't working properly yet. It needs to be improved before we can turn it on again (see #3119).
There was also an error in buffer ranges, possibly related to #3114 
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: quad
- [ ] `rustfmt` run on changed code
