### PR TITLE
[vk] fix debug color for markers

### DIFF
--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -33,7 +33,7 @@ pub struct CommandBuffer {
 fn debug_color(color: u32) -> [f32; 4] {
     let mut result = [0.0; 4];
     for (i, c) in result.iter_mut().enumerate() {
-        *c = ((color >> (24 + i * 8)) & 0xFF) as f32 / 255.0;
+        *c = ((color >> (24 - i * 8)) & 0xFF) as f32 / 255.0;
     }
     result
 }


### PR DESCRIPTION
Fixes #3183
That was a silly mistake, but now we might need to publish a patch version with this fix...
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
