### PR TITLE
[dx12] patch the pipeline layout with read-only decorations

### DIFF
--- a/src/auxil/auxil/src/lib.rs
+++ b/src/auxil/auxil/src/lib.rs
@@ -7,6 +7,8 @@ use {
 /// Fast hash map used internally.
 pub type FastHashMap<K, V> =
     std::collections::HashMap<K, V, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
+pub type FastHashSet<K> =
+    std::collections::HashSet<K, std::hash::BuildHasherDefault<fxhash::FxHasher>>;
 
 #[cfg(feature = "spirv_cross")]
 pub fn spirv_cross_specialize_ast<T>(

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -141,13 +141,14 @@ pub struct RootDescriptor {
     pub offset: RootSignatureOffset,
 }
 
-#[derive(Debug, Hash)]
+#[derive(Debug)]
 pub struct RootElement {
     pub table: RootTable,
     pub descriptors: Vec<RootDescriptor>,
+    pub mutable_bindings: auxil::FastHashSet<pso::DescriptorBinding>,
 }
 
-#[derive(Debug, Hash)]
+#[derive(Debug)]
 pub struct PipelineLayout {
     pub(crate) raw: native::RootSignature,
     // Disjunct, sorted vector of root constant ranges.


### PR DESCRIPTION
Fixes the read-only bindings now in dx12. What we used to get is the shader disagreeing with the pipeline layout as to which bindings are UAV and which are SRV. Now we are setting the `NonWritable` decorations where appropriate.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
