### PR TITLE
Hal cleanup for 0.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
       <img src="http://img.shields.io/crates/v/gfx-hal.svg?label=gfx-hal" alt = "gfx-hal on crates.io">
   </a>
   <a href="https://travis-ci.org/gfx-rs/gfx">
-      <img src="https://img.shields.io/travis/gfx-rs/gfx/master.svg?style=flat-square" alt="Travis Build Status">
+      <img src="https://img.shields.io/travis/gfx-rs/gfx/master.svg?branch=master" alt="Travis Build Status">
   </a>
   <br>
   <strong><a href="info/getting_started.md">Getting Started</a> | <a href="http://docs.rs/gfx-hal">Documentation</a> | <a href="http://gfx-rs.github.io/">Blog</a> </strong>

--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -1,6 +1,6 @@
 use hal::{
     format::Format,
-    image::{Anisotropic, Filter, WrapMode},
+    image::{Filter, WrapMode},
     pso::{
         BlendDesc,
         BlendOp,
@@ -798,13 +798,6 @@ pub fn map_wrapping(wrap: WrapMode) -> D3D11_TEXTURE_ADDRESS_MODE {
     }
 }
 
-pub fn map_anisotropic(anisotropic: Anisotropic) -> D3D11_FILTER {
-    match anisotropic {
-        Anisotropic::On(_) => D3D11_FILTER_ANISOTROPIC,
-        Anisotropic::Off => 0,
-    }
-}
-
 fn map_filter_type(filter: Filter) -> D3D11_FILTER_TYPE {
     match filter {
         Filter::Nearest => D3D11_FILTER_TYPE_POINT,
@@ -818,7 +811,7 @@ pub fn map_filter(
     min_filter: Filter,
     mip_filter: Filter,
     reduction: D3D11_FILTER_REDUCTION_TYPE,
-    anisotropic: Anisotropic,
+    anisotropy_clamp: Option<u8>,
 ) -> D3D11_FILTER {
     let mag = map_filter_type(mag_filter);
     let min = map_filter_type(min_filter);
@@ -828,5 +821,5 @@ pub fn map_filter(
         | (mag & D3D11_FILTER_TYPE_MASK) << D3D11_MAG_FILTER_SHIFT
         | (mip & D3D11_FILTER_TYPE_MASK) << D3D11_MIP_FILTER_SHIFT
         | (reduction & D3D11_FILTER_REDUCTION_TYPE_MASK) << D3D11_FILTER_REDUCTION_TYPE_SHIFT
-        | map_anisotropic(anisotropic)
+        | anisotropy_clamp.map(|_| D3D11_FILTER_ANISOTROPIC).unwrap_or(0)
 }

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -113,23 +113,23 @@ unsafe impl Send for Device {}
 unsafe impl Sync for Device {}
 
 impl Device {
-    pub fn as_raw(&self) -> *mut d3d11::ID3D11Device {
-        self.raw.as_raw()
-    }
-
     pub fn new(
         device: ComPtr<d3d11::ID3D11Device>,
         context: ComPtr<d3d11::ID3D11DeviceContext>,
+        features: hal::Features,
         memory_properties: MemoryProperties,
-        requested_features: hal::Features,
     ) -> Self {
         Device {
             raw: device.clone(),
             context,
-            features: hal::Features::empty(),
+            features,
             memory_properties,
             internal: internal::Internal::new(&device),
         }
+    }
+
+    pub fn as_raw(&self) -> *mut d3d11::ID3D11Device {
+        self.raw.as_raw()
     }
 
     fn create_rasterizer_state(

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -1189,7 +1189,7 @@ impl Internal {
             context.PSSetConstantBuffers(0, 1, [self.internal_buffer.as_raw()].as_ptr());
         }
 
-        let subpass = &cache.render_pass.subpasses[cache.current_subpass];
+        let subpass = &cache.render_pass.subpasses[cache.current_subpass as usize];
 
         for clear in clears {
             let clear = clear.borrow();

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1058,7 +1058,7 @@ pub struct RenderPassCache {
     pub framebuffer: Framebuffer,
     pub attachment_clear_values: Vec<AttachmentClear>,
     pub target_rect: pso::Rect,
-    pub current_subpass: usize,
+    pub current_subpass: pass::SubpassId,
 }
 
 impl RenderPassCache {
@@ -1087,7 +1087,7 @@ impl RenderPassCache {
             &self,
         );
 
-        let subpass = &self.render_pass.subpasses[self.current_subpass];
+        let subpass = &self.render_pass.subpasses[self.current_subpass as usize];
         let color_views = subpass
             .color_attachments
             .iter()
@@ -1547,7 +1547,10 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
             //let attachment = render_pass.attachments[attachment_ref];
             let format = attachment.format.unwrap();
 
-            let subpass_id = render_pass.subpasses.iter().position(|sp| sp.is_using(idx));
+            let subpass_id = render_pass.subpasses
+                .iter()
+                .position(|sp| sp.is_using(idx))
+                .map(|i| i as pass::SubpassId);
 
             if attachment.has_clears() {
                 let value = *clear_iter.next().unwrap().borrow();

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -589,8 +589,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         let device = device::Device::new(
             device,
             cxt,
-            self.memory_properties.clone(),
             requested_features,
+            self.memory_properties.clone(),
         );
 
         // TODO: deferred context => 1 cxt/queue?

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -433,19 +433,12 @@ fn map_filter_type(filter: image::Filter) -> D3D12_FILTER_TYPE {
     }
 }
 
-fn map_anisotropic(anisotropic: image::Anisotropic) -> D3D12_FILTER {
-    match anisotropic {
-        image::Anisotropic::On(_) => D3D12_FILTER_ANISOTROPIC,
-        image::Anisotropic::Off => 0,
-    }
-}
-
 pub fn map_filter(
     mag_filter: image::Filter,
     min_filter: image::Filter,
     mip_filter: image::Filter,
     reduction: D3D12_FILTER_REDUCTION_TYPE,
-    anisotropic: image::Anisotropic,
+    anisotropy_clamp: Option<u8>,
 ) -> D3D12_FILTER {
     let mag = map_filter_type(mag_filter);
     let min = map_filter_type(min_filter);
@@ -455,7 +448,7 @@ pub fn map_filter(
         | (mag & D3D12_FILTER_TYPE_MASK) << D3D12_MAG_FILTER_SHIFT
         | (mip & D3D12_FILTER_TYPE_MASK) << D3D12_MIP_FILTER_SHIFT
         | (reduction & D3D12_FILTER_REDUCTION_TYPE_MASK) << D3D12_FILTER_REDUCTION_TYPE_SHIFT
-        | map_anisotropic(anisotropic)
+        | anisotropy_clamp.map(|_| D3D12_FILTER_ANISOTROPIC).unwrap_or(0)
 }
 
 pub fn map_buffer_resource_state(access: buffer::Access) -> D3D12_RESOURCE_STATES {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -331,7 +331,7 @@ impl device::Device<Backend> for Device {
         _: format::Format,
         _: format::Swizzle,
         _: image::SubresourceRange,
-    ) -> Result<(), image::ViewError> {
+    ) -> Result<(), image::ViewCreationError> {
         panic!(DO_NOT_USE_MESSAGE)
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -262,7 +262,7 @@ pub struct CommandBuffer {
     cache: Cache,
 
     pass_cache: Option<RenderPassCache>,
-    cur_subpass: usize,
+    cur_subpass: pass::SubpassId,
 
     limits: Limits,
     legacy_featues: info::LegacyFeatures,
@@ -447,13 +447,13 @@ impl CommandBuffer {
 
     fn begin_subpass(&mut self) {
         let state = self.pass_cache.as_ref().unwrap();
-        let subpass = &state.render_pass.subpasses[self.cur_subpass];
+        let subpass = &state.render_pass.subpasses[self.cur_subpass as usize];
 
         // See `begin_renderpass_cache` for clearing strategy
 
         // Bind draw buffers for mapping color output locations with
         // framebuffer attachments.
-        let draw_buffers = if state.framebuffer.fbos[self.cur_subpass].is_none() {
+        let draw_buffers = if state.framebuffer.fbos[self.cur_subpass as usize].is_none() {
             // The default framebuffer is created by the driver
             // We don't have influence on its layout and we treat it as single image.
             //
@@ -544,7 +544,7 @@ impl CommandBuffer {
 
         let cmd = Command::BindFrameBuffer(
             glow::DRAW_FRAMEBUFFER,
-            state.framebuffer.fbos[self.cur_subpass],
+            state.framebuffer.fbos[self.cur_subpass as usize],
         );
 
         self.push_cmd(cmd);
@@ -673,7 +673,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
                     })
                     .next()?;
                 Some(AttachmentClear {
-                    subpass_id: subpass,
+                    subpass_id: subpass as pass::SubpassId,
                     index,
                     value: *cv.borrow(),
                 })

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -418,7 +418,7 @@ pub(crate) unsafe fn set_sampler_info<SetParamFloat, SetParamFloatVec, SetParamI
 {
     let (min, mag) = conv::filter_to_gl(info.mag_filter, info.min_filter, info.mip_filter);
     if let Some(fac) = info.anisotropy_clamp {
-        if share.features.contains(hal::Features::SAMPLER_ANISOTROPY) {
+        if features.contains(hal::Features::SAMPLER_ANISOTROPY) {
             set_param_float(glow::TEXTURE_MAX_ANISOTROPY, fac as f32);
         }
     }
@@ -749,7 +749,7 @@ impl d::Device<B> for Device {
         let desc = desc.borrow();
         let subpass = {
             let subpass = desc.subpass;
-            match subpass.main_pass.subpasses.get(subpass.index) {
+            match subpass.main_pass.subpasses.get(subpass.index as usize) {
                 Some(sp) => sp,
                 None => return Err(pso::CreationError::InvalidSubpass(subpass.index)),
             }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2558,7 +2558,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             self.state.target_extent = framebuffer.extent;
         }
         if let Some(sp) = info.subpass {
-            let subpass = &sp.main_pass.subpasses[sp.index];
+            let subpass = &sp.main_pass.subpasses[sp.index as usize];
             self.state.target_formats.copy_from(&subpass.target_formats);
 
             self.state.target_aspects = Aspects::empty();

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1375,7 +1375,7 @@ impl hal::device::Device<Backend> for Device {
         let pipeline_layout = &pipeline_desc.layout;
         let (rp_attachments, subpass) = {
             let pass::Subpass { main_pass, index } = pipeline_desc.subpass;
-            (&main_pass.attachments, &main_pass.subpasses[index])
+            (&main_pass.attachments, &main_pass.subpasses[index as usize])
         };
 
         let (primitive_class, primitive_type) = match pipeline_desc.input_assembler.primitive {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -799,7 +799,7 @@ impl Device {
             image::Filter::Linear => MTLSamplerMipFilter::Linear,
         });
 
-        if let image::Anisotropic::On(aniso) = info.anisotropic {
+        if let Some(aniso) = info.anisotropy_clamp {
             descriptor.set_max_anisotropy(aniso as _);
         }
 
@@ -902,10 +902,7 @@ impl Device {
             },
             lod_clamp_min: lods.start.into(),
             lod_clamp_max: lods.end.into(),
-            max_anisotropy: match info.anisotropic {
-                image::Anisotropic::On(aniso) => aniso as i32,
-                image::Anisotropic::Off => 0,
-            },
+            max_anisotropy: info.anisotropy_clamp.map_or(0, |aniso| aniso as i32),
             planes: 0,
             resolution: msl::FormatResolution::_444,
             chroma_filter: msl::SamplerFilter::Nearest,
@@ -2440,17 +2437,13 @@ impl hal::device::Device<Backend> for Device {
         let format = match format_maybe {
             Some(fmt) => fmt,
             None => {
-                return Err(buffer::ViewCreationError::UnsupportedFormat {
-                    format: format_maybe,
-                });
+                return Err(buffer::ViewCreationError::UnsupportedFormat(format_maybe));
             }
         };
         let format_desc = format.surface_desc();
         if format_desc.aspects != format::Aspects::COLOR || format_desc.is_compressed() {
             // Vadlidator says "Linear texture: cannot create compressed, depth, or stencil textures"
-            return Err(buffer::ViewCreationError::UnsupportedFormat {
-                format: format_maybe,
-            });
+            return Err(buffer::ViewCreationError::UnsupportedFormat(format_maybe));
         }
 
         //Note: we rely on SPIRV-Cross to use the proper 2D texel indexing here
@@ -2458,11 +2451,9 @@ impl hal::device::Device<Backend> for Device {
         let col_count = cmp::min(texel_count, self.shared.private_caps.max_texture_size);
         let row_count = (texel_count + self.shared.private_caps.max_texture_size - 1)
             / self.shared.private_caps.max_texture_size;
-        let mtl_format = self.shared.private_caps.map_format(format).ok_or(
-            buffer::ViewCreationError::UnsupportedFormat {
-                format: format_maybe,
-            },
-        )?;
+        let mtl_format = self.shared.private_caps
+            .map_format(format)
+            .ok_or(buffer::ViewCreationError::UnsupportedFormat(format_maybe))?;
 
         let descriptor = metal::TextureDescriptor::new();
         descriptor.set_texture_type(MTLTextureType::D2);
@@ -2748,7 +2739,7 @@ impl hal::device::Device<Backend> for Device {
         format: format::Format,
         swizzle: format::Swizzle,
         range: image::SubresourceRange,
-    ) -> Result<n::ImageView, image::ViewError> {
+    ) -> Result<n::ImageView, image::ViewCreationError> {
         let mtl_format = match self
             .shared
             .private_caps
@@ -2757,7 +2748,7 @@ impl hal::device::Device<Backend> for Device {
             Some(f) => f,
             None => {
                 error!("failed to swizzle format {:?} with {:?}", format, swizzle);
-                return Err(image::ViewError::BadFormat(format));
+                return Err(image::ViewCreationError::BadFormat(format));
             }
         };
         let raw = image.like.as_texture();

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -533,11 +533,6 @@ impl d::Device<B> for Device {
         ID: IntoIterator,
         ID::Item: Borrow<pass::SubpassDependency>,
     {
-        let map_subpass_ref = |pass: pass::SubpassRef| match pass {
-            pass::SubpassRef::External => vk::SUBPASS_EXTERNAL,
-            pass::SubpassRef::Pass(id) => id as u32,
-        };
-
         let attachments = attachments
             .into_iter()
             .map(|attachment| {
@@ -629,8 +624,8 @@ impl d::Device<B> for Device {
                 let sdep = subpass_dep.borrow();
                 // TODO: checks
                 vk::SubpassDependency {
-                    src_subpass: map_subpass_ref(sdep.passes.start),
-                    dst_subpass: map_subpass_ref(sdep.passes.end),
+                    src_subpass: sdep.passes.start.map_or(vk::SUBPASS_EXTERNAL, |id| id as u32),
+                    dst_subpass: sdep.passes.end.map_or(vk::SUBPASS_EXTERNAL, |id| id as u32),
                     src_stage_mask: conv::map_pipeline_stage(sdep.stages.start),
                     dst_stage_mask: conv::map_pipeline_stage(sdep.stages.end),
                     src_access_mask: conv::map_image_access(sdep.accesses.start),

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -23,7 +23,6 @@ bitflags = "1.0"
 mint = { version = "0.5", optional = true }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
-smallvec = "1.0"
 
 [dev-dependencies]
 gfx-backend-empty = { path = "../backend/empty", version = "0.4" }

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -87,10 +87,7 @@ pub enum ViewCreationError {
     OutOfMemory(device::OutOfMemory),
 
     /// Buffer view format is not supported.
-    UnsupportedFormat {
-        /// Unsupported format passed on view creation.
-        format: Option<format::Format>,
-    },
+    UnsupportedFormat(Option<format::Format>),
 }
 
 impl From<device::OutOfMemory> for ViewCreationError {
@@ -105,14 +102,14 @@ impl std::fmt::Display for ViewCreationError {
             ViewCreationError::OutOfMemory(err) => {
                 write!(fmt, "Failed to create buffer view: {}", err)
             }
-            ViewCreationError::UnsupportedFormat {
-                format: Some(format),
-            } => write!(
-                fmt,
-                "Failed to create buffer view: Unsupported format {:?}",
-                format
-            ),
-            ViewCreationError::UnsupportedFormat { format: None } => {
+            ViewCreationError::UnsupportedFormat(Some(format)) => {
+                write!(
+                    fmt,
+                    "Failed to create buffer view: Unsupported format {:?}",
+                    format
+                )
+            }
+            ViewCreationError::UnsupportedFormat(None) => {
                 write!(fmt, "Failed to create buffer view: Unspecified format")
             }
         }

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -281,6 +281,8 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     unsafe fn set_depth_bounds(&mut self, bounds: Range<f32>);
 
     /// Set the line width dynamically.
+    ///
+    /// Only valid to call if `Features::LINE_WIDTH` is enabled.
     unsafe fn set_line_width(&mut self, width: f32);
 
     /// Set the depth bias dynamically.

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -669,7 +669,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         format: format::Format,
         swizzle: format::Swizzle,
         range: image::SubresourceRange,
-    ) -> Result<B::ImageView, image::ViewError>;
+    ) -> Result<B::ImageView, image::ViewCreationError>;
 
     /// Destroy an image view object
     unsafe fn destroy_image_view(&self, view: B::ImageView);

--- a/src/hal/src/format.rs
+++ b/src/hal/src/format.rs
@@ -87,18 +87,19 @@ pub const BITS_ZERO: FormatBits = FormatBits {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Component {
+    //TODO: add `Identity = 0`?
     /// Hardcoded zero
-    Zero,
+    Zero = 1,
     /// Hardcoded one
-    One,
+    One = 2,
     /// Red channel
-    R,
+    R = 3,
     /// Green channel
-    G,
+    G = 4,
     /// Blue channel
-    B,
+    B = 5,
     /// Alpha channel.
-    A,
+    A = 6,
 }
 
 /// Channel swizzle configuration for the resource views.

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -65,7 +65,7 @@ impl Extent {
 /// that do not exist is undefined behavior -- for
 /// example, specifying a `z` offset of `1` in a
 /// two-dimensional image.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Offset {
     /// X offset.
@@ -97,10 +97,10 @@ impl Offset {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Tiling {
     /// Optimal tiling for GPU memory access. Implementation-dependent.
-    Optimal,
+    Optimal = 0,
     /// Optimal for CPU read/write. Texels are laid out in row-major order,
     /// possibly with some padding on each row.
-    Linear,
+    Linear = 1,
 }
 
 /// Pure image object creation error.
@@ -153,8 +153,7 @@ impl std::error::Error for CreationError {
 
 /// Error creating an `ImageView`.
 #[derive(Clone, Debug, PartialEq)]
-// TODO: Rename this or `buffer::ViewCreationError`
-pub enum ViewError {
+pub enum ViewCreationError {
     /// The required usage flag is not present in the image.
     Usage(Usage),
     /// Selected mip level doesn't exist.
@@ -171,30 +170,30 @@ pub enum ViewError {
     Unsupported,
 }
 
-impl From<device::OutOfMemory> for ViewError {
+impl From<device::OutOfMemory> for ViewCreationError {
     fn from(error: device::OutOfMemory) -> Self {
-        ViewError::OutOfMemory(error)
+        ViewCreationError::OutOfMemory(error)
     }
 }
 
-impl std::fmt::Display for ViewError {
+impl std::fmt::Display for ViewCreationError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ViewError::Usage(usage) => write!(fmt, "Failed to create image view: Specified usage flags are not present in the image {:?}", usage),
-            ViewError::Level(level) => write!(fmt, "Failed to create image view: Selected level doesn't exist in the image {}", level),
-            ViewError::Layer(err) => write!(fmt, "Failed to create image view: {}", err),
-            ViewError::BadFormat(format) => write!(fmt, "Failed to create image view: Incompatible format {:?}", format),
-            ViewError::BadKind(kind) => write!(fmt, "Failed to create image view: Incompatible kind {:?}", kind),
-            ViewError::OutOfMemory(err) => write!(fmt, "Failed to create image view: {}", err),
-            ViewError::Unsupported => write!(fmt, "Failed to create image view: Implementation specific error occurred"),
+            ViewCreationError::Usage(usage) => write!(fmt, "Failed to create image view: Specified usage flags are not present in the image {:?}", usage),
+            ViewCreationError::Level(level) => write!(fmt, "Failed to create image view: Selected level doesn't exist in the image {}", level),
+            ViewCreationError::Layer(err) => write!(fmt, "Failed to create image view: {}", err),
+            ViewCreationError::BadFormat(format) => write!(fmt, "Failed to create image view: Incompatible format {:?}", format),
+            ViewCreationError::BadKind(kind) => write!(fmt, "Failed to create image view: Incompatible kind {:?}", kind),
+            ViewCreationError::OutOfMemory(err) => write!(fmt, "Failed to create image view: {}", err),
+            ViewCreationError::Unsupported => write!(fmt, "Failed to create image view: Implementation specific error occurred"),
         }
     }
 }
 
-impl std::error::Error for ViewError {
+impl std::error::Error for ViewCreationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            ViewError::OutOfMemory(err) => Some(err),
+            ViewCreationError::OutOfMemory(err) => Some(err),
             _ => None,
         }
     }
@@ -239,16 +238,6 @@ pub enum Filter {
     ///     * 2D/Cube: Bilinear interpolation
     ///     * 3D: Trilinear interpolation
     Linear,
-}
-
-/// Anisotropic filtering description for the sampler.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Anisotropic {
-    /// Disable anisotropic filtering.
-    Off,
-    /// Enable anisotropic filtering with the anisotropy clamp value.
-    On(u8),
 }
 
 /// The face of a cube image to do an operation on.
@@ -539,7 +528,9 @@ pub struct SamplerDesc {
     /// Specifies whether the texture coordinates are normalized.
     pub normalized: bool,
     /// Anisotropic filtering.
-    pub anisotropic: Anisotropic,
+    ///
+    /// Can be `Some(_)` only if `Features::SAMPLER_ANISOTROPY` is enabled.
+    pub anisotropy_clamp: Option<u8>,
 }
 
 impl SamplerDesc {
@@ -556,7 +547,7 @@ impl SamplerDesc {
             comparison: None,
             border: PackedColor(0),
             normalized: true,
-            anisotropic: Anisotropic::Off,
+            anisotropy_clamp: None,
         }
     }
 }
@@ -591,7 +582,7 @@ pub enum Layout {
     /// source layout when transforming data to a specific destination
     /// layout or initializing data.  Does NOT guarentee that the contents
     /// of the source buffer are preserved.
-    Undefined, //TODO: consider Option<> instead?
+    Undefined,
     /// Like `Undefined`, but does guarentee that the contents of the source
     /// buffer are preserved.
     Preinitialized,

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -430,6 +430,16 @@ impl From<usize> for MemoryTypeId {
     }
 }
 
+struct PseudoVec<T>(Option<T>);
+
+impl<T> std::iter::Extend<T> for &'_ mut PseudoVec<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        let mut iter = iter.into_iter();
+        self.0 = iter.next();
+        assert!(iter.next().is_none());
+    }
+}
+
 /// The `Backend` trait wraps together all the types needed
 /// for a graphics backend. Each backend module, such as OpenGL
 /// or Metal, will implement this trait with its own concrete types.

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -8,17 +8,17 @@ bitflags!(
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct Properties: u16 {
         /// Device local memory on the GPU.
-        const DEVICE_LOCAL   = 0x1;
+        const DEVICE_LOCAL = 0x1;
 
         /// Host visible memory can be accessed by the CPU.
         ///
         /// Backends must provide at least one cpu visible memory.
-        const CPU_VISIBLE   = 0x2;
+        const CPU_VISIBLE = 0x2;
 
         /// CPU-GPU coherent.
         ///
         /// Non-coherent memory requires explicit flushing.
-        const COHERENT     = 0x4;
+        const COHERENT = 0x4;
 
         /// Cached memory by the CPU
         const CPU_CACHED = 0x8;
@@ -35,8 +35,10 @@ bitflags!(
     pub struct Dependencies: u32 {
         /// Specifies the memory dependency to be framebuffer-local.
         const BY_REGION    = 0x1;
-        //const VIEW_LOCAL   = 0x2;
-        //const DEVICE_GROUP = 0x4;
+        ///
+        const VIEW_LOCAL   = 0x2;
+        ///
+        const DEVICE_GROUP = 0x4;
     }
 );
 
@@ -57,11 +59,11 @@ pub enum Barrier<'a, B: Backend> {
         states: Range<buffer::State>,
         /// The buffer the barrier controls.
         target: &'a B::Buffer,
+        /// Subrange of the buffer the barrier applies to.
+        range: buffer::SubRange,
         /// The source and destination Queue family IDs, for a [queue family ownership transfer](https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#synchronization-queue-transfers)
         /// Can be `None` to indicate no ownership transfer.
         families: Option<Range<queue::QueueFamilyId>>,
-        /// Subrange of the buffer the barrier applies to.
-        range: buffer::SubRange,
     },
     /// A memory barrier that defines access to (a subset of) an image.
     Image {
@@ -69,11 +71,11 @@ pub enum Barrier<'a, B: Backend> {
         states: Range<image::State>,
         /// The image the barrier controls.
         target: &'a B::Image,
+        /// A `SubresourceRange` that defines which section of an image the barrier applies to.
+        range: image::SubresourceRange,
         /// The source and destination Queue family IDs, for a [queue family ownership transfer](https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#synchronization-queue-transfers)
         /// Can be `None` to indicate no ownership transfer.
         families: Option<Range<queue::QueueFamilyId>>,
-        /// A `SubresourceRange` that defines which section of an image the barrier applies to.
-        range: image::SubresourceRange,
     },
 }
 

--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -1,9 +1,8 @@
 //! Command pools
 
 use crate::command::Level;
-use crate::Backend;
+use crate::{Backend, PseudoVec};
 
-use smallvec::SmallVec;
 use std::any::Any;
 use std::fmt;
 
@@ -28,12 +27,17 @@ pub trait CommandPool<B: Backend>: fmt::Debug + Any + Send + Sync {
 
     /// Allocate a single command buffers from the pool.
     unsafe fn allocate_one(&mut self, level: Level) -> B::CommandBuffer {
-        self.allocate_vec(1, level).pop().unwrap()
+        let mut result = PseudoVec(None);
+        self.allocate(1, level, &mut result);
+        result.0.unwrap()
     }
 
     /// Allocate new command buffers from the pool.
-    unsafe fn allocate_vec(&mut self, num: usize, level: Level) -> SmallVec<[B::CommandBuffer; 1]> {
-        (0 .. num).map(|_| self.allocate_one(level)).collect()
+    unsafe fn allocate<E>(&mut self, num: usize, level: Level, mut list: E)
+    where
+        E: Extend<B::CommandBuffer>
+    {
+        list.extend((0 .. num).map(|_| self.allocate_one(level)));
     }
 
     /// Free command buffers which are allocated from this pool.

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -625,10 +625,12 @@ impl<B: hal::Backend> Scene<B> {
                     };
                     let subpass_ref = |s: &String| {
                         if s.is_empty() {
-                            hal::pass::SubpassRef::External
+                            None
                         } else {
-                            let id = subpasses.keys().position(|sp| s == sp).unwrap();
-                            hal::pass::SubpassRef::Pass(id)
+                            subpasses
+                                .keys()
+                                .position(|sp| s == sp)
+                                .map(|id| id as hal::pass::SubpassId)
                         }
                     };
 

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -75,7 +75,7 @@ pub struct GraphicsShaderSet {
 #[derive(Debug, Deserialize)]
 pub struct SubpassRef {
     pub parent: String,
-    pub index: usize,
+    pub index: hal::pass::SubpassId,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Generally simplifies the API by using more standard types and cleaner field names. This is preferred since we are no longer trying to be too much user-friendly. Simplicity is more important.
(last commit)
Fixes #2561

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
