### PR TITLE
check if addDebugMarker from Metal is supported

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -713,6 +713,7 @@ struct PrivateCapabilities {
     max_texture_layers: u64,
     max_fragment_input_components: u64,
     sample_count_mask: u8,
+    supports_debug_markers: bool,
 }
 
 impl PrivateCapabilities {
@@ -958,6 +959,20 @@ impl PrivateCapabilities {
             max_texture_layers: 2048,
             max_fragment_input_components: if os_is_mac { 128 } else { 60 },
             sample_count_mask,
+            supports_debug_markers: Self::supports_any(
+                &device,
+                &[
+                    MTLFeatureSet::macOS_GPUFamily1_v2,
+                    MTLFeatureSet::macOS_GPUFamily2_v1,
+                    MTLFeatureSet::iOS_GPUFamily1_v3,
+                    MTLFeatureSet::iOS_GPUFamily2_v3,
+                    MTLFeatureSet::iOS_GPUFamily3_v2,
+                    MTLFeatureSet::iOS_GPUFamily4_v1,
+                    MTLFeatureSet::iOS_GPUFamily5_v1,
+                    MTLFeatureSet::tvOS_GPUFamily1_v2,
+                    MTLFeatureSet::tvOS_GPUFamily2_v1,
+                ],
+            ),
         }
     }
 


### PR DESCRIPTION
Fixes #3098 fixes gfx-rs/wgpu-rs/issues/138
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] ~~`make reftests` succeeds~~
it complains about `Testing Metal` "metal-0.17.1/src/capturemanager.rs:50:25": `Scene 'transfer': thread 'main' panicked at 'Class with name MTLCaptureManager could not be found'` because [that object doesn't exist on my macOS 10.11 machine](https://developer.apple.com/documentation/metal/mtlcapturemanager)
- [x] tested examples with the following backends:
Metal
- [x] `rustfmt` run on changed code
