### PR TITLE
Basic debug markers API

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2288,6 +2288,16 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
     {
         unimplemented!()
     }
+
+    unsafe fn insert_debug_marker(&mut self, _name: &str, _color: u32) {
+        //TODO
+    }
+    unsafe fn begin_debug_marker(&mut self, _name: &str, _color: u32) {
+        //TODO
+    }
+    unsafe fn end_debug_marker(&mut self) {
+        //TODO
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -2632,4 +2632,14 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             error!("TODO: execute_commands");
         }
     }
+
+    unsafe fn insert_debug_marker(&mut self, _name: &str, _color: u32) {
+        //TODO
+    }
+    unsafe fn begin_debug_marker(&mut self, _name: &str, _color: u32) {
+        //TODO
+    }
+    unsafe fn end_debug_marker(&mut self) {
+        //TODO
+    }
 }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -916,6 +916,16 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
     {
         panic!(DO_NOT_USE_MESSAGE)
     }
+
+    unsafe fn insert_debug_marker(&mut self, _: &str, _: u32) {
+        panic!(DO_NOT_USE_MESSAGE)
+    }
+    unsafe fn begin_debug_marker(&mut self, _: &str, _: u32) {
+        panic!(DO_NOT_USE_MESSAGE)
+    }
+    unsafe fn end_debug_marker(&mut self) {
+        panic!(DO_NOT_USE_MESSAGE)
+    }
 }
 
 // Dummy descriptor pool.

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1481,6 +1481,16 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
     {
         unimplemented!()
     }
+
+    unsafe fn insert_debug_marker(&mut self, _name: &str, _color: u32) {
+        //TODO
+    }
+    unsafe fn begin_debug_marker(&mut self, _name: &str, _color: u32) {
+        //TODO
+    }
+    unsafe fn end_debug_marker(&mut self) {
+        //TODO
+    }
 }
 
 /// Avoids creating second mutable borrows of `self` by requiring mutable

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -4758,4 +4758,14 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             }
         }
     }
+
+    unsafe fn insert_debug_marker(&mut self, _name: &str, _color: u32) {
+        //TODO
+    }
+    unsafe fn begin_debug_marker(&mut self, _name: &str, _color: u32) {
+        //TODO
+    }
+    unsafe fn end_debug_marker(&mut self) {
+        //TODO
+    }
 }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -113,7 +113,7 @@ lazy_static! {
         );
 }
 
-pub struct RawInstance(pub ash::Instance, Option<DebugMessenger>);
+pub struct RawInstance(ash::Instance, Option<DebugMessenger>);
 
 pub enum DebugMessenger {
     Utils(DebugUtils, vk::DebugUtilsMessengerEXT),
@@ -1205,7 +1205,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 }
 
 #[doc(hidden)]
-pub struct RawDevice(pub ash::Device, Features, Arc<RawInstance>);
+pub struct RawDevice(ash::Device, Features, Arc<RawInstance>);
 
 impl fmt::Debug for RawDevice {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1217,6 +1217,12 @@ impl Drop for RawDevice {
         unsafe {
             self.0.destroy_device(None);
         }
+    }
+}
+
+impl RawDevice {
+    fn debug_messenger(&self) -> Option<&DebugMessenger> {
+        (self.2).1.as_ref()
     }
 }
 

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -556,4 +556,11 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     where
         T: 'a + Borrow<B::CommandBuffer>,
         I: IntoIterator<Item = &'a T>;
+
+    /// Debug mark the current spot in the command buffer.
+    unsafe fn insert_debug_marker(&mut self, name: &str, color: u32);
+    /// Start a debug marker at the current place in the command buffer.
+    unsafe fn begin_debug_marker(&mut self, name: &str, color: u32);
+    /// End the last started debug marker scope.
+    unsafe fn end_debug_marker(&mut self);
 }


### PR DESCRIPTION
Addresses the "Section/call marking" API portion of #1508 (only Vulkan implementation so far)
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
