### PR TITLE
[0.4] parking lot update for Metal and DX11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-metal-0.4.5, backend-dx11-0.4.6 (11-04-2020)
+  - updated "parking_lot" dependency
+
 ### backend-metal-0.4.4, backend-vulkan-0.4.3 (09-04-2020)
   - updated "core-foundation" and "cocoa" dependencies
 

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.4.5"
+version = "0.4.6"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -26,7 +26,7 @@ libloading = "0.5"
 log = { version = "0.4" }
 smallvec = "0.6"
 spirv_cross = { version = "0.16", features = ["hlsl"] }
-parking_lot = "0.9"
+parking_lot = "0.10"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 wio = "0.2"
 raw-window-handle = "0.3"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-metal"
-version = "0.4.4"
+version = "0.4.5"
 description = "Metal API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -37,7 +37,7 @@ cocoa = "0.20"
 core-graphics = "0.19"
 smallvec = "0.6"
 spirv_cross = { version = "0.16", features = ["msl"] }
-parking_lot = "0.9"
+parking_lot = "0.10"
 storage-map = "0.2"
 lazy_static = "1"
 raw-window-handle = "0.3"


### PR DESCRIPTION
Also required for a smooth update in gecko...
When dependencies change, Gecko engineering wants it to happen across all crates, preferably without functional changes