### PR TITLE
[mtl] fix NDC_Y_FLIP feature

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1276,7 +1276,7 @@ impl hal::device::Device<Backend> for Device {
             MTLLanguageVersion::V2_2 => msl::Version::V2_2,
         };
         shader_compiler_options.enable_point_size_builtin = false;
-        shader_compiler_options.vertex.invert_y = true;
+        shader_compiler_options.vertex.invert_y = !self.features.contains(hal::Features::NDC_Y_UP);
         shader_compiler_options.resource_binding_overrides = res_overrides;
         shader_compiler_options.const_samplers = const_samplers;
         shader_compiler_options.enable_argument_buffers = self.shared.private_caps.argument_buffers;


### PR DESCRIPTION
I missed the fact we have 2 spots where the options could be generated.
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
