### PR TITLE
[0.4] Fix Android surface creation

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-vulkan"
-version = "0.4.0"
+version = "0.4.1"
 description = "Vulkan API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -567,11 +567,10 @@ impl hal::Instance<Backend> for Instance {
             RawWindowHandle::Xcb(handle) if self.extensions.contains(&extensions::khr::XcbSurface::name()) => {
                 Ok(self.create_surface_from_xcb(handle.connection as *mut _, handle.window))
             }
-            // #[cfg(target_os = "android")]
-            // RawWindowHandle::ANativeWindowHandle(handle) => {
-            //     let native_window = unimplemented!();
-            //     self.create_surface_android(native_window)
-            //}
+            #[cfg(target_os = "android")]
+            RawWindowHandle::Android(handle) => {
+                Ok(self.create_surface_android(handle.a_native_window))
+            }
             #[cfg(windows)]
             RawWindowHandle::Windows(handle) => {
                 use winapi::um::libloaderapi::GetModuleHandleW;


### PR DESCRIPTION
#3132 backported to 0.4

Would it be possible to get this released?

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [x] `rustfmt` run on changed code