### PR TITLE
[0.5/vk] fix handling of AMD viewport negation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Change Log
 
-### backend-metal-0.5.1 (26-02-2020)
+### backend-vulkan-0.5.2 (01-04-2020)
+  - fix support for `AMD_NEGATIVE_VIEWPORT_HEIGHT`
+
+### backend-metal-0.5.1 (26-03-2020)
   - fix debug assertion for the index buffer range
   - fix `NDC_Y_FLIP` feature
 
-### backend-vulkan-0.5.1 (26-02-2020)
+### backend-vulkan-0.5.1 (26-03-2020)
   - fix debug color markers
   - fix detection of the `MirrorClamp` mode
 

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-vulkan"
-version = "0.5.1"
+version = "0.5.2"
 description = "Vulkan API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -544,10 +544,10 @@ pub fn map_clear_rect(rect: &pso::ClearRect) -> vk::ClearRect {
     }
 }
 
-pub fn map_viewport(vp: &pso::Viewport, flip_y: bool) -> vk::Viewport {
+pub fn map_viewport(vp: &pso::Viewport, flip_y: bool, shift_y: bool) -> vk::Viewport {
     vk::Viewport {
         x: vp.rect.x as _,
-        y: if flip_y {
+        y: if shift_y {
             vp.rect.y + vp.rect.h
         } else {
             vp.rect.y

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -137,7 +137,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         };
 
         self.device
-            .0
+            .raw
             .allocate_descriptor_sets(&info)
             .map(|sets| {
                 list.extend(
@@ -162,7 +162,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         self.set_free_vec
             .extend(descriptor_sets.into_iter().map(|d| d.raw));
         self.device
-            .0
+            .raw
             .free_descriptor_sets(self.raw, &self.set_free_vec);
     }
 
@@ -170,7 +170,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         assert_eq!(
             Ok(()),
             self.device
-                .0
+                .raw
                 .reset_descriptor_pool(self.raw, vk::DescriptorPoolResetFlags::empty())
         );
     }

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -23,7 +23,7 @@ impl pool::CommandPool<Backend> for RawCommandPool {
             vk::CommandPoolResetFlags::empty()
         };
 
-        assert_eq!(Ok(()), self.device.0.reset_command_pool(self.raw, flags));
+        assert_eq!(Ok(()), self.device.raw.reset_command_pool(self.raw, flags));
     }
 
     unsafe fn allocate<E>(&mut self, num: usize, level: command::Level, list: &mut E)
@@ -42,7 +42,7 @@ impl pool::CommandPool<Backend> for RawCommandPool {
 
         list.extend(
             device
-                .0
+                .raw
                 .allocate_command_buffers(&info)
                 .expect("Error on command buffer allocation")
                 .into_iter()
@@ -59,6 +59,6 @@ impl pool::CommandPool<Backend> for RawCommandPool {
     {
         let buffers: SmallVec<[vk::CommandBuffer; 16]> =
             cbufs.into_iter().map(|buffer| buffer.raw).collect();
-        self.device.0.free_command_buffers(self.raw, &buffers);
+        self.device.raw.free_command_buffers(self.raw, &buffers);
     }
 }

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -450,13 +450,13 @@ impl w::PresentationSurface<Backend> for Surface {
         let old = self
             .swapchain
             .take()
-            .map(|ssc| ssc.release_resources(&device.raw.0));
+            .map(|ssc| ssc.release_resources(&device.shared.raw));
 
         let (swapchain, images) = device.create_swapchain(self, config, old)?;
 
         self.swapchain = Some(SurfaceSwapchain {
             swapchain,
-            device: Arc::clone(&device.raw),
+            device: Arc::clone(&device.shared),
             fence: device.create_fence(false).unwrap(),
             semaphore: device.create_semaphore().unwrap(),
             frames: images
@@ -489,7 +489,7 @@ impl w::PresentationSurface<Backend> for Surface {
 
     unsafe fn unconfigure_swapchain(&mut self, device: &Device) {
         if let Some(ssc) = self.swapchain.take() {
-            let swapchain = ssc.release_resources(&device.raw.0);
+            let swapchain = ssc.release_resources(&device.shared.raw);
             swapchain.functor.destroy_swapchain(swapchain.raw, None);
         }
     }
@@ -508,14 +508,14 @@ impl w::PresentationSurface<Backend> for Surface {
         timeout_ns = timeout_ns.saturating_sub(moment.elapsed().as_nanos() as u64);
         let fences = &[ssc.fence.0];
 
-        match ssc.device.0.wait_for_fences(fences, true, timeout_ns) {
+        match ssc.device.raw.wait_for_fences(fences, true, timeout_ns) {
             Ok(()) => {
-                ssc.device.0.reset_fences(fences).unwrap();
+                ssc.device.raw.reset_fences(fences).unwrap();
                 let frame = &ssc.frames[index as usize];
                 // We have just waited for the frame to be fully available on CPU.
                 // All the associated framebuffers are expected to be destroyed by now.
                 for framebuffer in frame.framebuffers.0.lock().unwrap().framebuffers.drain(..) {
-                    ssc.device.0.destroy_framebuffer(framebuffer, None);
+                    ssc.device.raw.destroy_framebuffer(framebuffer, None);
                 }
                 let image = Self::SwapchainImage {
                     index,


### PR DESCRIPTION
Addresses https://github.com/gfx-rs/wgpu-rs/issues/227
We are now taking MAINTENANCE1 whenever it's supported. This code path is supposed to be unaffected. However, if it's not supported, and NDC_Y_FLIP is requested, and we end up using AMD_NEGATIVE_VIEWPORT_HEIGHT, then we don't shift the Y of the viewport.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
- [ ] `rustfmt` run on changed code
