### PR TITLE
WASM: set canvas width/height only if unset.

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -39,7 +39,7 @@ pub use window::web::{Surface, Swapchain};
 
 // Glutin implementation
 #[cfg(glutin)]
-pub use crate::window::glutin::{Headless, Instance, Surface, Swapchain, config_context};
+pub use crate::window::glutin::{config_context, Headless, Instance, Surface, Swapchain};
 #[cfg(glutin)]
 pub use glutin;
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -114,12 +114,16 @@ impl GlContainer {
         let context = {
             use wasm_bindgen::JsCast;
             // TODO: Remove hardcoded width/height
-            canvas
-                .set_attribute("width", "640")
-                .expect("Cannot set width");
-            canvas
-                .set_attribute("height", "480")
-                .expect("Cannot set height");
+            if canvas.get_attribute("width").is_none() {
+                canvas
+                    .set_attribute("width", "640")
+                    .expect("Cannot set width");
+            }
+            if canvas.get_attribute("height").is_none() {
+                canvas
+                    .set_attribute("height", "480")
+                    .expect("Cannot set height");
+            }
             let context_options = js_sys::Object::new();
             js_sys::Reflect::set(
                 &context_options,


### PR DESCRIPTION
Fixes #3224
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` -- Vulkan passes, GL fails on unimplemented!() for transfer
- [ ] tested examples with the following backends:
- [x] `rustfmt` run on changed code (note, there are other files that rustfmt changes, but I did not commit these)
