### PR TITLE
Add Rgb8Srgb format for GL

### DIFF
--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -125,6 +125,7 @@ pub fn describe_format(format: Format) -> Option<FormatDescription> {
         Rgba8Unorm => {
             FormatDescription::new(glow::RGBA8, glow::RGBA, glow::UNSIGNED_BYTE, 4, Float)
         }
+        Rgb8Srgb => FormatDescription::new(glow::SRGB8, glow::RGB, glow::UNSIGNED_BYTE, 3, Float),
         Rgba8Srgb => FormatDescription::new(
             glow::SRGB8_ALPHA8,
             glow::RGBA,


### PR DESCRIPTION
Fixes #3222

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` -- Vulkan passes, GL fails on `unimplemented!()` for `transfer`
- [x] tested examples with the following backends:
- [x] `rustfmt` run on changed code

cc: @chemicstry (PR-ing some loose ends)