### PR TITLE
Backport Surfman GL Backend to Hal 0.5

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -17,8 +17,9 @@ build = "build.rs"
 name = "gfx_backend_gl"
 
 [features]
-default = []
+default = ["wgl", "surfman", "surfman-x11"]
 wgl = []
+surfman-x11 = ["surfman/sm-x11"]
 
 [dependencies]
 arrayvec = "0.5"
@@ -32,9 +33,14 @@ parking_lot = "0.10"
 spirv_cross = { version = "0.18", features = ["glsl"] }
 lazy_static = "1"
 raw-window-handle = "0.3"
+glutin = { version = "0.23.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-glutin = { version = "0.23.0", optional = true }
+winit = "0.21.0"
+
+[target.'cfg(all(unix, not(target_os = "ios")))'.dependencies]
+# TODO: Update to released version when it comes out
+surfman = { git = "https://github.com/katharostech/surfman.git", branch = "gfx-support", features = ["sm-raw-window-handle"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"
@@ -65,3 +71,4 @@ winapi = { version = "0.3", features = ["libloaderapi", "windef", "wingdi", "win
 
 [build-dependencies]
 gl_generator = "0.11"
+cfg_aliases = "0.1.0"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -37,7 +37,7 @@ glutin = { version = "0.23.0", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "ios")))'.dependencies]
 # TODO: Update to released version when it comes out
-surfman = { git = "https://github.com/katharostech/surfman.git", branch = "gfx-support", features = ["sm-raw-window-handle"], optional = true }
+surfman = { git = "https://github.com/servo/surfman.git", rev = "41ac1ee", features = ["sm-raw-window-handle"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-gl"
-version = "0.5.0"
+version = "0.5.1"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -17,7 +17,7 @@ build = "build.rs"
 name = "gfx_backend_gl"
 
 [features]
-default = ["wgl", "surfman", "surfman-x11"]
+default = []
 wgl = ["winapi"]
 surfman-x11 = ["surfman/sm-x11"]
 

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -18,7 +18,7 @@ name = "gfx_backend_gl"
 
 [features]
 default = ["wgl", "surfman", "surfman-x11"]
-wgl = []
+wgl = ["winapi"]
 surfman-x11 = ["surfman/sm-x11"]
 
 [dependencies]
@@ -34,9 +34,6 @@ spirv_cross = { version = "0.18", features = ["glsl"] }
 lazy_static = "1"
 raw-window-handle = "0.3"
 glutin = { version = "0.23.0", optional = true }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-winit = "0.21.0"
 
 [target.'cfg(all(unix, not(target_os = "ios")))'.dependencies]
 # TODO: Update to released version when it comes out
@@ -67,7 +64,7 @@ features = [
 ]
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["libloaderapi", "windef", "wingdi", "winuser"] }
+winapi = { version = "0.3", features = ["libloaderapi", "windef", "wingdi", "winuser"], optional = true }
 
 [build-dependencies]
 gl_generator = "0.11"

--- a/src/backend/gl/build.rs
+++ b/src/backend/gl/build.rs
@@ -2,11 +2,10 @@ use gl_generator::{Api, Fallbacks, Profile, Registry};
 use std::env;
 use std::fs::File;
 use std::path::PathBuf;
-use cfg_aliases::cfg_aliases;
 
 fn main() {
     // Setup cfg aliases
-    cfg_aliases! {
+    cfg_aliases::cfg_aliases! {
         // Platforms
         wasm: { target_arch = "wasm32" },
         android: { target_os = "android" },
@@ -15,8 +14,8 @@ fn main() {
         linux: { target_os = "linux" },
         // Backends
         surfman: { all(unix, feature = "surfman", not(ios)) },
-        glutin: { all(feature = "glutin", not(wasm)) },
         wgl: { all(windows, feature = "wgl") },
+        glutin: { all(feature = "glutin", not(any(wasm, surfman))) },
         dummy: { not(any(wasm, glutin, wgl, surfman)) },
     }
 

--- a/src/backend/gl/build.rs
+++ b/src/backend/gl/build.rs
@@ -2,8 +2,24 @@ use gl_generator::{Api, Fallbacks, Profile, Registry};
 use std::env;
 use std::fs::File;
 use std::path::PathBuf;
+use cfg_aliases::cfg_aliases;
 
 fn main() {
+    // Setup cfg aliases
+    cfg_aliases! {
+        // Platforms
+        wasm: { target_arch = "wasm32" },
+        android: { target_os = "android" },
+        macos: { target_os = "macos" },
+        ios: { target_os = "ios" },
+        linux: { target_os = "linux" },
+        // Backends
+        surfman: { all(unix, feature = "surfman", not(ios)) },
+        glutin: { all(feature = "glutin", not(wasm)) },
+        wgl: { all(windows, feature = "wgl") },
+        dummy: { not(any(wasm, glutin, wgl, surfman)) },
+    }
+
     let target = env::var("TARGET").unwrap();
     let dest = PathBuf::from(&env::var("OUT_DIR").unwrap());
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1860,7 +1860,6 @@ impl d::Device<B> for Device {
         config: SwapchainConfig,
         _old_swapchain: Option<Swapchain>,
     ) -> Result<(Swapchain, Vec<n::Image>), hal::window::CreationError> {
-
         let gl = &self.share.context;
 
         #[cfg(wgl)]

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -262,17 +262,17 @@ impl Info {
     fn get(gl: &GlContainer) -> Info {
         let platform_name = PlatformName::get(gl);
         let version = Version::parse(get_string(gl, glow::VERSION).unwrap_or_default()).unwrap();
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(wasm))]
         let shading_language =
             Version::parse(get_string(gl, glow::SHADING_LANGUAGE_VERSION).unwrap_or_default())
                 .unwrap();
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(wasm)]
         let shading_language = Version::new_embedded(3, 0, String::from(""));
         // TODO: Use separate path for WebGL extensions in `glow` somehow
         // Perhaps automatic fallback for NUM_EXTENSIONS to EXTENSIONS on native
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(wasm)]
         let extensions = HashSet::new();
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(wasm))]
         let extensions = if version >= Version::new(3, 0, None, String::from("")) {
             let num_exts = get_usize(gl, glow::NUM_EXTENSIONS).unwrap();
             (0 .. num_exts)
@@ -331,7 +331,7 @@ impl Info {
     }
 }
 
-const IS_WEBGL: bool = cfg!(target_arch = "wasm32");
+const IS_WEBGL: bool = cfg!(wasm);
 
 /// Load the information pertaining to the driver and the corresponding device
 /// capabilities.
@@ -351,7 +351,7 @@ pub(crate) fn query_all(
     let min_storage_buffer_offset_alignment = if IS_WEBGL {
         1024
     } else {
-        get_u64(gl, glow::SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT).unwrap_or(1024)
+        get_u64(gl, glow::SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT).unwrap_or(256)
     };
 
     let mut limits = Limits {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -3,10 +3,6 @@
 
 #![allow(missing_docs, missing_copy_implementations)]
 
-// Check for incompatible feature flags
-#[cfg(all(surfman, glutin))]
-compile_error!("You cannot specify both `surfman` and `glutin` features at the same time.");
-
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -80,9 +80,14 @@ pub(crate) struct GlContainer {
 impl GlContainer {
     #[cfg(not(wasm))]
     fn make_current(&self) {
-        // TODO:
-        // NOTE: Beware, calling this on dereference breaks the surfman backend
-        // I'm not sure if there would be similar concequences with other backends.
+        // TODO: Implement for other backends?
+        #[cfg(surfman)]
+        {
+            self.surfman_device
+                .write()
+                .make_context_current(&self.surfman_context.read())
+                .expect("TODO")
+        }
     }
 
     #[cfg(any(glutin, wgl))]
@@ -794,5 +799,5 @@ fn resolve_sub_range(
     whole: Range<buffer::Offset>,
 ) -> Range<buffer::Offset> {
     let end = sub.size.map_or(whole.end, |s| whole.start + sub.offset + s);
-    whole.start + sub.offset .. end
+    whole.start + sub.offset..end
 }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -40,6 +40,10 @@ pub use window::web::{Surface, Swapchain};
 // Glutin implementation
 #[cfg(glutin)]
 pub use crate::window::glutin::{Instance, Surface, Swapchain};
+#[cfg(glutin)]
+pub use glutin;
+#[cfg(glutin)]
+pub use crate::window::glutin::config_context;
 
 // Surfman implementation
 #[cfg(surfman)]

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -39,11 +39,11 @@ pub use window::web::{Surface, Swapchain};
 
 // Glutin implementation
 #[cfg(glutin)]
+pub use crate::window::glutin::config_context;
+#[cfg(glutin)]
 pub use crate::window::glutin::{Instance, Surface, Swapchain};
 #[cfg(glutin)]
 pub use glutin;
-#[cfg(glutin)]
-pub use crate::window::glutin::config_context;
 
 // Surfman implementation
 #[cfg(surfman)]

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -41,7 +41,7 @@ pub use window::web::{Surface, Swapchain};
 #[cfg(glutin)]
 pub use crate::window::glutin::config_context;
 #[cfg(glutin)]
-pub use crate::window::glutin::{Instance, Surface, Swapchain};
+pub use crate::window::glutin::{Headless, Instance, Surface, Swapchain};
 #[cfg(glutin)]
 pub use glutin;
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -21,7 +21,9 @@ pub type Program = <GlContext as glow::HasContext>::Program;
 pub type Renderbuffer = <GlContext as glow::HasContext>::Renderbuffer;
 pub type Texture = <GlContext as glow::HasContext>::Texture;
 pub type Sampler = <GlContext as glow::HasContext>::Sampler;
-pub type UniformLocation = <GlContext as glow::HasContext>::UniformLocation;
+// TODO: UniformLocation was copy in glow 0.3, but in 0.4 it isn't. Wrap it in a Starc for now
+// to make it `Sync + Send` instead.
+pub type UniformLocation = crate::Starc<<GlContext as glow::HasContext>::UniformLocation>;
 pub type DescriptorSetLayout = Vec<pso::DescriptorSetLayoutBinding>;
 
 pub type RawFrameBuffer = <GlContext as glow::HasContext>::Framebuffer;
@@ -312,7 +314,7 @@ pub struct AttributeDesc {
     pub(crate) vertex_attrib_fn: VertexAttribFunction,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct UniformDesc {
     pub(crate) location: UniformLocation,
     pub(crate) offset: u32,

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -5,8 +5,17 @@ use glow::HasContext;
 use smallvec::SmallVec;
 
 use crate::{
-    command as com, device, info::LegacyFeatures, native, state, Backend, GlContext, Share, Starc,
-    Surface, Swapchain,
+    command as com,
+    device,
+    info::LegacyFeatures,
+    native,
+    state,
+    Backend,
+    GlContext,
+    Share,
+    Starc,
+    Surface,
+    Swapchain,
 };
 
 // State caching system for command queue.
@@ -200,7 +209,7 @@ impl CommandQueue {
     /// Return a reference to a stored data object.
     fn get_raw(data: &[u8], ptr: com::BufferSlice) -> &[u8] {
         assert!(data.len() >= (ptr.offset + ptr.size) as usize);
-        &data[ptr.offset as usize..(ptr.offset + ptr.size) as usize]
+        &data[ptr.offset as usize .. (ptr.offset + ptr.size) as usize]
     }
 
     fn present_by_copy(&self, swapchain: &Swapchain, index: hal::window::SwapImageIndex) {
@@ -313,11 +322,12 @@ impl CommandQueue {
             };
         } else if self.state.num_viewports > 1 {
             // 16 viewports is a common limit set in drivers.
-            let viewports: SmallVec<[[f32; 4]; 16]> = (0..self.state.num_viewports)
+            let viewports: SmallVec<[[f32; 4]; 16]> = (0 .. self.state.num_viewports)
                 .map(|_| [0.0, 0.0, 0.0, 0.0])
                 .collect();
-            let depth_ranges: SmallVec<[[f64; 2]; 16]> =
-                (0..self.state.num_viewports).map(|_| [0.0, 0.0]).collect();
+            let depth_ranges: SmallVec<[[f64; 2]; 16]> = (0 .. self.state.num_viewports)
+                .map(|_| [0.0, 0.0])
+                .collect();
             unsafe {
                 gl.viewport_f32_slice(0, viewports.len() as i32, &viewports);
                 gl.depth_range_f64_slice(0, depth_ranges.len() as i32, &depth_ranges);
@@ -329,8 +339,9 @@ impl CommandQueue {
             unsafe { gl.scissor(0, 0, 0, 0) };
         } else if self.state.num_scissors > 1 {
             // 16 viewports is a common limit set in drivers.
-            let scissors: SmallVec<[[i32; 4]; 16]> =
-                (0..self.state.num_scissors).map(|_| [0, 0, 0, 0]).collect();
+            let scissors: SmallVec<[[i32; 4]; 16]> = (0 .. self.state.num_scissors)
+                .map(|_| [0, 0, 0, 0])
+                .collect();
             unsafe { gl.scissor_slice(0, scissors.len() as i32, scissors.as_slice()) };
         }
     }
@@ -350,7 +361,7 @@ impl CommandQueue {
             } => {
                 let gl = &self.share.context;
                 let legacy = &self.share.legacy_features;
-                if instances == &(0u32..1) {
+                if instances == &(0u32 .. 1) {
                     unsafe {
                         gl.draw_arrays(
                             primitive,
@@ -399,7 +410,7 @@ impl CommandQueue {
                 let legacy = &self.share.legacy_features;
                 let hints = &self.share.hints;
 
-                if instances == &(0u32..1) {
+                if instances == &(0u32 .. 1) {
                     if base_vertex == 0 {
                         unsafe {
                             gl.draw_elements(
@@ -921,7 +932,10 @@ impl CommandQueue {
             com::Command::UnbindAttribute(slot) => unsafe {
             self.share.context.DisableVertexAttribArray(slot as gl::types::GLuint);
             },*/
-            com::Command::BindUniform { ref uniform, buffer } => {
+            com::Command::BindUniform {
+                ref uniform,
+                buffer,
+            } => {
                 let gl = &self.share.context;
 
                 unsafe {
@@ -966,15 +980,27 @@ impl CommandQueue {
                         }
                         glow::FLOAT_MAT2 => {
                             let data = Self::get::<[f32; 4]>(data_buf, buffer)[0];
-                            gl.uniform_matrix_2_f32_slice(Some((*uniform.location).clone()), false, &data);
+                            gl.uniform_matrix_2_f32_slice(
+                                Some((*uniform.location).clone()),
+                                false,
+                                &data,
+                            );
                         }
                         glow::FLOAT_MAT3 => {
                             let data = Self::get::<[f32; 9]>(data_buf, buffer)[0];
-                            gl.uniform_matrix_3_f32_slice(Some((*uniform.location).clone()), false, &data);
+                            gl.uniform_matrix_3_f32_slice(
+                                Some((*uniform.location).clone()),
+                                false,
+                                &data,
+                            );
                         }
                         glow::FLOAT_MAT4 => {
                             let data = Self::get::<[f32; 16]>(data_buf, buffer)[0];
-                            gl.uniform_matrix_4_f32_slice(Some((*uniform.location).clone()), false, &data);
+                            gl.uniform_matrix_4_f32_slice(
+                                Some((*uniform.location).clone()),
+                                false,
+                                &data,
+                            );
                         }
                         _ => panic!("Unsupported uniform datatype!"),
                     }
@@ -1151,7 +1177,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
 
                 assert!(buffer.commands.len() >= (cb.buf.offset + cb.buf.size) as usize);
                 let commands = &buffer.commands
-                    [cb.buf.offset as usize..(cb.buf.offset + cb.buf.size) as usize];
+                    [cb.buf.offset as usize .. (cb.buf.offset + cb.buf.size) as usize];
                 self.reset_state();
                 for com in commands {
                     self.process(com, &buffer.data);

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -5,17 +5,8 @@ use glow::HasContext;
 use smallvec::SmallVec;
 
 use crate::{
-    command as com,
-    device,
-    info::LegacyFeatures,
-    native,
-    state,
-    Backend,
-    GlContext,
-    Share,
-    Starc,
-    Surface,
-    Swapchain,
+    command as com, device, info::LegacyFeatures, native, state, Backend, GlContext, Share, Starc,
+    Surface, Swapchain,
 };
 
 // State caching system for command queue.
@@ -209,19 +200,44 @@ impl CommandQueue {
     /// Return a reference to a stored data object.
     fn get_raw(data: &[u8], ptr: com::BufferSlice) -> &[u8] {
         assert!(data.len() >= (ptr.offset + ptr.size) as usize);
-        &data[ptr.offset as usize .. (ptr.offset + ptr.size) as usize]
+        &data[ptr.offset as usize..(ptr.offset + ptr.size) as usize]
     }
 
     fn present_by_copy(&self, swapchain: &Swapchain, index: hal::window::SwapImageIndex) {
         let gl = &self.share.context;
         let extent = swapchain.extent;
 
-        #[cfg(feature = "wgl")]
+        #[cfg(wgl)]
         swapchain.make_current();
+
+        #[cfg(surfman)]
+        gl.surfman_device
+            .write()
+            .make_context_current(&swapchain.context.read())
+            .unwrap();
+
+        // Use the framebuffer from the surfman context
+        #[cfg(surfman)]
+        let fbo = gl
+            .surfman_device
+            .read()
+            .context_surface_info(&swapchain.context.read())
+            .unwrap()
+            .unwrap()
+            .framebuffer_object;
 
         unsafe {
             gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(swapchain.fbos[index as usize]));
-            gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, None);
+            gl.bind_framebuffer(
+                glow::DRAW_FRAMEBUFFER,
+                #[cfg(surfman)]
+                match fbo {
+                    0 => None,
+                    other => Some(other),
+                },
+                #[cfg(not(surfman))]
+                None,
+            );
             gl.blit_framebuffer(
                 0,
                 0,
@@ -236,9 +252,29 @@ impl CommandQueue {
             );
         }
 
-        #[cfg(all(feature = "glutin", not(target_arch = "wasm32")))]
+        // Present the surfman surface
+        #[cfg(surfman)]
+        {
+            let mut surface = gl
+                .surfman_device
+                .read()
+                .unbind_surface_from_context(&mut swapchain.context.write())
+                .expect("TODO")
+                .expect("TODO");
+            gl.surfman_device
+                .read()
+                .present_surface(&gl.surfman_context.read(), &mut surface)
+                .expect("TODO");
+            gl.surfman_device
+                .read()
+                .bind_surface_to_context(&mut swapchain.context.write(), surface)
+                .expect("TODO")
+        }
+
+        #[cfg(glutin)]
         swapchain.context.swap_buffers().unwrap();
-        #[cfg(all(feature = "wgl", not(target_arch = "wasm32")))]
+
+        #[cfg(wgl)]
         swapchain.swap_buffers();
     }
 
@@ -277,12 +313,11 @@ impl CommandQueue {
             };
         } else if self.state.num_viewports > 1 {
             // 16 viewports is a common limit set in drivers.
-            let viewports: SmallVec<[[f32; 4]; 16]> = (0 .. self.state.num_viewports)
+            let viewports: SmallVec<[[f32; 4]; 16]> = (0..self.state.num_viewports)
                 .map(|_| [0.0, 0.0, 0.0, 0.0])
                 .collect();
-            let depth_ranges: SmallVec<[[f64; 2]; 16]> = (0 .. self.state.num_viewports)
-                .map(|_| [0.0, 0.0])
-                .collect();
+            let depth_ranges: SmallVec<[[f64; 2]; 16]> =
+                (0..self.state.num_viewports).map(|_| [0.0, 0.0]).collect();
             unsafe {
                 gl.viewport_f32_slice(0, viewports.len() as i32, &viewports);
                 gl.depth_range_f64_slice(0, depth_ranges.len() as i32, &depth_ranges);
@@ -294,9 +329,8 @@ impl CommandQueue {
             unsafe { gl.scissor(0, 0, 0, 0) };
         } else if self.state.num_scissors > 1 {
             // 16 viewports is a common limit set in drivers.
-            let scissors: SmallVec<[[i32; 4]; 16]> = (0 .. self.state.num_scissors)
-                .map(|_| [0, 0, 0, 0])
-                .collect();
+            let scissors: SmallVec<[[i32; 4]; 16]> =
+                (0..self.state.num_scissors).map(|_| [0, 0, 0, 0]).collect();
             unsafe { gl.scissor_slice(0, scissors.len() as i32, scissors.as_slice()) };
         }
     }
@@ -316,7 +350,7 @@ impl CommandQueue {
             } => {
                 let gl = &self.share.context;
                 let legacy = &self.share.legacy_features;
-                if instances == &(0u32 .. 1) {
+                if instances == &(0u32..1) {
                     unsafe {
                         gl.draw_arrays(
                             primitive,
@@ -365,7 +399,7 @@ impl CommandQueue {
                 let legacy = &self.share.legacy_features;
                 let hints = &self.share.hints;
 
-                if instances == &(0u32 .. 1) {
+                if instances == &(0u32..1) {
                     if base_vertex == 0 {
                         unsafe {
                             gl.draw_elements(
@@ -887,60 +921,60 @@ impl CommandQueue {
             com::Command::UnbindAttribute(slot) => unsafe {
             self.share.context.DisableVertexAttribArray(slot as gl::types::GLuint);
             },*/
-            com::Command::BindUniform { uniform, buffer } => {
+            com::Command::BindUniform { ref uniform, buffer } => {
                 let gl = &self.share.context;
 
                 unsafe {
                     match uniform.utype {
                         glow::FLOAT => {
                             let data = Self::get::<f32>(data_buf, buffer)[0];
-                            gl.uniform_1_f32(Some(uniform.location), data);
+                            gl.uniform_1_f32(Some((*uniform.location).clone()), data);
                         }
                         glow::FLOAT_VEC2 => {
                             // TODO: Remove`mut`
                             let mut data = Self::get::<[f32; 2]>(data_buf, buffer)[0];
-                            gl.uniform_2_f32_slice(Some(uniform.location), &mut data);
+                            gl.uniform_2_f32_slice(Some((*uniform.location).clone()), &mut data);
                         }
                         glow::FLOAT_VEC3 => {
                             // TODO: Remove`mut`
                             let mut data = Self::get::<[f32; 3]>(data_buf, buffer)[0];
-                            gl.uniform_3_f32_slice(Some(uniform.location), &mut data);
+                            gl.uniform_3_f32_slice(Some((*uniform.location).clone()), &mut data);
                         }
                         glow::FLOAT_VEC4 => {
                             // TODO: Remove`mut`
                             let mut data = Self::get::<[f32; 4]>(data_buf, buffer)[0];
-                            gl.uniform_4_f32_slice(Some(uniform.location), &mut data);
+                            gl.uniform_4_f32_slice(Some((*uniform.location).clone()), &mut data);
                         }
                         glow::INT => {
                             let data = Self::get::<i32>(data_buf, buffer)[0];
-                            gl.uniform_1_i32(Some(uniform.location), data);
+                            gl.uniform_1_i32(Some((*uniform.location).clone()), data);
                         }
                         glow::INT_VEC2 => {
                             // TODO: Remove`mut`
                             let mut data = Self::get::<[i32; 2]>(data_buf, buffer)[0];
-                            gl.uniform_2_i32_slice(Some(uniform.location), &mut data);
+                            gl.uniform_2_i32_slice(Some((*uniform.location).clone()), &mut data);
                         }
                         glow::INT_VEC3 => {
                             // TODO: Remove`mut`
                             let mut data = Self::get::<[i32; 3]>(data_buf, buffer)[0];
-                            gl.uniform_3_i32_slice(Some(uniform.location), &mut data);
+                            gl.uniform_3_i32_slice(Some((*uniform.location).clone()), &mut data);
                         }
                         glow::INT_VEC4 => {
                             // TODO: Remove`mut`
                             let mut data = Self::get::<[i32; 4]>(data_buf, buffer)[0];
-                            gl.uniform_4_i32_slice(Some(uniform.location), &mut data);
+                            gl.uniform_4_i32_slice(Some((*uniform.location).clone()), &mut data);
                         }
                         glow::FLOAT_MAT2 => {
                             let data = Self::get::<[f32; 4]>(data_buf, buffer)[0];
-                            gl.uniform_matrix_2_f32_slice(Some(uniform.location), false, &data);
+                            gl.uniform_matrix_2_f32_slice(Some((*uniform.location).clone()), false, &data);
                         }
                         glow::FLOAT_MAT3 => {
                             let data = Self::get::<[f32; 9]>(data_buf, buffer)[0];
-                            gl.uniform_matrix_3_f32_slice(Some(uniform.location), false, &data);
+                            gl.uniform_matrix_3_f32_slice(Some((*uniform.location).clone()), false, &data);
                         }
                         glow::FLOAT_MAT4 => {
                             let data = Self::get::<[f32; 16]>(data_buf, buffer)[0];
-                            gl.uniform_matrix_4_f32_slice(Some(uniform.location), false, &data);
+                            gl.uniform_matrix_4_f32_slice(Some((*uniform.location).clone()), false, &data);
                         }
                         _ => panic!("Unsupported uniform datatype!"),
                     }
@@ -1117,7 +1151,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
 
                 assert!(buffer.commands.len() >= (cb.buf.offset + cb.buf.size) as usize);
                 let commands = &buffer.commands
-                    [cb.buf.offset as usize .. (cb.buf.offset + cb.buf.size) as usize];
+                    [cb.buf.offset as usize..(cb.buf.offset + cb.buf.size) as usize];
                 self.reset_state();
                 for com in commands {
                     self.process(com, &buffer.data);
@@ -1155,7 +1189,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
             self.present_by_copy(swapchain.borrow(), index);
         }
 
-        #[cfg(all(feature = "wgl", not(target_arch = "wasm32")))]
+        #[cfg(wgl)]
         self.share.instance_context.make_current();
 
         Ok(None)
@@ -1173,7 +1207,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
             .expect("No swapchain is configured!");
         self.present_by_copy(swapchain, 0);
 
-        #[cfg(all(feature = "wgl", not(target_arch = "wasm32")))]
+        #[cfg(wgl)]
         self.share.instance_context.make_current();
 
         Ok(None)

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -223,7 +223,7 @@ impl CommandQueue {
         gl.surfman_device
             .write()
             .make_context_current(&swapchain.context.read())
-            .unwrap();
+            .expect("TODO");
 
         // Use the framebuffer from the surfman context
         #[cfg(surfman)]
@@ -236,8 +236,11 @@ impl CommandQueue {
             .framebuffer_object;
 
         unsafe {
-            gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(swapchain.fbos[index as usize]));
-            gl.bind_framebuffer(
+            // Note that here we access the context with `gl.context` instead of accessing the gl context
+            // through the dereference of the `GlContainer` because that will make the `gl.context` current
+            // and we don't want that because we want the swapchain context to stay the current context.
+            gl.context.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(swapchain.fbos[index as usize]));
+            gl.context.bind_framebuffer(
                 glow::DRAW_FRAMEBUFFER,
                 #[cfg(surfman)]
                 match fbo {
@@ -247,7 +250,7 @@ impl CommandQueue {
                 #[cfg(not(surfman))]
                 None,
             );
-            gl.blit_framebuffer(
+            gl.context.blit_framebuffer(
                 0,
                 0,
                 extent.width as _,

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -319,15 +319,15 @@ impl window::Surface<B> for Surface {
             present_modes: window::PresentMode::FIFO, //TODO
             composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
             image_count: if self.context.get_pixel_format().double_buffer {
-                2..=2
+                2 ..= 2
             } else {
-                1..=1
+                1 ..= 1
             },
             current_extent: None,
             extents: window::Extent2D {
                 width: 4,
                 height: 4,
-            }..=window::Extent2D {
+            } ..= window::Extent2D {
                 width: 4096,
                 height: 4096,
             },

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -190,7 +190,7 @@ impl hal::Instance<B> for Instance {
             }
             #[cfg(all(unix, not(android), not(macos)))]
             RawWindowHandle::Xlib(handle) => {
-                Ok(self.create_surface_from_xlib(handle.display as *mut _, handle.window))
+                Ok(self.create_surface_from_xlib(handle.window, handle.display))
             }
             _ => Err(hal::window::InitError::UnsupportedWindowHandle),
         }
@@ -367,27 +367,26 @@ impl hal::Instance<B> for Surface {
 }
 
 // This isn't used anymore according to the linter. Keeping it commented just in case.
-//
-// pub fn config_context<C>(
-//     builder: glutin::ContextBuilder<C>,
-//     color_format: f::Format,
-//     ds_format: Option<f::Format>,
-// ) -> glutin::ContextBuilder<C>
-// where
-//     C: glutin::ContextCurrentState,
-// {
-//     let color_base = color_format.base_format();
-//     let color_bits = color_base.0.describe_bits();
-//     let depth_bits = match ds_format {
-//         Some(fm) => fm.base_format().0.describe_bits(),
-//         None => f::BITS_ZERO,
-//     };
-//     builder
-//         .with_depth_buffer(depth_bits.depth)
-//         .with_stencil_buffer(depth_bits.stencil)
-//         .with_pixel_format(color_bits.color, color_bits.alpha)
-//         .with_srgb(color_base.1 == f::ChannelType::Srgb)
-// }
+pub fn config_context<C>(
+    builder: glutin::ContextBuilder<C>,
+    color_format: f::Format,
+    ds_format: Option<f::Format>,
+) -> glutin::ContextBuilder<C>
+where
+    C: glutin::ContextCurrentState,
+{
+    let color_base = color_format.base_format();
+    let color_bits = color_base.0.describe_bits();
+    let depth_bits = match ds_format {
+        Some(fm) => fm.base_format().0.describe_bits(),
+        None => f::BITS_ZERO,
+    };
+    builder
+        .with_depth_buffer(depth_bits.depth)
+        .with_stencil_buffer(depth_bits.stencil)
+        .with_pixel_format(color_bits.color, color_bits.alpha)
+        .with_srgb(color_base.1 == f::ChannelType::Srgb)
+}
 
 #[derive(Debug)]
 pub struct Headless(pub Starc<glutin::Context<glutin::PossiblyCurrent>>);

--- a/src/backend/gl/src/window/glutin.rs
+++ b/src/backend/gl/src/window/glutin.rs
@@ -50,9 +50,13 @@
 use crate::{conv, native, Backend as B, Device, GlContainer, PhysicalDevice, QueueFamily, Starc};
 use hal::{adapter::Adapter, format as f, image, window};
 
+use std::ffi::c_void;
+use std::os::raw::c_ulong;
+use std::sync::Arc;
+
 use arrayvec::ArrayVec;
 use glow::HasContext;
-use glutin;
+use glutin::{self, platform::unix::RawContextExt};
 
 use std::iter;
 
@@ -75,6 +79,128 @@ impl window::Swapchain<B> for Swapchain {
     ) -> Result<(window::SwapImageIndex, Option<window::Suboptimal>), window::AcquireError> {
         // TODO: sync
         Ok((0, None))
+    }
+}
+
+#[derive(Debug)]
+pub enum Instance {
+    Headless(Headless),
+    Surface(Surface),
+}
+
+impl Instance {
+    pub fn create_surface_from_wayland(
+        &self,
+        display: *mut c_void,
+        surface: *mut c_void,
+    ) -> Surface {
+        log::trace!("Creating GL surface from wayland");
+        let context = unsafe {
+            glutin::ContextBuilder::new()
+                .with_vsync(true)
+                .build_raw_wayland_context(
+                    display as _,
+                    surface,
+                    /*TODO: do something with these dimensions*/
+                    400,
+                    400,
+                )
+                .expect("TODO: handle this error")
+        };
+        let context = unsafe { context.make_current().expect("TODO: handle this error") };
+        Surface::from_context(context)
+    }
+
+    pub fn create_surface_from_xlib(&self, window: c_ulong, display: *mut c_void) -> Surface {
+        log::trace!("Creating GL surface from Xlib");
+        let xconn = {
+            // This is taken from `glutin::platform::unix::x11::XConnection::new except with tweaks
+            // that allow us to create the connection with an existing display pointer
+            use glutin::platform::unix::x11::{ffi, XConnection};
+            // opening the libraries
+            let xlib = ffi::Xlib::open().expect("TODO: Handle error");
+            let xcursor = ffi::Xcursor::open().expect("TODO: Handle error");
+            let xrandr = ffi::Xrandr_2_2_0::open().expect("TODO: Handle error");
+            let xrandr_1_5 = ffi::Xrandr::open().ok();
+            let xinput2 = ffi::XInput2::open().expect("TODO: Handle error");
+            let xlib_xcb = ffi::Xlib_xcb::open().expect("TODO: Handle error");
+            let xrender = ffi::Xrender::open().expect("TODO: Handle error");
+
+            unsafe { (xlib.XInitThreads)() };
+            // unsafe { (xlib.XSetErrorHandler)(error_handler) };
+
+            // Get X11 socket file descriptor
+            let fd = unsafe { (xlib.XConnectionNumber)(display as *mut ffi::_XDisplay) };
+
+            XConnection {
+                xlib,
+                xrandr,
+                xrandr_1_5,
+                xcursor,
+                xinput2,
+                xlib_xcb,
+                xrender,
+                display: display as _,
+                x11_fd: fd,
+                latest_error: parking_lot::Mutex::new(None),
+                cursor_cache: Default::default(),
+            }
+        };
+        let xconn = Arc::new(xconn);
+
+        let context = unsafe {
+            glutin::ContextBuilder::new()
+                .with_vsync(true)
+                .build_raw_x11_context(xconn, window)
+                .expect("TODO: handle this error")
+        };
+        let context = unsafe { context.make_current().expect("TODO: handle this error") };
+        Surface::from_context(context)
+    }
+}
+
+impl hal::Instance<B> for Instance {
+    fn create(name: &str, version: u32) -> Result<Instance, hal::UnsupportedBackend> {
+        Headless::create(name, version).map(Instance::Headless)
+    }
+
+    fn enumerate_adapters(&self) -> Vec<Adapter<B>> {
+        match self {
+            Instance::Headless(instance) => instance.enumerate_adapters(),
+            Instance::Surface(instance) => instance.enumerate_adapters(),
+        }
+    }
+
+    unsafe fn create_surface(
+        &self,
+        has_handle: &impl raw_window_handle::HasRawWindowHandle,
+    ) -> Result<Surface, hal::window::InitError> {
+        use raw_window_handle::RawWindowHandle;
+
+        match self {
+            Instance::Headless(instance) => instance.create_surface(has_handle),
+            Instance::Surface(instance) => instance.create_surface(has_handle),
+        }
+        .expect("TODO");
+
+        match has_handle.raw_window_handle() {
+            #[cfg(all(unix, not(android), not(macos)))]
+            RawWindowHandle::Wayland(handle) => {
+                Ok(self.create_surface_from_wayland(handle.display, handle.surface))
+            }
+            #[cfg(all(unix, not(android), not(macos)))]
+            RawWindowHandle::Xlib(handle) => {
+                Ok(self.create_surface_from_xlib(handle.display as *mut _, handle.window))
+            }
+            _ => Err(hal::window::InitError::UnsupportedWindowHandle),
+        }
+    }
+
+    unsafe fn destroy_surface(&self, surface: Surface) {
+        match self {
+            Instance::Headless(instance) => instance.destroy_surface(surface),
+            Instance::Surface(instance) => instance.destroy_surface(surface),
+        }
     }
 }
 
@@ -193,15 +319,15 @@ impl window::Surface<B> for Surface {
             present_modes: window::PresentMode::FIFO, //TODO
             composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
             image_count: if self.context.get_pixel_format().double_buffer {
-                2 ..= 2
+                2..=2
             } else {
-                1 ..= 1
+                1..=1
             },
             current_extent: None,
             extents: window::Extent2D {
                 width: 4,
                 height: 4,
-            } ..= window::Extent2D {
+            }..=window::Extent2D {
                 width: 4096,
                 height: 4096,
             },
@@ -240,26 +366,28 @@ impl hal::Instance<B> for Surface {
     }
 }
 
-pub fn config_context<C>(
-    builder: glutin::ContextBuilder<C>,
-    color_format: f::Format,
-    ds_format: Option<f::Format>,
-) -> glutin::ContextBuilder<C>
-where
-    C: glutin::ContextCurrentState,
-{
-    let color_base = color_format.base_format();
-    let color_bits = color_base.0.describe_bits();
-    let depth_bits = match ds_format {
-        Some(fm) => fm.base_format().0.describe_bits(),
-        None => f::BITS_ZERO,
-    };
-    builder
-        .with_depth_buffer(depth_bits.depth)
-        .with_stencil_buffer(depth_bits.stencil)
-        .with_pixel_format(color_bits.color, color_bits.alpha)
-        .with_srgb(color_base.1 == f::ChannelType::Srgb)
-}
+// This isn't used anymore according to the linter. Keeping it commented just in case.
+//
+// pub fn config_context<C>(
+//     builder: glutin::ContextBuilder<C>,
+//     color_format: f::Format,
+//     ds_format: Option<f::Format>,
+// ) -> glutin::ContextBuilder<C>
+// where
+//     C: glutin::ContextCurrentState,
+// {
+//     let color_base = color_format.base_format();
+//     let color_bits = color_base.0.describe_bits();
+//     let depth_bits = match ds_format {
+//         Some(fm) => fm.base_format().0.describe_bits(),
+//         None => f::BITS_ZERO,
+//     };
+//     builder
+//         .with_depth_buffer(depth_bits.depth)
+//         .with_stencil_buffer(depth_bits.stencil)
+//         .with_pixel_format(color_bits.color, color_bits.alpha)
+//         .with_srgb(color_base.1 == f::ChannelType::Srgb)
+// }
 
 #[derive(Debug)]
 pub struct Headless(pub Starc<glutin::Context<glutin::PossiblyCurrent>>);
@@ -273,7 +401,7 @@ impl Headless {
 impl hal::Instance<B> for Headless {
     fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
         let context: glutin::Context<glutin::NotCurrent>;
-        #[cfg(target_os = "linux")]
+        #[cfg(linux)]
         {
             /// TODO: Update portability to make this more flexible
             use glutin::platform::unix::HeadlessContextExt;
@@ -284,7 +412,7 @@ impl hal::Instance<B> for Headless {
                 hal::UnsupportedBackend
             })?;
         }
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(linux))]
         {
             context = unimplemented!();
         }

--- a/src/backend/gl/src/window/mod.rs
+++ b/src/backend/gl/src/window/mod.rs
@@ -1,11 +1,14 @@
-#[cfg(all(feature = "glutin", not(target_arch = "wasm32")))]
-pub mod glutin;
-
-#[cfg(target_arch = "wasm32")]
+#[cfg(wasm)]
 pub mod web;
 
-#[cfg(all(feature = "wgl", not(target_arch = "wasm32")))]
+#[cfg(glutin)]
+pub mod glutin;
+
+#[cfg(surfman)]
+pub mod surfman;
+
+#[cfg(wgl)]
 pub mod wgl;
 
-#[cfg(not(any(target_arch = "wasm32", feature = "glutin", feature = "wgl")))]
+#[cfg(dummy)]
 pub mod dummy;

--- a/src/backend/gl/src/window/surfman.rs
+++ b/src/backend/gl/src/window/surfman.rs
@@ -59,11 +59,9 @@ impl Instance {
     fn get_default_context_attributes() -> sm::ContextAttributes {
         sm::ContextAttributes {
             version: sm::GLVersion::new(3, 3), // TODO: Figure out how to determine GL version
-            // TODO: Determine flags to provide. At least ALPH I think, but probably all of them.
-            // skipping COMPATIBILITY_PROFILE for now, because it panics with a TODO.
-            flags: sm::ContextAttributeFlags::ALPHA
-                | sm::ContextAttributeFlags::DEPTH
-                | sm::ContextAttributeFlags::STENCIL,
+            // TODO: Skipping COMPATIBILITY_PROFILE for now, because it panics with a TODO, but
+            // that is probably something we want to provide later.
+            flags: sm::ContextAttributeFlags::ALPHA,
         }
     }
 
@@ -186,10 +184,7 @@ impl hal::Instance<B> for Instance {
         Ok(self.create_surface_from_rwh(has_handle.raw_window_handle()))
     }
 
-    unsafe fn destroy_surface(&self, surface: Surface) {
-        // Surface implments Drop and will clean up the surface when it gets dropped
-        drop(surface);
-    }
+    unsafe fn destroy_surface(&self, _surface: Surface) {}
 }
 
 #[derive(Debug)]

--- a/src/backend/gl/src/window/surfman.rs
+++ b/src/backend/gl/src/window/surfman.rs
@@ -197,14 +197,6 @@ pub struct Surface {
 }
 
 impl Surface {
-    /// Make the surface's gl context the current context
-    pub fn make_context_current(&self) {
-        self.device
-            .write()
-            .make_context_current(&self.context.read())
-            .expect("TODO");
-    }
-
     pub fn context(&self) -> Starc<RwLock<sm::Context>> {
         self.context.clone()
     }
@@ -270,7 +262,6 @@ impl window::PresentationSurface<B> for Surface {
             config.extent.height as i32,
         );
 
-        // let fbo = surface_info.framebuffer_object;
         let fbo = gl.create_framebuffer().unwrap();
         gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(fbo));
         gl.framebuffer_renderbuffer(
@@ -283,7 +274,6 @@ impl window::PresentationSurface<B> for Surface {
             context: self.context.clone(),
             extent: config.extent,
             fbos: iter::once(fbo).collect(),
-            // out_fbo: Some(surface_info.framebuffer_object),
         });
 
         Ok(())
@@ -312,7 +302,6 @@ impl window::PresentationSurface<B> for Surface {
 
 impl window::Surface<B> for Surface {
     fn supports_queue_family(&self, _: &QueueFamily) -> bool {
-        self.make_context_current();
         true
     }
 

--- a/src/backend/gl/src/window/surfman.rs
+++ b/src/backend/gl/src/window/surfman.rs
@@ -326,12 +326,12 @@ impl window::Surface<B> for Surface {
             // } else {
             //     1..=1
             // },
-            image_count: 2..=2,
+            image_count: 2 ..= 2,
             current_extent: None,
             extents: window::Extent2D {
                 width: 4,
                 height: 4,
-            }..=window::Extent2D {
+            } ..= window::Extent2D {
                 width: 4096,
                 height: 4096,
             },

--- a/src/backend/gl/src/window/surfman.rs
+++ b/src/backend/gl/src/window/surfman.rs
@@ -1,0 +1,342 @@
+//! [Surfman](https://github.com/pcwalton/surfman)-based OpenGL backend for GFX-hal
+
+use crate::{conv, native, Backend as B, Device, GlContainer, PhysicalDevice, QueueFamily, Starc};
+use hal::{adapter::Adapter, format as f, image, window};
+
+use arrayvec::ArrayVec;
+use glow::HasContext;
+use parking_lot::RwLock;
+use surfman as sm;
+
+use std::cell::RefCell;
+use std::fmt;
+use std::iter;
+
+#[derive(Debug)]
+pub struct Swapchain {
+    // Underlying window, required for presentation
+    pub(crate) context: Starc<RwLock<sm::Context>>,
+    // Extent because the window lies
+    pub(crate) extent: window::Extent2D,
+    ///
+    pub(crate) fbos: ArrayVec<[native::RawFrameBuffer; 3]>,
+}
+
+impl window::Swapchain<B> for Swapchain {
+    unsafe fn acquire_image(
+        &mut self,
+        _timeout_ns: u64,
+        _semaphore: Option<&native::Semaphore>,
+        _fence: Option<&native::Fence>,
+    ) -> Result<(window::SwapImageIndex, Option<window::Suboptimal>), window::AcquireError> {
+        // TODO: sync
+        Ok((0, None))
+    }
+}
+
+thread_local! {
+    /// The thread-local surfman connection
+    static SM_CONN: RefCell<sm::Connection> =
+        RefCell::new(sm::Connection::new().expect("TODO"));
+}
+
+pub struct Instance {
+    hardware_adapter: sm::Adapter,
+    // TODO: We're not using these yet, but leave them here for later
+    #[allow(dead_code)]
+    low_power_adapter: sm::Adapter,
+    #[allow(dead_code)]
+    software_adapter: sm::Adapter,
+}
+
+impl fmt::Debug for Instance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Instance").field(&["Adapter..."; 3]).finish()
+    }
+}
+
+impl Instance {
+    fn get_default_context_attributes() -> sm::ContextAttributes {
+        sm::ContextAttributes {
+            version: sm::GLVersion::new(3, 3), // TODO: Figure out how to determine GL version
+            // TODO: Determine flags to provide. At least ALPH I think, but probably all of them.
+            // skipping COMPATIBILITY_PROFILE for now, because it panics with a TODO.
+            flags: sm::ContextAttributeFlags::ALPHA
+                | sm::ContextAttributeFlags::DEPTH
+                | sm::ContextAttributeFlags::STENCIL,
+        }
+    }
+
+    pub unsafe fn create_surface_from_rwh(
+        &self,
+        raw_handle: raw_window_handle::RawWindowHandle,
+    ) -> Surface {
+        // Get context attributes
+        let context_attributes = Self::get_default_context_attributes();
+
+        // Open a device for the surface
+        // TODO: Assume hardware adapter
+        let mut device = SM_CONN
+            .with(|c| c.borrow().create_device(&self.hardware_adapter))
+            .expect("TODO");
+
+        // Create context descriptor
+        let context_descriptor = device
+            .create_context_descriptor(&context_attributes)
+            .expect("TODO");
+
+        // Create context
+        let mut context = device.create_context(&context_descriptor).expect("TODO");
+
+        // Create the surface with the context
+        let surface = device
+            .create_surface(
+                &context,
+                surfman::SurfaceAccess::GPUOnly,
+                surfman::SurfaceType::Widget {
+                    // Create a native widget for the raw window handle
+                    native_widget: SM_CONN.with(|c| {
+                        c.borrow()
+                            .create_native_widget_from_rwh(raw_handle)
+                            .expect("TODO")
+                    }),
+                },
+            )
+            .expect("TODO");
+
+        // Bind surface to context
+        device
+            .bind_surface_to_context(&mut context, surface)
+            .expect("TODO");
+
+        device.make_context_current(&context).expect("TODO");
+
+        // Create a surface with the given context
+        Surface {
+            renderbuffer: None,
+            swapchain: None,
+            context: Starc::new(RwLock::new(context)),
+            device: Starc::new(RwLock::new(device)),
+        }
+    }
+}
+
+impl hal::Instance<B> for Instance {
+    fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
+        Ok(Instance {
+            hardware_adapter: SM_CONN.with(|c| c.borrow().create_hardware_adapter().expect("TODO")),
+            low_power_adapter: SM_CONN
+                .with(|c| c.borrow().create_low_power_adapter().expect("TODO")),
+            software_adapter: SM_CONN.with(|c| c.borrow().create_software_adapter().expect("TODO")),
+        })
+    }
+
+    fn enumerate_adapters(&self) -> Vec<Adapter<B>> {
+        let mut adapters = Vec::with_capacity(3);
+
+        let context_attributes = Self::get_default_context_attributes();
+
+        for surfman_adapter in &[
+            &self.hardware_adapter,
+            // TODO: Enabling these causes a segfault for an unknown reason
+            // &self.low_power_adapter,
+            // &self.software_adapter,
+        ] {
+            // Create a surfman device
+            let mut device =
+                SM_CONN.with(|c| c.borrow().create_device(surfman_adapter).expect("TODO"));
+
+            // Create context descriptor
+            let context_descriptor = device
+                .create_context_descriptor(&context_attributes)
+                .expect("TODO");
+
+            // Create context
+            let context = device.create_context(&context_descriptor).expect("TODO");
+
+            // Wrap in Starc<RwLock<T>>
+            let context = Starc::new(RwLock::new(context));
+            let context_ = context.clone();
+            let device = Starc::new(RwLock::new(device));
+            let device_ = device.clone();
+
+            // Create gl container
+            let gl = GlContainer::from_fn_proc(
+                |symbol_name| {
+                    device_
+                        .write()
+                        .get_proc_address(&context_.read(), symbol_name)
+                        as *const _
+                },
+                device,
+                context,
+            );
+
+            // Create physical device
+            adapters.push(PhysicalDevice::new_adapter((), gl));
+        }
+
+        adapters
+    }
+
+    unsafe fn create_surface(
+        &self,
+        has_handle: &impl raw_window_handle::HasRawWindowHandle,
+    ) -> Result<Surface, window::InitError> {
+        Ok(self.create_surface_from_rwh(has_handle.raw_window_handle()))
+    }
+
+    unsafe fn destroy_surface(&self, surface: Surface) {
+        // Surface implments Drop and will clean up the surface when it gets dropped
+        drop(surface);
+    }
+}
+
+#[derive(Debug)]
+pub struct Surface {
+    pub(crate) swapchain: Option<Swapchain>,
+    pub(crate) context: Starc<RwLock<sm::Context>>,
+    device: Starc<RwLock<sm::Device>>,
+    renderbuffer: Option<native::Renderbuffer>,
+}
+
+impl Surface {
+    pub fn context(&self) -> Starc<RwLock<sm::Context>> {
+        self.context.clone()
+    }
+
+    fn swapchain_formats(&self) -> Vec<f::Format> {
+        // TODO: Make sure this is correct. I believe it is. Reference:
+        // https://github.com/pcwalton/surfman/blob/master/surfman/src/context.rs#L34-L37
+        vec![f::Format::Rgba8Srgb, f::Format::Bgra8Srgb]
+    }
+}
+
+impl Drop for Surface {
+    fn drop(&mut self) {
+        // Unbind and get the underlying surface from the context
+        let surface = self
+            .device
+            .read()
+            .unbind_surface_from_context(&mut self.context.write())
+            .expect("TODO");
+
+        if let Some(mut surface) = surface {
+            // Destroy the underlying surface
+            self.device
+                .read()
+                .destroy_surface(&mut self.context.write(), &mut surface)
+                .expect("TODO");
+        }
+
+        // Destroy the backing context
+        self.device
+            .read()
+            .destroy_context(&mut self.context.write())
+            .expect("TODO");
+    }
+}
+
+impl window::PresentationSurface<B> for Surface {
+    type SwapchainImage = native::ImageView;
+
+    unsafe fn configure_swapchain(
+        &mut self,
+        device: &Device,
+        config: window::SwapchainConfig,
+    ) -> Result<(), window::CreationError> {
+        let gl = &device.share.context;
+        // let surface_info = self.device.read().surface_info(&self.surface.read());
+
+        if let Some(old) = self.swapchain.take() {
+            for fbo in old.fbos {
+                gl.delete_framebuffer(fbo);
+            }
+        }
+
+        if self.renderbuffer.is_none() {
+            self.renderbuffer = Some(gl.create_renderbuffer().unwrap());
+        }
+
+        let desc = conv::describe_format(config.format).unwrap();
+        gl.bind_renderbuffer(glow::RENDERBUFFER, self.renderbuffer);
+        gl.renderbuffer_storage(
+            glow::RENDERBUFFER,
+            desc.tex_internal,
+            config.extent.width as i32,
+            config.extent.height as i32,
+        );
+
+        // let fbo = surface_info.framebuffer_object;
+        let fbo = gl.create_framebuffer().unwrap();
+        gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(fbo));
+        gl.framebuffer_renderbuffer(
+            glow::READ_FRAMEBUFFER,
+            glow::COLOR_ATTACHMENT0,
+            glow::RENDERBUFFER,
+            self.renderbuffer,
+        );
+        self.swapchain = Some(Swapchain {
+            context: self.context.clone(),
+            extent: config.extent,
+            fbos: iter::once(fbo).collect(),
+            // out_fbo: Some(surface_info.framebuffer_object),
+        });
+
+        Ok(())
+    }
+
+    unsafe fn unconfigure_swapchain(&mut self, device: &Device) {
+        let gl = &device.share.context;
+        if let Some(old) = self.swapchain.take() {
+            for fbo in old.fbos {
+                gl.delete_framebuffer(fbo);
+            }
+        }
+        if let Some(rbo) = self.renderbuffer.take() {
+            gl.delete_renderbuffer(rbo);
+        }
+    }
+
+    unsafe fn acquire_image(
+        &mut self,
+        _timeout_ns: u64,
+    ) -> Result<(Self::SwapchainImage, Option<window::Suboptimal>), window::AcquireError> {
+        let image = native::ImageView::Renderbuffer(self.renderbuffer.unwrap());
+        Ok((image, None))
+    }
+}
+
+impl window::Surface<B> for Surface {
+    fn supports_queue_family(&self, _: &QueueFamily) -> bool {
+        true
+    }
+
+    fn capabilities(&self, _physical_device: &PhysicalDevice) -> window::SurfaceCapabilities {
+        window::SurfaceCapabilities {
+            present_modes: window::PresentMode::FIFO, //TODO
+            composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
+            // TODO: Figure out how to get pixel format from surfman
+            // image_count: if self.context.get_pixel_format().double_buffer {
+            //     2..=2
+            // } else {
+            //     1..=1
+            // },
+            image_count: 2..=2,
+            current_extent: None,
+            extents: window::Extent2D {
+                width: 4,
+                height: 4,
+            }..=window::Extent2D {
+                width: 4096,
+                height: 4096,
+            },
+            max_image_layers: 1,
+            usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
+        }
+    }
+
+    fn supported_formats(&self, _physical_device: &PhysicalDevice) -> Option<Vec<f::Format>> {
+        Some(self.swapchain_formats())
+    }
+}

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -14,9 +14,6 @@ use hal::{adapter::Adapter, format as f, image, window};
 use std::iter;
 use wasm_bindgen::JsCast;
 
-#[cfg(feature = "winit")]
-use winit::{platform::web::WindowExtWebSys, window::Window};
-
 #[derive(Clone, Debug)]
 pub struct Swapchain {
     pub(crate) extent: window::Extent2D,


### PR DESCRIPTION
This backports #3151 to 0.5. Only the changes to `gfx-backend-gl` have been backported. No changes have been made to the examples or to CI or the Makefile. The examples still work using the `glutin` backend like they are already doing. :tada:

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds ( *can't test because I don't have vulkan* )
- [x] tested examples with the following backends: `gl`
- [x] `rustfmt` run on changed code
