### PR TITLE
Pass Extend by mutable reference

### DIFF
--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -821,5 +821,7 @@ pub fn map_filter(
         | (mag & D3D11_FILTER_TYPE_MASK) << D3D11_MAG_FILTER_SHIFT
         | (mip & D3D11_FILTER_TYPE_MASK) << D3D11_MIP_FILTER_SHIFT
         | (reduction & D3D11_FILTER_REDUCTION_TYPE_MASK) << D3D11_FILTER_REDUCTION_TYPE_SHIFT
-        | anisotropy_clamp.map(|_| D3D11_FILTER_ANISOTROPIC).unwrap_or(0)
+        | anisotropy_clamp
+            .map(|_| D3D11_FILTER_ANISOTROPIC)
+            .unwrap_or(0)
 }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1547,7 +1547,8 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
             //let attachment = render_pass.attachments[attachment_ref];
             let format = attachment.format.unwrap();
 
-            let subpass_id = render_pass.subpasses
+            let subpass_id = render_pass
+                .subpasses
                 .iter()
                 .position(|sp| sp.is_using(idx))
                 .map(|i| i as pass::SubpassId);
@@ -3214,11 +3215,13 @@ impl From<pso::DescriptorType> for DescriptorContent {
                 ty: Idt::Sampled {
                     with_sampler: false,
                 },
-            } |
-            Dt::Image { ty: Idt::Storage { read_only: true } } |
-            Dt::InputAttachment => DescriptorContent::SRV,
+            }
+            | Dt::Image {
+                ty: Idt::Storage { read_only: true },
+            }
+            | Dt::InputAttachment => DescriptorContent::SRV,
             Dt::Image {
-                ty: Idt::Storage { read_only: false }
+                ty: Idt::Storage { read_only: false },
             } => DescriptorContent::SRV | DescriptorContent::UAV,
             Dt::Buffer {
                 ty: Bdt::Uniform,

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1219,7 +1219,8 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                 };
 
                 AttachmentClear {
-                    subpass_id: render_pass.subpasses
+                    subpass_id: render_pass
+                        .subpasses
                         .iter()
                         .position(|sp| sp.is_using(i))
                         .map(|i| i as pass::SubpassId),

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -448,7 +448,9 @@ pub fn map_filter(
         | (mag & D3D12_FILTER_TYPE_MASK) << D3D12_MAG_FILTER_SHIFT
         | (mip & D3D12_FILTER_TYPE_MASK) << D3D12_MIP_FILTER_SHIFT
         | (reduction & D3D12_FILTER_REDUCTION_TYPE_MASK) << D3D12_FILTER_REDUCTION_TYPE_SHIFT
-        | anisotropy_clamp.map(|_| D3D12_FILTER_ANISOTROPIC).unwrap_or(0)
+        | anisotropy_clamp
+            .map(|_| D3D12_FILTER_ANISOTROPIC)
+            .unwrap_or(0)
 }
 
 pub fn map_buffer_resource_state(access: buffer::Access) -> D3D12_RESOURCE_STATES {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -13,7 +13,17 @@ mod resource;
 mod root_constants;
 mod window;
 
-use hal::{adapter, format as f, image, memory, pso::PipelineStage, queue as q, Features, Hints, Limits};
+use hal::{
+    adapter,
+    format as f,
+    image,
+    memory,
+    pso::PipelineStage,
+    queue as q,
+    Features,
+    Hints,
+    Limits,
+};
 
 use winapi::{
     shared::{dxgi, dxgi1_2, dxgi1_4, dxgi1_6, minwindef::TRUE, winerror},

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -80,8 +80,11 @@ impl Drop for Device {
 
 impl Device {
     /// Create a new `Device`.
-    pub(crate) fn new(share: Starc<Share>, features: hal::Features,) -> Self {
-        Device { share: share, features }
+    pub(crate) fn new(share: Starc<Share>, features: hal::Features) -> Self {
+        Device {
+            share: share,
+            features,
+        }
     }
 
     pub fn create_shader_module_from_source(

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -335,7 +335,9 @@ const IS_WEBGL: bool = cfg!(target_arch = "wasm32");
 
 /// Load the information pertaining to the driver and the corresponding device
 /// capabilities.
-pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Hints, Limits, PrivateCaps) {
+pub(crate) fn query_all(
+    gl: &GlContainer,
+) -> (Info, Features, LegacyFeatures, Hints, Limits, PrivateCaps) {
     use self::Requirement::*;
     let info = Info::get(gl);
     let max_texture_size = get_usize(gl, glow::MAX_TEXTURE_SIZE).unwrap_or(64) as u32;
@@ -504,7 +506,7 @@ pub(crate) fn query_all(gl: &GlContainer) -> (Info, Features, LegacyFeatures, Hi
         frag_data_location: !info.version.is_embedded,
         sync: !info.is_webgl() && info.is_supported(&[Core(3, 2), Es(3, 0), Ext("GL_ARB_sync")]), // TODO
         map: !info.version.is_embedded, //TODO: OES extension
-        emulate_map,                                          // TODO
+        emulate_map,                    // TODO
         depth_range_f64_precision: !info.version.is_embedded, // TODO
         draw_buffers: info.is_supported(&[Core(2, 0), Es(3, 0)]),
     };

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -404,7 +404,8 @@ impl PhysicalDevice {
     #[allow(unused)]
     fn new_adapter(instance_context: DeviceContext, gl: GlContainer) -> adapter::Adapter<Backend> {
         // query information
-        let (info, supported_features, legacy_features, hints, limits, private_caps) = info::query_all(&gl);
+        let (info, supported_features, legacy_features, hints, limits, private_caps) =
+            info::query_all(&gl);
         info!("Vendor: {:?}", info.platform_name.vendor);
         info!("Renderer: {:?}", info.platform_name.renderer);
         info!("Version: {:?}", info.version);

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -163,7 +163,12 @@ pub(crate) fn set_blend(gl: &GlContainer, desc: &pso::ColorBlendDesc) {
     }
 }
 
-pub(crate) fn set_blend_slot(gl: &GlContainer, slot: ColorSlot, desc: &pso::ColorBlendDesc, features: &hal::Features) {
+pub(crate) fn set_blend_slot(
+    gl: &GlContainer,
+    slot: ColorSlot,
+    desc: &pso::ColorBlendDesc,
+    features: &hal::Features,
+) {
     use hal::pso::ColorMask as Cm;
 
     if !features.contains(hal::Features::INDEPENDENT_BLENDING) {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -860,7 +860,9 @@ impl Device {
                 image::WrapMode::Mirror => msl::SamplerAddress::MirroredRepeat,
                 image::WrapMode::Clamp => msl::SamplerAddress::ClampToEdge,
                 image::WrapMode::Border => msl::SamplerAddress::ClampToBorder,
-                image::WrapMode::MirrorClamp => unimplemented!("https://github.com/grovesNL/spirv_cross/issues/138"),
+                image::WrapMode::MirrorClamp => {
+                    unimplemented!("https://github.com/grovesNL/spirv_cross/issues/138")
+                }
             }
         }
 
@@ -2451,7 +2453,9 @@ impl hal::device::Device<Backend> for Device {
         let col_count = cmp::min(texel_count, self.shared.private_caps.max_texture_size);
         let row_count = (texel_count + self.shared.private_caps.max_texture_size - 1)
             / self.shared.private_caps.max_texture_size;
-        let mtl_format = self.shared.private_caps
+        let mtl_format = self
+            .shared
+            .private_caps
             .map_format(format)
             .ok_or(buffer::ViewCreationError::UnsupportedFormat(format_maybe))?;
 

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -33,7 +33,7 @@ pub struct CommandBuffer {
 fn debug_color(color: u32) -> [f32; 4] {
     let mut result = [0.0; 4];
     for (i, c) in result.iter_mut().enumerate() {
-        *c = ((color >> (24 + i*8)) & 0xFF) as f32 / 255.0;
+        *c = ((color >> (24 + i * 8)) & 0xFF) as f32 / 255.0;
     }
     result
 }

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -547,7 +547,11 @@ pub fn map_clear_rect(rect: &pso::ClearRect) -> vk::ClearRect {
 pub fn map_viewport(vp: &pso::Viewport, flip_y: bool) -> vk::Viewport {
     vk::Viewport {
         x: vp.rect.x as _,
-        y: if flip_y { vp.rect.y + vp.rect.h } else { vp.rect.y } as _,
+        y: if flip_y {
+            vp.rect.y + vp.rect.h
+        } else {
+            vp.rect.y
+        } as _,
         width: vp.rect.w as _,
         height: if flip_y { -vp.rect.h } else { vp.rect.h } as _,
         min_depth: vp.depth.start,

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -624,7 +624,10 @@ impl d::Device<B> for Device {
                 let sdep = subpass_dep.borrow();
                 // TODO: checks
                 vk::SubpassDependency {
-                    src_subpass: sdep.passes.start.map_or(vk::SUBPASS_EXTERNAL, |id| id as u32),
+                    src_subpass: sdep
+                        .passes
+                        .start
+                        .map_or(vk::SUBPASS_EXTERNAL, |id| id as u32),
                     dst_subpass: sdep.passes.end.map_or(vk::SUBPASS_EXTERNAL, |id| id as u32),
                     src_stage_mask: conv::map_pipeline_stage(sdep.stages.start),
                     dst_stage_mask: conv::map_pipeline_stage(sdep.stages.end),
@@ -1244,8 +1247,8 @@ impl d::Device<B> for Device {
     ) -> Result<n::Sampler, d::AllocationError> {
         use hal::pso::Comparison;
 
-        let (anisotropy_enable, max_anisotropy) = desc.anisotropy_clamp
-            .map_or((vk::FALSE, 1.0), |aniso| {
+        let (anisotropy_enable, max_anisotropy) =
+            desc.anisotropy_clamp.map_or((vk::FALSE, 1.0), |aniso| {
                 if self.raw.1.contains(Features::SAMPLER_ANISOTROPY) {
                     (vk::TRUE, aniso as f32)
                 } else {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -482,9 +482,8 @@ impl hal::Instance<Backend> for Instance {
         devices
             .into_iter()
             .map(|device| {
-                let extensions = unsafe {
-                    self.raw.0.enumerate_device_extension_properties(device)
-                }.unwrap();
+                let extensions =
+                    unsafe { self.raw.0.enumerate_device_extension_properties(device) }.unwrap();
                 let properties = unsafe { self.raw.0.get_physical_device_properties(device) };
                 let info = adapter::AdapterInfo {
                     name: unsafe {
@@ -667,10 +666,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         }
 
         let enabled_features = conv::map_device_features(requested_features);
-        let enabled_extensions = DEVICE_EXTENSIONS
-            .iter()
-            .cloned()
-            .chain(if requested_features.contains(Features::NDC_Y_UP) {
+        let enabled_extensions = DEVICE_EXTENSIONS.iter().cloned().chain(
+            if requested_features.contains(Features::NDC_Y_UP) {
                 //TODO: try also `VK_AMD_negative_viewport_height`?
                 Some(if self.supports_extension(*AMD_NEGATIVE_VIEWPORT_HEIGHT) {
                     *AMD_NEGATIVE_VIEWPORT_HEIGHT
@@ -679,13 +676,12 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 })
             } else {
                 None
-            });
+            },
+        );
 
         // Create device
         let device_raw = {
-            let cstrings = enabled_extensions
-                .map(CString::from)
-                .collect::<Vec<_>>();
+            let cstrings = enabled_extensions.map(CString::from).collect::<Vec<_>>();
 
             let str_pointers = cstrings.iter().map(|s| s.as_ptr()).collect::<Vec<_>>();
 
@@ -900,8 +896,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             | Features::SEPARATE_STENCIL_REF_VALUES
             | Features::SAMPLER_MIP_LOD_BIAS;
 
-        if self.supports_extension(*AMD_NEGATIVE_VIEWPORT_HEIGHT) ||
-            self.supports_extension(*KHR_MAINTENANCE1)
+        if self.supports_extension(*AMD_NEGATIVE_VIEWPORT_HEIGHT)
+            || self.supports_extension(*KHR_MAINTENANCE1)
         {
             bits |= Features::NDC_Y_UP;
         }

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -112,7 +112,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
     unsafe fn allocate<I, E>(
         &mut self,
         layout_iter: I,
-        mut list: E,
+        list: &mut E,
     ) -> Result<(), pso::AllocationError>
     where
         I: IntoIterator,

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -30,7 +30,7 @@ impl pool::CommandPool<Backend> for RawCommandPool {
         &mut self,
         num: usize,
         level: command::Level,
-        mut list: E,
+        list: &mut E,
     ) where
         E: Extend<CommandBuffer>,
     {

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -26,12 +26,8 @@ impl pool::CommandPool<Backend> for RawCommandPool {
         assert_eq!(Ok(()), self.device.0.reset_command_pool(self.raw, flags));
     }
 
-    unsafe fn allocate<E>(
-        &mut self,
-        num: usize,
-        level: command::Level,
-        list: &mut E,
-    ) where
+    unsafe fn allocate<E>(&mut self, num: usize, level: command::Level, list: &mut E)
+    where
         E: Extend<CommandBuffer>,
     {
         let info = vk::CommandBufferAllocateInfo {
@@ -46,14 +42,14 @@ impl pool::CommandPool<Backend> for RawCommandPool {
 
         list.extend(
             device
-            .0
-            .allocate_command_buffers(&info)
-            .expect("Error on command buffer allocation")
-            .into_iter()
-            .map(|buffer| CommandBuffer {
-                raw: buffer,
-                device: Arc::clone(device),
-            })
+                .0
+                .allocate_command_buffers(&info)
+                .expect("Error on command buffer allocation")
+                .into_iter()
+                .map(|buffer| CommandBuffer {
+                    raw: buffer,
+                    device: Arc::clone(device),
+                }),
         );
     }
 

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -102,13 +102,11 @@ impl std::fmt::Display for ViewCreationError {
             ViewCreationError::OutOfMemory(err) => {
                 write!(fmt, "Failed to create buffer view: {}", err)
             }
-            ViewCreationError::UnsupportedFormat(Some(format)) => {
-                write!(
-                    fmt,
-                    "Failed to create buffer view: Unsupported format {:?}",
-                    format
-                )
-            }
+            ViewCreationError::UnsupportedFormat(Some(format)) => write!(
+                fmt,
+                "Failed to create buffer view: Unsupported format {:?}",
+                format
+            ),
             ViewCreationError::UnsupportedFormat(None) => {
                 write!(fmt, "Failed to create buffer view: Unspecified format")
             }

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -186,7 +186,7 @@ bitflags! {
         const VARIABLE_MULTISAMPLE_RATE = 0x0020_0000_0000_0000;
         ///
         const INHERITED_QUERIES = 0x0040_0000_0000_0000;
-        /// Support for 
+        /// Support for
         const SAMPLER_MIRROR_CLAMP_EDGE = 0x0100_0000_0000_0000;
 
         /// Support triangle fan primitive topology.

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -432,7 +432,7 @@ impl From<usize> for MemoryTypeId {
 
 struct PseudoVec<T>(Option<T>);
 
-impl<T> std::iter::Extend<T> for &'_ mut PseudoVec<T> {
+impl<T> std::iter::Extend<T> for PseudoVec<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         let mut iter = iter.into_iter();
         self.0 = iter.next();

--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -35,7 +35,7 @@ pub trait CommandPool<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Allocate new command buffers from the pool.
     unsafe fn allocate<E>(&mut self, num: usize, level: Level, list: &mut E)
     where
-        E: Extend<B::CommandBuffer>
+        E: Extend<B::CommandBuffer>,
     {
         list.extend((0 .. num).map(|_| self.allocate_one(level)));
     }

--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -33,7 +33,7 @@ pub trait CommandPool<B: Backend>: fmt::Debug + Any + Send + Sync {
     }
 
     /// Allocate new command buffers from the pool.
-    unsafe fn allocate<E>(&mut self, num: usize, level: Level, mut list: E)
+    unsafe fn allocate<E>(&mut self, num: usize, level: Level, list: &mut E)
     where
         E: Extend<B::CommandBuffer>
     {

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -217,7 +217,7 @@ pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
     ///
     /// [`DescriptorSetWrite`]: struct.DescriptorSetWrite.html
     /// [`DescriptorSetCopy`]: struct.DescriptorSetCopy.html
-    unsafe fn allocate<I, E>(&mut self, layouts: I, mut list: E) -> Result<(), AllocationError>
+    unsafe fn allocate<I, E>(&mut self, layouts: I, list: &mut E) -> Result<(), AllocationError>
     where
         I: IntoIterator,
         I::Item: Borrow<B::DescriptorSetLayout>,

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -18,12 +18,7 @@
 
 use std::{borrow::Borrow, fmt, iter};
 
-use crate::{
-    buffer::SubRange,
-    image::Layout,
-    pso::ShaderStageFlags,
-    Backend, PseudoVec,
-};
+use crate::{buffer::SubRange, image::Layout, pso::ShaderStageFlags, Backend, PseudoVec};
 
 ///
 pub type DescriptorSetIndex = u16;

--- a/src/warden/src/bin/bench.rs
+++ b/src/warden/src/bin/bench.rs
@@ -75,10 +75,16 @@ impl Harness {
                     .map_err(de::Error::from)
                     .and_then(de::from_reader)
                     .expect("failed to open/parse the scene");
-                let features = raw_group.features
+                let features = raw_group
+                    .features
                     .into_iter()
                     .fold(hal::Features::empty(), |u, f| u | f.into_hal());
-                TestGroup { name, scene, tests: raw_group.tests, features }
+                TestGroup {
+                    name,
+                    scene,
+                    tests: raw_group.tests,
+                    features,
+                }
             })
             .collect();
 
@@ -122,12 +128,16 @@ impl Harness {
                     "\tskipped (features missing: {:?})",
                     tg.features - supported_features
                 );
-                continue
+                continue;
             }
 
-            let mut scene =
-                warden::gpu::Scene::<B>::new(adapter, tg.features, &tg.scene, self.base_path.join("data"))
-                    .unwrap();
+            let mut scene = warden::gpu::Scene::<B>::new(
+                adapter,
+                tg.features,
+                &tg.scene,
+                self.base_path.join("data"),
+            )
+            .unwrap();
 
             for (test_name, test) in &tg.tests {
                 print!("\t\tTest '{}' ...", test_name);

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -84,10 +84,16 @@ impl Harness {
                     .map_err(de::Error::from)
                     .and_then(de::from_reader)
                     .expect(&format!("failed to open/parse the scene '{:?}'", name));
-                let features = raw_group.features
+                let features = raw_group
+                    .features
                     .into_iter()
                     .fold(hal::Features::empty(), |u, f| u | f.into_hal());
-                TestGroup { name, scene, tests: raw_group.tests, features }
+                TestGroup {
+                    name,
+                    scene,
+                    tests: raw_group.tests,
+                    features,
+                }
             })
             .collect();
 
@@ -138,12 +144,16 @@ impl Harness {
                     tg.features - supported_features
                 );
                 results.skip += tg.tests.len();
-                continue
+                continue;
             }
 
-            let mut scene =
-                warden::gpu::Scene::<B>::new(adapter, tg.features, &tg.scene, self.base_path.join("data"))
-                    .unwrap();
+            let mut scene = warden::gpu::Scene::<B>::new(
+                adapter,
+                tg.features,
+                &tg.scene,
+                self.base_path.join("data"),
+            )
+            .unwrap();
 
             for (test_name, test) in &tg.tests {
                 print!("\t\tTest '{}' ...", test_name);

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -212,10 +212,7 @@ impl<B: hal::Backend> Scene<B> {
         let mut gpu = unsafe {
             adapter
                 .physical_device
-                .open(
-                    &[(&adapter.queue_families[0], &[1.0])],
-                    featues,
-                )
+                .open(&[(&adapter.queue_families[0], &[1.0])], featues)
                 .unwrap()
         };
         let device = gpu.device;
@@ -1731,13 +1728,7 @@ impl<B: hal::Backend> Scene<B> {
                 self.device.wait_idle().unwrap();
                 let raw_data = slice::from_raw_parts_mut(results.as_mut_ptr() as *mut u8, 4 * 2);
                 self.device
-                    .get_query_pool_results(
-                        pool,
-                        0 .. 2,
-                        raw_data,
-                        4,
-                        query::ResultFlags::empty(),
-                    )
+                    .get_query_pool_results(pool, 0 .. 2, raw_data, 4, query::ResultFlags::empty())
                     .unwrap();
             }
         }
@@ -1757,8 +1748,7 @@ impl<B: hal::Backend> Drop for Scene<B> {
             self.device
                 .destroy_command_pool(self.command_pool.take().unwrap());
             if let Some(pool) = self.query_pool.take() {
-                self.device
-                    .destroy_query_pool(pool);
+                self.device.destroy_query_pool(pool);
             }
         }
     }

--- a/src/warden/src/lib.rs
+++ b/src/warden/src/lib.rs
@@ -51,12 +51,10 @@ pub fn init_gl_on_ci() -> gfx_backend_gl::Headless {
 }
 
 #[derive(Debug, serde::Deserialize)]
-pub enum Feature {
-}
+pub enum Feature {}
 
 impl Feature {
     pub fn into_hal(self) -> hal::Features {
-        match self {
-        }
+        match self {}
     }
 }


### PR DESCRIPTION
Fixes the use of Extend. The last version was wrong because we can't pass Extend by reference if a value was expected.
Also has a commit for formatting pass: having the code formatted will help aligning the hal-0.5 with master in the future.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
