### PR TITLE
Rename DescriptorPool::free_sets to free

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -3368,7 +3368,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
             .map_err(|_| pso::AllocationError::OutOfPoolMemory)
     }
 
-    unsafe fn free_sets<I>(&mut self, descriptor_sets: I)
+    unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
         I: IntoIterator<Item = DescriptorSet>,
     {

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -757,7 +757,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         })
     }
 
-    unsafe fn free_sets<I>(&mut self, descriptor_sets: I)
+    unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
         I: IntoIterator<Item = DescriptorSet>,
     {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -932,7 +932,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 #[derive(Debug)]
 pub struct DescriptorPool;
 impl pso::DescriptorPool<Backend> for DescriptorPool {
-    unsafe fn free_sets<I>(&mut self, _descriptor_sets: I)
+    unsafe fn free<I>(&mut self, _descriptor_sets: I)
     where
         I: IntoIterator<Item = ()>,
     {

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -234,7 +234,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         })
     }
 
-    unsafe fn free_sets<I>(&mut self, _descriptor_sets: I)
+    unsafe fn free<I>(&mut self, _descriptor_sets: I)
     where
         I: IntoIterator<Item = DescriptorSet>,
     {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -668,7 +668,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         }
     }
 
-    unsafe fn free_sets<I>(&mut self, descriptor_sets: I)
+    unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
         I: IntoIterator<Item = DescriptorSet>,
     {

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -154,7 +154,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
             })
     }
 
-    unsafe fn free_sets<I>(&mut self, descriptor_sets: I)
+    unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
         I: IntoIterator<Item = DescriptorSet>,
     {

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -226,7 +226,7 @@ pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
     }
 
     /// Free the given descriptor sets provided as an iterator.
-    unsafe fn free_sets<I>(&mut self, descriptor_sets: I)
+    unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
         I: IntoIterator<Item = B::DescriptorSet>;
 


### PR DESCRIPTION
Fixes #3179
PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
