### PR TITLE
allow specification of API version during instance creation

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -597,7 +597,8 @@ fn create_backend(
 ) -> BackendState<back::Backend> {
     let window = wb.build(event_loop).unwrap();
     let instance =
-        back::Instance::create("gfx-rs colour-uniform", 1).expect("Failed to create an instance!");
+        back::Instance::create("gfx-rs colour-uniform", 1, hal::ApiVersion::new(1, 1, 1))
+            .expect("Failed to create an instance!");
     let surface = unsafe {
         instance
             .create_surface(&window)

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -41,8 +41,8 @@ fn main() {
         .collect();
     let stride = std::mem::size_of::<u32>() as u64;
 
-    let instance =
-        back::Instance::create("gfx-rs compute", 1).expect("Failed to create an instance!");
+    let instance = back::Instance::create("gfx-rs compute", 1, hal::ApiVersion::new(1, 1, 1))
+        .expect("Failed to create an instance!");
 
     let adapter = instance
         .enumerate_adapters()

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -115,8 +115,8 @@ fn main() {
     #[cfg(not(feature = "gl"))]
     let (_window, instance, mut adapters, surface) = {
         let window = wb.build(&event_loop).unwrap();
-        let instance =
-            back::Instance::create("gfx-rs quad", 1).expect("Failed to create an instance!");
+        let instance = back::Instance::create("gfx-rs quad", 1, hal::ApiVersion::new(1, 1, 1))
+            .expect("Failed to create an instance!");
         let surface = unsafe {
             instance
                 .create_surface(&window)

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -270,7 +270,7 @@ fn get_format_properties(
 }
 
 impl hal::Instance<Backend> for Instance {
-    fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
+    fn create(_: &str, _: u32, _: hal::ApiVersion) -> Result<Self, hal::UnsupportedBackend> {
         // TODO: get the latest factory we can find
 
         match dxgi::get_dxgi_factory() {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -712,7 +712,7 @@ unsafe impl Send for Instance {}
 unsafe impl Sync for Instance {}
 
 impl hal::Instance<Backend> for Instance {
-    fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
+    fn create(_: &str, _: u32, _: hal::ApiVersion) -> Result<Self, hal::UnsupportedBackend> {
         let lib_main = match native::D3D12Lib::new() {
             Ok(lib) => lib,
             Err(_) => return Err(hal::UnsupportedBackend),

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -1000,7 +1000,11 @@ impl window::Swapchain<Backend> for Swapchain {
 pub struct Instance;
 
 impl hal::Instance<Backend> for Instance {
-    fn create(_name: &str, _version: u32) -> Result<Self, hal::UnsupportedBackend> {
+    fn create(
+        _name: &str,
+        _app_version: u32,
+        _api_version: hal::ApiVersion,
+    ) -> Result<Self, hal::UnsupportedBackend> {
         Ok(Instance)
     }
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -712,7 +712,7 @@ pub struct DummyInstance;
 
 #[cfg(not(any(target_arch = "wasm32", feature = "glutin", feature = "wgl")))]
 impl hal::Instance<Backend> for DummyInstance {
-    fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
+    fn create(_: &str, _: u32, _: hal::ApiVersion) -> Result<Self, hal::UnsupportedBackend> {
         unimplemented!()
     }
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Backend>> {
@@ -738,8 +738,12 @@ pub enum Instance {
 
 #[cfg(all(feature = "glutin", not(target_arch = "wasm32")))]
 impl hal::Instance<Backend> for Instance {
-    fn create(name: &str, version: u32) -> Result<Instance, hal::UnsupportedBackend> {
-        Headless::create(name, version).map(Instance::Headless)
+    fn create(
+        name: &str,
+        app_version: u32,
+        api_version: hal::ApiVersion,
+    ) -> Result<Instance, hal::UnsupportedBackend> {
+        Headless::create(name, app_version, api_version).map(Instance::Headless)
     }
 
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Backend>> {

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -216,7 +216,7 @@ impl window::Surface<B> for Surface {
 }
 
 impl hal::Instance<B> for Surface {
-    fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
+    fn create(_: &str, _: u32, _: hal::ApiVersion) -> Result<Self, hal::UnsupportedBackend> {
         panic!("Unable to create a surface")
     }
 
@@ -271,7 +271,7 @@ impl Headless {
 }
 
 impl hal::Instance<B> for Headless {
-    fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
+    fn create(_: &str, _: u32, _: hal::ApiVersion) -> Result<Self, hal::UnsupportedBackend> {
         let context: glutin::Context<glutin::NotCurrent>;
         #[cfg(target_os = "linux")]
         {

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -166,7 +166,7 @@ impl window::PresentationSurface<B> for Surface {
 }
 
 impl hal::Instance<B> for Surface {
-    fn create(_name: &str, _version: u32) -> Result<Self, hal::UnsupportedBackend> {
+    fn create(_name: &str, _version: u32, _: hal::ApiVersion) -> Result<Self, hal::UnsupportedBackend> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -166,7 +166,7 @@ impl Instance {
 }
 
 impl hal::Instance<Backend> for Instance {
-    fn create(_name: &str, version: u32) -> Result<Self, hal::UnsupportedBackend> {
+    fn create(_name: &str, _: u32, _: hal::ApiVersion) -> Result<Self, hal::UnsupportedBackend> {
         unsafe {
             let glrc = WGL_ENTRY.wgl.CreateContextAttribsARB(
                 WGL_ENTRY.hdc as *const _,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -905,7 +905,7 @@ impl Device {
                 msl::ComponentSwizzle::Identity,
                 msl::ComponentSwizzle::Identity,
                 msl::ComponentSwizzle::Identity,
-                msl::ComponentSwizzle::Identity
+                msl::ComponentSwizzle::Identity,
             ],
             ycbcr_conversion_enable: false,
             ycbcr_model: msl::SamplerYCbCrModelConversion::RgbIdentity,

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -212,7 +212,7 @@ pub struct Instance {
 }
 
 impl hal::Instance<Backend> for Instance {
-    fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
+    fn create(_: &str, _: u32, _: hal::ApiVersion) -> Result<Self, hal::UnsupportedBackend> {
         Ok(Instance {
             experiments: Experiments::default(),
             gfx_managed_metal_layer_delegate: GfxManagedMetalLayerDelegate::new(),

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -333,7 +333,11 @@ unsafe extern "system" fn debug_report_callback(
 }
 
 impl hal::Instance<Backend> for Instance {
-    fn create(name: &str, version: u32) -> Result<Self, hal::UnsupportedBackend> {
+    fn create(
+        name: &str,
+        app_version: u32,
+        api_version: hal::ApiVersion,
+    ) -> Result<Self, hal::UnsupportedBackend> {
         // TODO: return errors instead of panic
         let entry = VK_ENTRY.as_ref().map_err(|e| {
             info!("Missing Vulkan entry points: {:?}", e);
@@ -345,10 +349,10 @@ impl hal::Instance<Backend> for Instance {
             s_type: vk::StructureType::APPLICATION_INFO,
             p_next: ptr::null(),
             p_application_name: app_name.as_ptr(),
-            application_version: version,
+            application_version: app_version,
             p_engine_name: b"gfx-rs\0".as_ptr() as *const _,
             engine_version: 1,
-            api_version: vk_make_version!(1, 0, 0),
+            api_version: vk_make_version!(api_version.major, api_version.minor, api_version.patch),
         };
 
         let instance_extensions = entry

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -577,7 +577,9 @@ impl w::Swapchain<Backend> for Swapchain {
 
         match index {
             // special case for Intel Vulkan returning bizzare values (ugh)
-            Ok((i, _)) if self.vendor_id == info::intel::VENDOR && i > 0x100 => Err(w::AcquireError::OutOfDate),
+            Ok((i, _)) if self.vendor_id == info::intel::VENDOR && i > 0x100 => {
+                Err(w::AcquireError::OutOfDate)
+            }
             Ok((i, true)) => Ok((i, Some(w::Suboptimal))),
             Ok((i, false)) => Ok((i, None)),
             Err(vk::Result::NOT_READY) => Err(w::AcquireError::NotReady),

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -364,6 +364,37 @@ pub enum IndexType {
 #[derive(Clone, Debug, PartialEq)]
 pub struct UnsupportedBackend;
 
+/// API version information given to `Instance::create`.
+/// Versioning semantics are based on [Vulkan specification](/// Versioning is based on [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1/html/vkspec.html#extendingvulkan-coreversions-versionnumbers).
+#[derive(Clone, Copy, Debug)]
+pub struct ApiVersion {
+    /// Major version. Example: "1" in "1.2.3".
+    pub major: u32,
+    /// Minor version. Example: "2" in "1.2.3".
+    pub minor: u32,
+    /// Patch version. Example: "3" in "1.2.3".
+    pub patch: u32,
+}
+
+impl ApiVersion {
+    /// Creates `ApiVersion` structure using given `major`, `minor` and `patch` information.
+    pub fn new(major: u32, minor: u32, patch: u32) -> ApiVersion {
+        ApiVersion {
+            major,
+            minor,
+            patch,
+        }
+    }
+    /// Creates a dummy `ApiVersion` structure for those backends which do not use it.
+    pub fn dummy() -> ApiVersion {
+        ApiVersion {
+            major: 0,
+            minor: 0,
+            patch: 0,
+        }
+    }
+}
+
 /// An instantiated backend.
 ///
 /// Any startup the backend needs to perform will be done when creating the type that implements
@@ -389,7 +420,11 @@ pub struct UnsupportedBackend;
 /// ```
 pub trait Instance<B: Backend>: Any + Send + Sync + Sized {
     /// Create a new instance.
-    fn create(name: &str, version: u32) -> Result<Self, UnsupportedBackend>;
+    fn create(
+        name: &str,
+        app_version: u32,
+        api_version: ApiVersion,
+    ) -> Result<Self, UnsupportedBackend>;
     /// Return all available adapters.
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<B>>;
     /// Create a new surface.

--- a/src/warden/src/bin/bench.rs
+++ b/src/warden/src/bin/bench.rs
@@ -79,7 +79,7 @@ impl Harness {
     #[cfg_attr(any(feature = "gl", feature = "gl-ci"), allow(dead_code))]
     fn run<B: hal::Backend>(&self, name: &str, disabilities: Disabilities) {
         println!("Benching {}:", name);
-        let instance = B::Instance::create("warden", 1).unwrap();
+        let instance = B::Instance::create("warden", 1, hal::ApiVersion::dummy()).unwrap();
         self.run_instance(instance, disabilities)
     }
 

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -87,7 +87,7 @@ impl Harness {
     #[cfg_attr(any(feature = "gl", feature = "gl-ci"), allow(dead_code))]
     fn run<B: hal::Backend>(&self, name: &str, disabilities: Disabilities) -> usize {
         println!("Testing {}:", name);
-        let instance = B::Instance::create("warden", 1).unwrap();
+        let instance = B::Instance::create("warden", 1, hal::ApiVersion::dummy()).unwrap();
         self.run_instance(instance, disabilities)
     }
 


### PR DESCRIPTION
Can I have input on:

1) the approach I have taken to solve the issue? In particular, see the `ApiVersion` struct defined in `src/hal/lib.rs`

2) the documentation I have provided. 

Fixes #3146
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan, DX12
- [x] `rustfmt` run on changed code (**except** for `backend/gl`, which produces an error)

`cargo fmt` error when it is run on `backend/gl`:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src\tools\rustfmt\src\lists.rs:678:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src\tools\rustfmt\src\lists.rs:678:17
```

