### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,14 +2,12 @@
 
 ### Communication
 
-General-purpose chat is on [Gitter](https://gitter.im/gfx-rs/gfx-rs). It has all the project activity displayed on the right side for your convenience. Note that it embeds images and gists automatically, so post bare links with discretion.
+General-purpose chat is on [matrix](https://matrix.to/#/#gfx:matrix.org).
 
 If you've got the code, making a pull request to discuss things on the way may be more efficient than posting it to the chat.
-
-There is also a [Waffle board](https://waffle.io/gfx-rs/gfx-rs), which you can use conveniently to track the whole picture.
 
 Finally, feel free to hop on [#rust-gamedev](http://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-gamedev).
 
 ### Code
 
-gfx-rs adheres to [Rust Coding Guidelines](http://aturon.github.io/).
+gfx-rs adheres to Rust Coding Guidelines.


### PR DESCRIPTION
Just some simple stuff:
- Replace `gitter` link with `matrix`
- Remove reference to waffle board (apparently the whole site is gone)
- Removed the link on `Rust Coding Guidelines` (as the link only leads to Aaron Turon's blog, where I also couldn't find anything related to coding guidelines - I would've updated the link but I'm not knowledgeable enough in rust to say which guidelines are referred to here :))

As I'm not (yet) on matrix, I'll leave this here: gfx-hal is a fantastic project - I'm super thankful for how all the work you did here enables me and others to dive into low level graphics with rust - thanks so much!
