### PR TITLE
[mtl] fix index buffer range check

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -3300,7 +3300,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn bind_index_buffer(&mut self, view: buffer::IndexBufferView<Backend>) {
         let (raw, range) = view.buffer.as_bound();
-        assert!(range.start + view.range.offset + view.range.size.unwrap_or(0) < range.end); // conservative
+        assert!(range.start + view.range.offset + view.range.size.unwrap_or(0) <= range.end); // conservative
         self.state.index_buffer = Some(IndexBuffer {
             buffer: AsNative::from(raw),
             offset: (range.start + view.range.offset) as _,


### PR DESCRIPTION
Another silly thing that wasn't covered by release testing.
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
