### PR TITLE
Update spirv_cross to 0.18

### DIFF
--- a/src/auxil/auxil/Cargo.toml
+++ b/src/auxil/auxil/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 hal = { path = "../../hal", version = "0.4", package = "gfx-hal" }
 fxhash = "0.2.1"
-spirv_cross = { version = "0.17", optional = true }
+spirv_cross = { version = "0.18", optional = true }
 
 [lib]
 name = "gfx_auxil"

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "1"
 libloading = "0.5"
 log = { version = "0.4" }
 smallvec = "1.0"
-spirv_cross = { version = "0.17", features = ["hlsl"] }
+spirv_cross = { version = "0.18", features = ["hlsl"] }
 parking_lot = "0.10"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 wio = "0.2"

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "1"
 native = { package = "d3d12", version = "0.3", features = ["libloading"] }
 log = { version = "0.4" }
 smallvec = "1.0"
-spirv_cross = { version = "0.17", features = ["hlsl"] }
+spirv_cross = { version = "0.18", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 raw-window-handle = "0.3"
 

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -29,7 +29,7 @@ auxil = { path = "../../auxil/auxil", version = "0.2", package = "gfx-auxil", fe
 smallvec = "1.0"
 glow = "0.3.0-alpha3"
 parking_lot = "0.10"
-spirv_cross = { version = "0.17", features = ["glsl"] }
+spirv_cross = { version = "0.18", features = ["glsl"] }
 lazy_static = "1"
 raw-window-handle = "0.3"
 

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -36,7 +36,7 @@ block = "0.1"
 cocoa = "0.19"
 core-graphics = "0.17"
 smallvec = "1.0"
-spirv_cross = { version = "0.17", features = ["msl"] }
+spirv_cross = { version = "0.18", features = ["msl"] }
 parking_lot = "0.10"
 storage-map = "0.2"
 lazy_static = "1"


### PR DESCRIPTION
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: quad on gl+metal
- [ ] `rustfmt` run on changed code
