### PR TITLE
Add Missing glutin export

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -39,11 +39,9 @@ pub use window::web::{Surface, Swapchain};
 
 // Glutin implementation
 #[cfg(glutin)]
-pub use crate::window::glutin::{Instance, Surface, Swapchain};
+pub use crate::window::glutin::{Headless, Instance, Surface, Swapchain, config_context};
 #[cfg(glutin)]
 pub use glutin;
-#[cfg(glutin)]
-pub use crate::window::glutin::config_context;
 
 // Surfman implementation
 #[cfg(surfman)]


### PR DESCRIPTION
Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds ( can't test because I don't have Vulkan )
- [x] tested examples with the following backends: `gl`
- [x] `rustfmt` run on changed code

Review the latest commit alone if you don't want to see all the rustfmt clutter. :wink:

This adds an extra export to the `glutin` backend for GL which was accidentally removed with the surfman update. This will keep code that is still using the `glutin` backend working.