### PR TITLE
fix incorrect syntax in spec_const_list macro

### DIFF
--- a/src/hal/src/pso/specialization.rs
+++ b/src/hal/src/pso/specialization.rs
@@ -115,7 +115,7 @@ macro_rules! spec_const_list {
     (@ $head_id:expr => $head_constant:expr $(,$tail_id:expr => $tail_constant:expr)* $(,)?) => {
         $crate::pso::SpecConstListCons {
             head: ($head_id, $head_constant),
-            tail: $crate::spec_const_list!(@ $($tail_id:expr => $tail_constant:expr),*),
+            tail: $crate::spec_const_list!(@ $($tail_id => $tail_constant),*),
         }
     };
 


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12
- [x] `rustfmt` run on changed code

Fix syntax error in the recursive cases of the spec_const_list macro that cause compilation to fail when there is more than one argument passed in.