### PR TITLE
[dx11] new binding model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+### backend-dx11-0.4.4, backend-dx11-0.4.5 (06-01-2020)
+  - disable coherent memory for being broken
+  - rewrite the binding model completely
+
+### backend-metal-0.4.2 (18-11-2019)
+  - fix missing iOS metallib
+  - fix viewport/scissor after `clear_attachments` call
+
 ### hal-0.4.1 (04-11-2019)
   - `Error` implementations
   - fix `ShaderStageFlags::ALL`

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ check:
 	cd examples && cargo check $(CHECK_TARGET_FLAG) --features "$(FEATURES_HAL2)"
 	cd examples && cargo check $(CHECK_TARGET_FLAG) --features "$(FEATURES_HAL3)"
 	cd src/warden && cargo check $(CHECK_TARGET_FLAG) --no-default-features
-	cd src/warden && cargo check $(CHECK_TARGET_FLAG) --features "env_logger gl gl-headless $(FEATURES_HAL) $(FEATURES_HAL2)"
+	cd src/warden && cargo check $(CHECK_TARGET_FLAG) --features "env_logger gl gl-ci $(FEATURES_HAL) $(FEATURES_HAL2)"
 
 test:
 	cargo test --all $(EXCLUDES)
@@ -69,8 +69,8 @@ benches:
 	cd src/warden && cargo run --release --bin bench --features "$(FEATURES_HAL) $(FEATURES_HAL2)" -- blit
 
 reftests-ci:
-	cd src/warden && cargo test --features "gl"
-	cd src/warden && cargo run --features "gl" -- ci #TODO: "gl-headless"
+	cd src/warden && cargo test
+	cd src/warden && cargo run --features "gl-ci" -- ci
 
 quad:
 	cd examples && cargo run --bin quad --features ${FEATURES_HAL}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -32,7 +32,7 @@ image = "0.21"
 log = "0.4"
 hal = { path = "../src/hal", version = "0.4", package = "gfx-hal" }
 gfx-backend-empty = { path = "../src/backend/empty", version = "0.4" }
-winit = { version = "0.20.0-alpha6", features = ["web-sys"] }
+winit = { version = "0.20", features = ["web-sys"] }
 
 [target.'cfg(debug_assertions)'.dependencies]
 env_logger = "0.6"

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1607,10 +1607,11 @@ fn main() {
 
     let event_loop = winit::event_loop::EventLoop::new();
     let window_builder = winit::window::WindowBuilder::new()
-        .with_min_inner_size(winit::dpi::LogicalSize::new(1.0, 1.0))
-        .with_inner_size(winit::dpi::LogicalSize::new(
-            DIMS.width as _,
-            DIMS.height as _,
+        .with_min_inner_size(
+            winit::dpi::Size::Logical(winit::dpi::LogicalSize::new(64.0, 64.0))
+        )
+        .with_inner_size(winit::dpi::Size::Physical(
+            winit::dpi::PhysicalSize::new(DIMS.width, DIMS.height)
         ))
         .with_title("colour-uniform".to_string());
 
@@ -1653,7 +1654,7 @@ fn main() {
                             .backend
                             .surface
                             .get_context_t()
-                            .resize(dims.to_physical(renderer_state.backend.window.hidpi_factor()));
+                            .resize(dims);
                         println!("RESIZE EVENT");
                         renderer_state.recreate_swapchain = true;
                     }

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -101,12 +101,12 @@ fn main() {
 
     let event_loop = winit::event_loop::EventLoop::new();
 
-    let dpi = event_loop.primary_monitor().hidpi_factor();
     let wb = winit::window::WindowBuilder::new()
-        .with_min_inner_size(winit::dpi::LogicalSize::new(1.0, 1.0))
-        .with_inner_size(winit::dpi::LogicalSize::from_physical(
-            winit::dpi::PhysicalSize::new(DIMS.width as _, DIMS.height as _),
-            dpi,
+        .with_min_inner_size(
+            winit::dpi::Size::Logical(winit::dpi::LogicalSize::new(64.0, 64.0))
+        )
+        .with_inner_size(winit::dpi::Size::Physical(
+            winit::dpi::PhysicalSize::new(DIMS.width, DIMS.height),
         ))
         .with_title("quad".to_string());
 
@@ -124,7 +124,7 @@ fn main() {
         (window, Some(instance), adapters, surface)
     };
     #[cfg(feature = "gl")]
-    let (window, instance, mut adapters, surface) = {
+    let (_window, instance, mut adapters, surface) = {
         #[cfg(not(target_arch = "wasm32"))]
         let (window, surface) = {
             let builder =
@@ -185,11 +185,11 @@ fn main() {
                     #[cfg(all(feature = "gl", not(target_arch = "wasm32")))]
                     {
                         let context = renderer.surface.context();
-                        context.resize(dims.to_physical(window.hidpi_factor()));
+                        context.resize(dims);
                     }
                     renderer.dimensions = window::Extent2D {
-                        width: (dims.width * dpi) as u32,
-                        height: (dims.height * dpi) as u32,
+                        width: dims.width,
+                        height: dims.height,
                     };
                     renderer.recreate_swapchain();
                 }

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.4.4"
+version = "0.4.5"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -44,9 +44,11 @@ use crate::{
     CommandBuffer,
     CommandPool,
     ComputePipeline,
-    Descriptor,
+    DescriptorContent,
+    DescriptorIndex,
     DescriptorPool,
     DescriptorSet,
+    DescriptorSetInfo,
     DescriptorSetLayout,
     Fence,
     Framebuffer,
@@ -56,13 +58,14 @@ use crate::{
     InternalBuffer,
     InternalImage,
     Memory,
-    PipelineBinding,
+    MultiStageData,
     PipelineLayout,
     QueryPool,
     RawFence,
-    RegisterMapping,
-    RegisterRemapping,
+    RegisterData,
+    RegisterAccumulator,
     RenderPass,
+    ResourceIndex,
     Sampler,
     Semaphore,
     ShaderModule,
@@ -857,186 +860,20 @@ impl device::Device<Backend> for Device {
         IR: IntoIterator,
         IR::Item: Borrow<(pso::ShaderStageFlags, Range<u32>)>,
     {
-        use pso::DescriptorType::*;
-
-        let mut set_bindings = Vec::new();
-        let mut set_remapping = Vec::new();
-
-        // since we remapped the bindings in our descriptor set layouts to their own local space
-        // (starting from register 0), we need to combine all the registers when creating our
-        // pipeline layout. we do this by simply offsetting all the registers by the amount of
-        // registers in the previous descriptor set layout
-        let mut s_offset = 0;
-        let mut t_offset = 0;
-        let mut c_offset = 0;
-        let mut u_offset = 0;
-
-        fn get_descriptor_offset(ty: pso::DescriptorType, s: u32, t: u32, c: u32, u: u32) -> u32 {
-            use pso::{
-                BufferDescriptorType as Bdt,
-                BufferDescriptorFormat as Bdf,
-                ImageDescriptorType as Idt,
-            };
-
-            match ty {
-                Sampler => s,
-                Image { ty } => match ty {
-                    Idt::Sampled { with_sampler } => match with_sampler {
-                        true => unreachable!(),
-                        false => t,
-                    },
-                    Idt::Storage => u,
-                }
-                Buffer { ty: bty, format } => match bty {
-                    Bdt::Storage { .. } => u,
-                    Bdt::Uniform => match format {
-                        Bdf::Structured { .. } => c,
-                        Bdf::Texel => t,
-                    }
-                }
-                InputAttachment => u,
-            }
-        }
-
-        for layout in set_layouts {
-            let layout = layout.borrow();
-
-            let bindings = &layout.bindings;
-
-            let stages = [
-                pso::ShaderStageFlags::VERTEX,
-                pso::ShaderStageFlags::HULL,
-                pso::ShaderStageFlags::DOMAIN,
-                pso::ShaderStageFlags::GEOMETRY,
-                pso::ShaderStageFlags::FRAGMENT,
-                pso::ShaderStageFlags::COMPUTE,
-            ];
-
-            let mut optimized_bindings = Vec::new();
-
-            // for every shader stage we get a range of descriptor handles that can be bound with
-            // PS/VS/CSSetXX()
-            for &stage in &stages {
-                let mut state = None;
-
-                for binding in bindings {
-                    if !binding.stage.contains(stage) {
-                        continue;
-                    }
-
-                    state = match state {
-                        None => {
-                            if binding.stage.contains(stage) {
-                                let offset = binding.handle_offset;
-
-                                Some((
-                                    binding.ty,
-                                    binding.binding_range.start,
-                                    binding.binding_range.end,
-                                    offset,
-                                    offset,
-                                ))
-                            } else {
-                                None
-                            }
-                        }
-                        Some((
-                            mut ty,
-                            mut start,
-                            mut end,
-                            mut start_offset,
-                            mut current_offset,
-                        )) => {
-                            // if we encounter another type or the binding/handle
-                            // range is broken, push our current descriptor range
-                            // and begin a new one.
-                            if ty != binding.ty
-                                || end != binding.binding_range.start
-                                || current_offset + 1 != binding.handle_offset
-                            {
-                                let register_offset = get_descriptor_offset(
-                                    ty, s_offset, t_offset, c_offset, u_offset,
-                                );
-
-                                optimized_bindings.push(PipelineBinding {
-                                    stage,
-                                    ty,
-                                    binding_range: (register_offset + start)
-                                        .. (register_offset + end),
-                                    handle_offset: start_offset,
-                                });
-
-                                if binding.stage.contains(stage) {
-                                    ty = binding.ty;
-                                    start = binding.binding_range.start;
-                                    end = binding.binding_range.end;
-
-                                    start_offset = binding.handle_offset;
-                                    current_offset = binding.handle_offset;
-
-                                    Some((ty, start, end, start_offset, current_offset))
-                                } else {
-                                    None
-                                }
-                            } else {
-                                end += 1;
-                                current_offset += 1;
-
-                                Some((ty, start, end, start_offset, current_offset))
-                            }
-                        }
-                    }
-                }
-
-                // catch trailing descriptors
-                if let Some((ty, start, end, start_offset, _)) = state {
-                    let register_offset =
-                        get_descriptor_offset(ty, s_offset, t_offset, c_offset, u_offset);
-
-                    optimized_bindings.push(PipelineBinding {
-                        stage,
-                        ty,
-                        binding_range: (register_offset + start) .. (register_offset + end),
-                        handle_offset: start_offset,
-                    });
-                }
-            }
-
-            let offset_mappings = layout
-                .register_remap
-                .mapping
-                .iter()
-                .map(|register| {
-                    let register_offset =
-                        get_descriptor_offset(register.ty, s_offset, t_offset, c_offset, u_offset);
-
-                    RegisterMapping {
-                        ty: register.ty,
-                        spirv_binding: register.spirv_binding,
-                        hlsl_register: register.hlsl_register + register_offset as u8,
-                        combined: register.combined,
-                    }
-                })
-                .collect();
-
-            set_bindings.push(optimized_bindings);
-            set_remapping.push(RegisterRemapping {
-                mapping: offset_mappings,
-                num_s: layout.register_remap.num_s,
-                num_t: layout.register_remap.num_t,
-                num_c: layout.register_remap.num_c,
-                num_u: layout.register_remap.num_u,
+        let mut res_offsets = MultiStageData::<RegisterData<RegisterAccumulator>>::default();
+        let mut sets = Vec::new();
+        for set_layout in set_layouts {
+            let layout = set_layout.borrow();
+            sets.push(DescriptorSetInfo {
+                bindings: Arc::clone(&layout.bindings),
+                registers: res_offsets.advance(&layout.pool_mapping),
             });
+        };
 
-            s_offset += layout.register_remap.num_s as u32;
-            t_offset += layout.register_remap.num_t as u32;
-            c_offset += layout.register_remap.num_c as u32;
-            u_offset += layout.register_remap.num_u as u32;
-        }
+        //TODO: assert that res_offsets are within supported range
 
         Ok(PipelineLayout {
-            set_bindings,
-            set_remapping,
+            sets,
         })
     }
 
@@ -1979,7 +1816,6 @@ impl device::Device<Backend> for Device {
         })
     }
 
-    // TODO: make use of `max_sets`
     unsafe fn create_descriptor_pool<I>(
         &self,
         _max_sets: usize,
@@ -1990,21 +1826,15 @@ impl device::Device<Backend> for Device {
         I: IntoIterator,
         I::Item: Borrow<pso::DescriptorRangeDesc>,
     {
-        let count = ranges
-            .into_iter()
-            .map(|r| {
-                let r = r.borrow();
+        let mut total = RegisterData::default();
+        for range in ranges {
+            let r = range.borrow();
+            let content = DescriptorContent::from(r.ty);
+            total.add_content_many(content, r.count as DescriptorIndex);
+        }
 
-                r.count
-                    * match r.ty {
-                        pso::DescriptorType::Image {
-                            ty: pso::ImageDescriptorType::Sampled { with_sampler: true }
-                        } => 2,
-                        _ => 1,
-                    }
-            })
-            .sum::<usize>();
-
+        let max_stages = 6;
+        let count = total.sum() * max_stages;
         Ok(DescriptorPool::with_capacity(count))
     }
 
@@ -2019,171 +1849,26 @@ impl device::Device<Backend> for Device {
         J: IntoIterator,
         J::Item: Borrow<Sampler>,
     {
-        use pso::{
-            BufferDescriptorType as Bdt,
-            BufferDescriptorFormat as Bdf,
-            DescriptorType::*,
-            ImageDescriptorType as Idt,
-        };
+        let mut total = MultiStageData::<RegisterData<_>>::default();
+        let mut bindings = layout_bindings
+            .into_iter()
+            .map(|b| b.borrow().clone())
+            .collect::<Vec<_>>();
 
-        let mut bindings = Vec::new();
-
-        let mut mapping = Vec::new();
-        let mut num_t = 0;
-        let mut num_s = 0;
-        let mut num_c = 0;
-        let mut num_u = 0;
-
-        // we check how many hlsl registers we should use
-        for binding in layout_bindings {
-            let binding = binding.borrow();
-
-
-            let hlsl_reg = match binding.ty {
-                Sampler => {
-                    num_s += 1;
-                    num_s
-                }
-                Image { ty: Idt::Sampled { with_sampler: true }} => {
-                    num_t += 1;
-                    num_s += 1;
-                    num_t
-                }
-                Image { ty: Idt::Sampled { with_sampler: false }}
-                | Buffer { ty: Bdt::Uniform, format: Bdf::Texel } => {
-                    num_t += 1;
-                    num_t
-                }
-                Buffer { ty: Bdt::Uniform, .. } => {
-                    num_c += 1;
-                    num_c
-                }
-                Buffer { ty: Bdt::Storage { .. }, .. }
-                | Image { ty: Idt::Storage, .. }
-                | InputAttachment => {
-                    num_u += 1;
-                    num_u
-                }
-            } - 1;
-
-            // we decompose combined image samplers into a separate sampler and image internally
-            if binding.ty == (pso::DescriptorType::Image {
-                ty: Idt::Sampled { with_sampler: true }
-            }) {
-                // TODO: for now we have to make combined image samplers share registers since
-                //       spirv-cross doesn't support setting the register of the sampler/texture
-                //       pair to separate values (only one `DescriptorSet` decorator)
-                let shared_reg = num_s.max(num_t);
-
-                num_s = shared_reg;
-                num_t = shared_reg;
-
-                let sampler_reg = num_s - 1;
-                let image_reg = num_t - 1;
-
-                mapping.push(RegisterMapping {
-                    ty: pso::DescriptorType::Sampler,
-                    spirv_binding: binding.binding,
-                    hlsl_register: sampler_reg as u8,
-                    combined: true,
-                });
-                mapping.push(RegisterMapping {
-                    ty: pso::DescriptorType::Image {
-                        ty: pso::ImageDescriptorType::Sampled { with_sampler: false },
-                    },
-                    spirv_binding: binding.binding,
-                    hlsl_register: image_reg as u8,
-                    combined: true,
-                });
-
-                bindings.push(PipelineBinding {
-                    stage: binding.stage_flags,
-                    ty: pso::DescriptorType::Sampler,
-                    binding_range: sampler_reg .. (sampler_reg + 1),
-                    handle_offset: 0,
-                });
-                bindings.push(PipelineBinding {
-                    stage: binding.stage_flags,
-                    ty: pso::DescriptorType::Image {
-                        ty: pso::ImageDescriptorType::Sampled { with_sampler: false },
-                    },
-                    binding_range: image_reg .. (image_reg + 1),
-                    handle_offset: 0,
-                });
-            } else {
-                mapping.push(RegisterMapping {
-                    ty: binding.ty,
-                    spirv_binding: binding.binding,
-                    hlsl_register: hlsl_reg as u8,
-                    combined: false,
-                });
-
-                bindings.push(PipelineBinding {
-                    stage: binding.stage_flags,
-                    ty: binding.ty,
-                    binding_range: hlsl_reg .. (hlsl_reg + 1),
-                    handle_offset: 0,
-                });
-            }
+        for binding in bindings.iter() {
+            let content = DescriptorContent::from(binding.ty);
+            total.add_content(content, binding.stage_flags);
         }
 
-        // we sort the internal descriptor's handle (the actual dx interface) by some categories to
-        // make it easier to group api calls together
-        bindings.sort_unstable_by(|a, b| {
-            (b.ty)
-                .cmp(&a.ty)
-                .then(a.binding_range.start.cmp(&b.binding_range.start))
-                .then(a.stage.cmp(&b.stage))
+        bindings.sort_by_key(|a| a.binding);
+
+        let accum = total.map_register(|count| RegisterAccumulator {
+            res_index: *count as ResourceIndex,
         });
 
-        // we assign the handle (interface ptr) offset according to what register type the
-        // descriptor is. the final layout of the handles should look like this:
-        //
-        //       0..num_s     num_s..num_t  num_t..num_c  num_c..handle_len
-        //   +----------+----------------+-------------+------------------+
-        //   |          |                |             |                  |
-        //   +----------+----------------+-------------+------------------+
-        //   0                                                   handle_len
-        //
-        let mut s = 0;
-        let mut t = 0;
-        let mut c = 0;
-        let mut u = 0;
-        for mut binding in bindings.iter_mut() {
-            match binding.ty {
-                Sampler => {
-                    binding.handle_offset = s;
-                    s += 1;
-                }
-                Image { ty: Idt::Sampled { with_sampler: false }}
-                | Buffer { ty: Bdt::Uniform, format: Bdf::Texel } => {
-                    binding.handle_offset = num_s + t;
-                    t += 1;
-                }
-                Buffer { ty: Bdt::Uniform, .. } => {
-                    binding.handle_offset = num_s + num_t + c;
-                    c += 1;
-                }
-                Buffer { ty: Bdt::Storage { .. }, .. }
-                | Image { ty: Idt::Storage }
-                | InputAttachment => {
-                    binding.handle_offset = num_s + num_t + num_c + u;
-                    u += 1;
-                }
-                Image { ty: Idt::Sampled { with_sampler: true }} => unreachable!(),
-            };
-        }
-
         Ok(DescriptorSetLayout {
-            bindings,
-            handle_count: num_s + num_t + num_c + num_u,
-            register_remap: RegisterRemapping {
-                mapping,
-                num_s: num_s as _,
-                num_t: num_t as _,
-                num_c: num_c as _,
-                num_u: num_u as _,
-            },
+            bindings: Arc::new(bindings),
+            pool_mapping: accum.to_mapping(),
         })
     }
 
@@ -2193,76 +1878,73 @@ impl device::Device<Backend> for Device {
         J: IntoIterator,
         J::Item: Borrow<pso::Descriptor<'a, Backend>>,
     {
-        use pso::{
-            BufferDescriptorType as Bdt,
-            BufferDescriptorFormat as Bdf,
-            DescriptorType as Dt,
-            ImageDescriptorType as Idt,
-        };
-
         for write in write_iter {
-            //println!("WriteDescriptorSets({:?})", write.set.handles);
-            let target_binding = write.binding;
-            let (ty, first_offset, second_offset) = write.set.get_handle_offset(target_binding);
-            assert!((first_offset as usize) < write.set.len);
-            assert!((second_offset as usize) < write.set.len);
+            let mut mapping = write.set.layout.pool_mapping
+                .map_register(|mapping| mapping.offset);
+            let binding_start = write.set.layout.bindings
+                .iter()
+                .position(|binding| binding.binding == write.binding)
+                .unwrap();
+            for binding in &write.set.layout.bindings[.. binding_start] {
+                let content = DescriptorContent::from(binding.ty);
+                mapping.add_content(content, binding.stage_flags);
+            }
 
-            for descriptor in write.descriptors {
-                let handle = write.set.handles.offset(first_offset as isize);
-                let second_handle = write.set.handles.offset(second_offset as isize);
-
-                //println!("  Write(offset={}, handle={:?}) <= {:?}", first_offset, handle, ty);
-
-                match *descriptor.borrow() {
-                    pso::Descriptor::Buffer(buffer, ref _range) => match ty {
-                        Dt::Buffer { ty: Bdt::Uniform, format } if format != Bdf::Texel => {
-                            if buffer.properties.contains(memory::Properties::COHERENT) {
-                                let old_buffer = (*handle).0 as *mut _;
-                                write.set.add_flush(old_buffer, buffer);
-                            }
-
-                            *handle = if let Some(buffer) = buffer.internal.disjoint_cb {
-                                Descriptor(buffer as *mut _)
-                            } else {
-                                Descriptor(buffer.internal.raw as *mut _)
-                            };
-                        }
-                        Dt::Buffer {
-                            ty: Bdt::Storage { .. },
-                            format: Bdf::Structured { dynamic_offset: false },
-                        } => {
-                            if buffer.properties.contains(memory::Properties::COHERENT) {
-                                let old_buffer = (*handle).0 as *mut _;
-                                write.set.add_flush(old_buffer, buffer);
-                                write.set.add_invalidate(old_buffer, buffer);
-                            }
-
-                            *handle = Descriptor(buffer.internal.uav.unwrap() as *mut _);
-                        }
-                        _ => unreachable!(),
-                    },
-                    pso::Descriptor::Image(image, _layout) => *handle = Descriptor(match ty {
-                        Dt::Image { ty: img_ty } => match img_ty {
-                            Idt::Sampled { with_sampler } => match with_sampler {
-                                true => unreachable!(),
-                                false => image.srv_handle.clone().unwrap().as_raw() as *mut _,
-                            }
-                            Idt::Storage => image.uav_handle.clone().unwrap().as_raw() as *mut _,
+            for (binding, descriptor) in write.set.layout.bindings[binding_start ..]
+                .iter()
+                .zip(write.descriptors)
+            {
+                let handles = match *descriptor.borrow() {
+                    pso::Descriptor::Buffer(buffer, ref _range) => RegisterData {
+                        c: match buffer.internal.disjoint_cb {
+                            Some(dj_buf) => dj_buf as *mut _,
+                            None => buffer.internal.raw as *mut _,
                         },
-                        Dt::InputAttachment => image.srv_handle.clone().unwrap().as_raw() as *mut _,
-                        _ => unreachable!(),
-                    }),
-                    pso::Descriptor::Sampler(sampler) => {
-                        *handle = Descriptor(sampler.sampler_handle.as_raw() as *mut _);
-                    }
-                    pso::Descriptor::CombinedImageSampler(image, _layout, sampler) => {
-                        *handle = Descriptor(sampler.sampler_handle.as_raw() as *mut _);
-                        *second_handle =
-                            Descriptor(image.srv_handle.clone().unwrap().as_raw() as *mut _);
-                    }
-                    pso::Descriptor::UniformTexelBuffer(_buffer_view) => {}
-                    pso::Descriptor::StorageTexelBuffer(_buffer_view) => {}
-                }
+                        t: buffer.internal.srv.map_or(ptr::null_mut(), |p| p as *mut _),
+                        u: buffer.internal.uav.map_or(ptr::null_mut(), |p| p as *mut _),
+                        s: ptr::null_mut(),
+                    },
+                    pso::Descriptor::Image(image, _layout) => RegisterData {
+                        c: ptr::null_mut(),
+                        t: image.srv_handle.clone().map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                        u: image.uav_handle.clone().map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                        s: ptr::null_mut(),
+                    },
+                    pso::Descriptor::Sampler(sampler) => RegisterData {
+                        c: ptr::null_mut(),
+                        t: ptr::null_mut(),
+                        u: ptr::null_mut(),
+                        s: sampler.sampler_handle.as_raw() as *mut _,
+                    },
+                    pso::Descriptor::CombinedImageSampler(image, _layout, sampler) => RegisterData {
+                        c: ptr::null_mut(),
+                        t: image.srv_handle.clone().map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                        u: image.uav_handle.clone().map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                        s: sampler.sampler_handle.as_raw() as *mut _,
+                    },
+                    pso::Descriptor::UniformTexelBuffer(_buffer_view) => unimplemented!(),
+                    pso::Descriptor::StorageTexelBuffer(_buffer_view) => unimplemented!(),
+                };
+
+                let content = DescriptorContent::from(binding.ty);
+                if content.contains(DescriptorContent::CBV) {
+                    let offsets = mapping.map_other(|map| map.c);
+                    write.set.assign_stages(&offsets, binding.stage_flags, handles.c);
+                };
+                if content.contains(DescriptorContent::SRV) {
+                    let offsets = mapping.map_other(|map| map.t);
+                    write.set.assign_stages(&offsets, binding.stage_flags, handles.t);
+                };
+                if content.contains(DescriptorContent::UAV) {
+                    let offsets = mapping.map_other(|map| map.u);
+                    write.set.assign_stages(&offsets, binding.stage_flags, handles.u);
+                };
+                if content.contains(DescriptorContent::SAMPLER) {
+                    let offsets = mapping.map_other(|map| map.s);
+                    write.set.assign_stages(&offsets, binding.stage_flags, handles.s);
+                };
+
+                mapping.add_content(content, binding.stage_flags);
             }
         }
     }
@@ -2273,8 +1955,9 @@ impl device::Device<Backend> for Device {
         I::Item: Borrow<pso::DescriptorSetCopy<'a, Backend>>,
     {
         for copy in copy_iter {
-            let copy = copy.borrow();
-
+            let _copy = copy.borrow();
+            //TODO
+            /*
             for offset in 0 .. copy.count {
                 let (dst_ty, dst_handle_offset, dst_second_handle_offset) = copy
                     .dst_set
@@ -2305,7 +1988,7 @@ impl device::Device<Backend> for Device {
                     }
                     _ => *dst_handle = *src_handle,
                 }
-            }
+            }*/
         }
     }
 

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1,3 +1,19 @@
+/*!
+# DX11 backend internals.
+
+## Pipeline Layout
+
+In D3D11 there are tables of CBVs, SRVs, UAVs, and samplers.
+
+Each descriptor type can take 1 or two of those entry points.
+
+The descriptor pool is just and array of handles, belonging to descriptor set 1, descriptor set 2, etc.
+Each range of descriptors in a descriptor set area of the pool is split into shader stages,
+which in turn is split into CBS/SRV/UAV/Sampler parts. That allows binding a descriptor set as a list
+of continuous descriptor ranges (per type, per shader stage).
+
+!*/
+
 //#[deny(missing_docs)]
 
 #[macro_use]
@@ -1439,151 +1455,6 @@ impl CommandBuffer {
         }
     }
 
-    unsafe fn bind_vertex_descriptor(
-        &self,
-        context: &ComPtr<d3d11::ID3D11DeviceContext>,
-        binding: &PipelineBinding,
-        handles: *mut Descriptor,
-    ) {
-        use pso::DescriptorType::*;
-
-        let handles = handles.offset(binding.handle_offset as isize);
-        let start = binding.binding_range.start as UINT;
-        let len = binding.binding_range.end as UINT - start;
-
-        match binding.ty {
-            Sampler => context.VSSetSamplers(start, len, handles as *const *mut _ as *const *mut _),
-            Image { ty: pso::ImageDescriptorType::Sampled { with_sampler: true }} => {
-                context.VSSetShaderResources(start, len, handles as *const *mut _ as *const *mut _);
-                context.VSSetSamplers(
-                    start,
-                    len,
-                    handles.offset(1) as *const *mut _ as *const *mut _,
-                );
-            }
-
-            Image { ty: pso::ImageDescriptorType::Sampled { with_sampler: false }} | InputAttachment => {
-                context.VSSetShaderResources(start, len, handles as *const *mut _ as *const *mut _)
-            }
-
-            Buffer {
-                ty: pso::BufferDescriptorType::Uniform , format
-            } if format != pso::BufferDescriptorFormat::Texel => {
-                context.VSSetConstantBuffers(start, len, handles as *const *mut _ as *const *mut _)
-            }
-
-            _ => (),
-        }
-    }
-
-    unsafe fn bind_fragment_descriptor(
-        &self,
-        context: &ComPtr<d3d11::ID3D11DeviceContext>,
-        binding: &PipelineBinding,
-        handles: *mut Descriptor,
-    ) {
-        use pso::DescriptorType::*;
-
-        let handles = handles.offset(binding.handle_offset as isize);
-        let start = binding.binding_range.start as UINT;
-        let len = binding.binding_range.end as UINT - start;
-
-        match binding.ty {
-            Sampler => context.PSSetSamplers(start, len, handles as *const *mut _ as *const *mut _),
-            Image { ty: pso::ImageDescriptorType::Sampled { with_sampler: true }} => {
-                context.PSSetShaderResources(start, len, handles as *const *mut _ as *const *mut _);
-                context.PSSetSamplers(
-                    start,
-                    len,
-                    handles.offset(1) as *const *mut _ as *const *mut _,
-                );
-            }
-
-            Image { ty: pso::ImageDescriptorType::Sampled { with_sampler: false }} | InputAttachment => {
-                context.PSSetShaderResources(start, len, handles as *const *mut _ as *const *mut _)
-            }
-
-            Buffer {
-                ty: pso::BufferDescriptorType::Uniform , format
-            } if format != pso::BufferDescriptorFormat::Texel => {
-                context.PSSetConstantBuffers(start, len, handles as *const *mut _ as *const *mut _)
-            }
-
-            _ => (),
-        }
-    }
-
-    unsafe fn bind_compute_descriptor(
-        &self,
-        context: &ComPtr<d3d11::ID3D11DeviceContext>,
-        binding: &PipelineBinding,
-        handles: *mut Descriptor,
-    ) {
-        use pso::DescriptorType::*;
-
-        let handles = handles.offset(binding.handle_offset as isize);
-        let start = binding.binding_range.start as UINT;
-        let len = binding.binding_range.end as UINT - start;
-
-        match binding.ty {
-            Sampler => context.CSSetSamplers(start, len, handles as *const *mut _ as *const *mut _),
-            Image { ty: pso::ImageDescriptorType::Sampled { with_sampler: true }} => {
-                context.CSSetShaderResources(start, len, handles as *const *mut _ as *const *mut _);
-                context.CSSetSamplers(
-                    start,
-                    len,
-                    handles.offset(1) as *const *mut _ as *const *mut _,
-                );
-            }
-
-            Image { ty: pso::ImageDescriptorType::Sampled { with_sampler: false }}
-            | InputAttachment => {
-                context.CSSetShaderResources(start, len, handles as *const *mut _ as *const *mut _)
-            }
-
-            Buffer {
-                ty: pso::BufferDescriptorType::Uniform , format
-            } if format != pso::BufferDescriptorFormat::Texel => {
-                context.CSSetConstantBuffers(start, len, handles as *const *mut _ as *const *mut _)
-            }
-
-            Image { ty: pso::ImageDescriptorType::Storage } | Buffer {
-                ty: pso::BufferDescriptorType::Storage { .. },
-                format: pso::BufferDescriptorFormat::Structured { dynamic_offset: false },
-            } => context.CSSetUnorderedAccessViews(
-                start,
-                len,
-                handles as *const *mut _ as *const *mut _,
-                ptr::null_mut(),
-            ),
-
-            _ => unimplemented!(),
-        }
-    }
-
-    fn bind_descriptor(
-        &self,
-        context: &ComPtr<d3d11::ID3D11DeviceContext>,
-        binding: &PipelineBinding,
-        handles: *mut Descriptor,
-    ) {
-        //use pso::ShaderStageFlags::*;
-
-        unsafe {
-            if binding.stage.contains(pso::ShaderStageFlags::VERTEX) {
-                self.bind_vertex_descriptor(context, binding, handles);
-            }
-
-            if binding.stage.contains(pso::ShaderStageFlags::FRAGMENT) {
-                self.bind_fragment_descriptor(context, binding, handles);
-            }
-
-            if binding.stage.contains(pso::ShaderStageFlags::COMPUTE) {
-                self.bind_compute_descriptor(context, binding, handles);
-            }
-        }
-    }
-
     fn defer_coherent_flush(&mut self, buffer: &Buffer) {
         if !self
             .flush_coherent_memory
@@ -2006,11 +1877,10 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
         //let offsets: Vec<command::DescriptorSetOffset> = offsets.into_iter().map(|o| *o.borrow()).collect();
 
-        let iter = sets
+        for (set, info) in sets
             .into_iter()
-            .zip(layout.set_bindings.iter().skip(first_set));
-
-        for (set, bindings) in iter {
+            .zip(&layout.sets[first_set ..])
+        {
             let set = set.borrow();
 
             {
@@ -2048,8 +1918,49 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
             }
 
             // TODO: offsets
-            for binding in bindings.iter() {
-                self.bind_descriptor(&self.context, binding, set.handles);
+
+            if let Some(rd) = info.registers.vs.c.as_some() {
+                self.context.VSSetConstantBuffers(
+                    rd.res_index as u32,
+                    rd.count as u32,
+                    set.handles.offset(rd.pool_offset as isize) as *const *mut _ as *const *mut _,
+                );
+            }
+            if let Some(rd) = info.registers.vs.t.as_some() {
+                self.context.VSSetShaderResources(
+                    rd.res_index as u32,
+                    rd.count as u32,
+                    set.handles.offset(rd.pool_offset as isize) as *const *mut _ as *const *mut _,
+                );
+            }
+            if let Some(rd) = info.registers.vs.s.as_some() {
+                self.context.VSSetSamplers(
+                    rd.res_index as u32,
+                    rd.count as u32,
+                    set.handles.offset(rd.pool_offset as isize) as *const *mut _ as *const *mut _,
+                );
+            }
+
+            if let Some(rd) = info.registers.ps.c.as_some() {
+                self.context.PSSetConstantBuffers(
+                    rd.res_index as u32,
+                    rd.count as u32,
+                    set.handles.offset(rd.pool_offset as isize) as *const *mut _ as *const *mut _,
+                );
+            }
+            if let Some(rd) = info.registers.ps.t.as_some() {
+                self.context.PSSetShaderResources(
+                    rd.res_index as u32,
+                    rd.count as u32,
+                    set.handles.offset(rd.pool_offset as isize) as *const *mut _ as *const *mut _,
+                );
+            }
+            if let Some(rd) = info.registers.ps.s.as_some() {
+                self.context.PSSetSamplers(
+                    rd.res_index as u32,
+                    rd.count as u32,
+                    set.handles.offset(rd.pool_offset as isize) as *const *mut _ as *const *mut _,
+                );
             }
         }
     }
@@ -2079,11 +1990,10 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
             [ptr::null_mut(); 16].as_ptr(),
             ptr::null_mut(),
         );
-        let iter = sets
+        for (set, info) in sets
             .into_iter()
-            .zip(layout.set_bindings.iter().skip(first_set));
-
-        for (set, bindings) in iter {
+            .zip(&layout.sets[first_set ..])
+        {
             let set = set.borrow();
 
             {
@@ -2120,8 +2030,35 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
             }
 
             // TODO: offsets
-            for binding in bindings.iter() {
-                self.bind_descriptor(&self.context, binding, set.handles);
+
+            if let Some(rd) = info.registers.cs.c.as_some() {
+                self.context.CSSetConstantBuffers(
+                    rd.res_index as u32,
+                    rd.count as u32,
+                    set.handles.offset(rd.pool_offset as isize) as *const *mut _ as *const *mut _,
+                );
+            }
+            if let Some(rd) = info.registers.cs.t.as_some() {
+                self.context.CSSetShaderResources(
+                    rd.res_index as u32,
+                    rd.count as u32,
+                    set.handles.offset(rd.pool_offset as isize) as *const *mut _ as *const *mut _,
+                );
+            }
+            if let Some(rd) = info.registers.cs.u.as_some() {
+                self.context.CSSetUnorderedAccessViews(
+                    rd.res_index as u32,
+                    rd.count as u32,
+                    set.handles.offset(rd.pool_offset as isize) as *const *mut _ as *const *mut _,
+                    ptr::null_mut(),
+                );
+            }
+            if let Some(rd) = info.registers.cs.s.as_some() {
+                self.context.CSSetSamplers(
+                    rd.res_index as u32,
+                    rd.count as u32,
+                    set.handles.offset(rd.pool_offset as isize) as *const *mut _ as *const *mut _,
+                );
             }
         }
     }
@@ -2897,37 +2834,255 @@ impl fmt::Debug for GraphicsPipeline {
 unsafe impl Send for GraphicsPipeline {}
 unsafe impl Sync for GraphicsPipeline {}
 
-#[derive(Clone, Debug)]
-struct PipelineBinding {
-    stage: pso::ShaderStageFlags,
-    ty: pso::DescriptorType,
-    binding_range: Range<u32>,
-    handle_offset: u32,
+type ResourceIndex = u8;
+type DescriptorIndex = u16;
+
+#[derive(Clone, Debug, Default)]
+struct RegisterData<T> {
+    // CBV
+    c: T,
+    // SRV
+    t: T,
+    // UAV
+    u: T,
+    // Sampler
+    s: T,
+}
+
+impl<T> RegisterData<T> {
+    fn map<U, F: Fn(&T) -> U>(
+        &self,
+        fun: F,
+    ) -> RegisterData<U> {
+        RegisterData {
+            c: fun(&self.c),
+            t: fun(&self.t),
+            u: fun(&self.u),
+            s: fun(&self.s),
+        }
+    }
+}
+
+impl RegisterData<DescriptorIndex> {
+    fn add_content_many(&mut self, content: DescriptorContent, many: DescriptorIndex) {
+        if content.contains(DescriptorContent::CBV) {
+            self.c += many;
+        }
+        if content.contains(DescriptorContent::SRV) {
+            self.t += many;
+        }
+        if content.contains(DescriptorContent::UAV) {
+            self.u += many;
+        }
+        if content.contains(DescriptorContent::SAMPLER) {
+            self.s += many;
+        }
+    }
+
+    fn add_content(&mut self, content: DescriptorContent) {
+        self.add_content_many(content, 1)
+    }
+
+    fn sum(&self) -> DescriptorIndex {
+        self.c + self.t + self.u + self.s
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct MultiStageData<T> {
+    vs: T,
+    ps: T,
+    cs: T,
+}
+
+impl<T> MultiStageData<T> {
+    fn select(self, stage: pso::Stage) -> T {
+        match stage {
+            pso::Stage::Vertex => self.vs,
+            pso::Stage::Fragment => self.ps,
+            pso::Stage::Compute => self.cs,
+            _ => panic!("Unsupported stage {:?}", stage)
+        }
+    }
+}
+
+impl<T> MultiStageData<RegisterData<T>> {
+    fn map_register<U, F: Fn(&T) -> U>(
+        &self,
+        fun: F,
+    ) -> MultiStageData<RegisterData<U>> {
+        MultiStageData {
+            vs: self.vs.map(&fun),
+            ps: self.ps.map(&fun),
+            cs: self.cs.map(&fun),
+        }
+    }
+
+    fn map_other<U, F: Fn(&RegisterData<T>) -> U>(
+        &self,
+        fun: F,
+    ) -> MultiStageData<U> {
+        MultiStageData {
+            vs: fun(&self.vs),
+            ps: fun(&self.ps),
+            cs: fun(&self.cs),
+        }
+    }
+}
+
+impl MultiStageData<RegisterData<DescriptorIndex>> {
+    fn add_content(&mut self, content: DescriptorContent, stages: pso::ShaderStageFlags) {
+        if stages.contains(pso::ShaderStageFlags::VERTEX) {
+            self.vs.add_content(content);
+        }
+        if stages.contains(pso::ShaderStageFlags::FRAGMENT) {
+            self.ps.add_content(content);
+        }
+        if stages.contains(pso::ShaderStageFlags::COMPUTE) {
+            self.cs.add_content(content);
+        }
+    }
+
+    fn sum(&self) -> DescriptorIndex {
+        self.vs.sum() + self.ps.sum() + self.cs.sum()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct RegisterPoolMapping {
+    offset: DescriptorIndex,
+    count: ResourceIndex,
+}
+
+#[derive(Clone, Debug, Default)]
+struct RegisterInfo {
+    res_index: ResourceIndex,
+    pool_offset: DescriptorIndex,
+    count: ResourceIndex,
+}
+
+impl RegisterInfo {
+    fn as_some(&self) -> Option<&Self> {
+        if self.count == 0 {
+            None
+        } else {
+            Some(self)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct RegisterAccumulator {
+    res_index: ResourceIndex,
+}
+
+impl RegisterAccumulator {
+    fn to_mapping(
+        &self,
+        cur_offset: &mut DescriptorIndex,
+    ) -> RegisterPoolMapping {
+        let offset = *cur_offset;
+        *cur_offset += self.res_index as DescriptorIndex;
+
+        RegisterPoolMapping {
+            offset,
+            count: self.res_index,
+        }
+    }
+
+    fn advance(
+        &mut self,
+        mapping: &RegisterPoolMapping,
+    ) -> RegisterInfo {
+        let res_index = self.res_index;
+        self.res_index += mapping.count;
+        RegisterInfo {
+            res_index,
+            pool_offset: mapping.offset,
+            count: mapping.count,
+        }
+    }
+}
+
+impl RegisterData<RegisterAccumulator> {
+    fn to_mapping(
+        &self,
+        pool_offset: &mut DescriptorIndex,
+    ) -> RegisterData<RegisterPoolMapping> {
+        RegisterData {
+            c: self.c.to_mapping(pool_offset),
+            t: self.t.to_mapping(pool_offset),
+            u: self.u.to_mapping(pool_offset),
+            s: self.s.to_mapping(pool_offset),
+        }
+    }
+
+    fn advance(
+        &mut self,
+        mapping: &RegisterData<RegisterPoolMapping>,
+    ) -> RegisterData<RegisterInfo> {
+        RegisterData {
+            c: self.c.advance(&mapping.c),
+            t: self.t.advance(&mapping.t),
+            u: self.u.advance(&mapping.u),
+            s: self.s.advance(&mapping.s),
+        }
+    }
+}
+
+impl MultiStageData<RegisterData<RegisterAccumulator>> {
+    fn to_mapping(&self) -> MultiStageData<RegisterData<RegisterPoolMapping>> {
+        let mut pool_offset = 0;
+        MultiStageData {
+            vs: self.vs.to_mapping(&mut pool_offset),
+            ps: self.ps.to_mapping(&mut pool_offset),
+            cs: self.cs.to_mapping(&mut pool_offset),
+        }
+    }
+
+    fn advance(
+        &mut self,
+        mapping: &MultiStageData<RegisterData<RegisterPoolMapping>>,
+    ) -> MultiStageData<RegisterData<RegisterInfo>> {
+        MultiStageData {
+            vs: self.vs.advance(&mapping.vs),
+            ps: self.ps.advance(&mapping.ps),
+            cs: self.cs.advance(&mapping.cs),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
-struct RegisterMapping {
-    ty: pso::DescriptorType,
-    spirv_binding: u32,
-    hlsl_register: u8,
-    combined: bool,
+struct DescriptorSetInfo {
+    bindings: Arc<Vec<pso::DescriptorSetLayoutBinding>>,
+    registers: MultiStageData<RegisterData<RegisterInfo>>,
 }
 
-#[derive(Clone, Debug)]
-struct RegisterRemapping {
-    mapping: Vec<RegisterMapping>,
-    num_t: u8,
-    num_s: u8,
-    num_c: u8,
-    num_u: u8,
+impl DescriptorSetInfo {
+    fn find_register(
+        &self,
+        stage: pso::Stage,
+        binding_index: pso::DescriptorBinding,
+    ) -> (DescriptorContent, RegisterData<ResourceIndex>) {
+        let mut res_offsets = self.registers
+            .map_register(|info| info.res_index as DescriptorIndex)
+            .select(stage);
+        for binding in self.bindings.iter() {
+            let content = DescriptorContent::from(binding.ty);
+            if binding.binding == binding_index {
+                return (content, res_offsets.map(|offset| *offset as ResourceIndex))
+            }
+            res_offsets.add_content(content);
+        }
+        panic!("Unable to find binding {:?}", binding_index);
+    }
 }
 
 /// The pipeline layout holds optimized (less api calls) ranges of objects for all descriptor sets
 /// belonging to the pipeline object.
 #[derive(Debug)]
 pub struct PipelineLayout {
-    set_bindings: Vec<Vec<PipelineBinding>>,
-    set_remapping: Vec<RegisterRemapping>,
+    sets: Vec<DescriptorSetInfo>,
 }
 
 /// The descriptor set layout contains mappings from a given binding to the offset in our
@@ -2935,9 +3090,8 @@ pub struct PipelineLayout {
 /// handles).
 #[derive(Debug)]
 pub struct DescriptorSetLayout {
-    bindings: Vec<PipelineBinding>,
-    handle_count: u32,
-    register_remap: RegisterRemapping,
+    bindings: Arc<Vec<pso::DescriptorSetLayoutBinding>>,
+    pool_mapping: MultiStageData<RegisterData<RegisterPoolMapping>>,
 }
 
 #[derive(Debug)]
@@ -2963,7 +3117,7 @@ struct CoherentBuffers {
 }
 
 impl CoherentBuffers {
-    fn add_flush(&self, old: *mut d3d11::ID3D11Buffer, buffer: &Buffer) {
+    fn _add_flush(&self, old: *mut d3d11::ID3D11Buffer, buffer: &Buffer) {
         let new = buffer.internal.raw;
 
         if old != new {
@@ -3003,7 +3157,7 @@ impl CoherentBuffers {
         }
     }
 
-    fn add_invalidate(&self, old: *mut d3d11::ID3D11Buffer, buffer: &Buffer) {
+    fn _add_invalidate(&self, old: *mut d3d11::ID3D11Buffer, buffer: &Buffer) {
         let new = buffer.internal.raw;
 
         if old != new {
@@ -3031,12 +3185,61 @@ impl CoherentBuffers {
 #[repr(C)]
 struct Descriptor(*mut d3d11::ID3D11DeviceChild);
 
+bitflags! {
+    /// A set of D3D11 descriptor types that need to be associated
+    /// with a single gfx-hal `DescriptorType`.
+    #[derive(Default)]
+    pub struct DescriptorContent: u8 {
+        const CBV = 0x1;
+        const SRV = 0x2;
+        const UAV = 0x4;
+        const SAMPLER = 0x8;
+        /// Indicates if the descriptor is a dynamic uniform/storage buffer.
+        /// Important as dynamic buffers are implemented as root descriptors.
+        const DYNAMIC = 0x10;
+    }
+}
+
+impl From<pso::DescriptorType> for DescriptorContent {
+    fn from(ty: pso::DescriptorType) -> Self {
+        use hal::pso::{
+            DescriptorType as Dt,
+            BufferDescriptorFormat as Bdf,
+            BufferDescriptorType as Bdt,
+            ImageDescriptorType as Idt,
+        };
+        match ty {
+            Dt::Sampler =>
+                DescriptorContent::SAMPLER,
+            Dt::Image { ty: Idt::Sampled { with_sampler: true } } =>
+                DescriptorContent::SRV | DescriptorContent::SAMPLER,
+            Dt::Image { ty: Idt::Sampled { with_sampler: false } } |
+            Dt::InputAttachment =>
+                DescriptorContent::SRV,
+            Dt::Image { ty: Idt::Storage } =>
+                DescriptorContent::SRV | DescriptorContent::UAV,
+            Dt::Buffer { ty: Bdt::Uniform, format: Bdf::Structured { dynamic_offset: true } } =>
+                DescriptorContent::CBV | DescriptorContent::DYNAMIC,
+            Dt::Buffer { ty: Bdt::Uniform, .. } =>
+                DescriptorContent::CBV,
+            Dt::Buffer { ty: Bdt::Storage { read_only: true }, format: Bdf::Structured { dynamic_offset: true } } =>
+                DescriptorContent::SRV | DescriptorContent::DYNAMIC,
+            Dt::Buffer { ty: Bdt::Storage { read_only: false }, format: Bdf::Structured { dynamic_offset: true } } =>
+                DescriptorContent::SRV | DescriptorContent::UAV | DescriptorContent::DYNAMIC,
+            Dt::Buffer { ty: Bdt::Storage { read_only: true }, .. } =>
+                DescriptorContent::SRV,
+            Dt::Buffer { ty: Bdt::Storage { read_only: false }, .. } =>
+                DescriptorContent::SRV | DescriptorContent::UAV,
+        }
+    }
+}
+
 pub struct DescriptorSet {
-    offset: usize,
-    len: usize,
+    offset: DescriptorIndex,
+    len: DescriptorIndex,
     handles: *mut Descriptor,
-    register_remap: RegisterRemapping,
     coherent_buffers: Mutex<CoherentBuffers>,
+    layout: DescriptorSetLayout,
 }
 
 impl fmt::Debug for DescriptorSet {
@@ -3049,81 +3252,40 @@ unsafe impl Send for DescriptorSet {}
 unsafe impl Sync for DescriptorSet {}
 
 impl DescriptorSet {
-    fn get_handle_offset(&self, target_binding: u32) -> (pso::DescriptorType, u8, u8) {
-        use pso::{
-            BufferDescriptorType as Bdt,
-            BufferDescriptorFormat as Bdf,
-            DescriptorType::*,
-            ImageDescriptorType as Idt,
-        };
-
-        let mapping = self
-            .register_remap
-            .mapping
-            .iter()
-            .find(|&mapping| target_binding == mapping.spirv_binding)
-            .unwrap();
-
-        let (ty, register) = (mapping.ty, mapping.hlsl_register);
-
-        match ty {
-            Sampler => {
-                let (ty, t_reg) = if mapping.combined {
-                    let combined_mapping = self
-                        .register_remap
-                        .mapping
-                        .iter()
-                        .find(|&mapping| {
-                            mapping.ty == Image { ty: Idt::Sampled { with_sampler: false } }
-                                && target_binding == mapping.spirv_binding
-                        })
-                        .unwrap();
-                    (
-                        Image { ty: Idt::Sampled { with_sampler: true }},
-                        combined_mapping.hlsl_register
-                    )
-                } else {
-                    (ty, 0)
-                };
-
-                (ty, register, self.register_remap.num_s + t_reg)
-            }
-            Image { ty: Idt::Sampled { with_sampler: false } }
-            | Buffer { ty: Bdt::Uniform, format: Bdf::Texel } => {
-                (ty, self.register_remap.num_s + register, 0)
-            }
-            Buffer { ty: Bdt::Uniform, .. } => (
-                ty,
-                self.register_remap.num_s + self.register_remap.num_t + register,
-                0,
-            ),
-            Buffer { ty: Bdt::Storage { .. }, .. }
-            | Image { ty: Idt::Storage }
-            | InputAttachment => (
-                ty,
-                self.register_remap.num_s
-                    + self.register_remap.num_t
-                    + self.register_remap.num_c
-                    + register,
-                0,
-            ),
-            Image { ty: Idt::Sampled { with_sampler: true }} => unreachable!(),
-        }
-    }
-
-    fn add_flush(&self, old: *mut d3d11::ID3D11Buffer, buffer: &Buffer) {
+    fn _add_flush(&self, old: *mut d3d11::ID3D11Buffer, buffer: &Buffer) {
         let new = buffer.internal.raw;
 
         if old != new {
-            self.coherent_buffers.lock().add_flush(old, buffer);
+            self.coherent_buffers.lock()._add_flush(old, buffer);
         }
     }
 
-    fn add_invalidate(&self, old: *mut d3d11::ID3D11Buffer, buffer: &Buffer) {
+    fn _add_invalidate(&self, old: *mut d3d11::ID3D11Buffer, buffer: &Buffer) {
         let new = buffer.internal.raw;
 
         if old != new {
-            self.coherent_buffers.lock().add_invalidate(old, buffer);
+            self.coherent_buffers.lock()._add_invalidate(old, buffer);
+        }
+    }
+
+    unsafe fn assign(&self, offset: DescriptorIndex, value: *mut d3d11::ID3D11DeviceChild) {
+        *self.handles.offset(offset as isize) = Descriptor(value);
+    }
+
+    unsafe fn assign_stages(
+        &self,
+        offsets: &MultiStageData<DescriptorIndex>,
+        stages: pso::ShaderStageFlags,
+        value: *mut d3d11::ID3D11DeviceChild,
+    ) {
+        if stages.contains(pso::ShaderStageFlags::VERTEX) {
+            self.assign(offsets.vs, value);
+        }
+        if stages.contains(pso::ShaderStageFlags::FRAGMENT) {
+            self.assign(offsets.ps, value);
+        }
+        if stages.contains(pso::ShaderStageFlags::COMPUTE) {
+            self.assign(offsets.cs, value);
         }
     }
 }
@@ -3131,16 +3293,16 @@ impl DescriptorSet {
 #[derive(Debug)]
 pub struct DescriptorPool {
     handles: Vec<Descriptor>,
-    allocator: RangeAllocator<usize>,
+    allocator: RangeAllocator<DescriptorIndex>,
 }
 
 unsafe impl Send for DescriptorPool {}
 unsafe impl Sync for DescriptorPool {}
 
 impl DescriptorPool {
-    pub fn with_capacity(size: usize) -> Self {
+    fn with_capacity(size: DescriptorIndex) -> Self {
         DescriptorPool {
-            handles: vec![Descriptor(ptr::null_mut()); size],
+            handles: vec![Descriptor(ptr::null_mut()); size as usize],
             allocator: RangeAllocator::new(0 .. size),
         }
     }
@@ -3151,14 +3313,15 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         &mut self,
         layout: &DescriptorSetLayout,
     ) -> Result<DescriptorSet, pso::AllocationError> {
-        // TODO: make sure this doesn't contradict vulkan semantics
-        // if layout has 0 bindings, allocate 1 handle anyway
-        let len = layout.handle_count.max(1) as _;
+        let len = layout.pool_mapping
+            .map_register(|mapping| mapping.count as DescriptorIndex)
+            .sum()
+            .max(1);
 
         self.allocator
             .allocate_range(len)
             .map(|range| {
-                for handle in &mut self.handles[range.clone()] {
+                for handle in &mut self.handles[range.start as usize .. range.end as usize] {
                     *handle = Descriptor(ptr::null_mut());
                 }
 
@@ -3166,11 +3329,14 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
                     offset: range.start,
                     len,
                     handles: self.handles.as_mut_ptr().offset(range.start as _),
-                    register_remap: layout.register_remap.clone(),
                     coherent_buffers: Mutex::new(CoherentBuffers {
                         flush_coherent_buffers: RefCell::new(Vec::new()),
                         invalidate_coherent_buffers: RefCell::new(Vec::new()),
                     }),
+                    layout: DescriptorSetLayout {
+                        bindings: Arc::clone(&layout.bindings),
+                        pool_mapping: layout.pool_mapping.clone(),
+                    },
                 }
             })
             .map_err(|_| pso::AllocationError::OutOfPoolMemory)

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -34,7 +34,7 @@ lazy_static = "1"
 raw-window-handle = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-glutin = { version = "0.22.0-alpha5", optional = true }
+glutin = { version = "0.22", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1954,8 +1954,8 @@ impl d::Device<B> for Device {
             extent: config.extent,
             context: {
                 surface.context().resize(glutin::dpi::PhysicalSize::new(
-                    config.extent.width as f64,
-                    config.extent.height as f64,
+                    config.extent.width,
+                    config.extent.height,
                 ));
                 surface.context.clone()
             },

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -24,7 +24,7 @@ dx12 = ["gfx-backend-dx12"]
 dx11 = ["gfx-backend-dx11"]
 metal = ["gfx-backend-metal"]
 gl = ["gfx-backend-gl"]
-gl-headless = ["gfx-backend-gl"] # "glsl-to-spirv"
+gl-ci = ["gfx-backend-gl"] # "glsl-to-spirv"
 
 #TODO: keep Warden backend-agnostic?
 

--- a/src/warden/src/bin/bench.rs
+++ b/src/warden/src/bin/bench.rs
@@ -4,7 +4,8 @@
         feature = "dx12",
         feature = "dx11",
         feature = "metal",
-        feature = "gl"
+        feature = "gl",
+        feature = "gl-ci"
     )),
     allow(dead_code)
 )]
@@ -72,6 +73,7 @@ impl Harness {
         Harness { base_path, suite }
     }
 
+    #[cfg_attr(any(feature = "gl", feature = "gl-ci"), allow(dead_code))]
     fn run<B: hal::Backend>(&self, name: &str, disabilities: Disabilities) {
         println!("Benching {}:", name);
         let instance = B::Instance::create("warden", 1).unwrap();
@@ -174,32 +176,14 @@ fn main() {
     }
     #[cfg(feature = "gl")]
     {
-        use gfx_backend_gl::glutin;
         println!("Benching GL:");
-        let events_loop = glutin::event_loop::EventLoop::new();
-        let windowed_context = glutin::ContextBuilder::new()
-            .with_gl_profile(glutin::GlProfile::Core)
-            .build_windowed(glutin::window::WindowBuilder::new(), &events_loop)
-            .unwrap();
-        let (context, _window) = unsafe {
-            windowed_context
-                .make_current()
-                .expect("Unable to make window current")
-                .split()
-        };
-        let instance = gfx_backend_gl::Surface::from_context(context);
+        let instance = warden::init_gl_surface();
         harness.run_instance(instance, Disabilities::default());
     }
-    #[cfg(feature = "gl-headless")]
+    #[cfg(feature = "gl-ci")]
     {
-        use gfx_backend_gl::glutin;
-        println!("Benching GL headless:");
-        let events_loop = glutin::event_loop::EventLoop::new();
-        let context = glutin::ContextBuilder::new()
-            .build_headless(&events_loop, glutin::dpi::PhysicalSize::new(0.0, 0.0))
-            .unwrap();
-        let context = unsafe { context.make_current() }.expect("Unable to make context current");
-        let instance = gfx_backend_gl::Headless::from_context(context);
+        println!("Benching GL on CI:");
+        let instance = warden::init_gl_on_ci();
         harness.run_instance(instance, Disabilities::default());
     }
     #[cfg(not(any(
@@ -207,7 +191,8 @@ fn main() {
         feature = "dx12",
         feature = "dx11",
         feature = "metal",
-        feature = "gl"
+        feature = "gl",
+        feature = "gl-ci"
     )))]
     {
         println!("No backend selected!");

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -4,7 +4,8 @@
         feature = "dx12",
         feature = "dx11",
         feature = "metal",
-        feature = "gl"
+        feature = "gl",
+        feature = "gl-ci"
     )),
     allow(dead_code)
 )]
@@ -80,6 +81,7 @@ impl Harness {
         Harness { base_path, suite }
     }
 
+    #[cfg_attr(any(feature = "gl", feature = "gl-ci"), allow(dead_code))]
     fn run<B: hal::Backend>(&self, name: &str, disabilities: Disabilities) -> usize {
         println!("Testing {}:", name);
         let instance = B::Instance::create("warden", 1).unwrap();
@@ -212,32 +214,14 @@ fn main() {
     }
     #[cfg(feature = "gl")]
     {
-        use gfx_backend_gl::glutin;
         println!("Testing GL:");
-        let events_loop = glutin::event_loop::EventLoop::new();
-        let windowed_context = glutin::ContextBuilder::new()
-            .with_gl_profile(glutin::GlProfile::Core)
-            .build_windowed(glutin::window::WindowBuilder::new(), &events_loop)
-            .unwrap();
-        let (context, _window) = unsafe {
-            windowed_context
-                .make_current()
-                .expect("Unable to make window current")
-                .split()
-        };
-        let instance = gfx_backend_gl::Surface::from_context(context);
+        let instance = warden::init_gl_surface();
         num_failures += harness.run_instance(instance, Disabilities::default());
     }
-    #[cfg(feature = "gl-headless")]
+    #[cfg(feature = "gl-ci")]
     {
-        use gfx_backend_gl::glutin;
-        println!("Testing GL headless:");
-        let events_loop = glutin::event_loop::EventLoop::new();
-        let context = glutin::ContextBuilder::new()
-            .build_headless(&events_loop, glutin::dpi::PhysicalSize::new(0.0, 0.0))
-            .unwrap();
-        let context = unsafe { context.make_current() }.expect("Unable to make context current");
-        let instance = gfx_backend_gl::Headless::from_context(context);
+        println!("Testing GL on CI:");
+        let instance = warden::init_gl_on_ci();
         num_failures += harness.run_instance(instance, Disabilities::default());
     }
     let _ = harness;

--- a/src/warden/src/lib.rs
+++ b/src/warden/src/lib.rs
@@ -8,3 +8,46 @@ extern crate serde;
 
 pub mod gpu;
 pub mod raw;
+
+#[cfg(feature = "gl")]
+pub fn init_gl_surface() -> gfx_backend_gl::Surface {
+    use gfx_backend_gl::glutin;
+
+    let events_loop = glutin::event_loop::EventLoop::new();
+    let windowed_context = glutin::ContextBuilder::new()
+        .with_gl_profile(glutin::GlProfile::Core)
+        .build_windowed(glutin::window::WindowBuilder::new(), &events_loop)
+        .unwrap();
+    let (context, _window) = unsafe {
+        windowed_context
+            .make_current()
+            .expect("Unable to make window current")
+            .split()
+    };
+
+    gfx_backend_gl::Surface::from_context(context)
+}
+
+#[cfg(feature = "gl-ci")]
+pub fn init_gl_on_ci() -> gfx_backend_gl::Headless {
+    use gfx_backend_gl::glutin;
+
+    let events_loop = glutin::event_loop::EventLoop::new();
+    let context;
+    #[cfg(all(unix, not(target_vendor = "apple")))]
+    {
+        use gfx_backend_gl::glutin::platform::unix::HeadlessContextExt as _;
+        context = glutin::ContextBuilder::new()
+            .build_surfaceless(&events_loop);
+    }
+    #[cfg(any(not(unix), target_vendor = "apple"))]
+    {
+        context = glutin::ContextBuilder::new()
+            .build_headless(&events_loop, glutin::dpi::PhysicalSize::new(0, 0));
+    }
+    let current_context = unsafe {
+        context.unwrap().make_current()
+    }.expect("Unable to make context current");
+
+    gfx_backend_gl::Headless::from_context(current_context)
+}


### PR DESCRIPTION
Sibling of #3122 on master

This change *really* shines on master, because the `DescriptorType` enum is now more complex, and all the matching is concentrated in one single place instead of being spread thin over the code.