### PR TITLE
[gl] add missing R/Rg/Rgba16Unorm format conversions

### DIFF
--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -151,6 +151,7 @@ pub fn describe_format(format: Format) -> Option<FormatDescription> {
         ),
         R16Sint => FormatDescription::new(glow::R16I, glow::RED_INTEGER, glow::SHORT, 1, Integer),
         R16Sfloat => FormatDescription::new(glow::R16, glow::RED, glow::HALF_FLOAT, 1, Float),
+        R16Unorm => FormatDescription::new(glow::R16, glow::RED, glow::UNSIGNED_SHORT, 1, Float),
         Rg16Uint => FormatDescription::new(
             glow::RG16UI,
             glow::RG_INTEGER,
@@ -159,6 +160,7 @@ pub fn describe_format(format: Format) -> Option<FormatDescription> {
             Integer,
         ),
         Rg16Sint => FormatDescription::new(glow::RG16I, glow::RG_INTEGER, glow::SHORT, 2, Integer),
+        Rg16Unorm => FormatDescription::new(glow::RG16, glow::RG, glow::UNSIGNED_SHORT, 2, Float),
         Rg16Sfloat => FormatDescription::new(glow::RG16, glow::RG, glow::HALF_FLOAT, 2, Float),
         Rgba16Uint => FormatDescription::new(
             glow::RGBA16UI,
@@ -172,6 +174,9 @@ pub fn describe_format(format: Format) -> Option<FormatDescription> {
         }
         Rgba16Sfloat => {
             FormatDescription::new(glow::RGBA16, glow::RGBA, glow::HALF_FLOAT, 4, Float)
+        }
+        Rgba16Unorm => {
+            FormatDescription::new(glow::RGBA16, glow::RGBA, glow::UNSIGNED_SHORT, 4, Float)
         }
         R32Uint => FormatDescription::new(
             glow::R32UI,


### PR DESCRIPTION
Hi gfx team!

In my project I'm using `gfx_hal::format::Rg16Unorm`, passing it to `device.create_image(...)` as a format at some point, however as I discovered there is not yet any conversion for that format defined in the gl backend in `conv.rs` (which later leads to a crash at runtime):

https://github.com/gfx-rs/gfx/blob/fdfe887f5afab7ca057e3e824817d0bcdcf794ba/src/backend/gl/src/conv.rs#L95-L101

I made a naive attempt to add a mapping myself, based on deductions from the other entries in the mapping table and eventually experimenting with different combinations, the last one I arrived at being the one in this draft PR:

```rust
 Rg16Unorm => FormatDescription::new(glow::RG16, glow::RG_INTEGER, glow::UNSIGNED_SHORT, 2, Float),
```

However every variant I tried leads to an `Unsupported uniform datatype!` panic at a later point, right here:

https://github.com/gfx-rs/gfx/blob/fdfe887f5afab7ca057e3e824817d0bcdcf794ba/src/backend/gl/src/queue.rs#L938-L945

I'd love to make myself useful here and provide a fully working patch but right now I fear I'm stumbling around in the dark a bit, so glad for any pointers how I could continue this!

---

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds

This currently fails elsewhere (in the Vulkan backend) so I can't tell right now:
```
Testing Vulkan:
	Scene 'vertex-offset':
thread 'main' panicked at 'attempt to shift right with overflow', src/backend/vulkan/src/command.rs:36:15
```

- [ ] tested examples with the following backends:

Not working yet, see above, I'm testing this against a project that uses gfx-hal (https://codeberg.org/suchbliss/good-form), the examples won't likely cover this as this is about unimplemented features.

- [x] `rustfmt` run on changed code