### PR TITLE
Fix Android surface creation

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -567,11 +567,10 @@ impl hal::Instance<Backend> for Instance {
             RawWindowHandle::Xcb(handle) if self.extensions.contains(&extensions::khr::XcbSurface::name()) => {
                 Ok(self.create_surface_from_xcb(handle.connection as *mut _, handle.window))
             }
-            // #[cfg(target_os = "android")]
-            // RawWindowHandle::ANativeWindowHandle(handle) => {
-            //     let native_window = unimplemented!();
-            //     self.create_surface_android(native_window)
-            //}
+            #[cfg(target_os = "android")]
+            RawWindowHandle::Android(handle) => {
+                Ok(self.create_surface_android(handle.a_native_window))
+            }
             #[cfg(windows)]
             RawWindowHandle::Windows(handle) => {
                 use winapi::um::libloaderapi::GetModuleHandleW;


### PR DESCRIPTION
Android support was added to `raw-window-handle` a while ago, so with this, gfx works on Android again!

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [x] `rustfmt` run on changed code