### PR TITLE
[vk] supress into_iter autoref coercion warning

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -293,6 +293,7 @@ unsafe extern "system" fn debug_utils_messenger_callback(
             message
         );
 
+        #[allow(array_into_iter)]
         for (info_label, info) in additional_info.into_iter() {
             match info {
                 Some(data) => {


### PR DESCRIPTION
Currently, the following warning is emitted during building:

```
warning: this method call currently resolves to `<&[T; N] as IntoIterator>::into_iter` (due to autoref coercions), but that might change in the future when `IntoIterator` impls for arrays are added.

   --> src/backend/vulkan/src/lib.rs:296:51

    |

296 |         for (info_label, info) in additional_info.into_iter() {

    |                                                   ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`

    |

    = note: `#[warn(array_into_iter)]` on by default

    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

    = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
```

This PR wonders if it would be okay to do what the warning suggests we do.

Fixes #issue (not applicable, no known issue)
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan
- [x] `rustfmt` run on changed code
