### PR TITLE
Update winit (0.21.0) and glutin (0.23.0)

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -32,7 +32,7 @@ image = "0.21"
 log = "0.4"
 hal = { path = "../src/hal", version = "0.4", package = "gfx-hal" }
 gfx-backend-empty = { path = "../src/backend/empty", version = "0.4" }
-winit = { version = "0.20", features = ["web-sys"] }
+winit = { version = "0.21.0", features = ["web-sys"] }
 
 [target.'cfg(debug_assertions)'.dependencies]
 env_logger = "0.6"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -34,7 +34,7 @@ lazy_static = "1"
 raw-window-handle = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-glutin = { version = "0.22", optional = true }
+glutin = { version = "0.23.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"


### PR DESCRIPTION
Fixes `STATUS_ENTRYPOINT_NOT_FOUND` error on Windows (all backends).

`glutin` needed to be updated for `winit` to work correctly.

PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends: gl, dx11, vulkan
- [X] `rustfmt` run on changed code
