### PR TITLE
Move line width out of line polygon mode

### DIFF
--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -511,7 +511,7 @@ pub fn map_topology(ia: &InputAssemblerDesc) -> D3D11_PRIMITIVE_TOPOLOGY {
 fn map_fill_mode(mode: PolygonMode) -> D3D11_FILL_MODE {
     match mode {
         PolygonMode::Fill => D3D11_FILL_SOLID,
-        PolygonMode::Line(_) => D3D11_FILL_WIREFRAME,
+        PolygonMode::Line => D3D11_FILL_WIREFRAME,
         // TODO: return error
         _ => unimplemented!(),
     }
@@ -532,6 +532,9 @@ pub(crate) fn map_rasterizer_desc(desc: &Rasterizer) -> D3D11_RASTERIZER_DESC {
         Some(State::Static(db)) => db,
         Some(_) | None => DepthBias::default(),
     };
+    if let State::Static(w) = desc.line_width {
+        super::validate_line_width(w);
+    }
     D3D11_RASTERIZER_DESC {
         FillMode: map_fill_mode(desc.polygon_mode),
         CullMode: map_cull_mode(desc.cull_face),

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -223,18 +223,17 @@ pub fn map_rasterizer(rasterizer: &pso::Rasterizer) -> D3D12_RASTERIZER_DESC {
         Some(_) | None => pso::DepthBias::default(),
     };
 
+    if let pso::State::Static(w) = rasterizer.line_width {
+        validate_line_width(w);
+    }
+
     D3D12_RASTERIZER_DESC {
         FillMode: match rasterizer.polygon_mode {
             Point => {
                 error!("Point rasterization is not supported");
                 D3D12_FILL_MODE_WIREFRAME
             }
-            Line(width) => {
-                if let pso::State::Static(w) = width {
-                    validate_line_width(w);
-                }
-                D3D12_FILL_MODE_WIREFRAME
-            }
+            Line => D3D12_FILL_MODE_WIREFRAME,
             Fill => D3D12_FILL_MODE_SOLID,
         },
         CullMode: match rasterizer.cull_face {

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -964,14 +964,13 @@ impl CommandQueue {
 
                 let (gl_draw, gl_offset) = match rasterizer.polygon_mode {
                     Point => (glow::POINT, glow::POLYGON_OFFSET_POINT),
-                    Line(width) => {
-                        if let hal::pso::State::Static(w) = width {
-                            unsafe { gl.line_width(w) };
-                        }
-                        (glow::LINE, glow::POLYGON_OFFSET_LINE)
-                    }
+                    Line => (glow::LINE, glow::POLYGON_OFFSET_LINE),
                     Fill => (glow::FILL, glow::POLYGON_OFFSET_FILL),
                 };
+
+                if let hal::pso::State::Static(w) = rasterizer.line_width {
+                    unsafe { gl.line_width(w) };
+                }
 
                 unsafe { gl.polygon_mode(glow::FRONT_AND_BACK, gl_draw) };
 

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -1208,15 +1208,7 @@ pub fn map_polygon_mode(mode: pso::PolygonMode) -> MTLTriangleFillMode {
             warn!("Unable to fill with points");
             MTLTriangleFillMode::Lines
         }
-        pso::PolygonMode::Line(width) => {
-            match width {
-                pso::State::Static(w) if w != 1.0 => {
-                    warn!("Unsupported line width: {:?}", w);
-                }
-                _ => {}
-            }
-            MTLTriangleFillMode::Lines
-        }
+        pso::PolygonMode::Line => MTLTriangleFillMode::Lines,
         pso::PolygonMode::Fill => MTLTriangleFillMode::Fill,
     }
 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1567,6 +1567,12 @@ impl hal::device::Device<Backend> for Device {
             pipeline.set_vertex_descriptor(Some(&vertex_descriptor));
         }
 
+        if let pso::State::Static(w) = pipeline_desc.rasterizer.line_width {
+            if w != 1.0 {
+                warn!("Unsupported line width: {:?}", w);
+            }
+        }
+
         let rasterizer_state = Some(n::RasterizerState {
             front_winding: conv::map_winding(pipeline_desc.rasterizer.front_face),
             fill_mode: conv::map_polygon_mode(pipeline_desc.rasterizer.polygon_mode),

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -177,19 +177,18 @@ impl GraphicsPipelineInfoBuf {
             None => pso::DepthBias::default(),
         };
 
-        let (polygon_mode, line_width) = match desc.rasterizer.polygon_mode {
-            pso::PolygonMode::Point => (vk::PolygonMode::POINT, 1.0),
-            pso::PolygonMode::Line(width) => (
-                vk::PolygonMode::LINE,
-                match width {
-                    pso::State::Static(w) => w,
-                    pso::State::Dynamic => {
-                        this.dynamic_states.push(vk::DynamicState::LINE_WIDTH);
-                        1.0
-                    }
-                },
-            ),
-            pso::PolygonMode::Fill => (vk::PolygonMode::FILL, 1.0),
+        let polygon_mode = match desc.rasterizer.polygon_mode {
+            pso::PolygonMode::Point => vk::PolygonMode::POINT,
+            pso::PolygonMode::Line => vk::PolygonMode::LINE,
+            pso::PolygonMode::Fill => vk::PolygonMode::FILL,
+        };
+
+        let line_width = match desc.rasterizer.line_width {
+            pso::State::Static(w) => w,
+            pso::State::Dynamic => {
+                this.dynamic_states.push(vk::DynamicState::LINE_WIDTH);
+                1.0
+            }
         };
 
         this.rasterization_state = vk::PipelineRasterizationStateCreateInfo {

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -171,7 +171,7 @@ pub enum PolygonMode {
     /// Rasterize as a point.
     Point,
     /// Rasterize as a line with the given width.
-    Line(State<f32>),
+    Line,
     /// Rasterize as a face.
     Fill,
 }
@@ -224,6 +224,8 @@ pub struct Rasterizer {
     pub depth_bias: Option<State<DepthBias>>,
     /// Controls how triangles will be rasterized depending on their overlap with pixels.
     pub conservative: bool,
+    /// Controls width of rasterized line segments.
+    pub line_width: State<f32>,
 }
 
 impl Rasterizer {
@@ -235,6 +237,7 @@ impl Rasterizer {
         depth_clamping: false,
         depth_bias: None,
         conservative: false,
+        line_width: State::Static(1.0),
     };
 }
 

--- a/work/scenes/basic.ron
+++ b/work/scenes/basic.ron
@@ -62,6 +62,7 @@
 				depth_clamping: false,
 				depth_bias: None,
 				conservative: false,
+				line_width: Static(1.0),
 			),
 			input_assembler: (
 				primitive: TriangleList,

--- a/work/scenes/large.ron
+++ b/work/scenes/large.ron
@@ -182,6 +182,7 @@
 				depth_clamping: false,
 				depth_bias: None,
 				conservative: false,
+				line_width: Static(1.0),
 			),
 			input_assembler: (
 				primitive: TriangleStrip,

--- a/work/scenes/vertex-offset.ron
+++ b/work/scenes/vertex-offset.ron
@@ -67,6 +67,7 @@
                 depth_clamping: false,
                 depth_bias: None,
                 conservative: false,
+                line_width: Static(1.0),
             ),
             vertex_buffers: [
                 VertexBufferDesc(
@@ -115,6 +116,7 @@
                 depth_clamping: false,
                 depth_bias: None,
                 conservative: false,
+                line_width: Static(1.0),
             ),
             vertex_buffers: [
                 VertexBufferDesc(


### PR DESCRIPTION
Line width state is not tied only to line polygon mode and storing it
there has correctness implications on Vulkan back-end. This is
problematic for gfx-portability when targeting Vulkan back-end, since it
can cause correct Vulkan application to trigger validation errors.

Prepares for fixing https://github.com/gfx-rs/portability/issues/206
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: dx12, vulkan
- [x] `rustfmt` run on changed code
