### PR TITLE
Fix Solaris build.

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -543,7 +543,12 @@ impl hal::Instance<Backend> for Instance {
         use raw_window_handle::RawWindowHandle;
 
         match has_handle.raw_window_handle() {
-            #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
+            #[cfg(all(
+                unix,
+                not(target_os = "android"),
+                not(target_os = "macos"),
+                not(target_os = "solaris")
+            ))]
             RawWindowHandle::Wayland(handle)
                 if self
                     .extensions
@@ -555,7 +560,8 @@ impl hal::Instance<Backend> for Instance {
                 feature = "x11",
                 unix,
                 not(target_os = "android"),
-                not(target_os = "macos")
+                not(target_os = "macos"),
+                not(target_os = "solaris")
             ))]
             RawWindowHandle::Xlib(handle)
                 if self


### PR DESCRIPTION
Fixes:

error[E0599]: no variant or associated item named `Wayland` found for enum `raw_window_handle::RawWindowHandle` in the current scope
   --> src/backend/vulkan/src/lib.rs:547:30

PR checklist:
- [y] `make` succeeds (on *nix)
- [n] `make reftests` succeeds
- [n] tested examples with the following backends:
- [n] `rustfmt` run on changed code
rustfmt doesn't build on Solaris