### PR TITLE
[vk] expect -1 returned by acquire_next_image

### DIFF
--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -2121,6 +2121,7 @@ impl d::Device<B> for Device {
         let swapchain = w::Swapchain {
             raw: swapchain_raw,
             functor,
+            vendor_id: self.vendor_id,
         };
 
         let images = backbuffer_images

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -708,6 +708,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 requested_features,
                 self.instance.clone(),
             )),
+            vendor_id: self.properties.vendor_id,
         };
 
         let device_arc = device.raw.clone();
@@ -1402,6 +1403,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
 #[derive(Debug)]
 pub struct Device {
     raw: Arc<RawDevice>,
+    vendor_id: u32,
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -12,7 +12,7 @@ use ash::{extensions::khr, version::DeviceV1_0 as _, vk};
 use hal::{format::Format, window as w};
 use smallvec::SmallVec;
 
-use crate::{conv, native};
+use crate::{conv, info, native};
 use crate::{
     Backend,
     Device,
@@ -551,6 +551,7 @@ impl w::PresentationSurface<Backend> for Surface {
 pub struct Swapchain {
     pub(crate) raw: vk::SwapchainKHR,
     pub(crate) functor: khr::Swapchain,
+    pub(crate) vendor_id: u32,
 }
 
 impl fmt::Debug for Swapchain {
@@ -575,6 +576,8 @@ impl w::Swapchain<Backend> for Swapchain {
             .acquire_next_image(self.raw, timeout_ns, semaphore, fence);
 
         match index {
+            // special case for Intel Vulkan returning bizzare values (ugh)
+            Ok((i, _)) if self.vendor_id == info::intel::VENDOR && i > 0x100 => Err(w::AcquireError::OutOfDate),
             Ok((i, true)) => Ok((i, Some(w::Suboptimal))),
             Ok((i, false)) => Ok((i, None)),
             Err(vk::Result::NOT_READY) => Err(w::AcquireError::NotReady),


### PR DESCRIPTION
Fixes #3141 (works around)
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
