### PR TITLE
Stricten the warnings on hal and range-alloc

### DIFF
--- a/src/auxil/range-alloc/src/lib.rs
+++ b/src/auxil/range-alloc/src/lib.rs
@@ -1,6 +1,16 @@
-use std::fmt::Debug;
-use std::iter::Sum;
-use std::ops::{Add, AddAssign, Range, Sub};
+#![warn(
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications
+)]
+
+use std::{
+    fmt::Debug,
+    iter::Sum,
+    ops::{Add, AddAssign, Range, Sub},
+};
 
 #[derive(Debug)]
 pub struct RangeAllocator<T> {

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -1,3 +1,10 @@
+#![warn(
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications
+)]
 #![deny(missing_debug_implementations, missing_docs, unused)]
 
 //! Low-level graphics abstraction for Rust. Mostly operates on data, not types.
@@ -432,7 +439,7 @@ impl From<usize> for MemoryTypeId {
 
 struct PseudoVec<T>(Option<T>);
 
-impl<T> std::iter::Extend<T> for PseudoVec<T> {
+impl<T> Extend<T> for PseudoVec<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         let mut iter = iter.into_iter();
         self.0 = iter.next();

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -172,7 +172,7 @@ impl<'a, B: Backend> Clone for Subpass<'a, B> {
 
 impl<'a, B: Backend> PartialEq for Subpass<'a, B> {
     fn eq(&self, other: &Self) -> bool {
-        self.index == other.index && self.main_pass as *const _ == other.main_pass as *const _
+        self.index == other.index && std::ptr::eq(self.main_pass, other.main_pass)
     }
 }
 

--- a/src/hal/src/pso/specialization.rs
+++ b/src/hal/src/pso/specialization.rs
@@ -95,7 +95,8 @@ where
         let offset = storage.data.len() as u16;
         storage.data.extend_from_slice(unsafe {
             // Inspecting bytes is always safe.
-            slice::from_raw_parts(&self.head.1 as *const H as *const u8, size)
+            let head_ptr: *const H = &self.head.1;
+            slice::from_raw_parts(head_ptr as *const u8, size)
         });
         storage.constants.push(SpecializationConstant {
             id: self.head.0,


### PR DESCRIPTION
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
