### PR TITLE
Metal multiple attachment clears

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -15,6 +15,7 @@ use crate::{
     Shared,
     TexturePtr,
     MAX_BOUND_DESCRIPTOR_SETS,
+    MAX_COLOR_ATTACHMENTS,
 };
 
 use hal::{
@@ -2878,7 +2879,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         //  issue a PSO+color switch and a draw for each requested clear
         let mut key = ClearKey {
             framebuffer_aspects: self.state.target_aspects,
-            color_formats: [metal::MTLPixelFormat::Invalid; 1],
+            color_formats: [metal::MTLPixelFormat::Invalid; MAX_COLOR_ATTACHMENTS],
             depth_stencil_format: self
                 .state
                 .target_formats

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2495,8 +2495,8 @@ impl hal::device::Device<Backend> for Device {
         view_caps: image::ViewCapabilities,
     ) -> Result<n::Image, image::CreationError> {
         debug!(
-            "create_image {:?} with {} mips of {:?} {:?} and usage {:?}",
-            kind, mip_levels, format, tiling, usage
+            "create_image {:?} with {} mips of {:?} {:?} and usage {:?} with {:?}",
+            kind, mip_levels, format, tiling, usage, view_caps
         );
 
         let is_cube = view_caps.contains(image::ViewCapabilities::KIND_CUBE);
@@ -2542,7 +2542,10 @@ impl hal::device::Device<Backend> for Device {
                 return Err(image::CreationError::Kind);
             }
             image::Kind::D3(..) => {
-                assert!(!is_cube && !view_caps.contains(image::ViewCapabilities::KIND_2D_ARRAY));
+                assert!(!is_cube);
+                if view_caps.contains(image::ViewCapabilities::KIND_2D_ARRAY) {
+                    warn!("Unable to support 2D array views of 3D textures");
+                }
                 (MTLTextureType::D3, None)
             }
         };

--- a/src/backend/metal/src/internal.rs
+++ b/src/backend/metal/src/internal.rs
@@ -1,4 +1,4 @@
-use crate::{conversions as conv, PrivateCapabilities};
+use crate::{conversions as conv, PrivateCapabilities, MAX_COLOR_ATTACHMENTS};
 
 use auxil::FastHashMap;
 use hal::{
@@ -257,7 +257,7 @@ impl DepthStencilStates {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct ClearKey {
     pub framebuffer_aspects: Aspects,
-    pub color_formats: [metal::MTLPixelFormat; 1],
+    pub color_formats: [metal::MTLPixelFormat; MAX_COLOR_ATTACHMENTS],
     pub depth_stencil_format: metal::MTLPixelFormat,
     pub target_index: Option<(u8, Channel)>,
 }


### PR DESCRIPTION
Gets us the Atmosphere demo working from Diligent Engine on macOS:
<img width="797" alt="Screen Shot 2020-04-08 at 22 23 46" src="https://user-images.githubusercontent.com/107301/78851397-b045eb80-79e7-11ea-9b3e-785c97196cec.png">
