### PR TITLE
Support for NDC_Y_UP feature

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -154,11 +154,13 @@ fn get_features(
     _device: ComPtr<d3d11::ID3D11Device>,
     _feature_level: d3dcommon::D3D_FEATURE_LEVEL,
 ) -> hal::Features {
-    hal::Features::ROBUST_BUFFER_ACCESS
+    hal::Features::empty()
+        | hal::Features::ROBUST_BUFFER_ACCESS
         | hal::Features::FULL_DRAW_INDEX_U32
         | hal::Features::FORMAT_BC
         | hal::Features::INSTANCE_RATE
         | hal::Features::SAMPLER_MIP_LOD_BIAS
+        | hal::Features::NDC_Y_UP
 }
 
 fn get_format_properties(
@@ -583,7 +585,12 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             (ComPtr::from_raw(device), ComPtr::from_raw(cxt))
         };
 
-        let device = device::Device::new(device, cxt, self.memory_properties.clone());
+        let device = device::Device::new(
+            device,
+            cxt,
+            self.memory_properties.clone(),
+            requested_features,
+        );
 
         // TODO: deferred context => 1 cxt/queue?
         let queue_groups = families

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -233,6 +233,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         }
 
         let mut device = Device::new(device_raw, &self, present_queue);
+        device.features = requested_features;
 
         let queue_groups = families
             .into_iter()
@@ -557,6 +558,7 @@ pub struct Device {
     raw: native::Device,
     library: Arc<native::D3D12Lib>,
     private_caps: Capabilities,
+    features: Features,
     format_properties: Arc<FormatProperties>,
     heap_properties: &'static [HeapProperties],
     // CPU only pools
@@ -637,6 +639,7 @@ impl Device {
             raw: device,
             library: Arc::clone(&physical_device.library),
             private_caps: physical_device.private_caps,
+            features: Features::empty(),
             format_properties: physical_device.format_properties.clone(),
             heap_properties: physical_device.heap_properties,
             rtv_pool: Mutex::new(rtv_pool),
@@ -1072,7 +1075,8 @@ impl hal::Instance<Backend> for Instance {
                     Features::FORMAT_BC |
                     Features::INSTANCE_RATE |
                     Features::SAMPLER_MIP_LOD_BIAS |
-                    Features::SAMPLER_ANISOTROPY,
+                    Features::SAMPLER_ANISOTROPY |
+                    Features::NDC_Y_UP,
                 hints:
                     Hints::BASE_VERTEX_INSTANCE_DRAWING,
                 limits: Limits { // TODO

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -195,8 +195,6 @@ pub struct PrivateCaps {
     /// - In OpenGL ES 2 it may be available behind optional extensions
     /// - In WebGL 1 and WebGL 2 it is never available
     pub emulate_map: bool,
-    /// Indicates if we only have support via the EXT.
-    pub sampler_anisotropy_ext: bool,
     /// Whether f64 precision is supported for depth ranges
     pub depth_range_f64_precision: bool,
     /// Whether draw buffers are supported
@@ -400,7 +398,7 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Hi
         }
     }
 
-    let mut features = Features::empty();
+    let mut features = Features::NDC_Y_UP;
     let mut legacy = LegacyFeatures::empty();
 
     if info.is_supported(&[
@@ -508,9 +506,6 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Hi
         frag_data_location: !info.version.is_embedded,
         sync: !info.is_webgl() && info.is_supported(&[Core(3, 2), Es(3, 0), Ext("GL_ARB_sync")]), // TODO
         map: !info.version.is_embedded, //TODO: OES extension
-        sampler_anisotropy_ext: !info
-            .is_supported(&[Core(4, 6), Ext("GL_ARB_texture_filter_anisotropic")])
-            && info.is_supported(&[Ext("GL_EXT_texture_filter_anisotropic")]),
         emulate_map,                                          // TODO
         depth_range_f64_precision: !info.version.is_embedded, // TODO
         draw_buffers: info.is_supported(&[Core(2, 0), Es(3, 0)]),

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -199,8 +199,6 @@ pub struct PrivateCaps {
     pub depth_range_f64_precision: bool,
     /// Whether draw buffers are supported
     pub draw_buffers: bool,
-    /// Whether or not glColorMaski / glBlendEquationi / glBlendFunci are available
-    pub per_draw_buffer_blending: bool,
 }
 
 /// OpenGL implementation information
@@ -418,6 +416,9 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Hi
         // TODO: extension
         features |= Features::SAMPLER_MIP_LOD_BIAS;
     }
+    if info.is_supported(&[Core(4, 0), Es(3, 2), Ext("GL_EXT_draw_buffers2")]) && !info.is_webgl() {
+        features |= Features::INDEPENDENT_BLENDING;
+    }
 
     // TODO
     if false && info.is_supported(&[Core(4, 3), Es(3, 1)]) {
@@ -478,12 +479,6 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Hi
         legacy |= LegacyFeatures::INSTANCED_ATTRIBUTE_BINDING;
     }
 
-    let per_draw_buffer_blending =
-        info.is_supported(&[Core(4, 0), Es(3, 2), Ext("GL_EXT_draw_buffers2")]) && !info.is_webgl();
-    if per_draw_buffer_blending {
-        features |= Features::INDEPENDENT_BLENDING;
-    }
-
     let mut hints = Hints::empty();
     if info.is_supported(&[Core(4, 2)]) {
         // TODO: extension
@@ -509,7 +504,6 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Hi
         emulate_map,                                          // TODO
         depth_range_f64_precision: !info.version.is_embedded, // TODO
         draw_buffers: info.is_supported(&[Core(2, 0), Es(3, 0)]),
-        per_draw_buffer_blending,
     };
 
     (info, features, legacy, hints, limits, private)

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -590,7 +590,11 @@ impl CommandQueue {
                 state::set_blend(&self.share.context, blend);
             }
             com::Command::SetBlendSlot(slot, ref blend) => {
-                state::set_blend_slot(&self.share, slot, blend);
+                if self.share.private_caps.draw_buffers {
+                    state::set_blend_slot(&self.share.context, slot, blend, &self.features);
+                } else {
+                    warn!("Draw buffers are not supported");
+                }
             }
             com::Command::BindAttribute(ref attribute, handle, stride, rate) => unsafe {
                 use crate::native::VertexAttribFunction::*;

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -68,15 +68,21 @@ impl State {
 #[derive(Debug)]
 pub struct CommandQueue {
     pub(crate) share: Starc<Share>,
+    features: hal::Features,
     vao: Option<native::VertexArray>,
     state: State,
 }
 
 impl CommandQueue {
     /// Create a new command queue.
-    pub(crate) fn new(share: &Starc<Share>, vao: Option<native::VertexArray>) -> Self {
+    pub(crate) fn new(
+        share: &Starc<Share>,
+        features: hal::Features,
+        vao: Option<native::VertexArray>,
+    ) -> Self {
         CommandQueue {
             share: share.clone(),
+            features,
             vao,
             state: State::new(),
         }
@@ -824,8 +830,9 @@ impl CommandQueue {
 
                 // TODO: Optimization: only change texture properties that have changed.
                 device::set_sampler_info(
-                    &self.share,
                     &sinfo,
+                    &self.features,
+                    &self.share.legacy_features,
                     |a, b| gl.tex_parameter_f32(textype, a, b),
                     |a, b| gl.tex_parameter_f32_slice(textype, a, &b),
                     |a, b| gl.tex_parameter_i32(textype, a, b),

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)] //TODO: remove
 
-use crate::{ColorSlot, GlContainer, Share};
+use crate::{ColorSlot, GlContainer};
 use glow::HasContext;
 use hal::pso;
 use smallvec::SmallVec;
@@ -163,11 +163,10 @@ pub(crate) fn set_blend(gl: &GlContainer, desc: &pso::ColorBlendDesc) {
     }
 }
 
-pub(crate) fn set_blend_slot(share: &Share, slot: ColorSlot, desc: &pso::ColorBlendDesc) {
+pub(crate) fn set_blend_slot(gl: &GlContainer, slot: ColorSlot, desc: &pso::ColorBlendDesc, features: &hal::Features) {
     use hal::pso::ColorMask as Cm;
 
-    let gl = &share.context;
-    if !share.private_caps.draw_buffers || !share.private_caps.per_draw_buffer_blending {
+    if !features.contains(hal::Features::INDEPENDENT_BLENDING) {
         warn!("independent blending is not supported");
         return;
     }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -419,7 +419,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn features(&self) -> hal::Features {
-        hal::Features::ROBUST_BUFFER_ACCESS
+        hal::Features::empty()
+            | hal::Features::ROBUST_BUFFER_ACCESS
             | hal::Features::DRAW_INDIRECT_FIRST_INSTANCE
             | hal::Features::DEPTH_CLAMP
             | hal::Features::SAMPLER_ANISOTROPY
@@ -441,6 +442,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 hal::Features::empty()
             }
             | hal::Features::SHADER_CLIP_DISTANCE
+            | hal::Features::NDC_Y_UP
     }
 
     fn hints(&self) -> hal::Hints {
@@ -1726,7 +1728,7 @@ impl hal::device::Device<Backend> for Device {
         } else {
             let mut options = msl::CompilerOptions::default();
             options.enable_point_size_builtin = false;
-            options.vertex.invert_y = true;
+            options.vertex.invert_y = !self.features.contains(hal::Features::NDC_Y_UP);
             let info = Self::compile_shader_library(
                 &self.shared.device,
                 raw_data,

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -545,9 +545,10 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<pso::Viewport>,
     {
+        let flip_y = self.device.1.contains(hal::Features::NDC_Y_UP);
         let viewports: SmallVec<[vk::Viewport; 16]> = viewports
             .into_iter()
-            .map(|viewport| conv::map_viewport(viewport.borrow()))
+            .map(|viewport| conv::map_viewport(viewport.borrow(), flip_y))
             .collect();
 
         self.device

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -543,12 +543,12 @@ pub fn map_clear_rect(rect: &pso::ClearRect) -> vk::ClearRect {
     }
 }
 
-pub fn map_viewport(vp: &pso::Viewport) -> vk::Viewport {
+pub fn map_viewport(vp: &pso::Viewport, flip_y: bool) -> vk::Viewport {
     vk::Viewport {
         x: vp.rect.x as _,
-        y: vp.rect.y as _,
+        y: if flip_y { vp.rect.y + vp.rect.h } else { vp.rect.y } as _,
         width: vp.rect.w as _,
-        height: vp.rect.h as _,
+        height: if flip_y { -vp.rect.h } else { vp.rect.h } as _,
         min_depth: vp.depth.start,
         max_depth: vp.depth.end,
     }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -258,7 +258,8 @@ impl GraphicsPipelineInfoBuf {
             viewport_count: 1, // TODO
             p_viewports: match desc.baked_states.viewport {
                 Some(ref vp) => {
-                    this.viewport = conv::map_viewport(vp);
+                    let flip_y = device.raw.1.contains(hal::Features::NDC_Y_UP);
+                    this.viewport = conv::map_viewport(vp, flip_y);
                     &this.viewport
                 }
                 None => {

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -195,6 +195,9 @@ bitflags! {
         const INSTANCE_RATE = 0x0004 << 64;
         /// Support non-zero mipmap bias on samplers.
         const SAMPLER_MIP_LOD_BIAS = 0x0008 << 64;
+
+        /// Make the NDC coordinate system pointing Y up, to match D3D and Metal.
+        const NDC_Y_UP = 0x01 << 80;
     }
 }
 


### PR DESCRIPTION
Paves the way to https://github.com/gfx-rs/wgpu/issues/519
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code

If I undetstand correctly, the only thing missing here is a proper check for supported device extensions in Vulkan backend.