### PR TITLE
Improve documentation

### DIFF
--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -1,10 +1,12 @@
-//! Physical devices and adapters.
+//! Physical graphics devices.
 //!
-//! The `PhysicalDevice` trait specifies the API a backend must provide for dealing with
-//! and querying a physical device, such as a particular GPU.  An `Adapter` is a struct
-//! containing a `PhysicalDevice` and metadata for a particular GPU, generally created
-//! from an `Instance` of that backend.  `adapter.open_with(...)` will return a `Device`
-//! that has the properties specified.
+//! The [`PhysicalDevice`][PhysicalDevice] trait specifies the API a backend
+//! must provide for dealing with and querying a physical device, such as
+//! a particular GPU.
+//!
+//! An [adapter][Adapter] is a struct containing a physical device and metadata
+//! for a particular GPU, generally created from an [instance][crate::Instance]
+//! of that [backend][crate::Backend].
 
 use std::{any::Any, fmt};
 
@@ -42,22 +44,31 @@ pub struct MemoryProperties {
     pub memory_heaps: Vec<u64>,
 }
 
-/// Represents a combination of a logical device and the
-/// hardware queues it provides.
+/// Represents a combination of a [logical device][crate::device::Device] and the
+/// [hardware queues][QueueGroup] it provides.
 ///
-/// This structure is typically created using an `Adapter`.
+/// This structure is typically created from an [adapter][crate::adapter::Adapter].
 #[derive(Debug)]
 pub struct Gpu<B: Backend> {
-    /// Logical device for a given backend.
+    /// [Logical device][crate::device::Device] for a given backend.
     pub device: B::Device,
-    /// The command queues that the device provides.
+    /// The [command queues][crate::queue::CommandQueue] that the device provides.
     pub queue_groups: Vec<QueueGroup<B>>,
 }
 
 /// Represents a physical device (such as a GPU) capable of supporting the given backend.
 pub trait PhysicalDevice<B: Backend>: fmt::Debug + Any + Send + Sync {
-    /// Create a new logical device with the requested features. If `requested_features` is
-    /// empty (e.g. through `Features::empty()`) then only the core features are supported.
+    /// Create a new [logical device][crate::device::Device] with the requested features.
+    /// If `requested_features` is [empty][crate::Features::empty], then only
+    /// the core features are supported.
+    ///
+    /// # Arguments
+    ///
+    /// * `families` - which [queue families][crate::queue::family::QueueFamily]
+    ///   to create queues from. The implementation may allocate more processing time to
+    ///   the queues with higher [priority][QueuePriority].
+    /// * `requested_features` - device features to enable. Must be a subset of
+    ///   the [features][PhysicalDevice::features] supported by this device.
     ///
     /// # Errors
     ///
@@ -116,7 +127,7 @@ pub trait PhysicalDevice<B: Backend>: fmt::Debug + Any + Send + Sync {
     }
 }
 
-/// Supported physical device types
+/// The type of a physical graphics device
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DeviceType {
@@ -128,36 +139,37 @@ pub enum DeviceType {
     DiscreteGpu = 2,
     /// Virtual / Hosted
     VirtualGpu = 3,
-    /// Cpu / Software Rendering
+    /// CPU / Software Rendering
     Cpu = 4,
 }
 
-/// Metadata about a backend adapter.
+/// Metadata about a backend [adapter][Adapter].
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AdapterInfo {
     /// Adapter name
     pub name: String,
-    /// Vendor PCI id of the adapter
+    /// PCI ID of the device vendor
     pub vendor: usize,
-    /// PCI id of the adapter
+    /// PCI ID of the device
     pub device: usize,
     /// Type of device
     pub device_type: DeviceType,
 }
 
-/// The list of `Adapter` instances is obtained by calling `Instance::enumerate_adapters()`.
+/// Information about a graphics device, supported by the backend.
 ///
-/// Given an `Adapter` a `Gpu` can be constructed by calling `PhysicalDevice::open()` on its
-/// `physical_device` field. However, if only a single queue family is needed or if no
-/// additional device features are required, then the `Adapter::open_with` convenience method
-/// can be used instead.
+/// The list of available adapters is obtained by calling
+/// [`Instance::enumerate_adapters`][crate::Instance::enumerate_adapters].
+///
+/// To create a [`Gpu`][Gpu] from this type you can use the [`open`](PhysicalDevice::open)
+/// method on its [`physical_device`][Adapter::physical_device] field.
 #[derive(Debug)]
 pub struct Adapter<B: Backend> {
     /// General information about this adapter.
     pub info: AdapterInfo,
-    /// Actual physical device.
+    /// Actual [physical device][PhysicalDevice].
     pub physical_device: B::PhysicalDevice,
-    /// Queue families supported by this adapter.
+    /// [Queue families][crate::queue::family::QueueFamily] supported by this adapter.
     pub queue_families: Vec<B::QueueFamily>,
 }

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -1,8 +1,7 @@
 //! Memory buffers.
 //!
-//! # Buffer
-//!
 //! Buffers interpret memory slices as linear contiguous data array.
+//!
 //! They can be used as shader resources, vertex buffers, index buffers or for
 //! specifying the action commands for indirect execution.
 

--- a/src/hal/src/command/clear.rs
+++ b/src/hal/src/command/clear.rs
@@ -1,7 +1,7 @@
 use crate::pso;
 use std::fmt;
 
-/// A clear color union, which can be either f32, i32, or u32.
+/// A clear color union, which can be either `f32`, `i32`, or `u32`.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ClearColor {
@@ -31,6 +31,9 @@ pub struct ClearDepthStencil {
 }
 
 /// A set of clear values for a single attachment.
+///
+/// These are passed to a command buffer by
+/// [beginning a render pass][crate::command::CommandBuffer::begin_render_pass].
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ClearValue {

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -1,15 +1,15 @@
 //! Command buffers.
 //!
 //! A command buffer collects a list of commands to be submitted to the device.
-//! Each command buffer has specific capabilities for graphics, compute or transfer operations,
-//! and can be either a "primary" command buffer or a "secondary" command buffer.  Operations
-//! always start from a primary command buffer, but a primary command buffer can contain calls
-//! to secondary command buffers that contain snippets of commands that do specific things, similar
-//! to function calls.
 //!
-//! All the possible commands are implemented in the `RawCommandBuffer` trait, and then the `CommandBuffer`
-//! and related types make a generic, strongly-typed wrapper around it that only expose the methods that
-//! are valid for the capabilities it provides.
+//! Each command buffer has specific capabilities for graphics, compute or transfer operations,
+//! and can be either a *primary* command buffer or a *secondary* command buffer.
+//!
+//! Operations are always initiated by a primary command buffer,
+//! but a primary command buffer can contain calls to secondary command buffers
+//! that contain snippets of commands that do specific things, similar to function calls.
+//!
+//! All the possible commands are exposed by the [`CommandBuffer`][CommandBuffer] trait.
 
 // TODO: Document pipelines and subpasses better.
 
@@ -62,9 +62,7 @@ bitflags! {
     }
 }
 
-/// An enum that indicates at runtime whether a command buffer
-/// is primary or secondary, similar to what `command::Primary`
-/// and `command::Secondary` do at compile-time.
+/// An enum that indicates whether a command buffer is primary or secondary.
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Level {
@@ -219,7 +217,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         I: IntoIterator<Item = (T, buffer::SubRange)>,
         T: Borrow<B::Buffer>;
 
-    /// Set the viewport parameters for the rasterizer.
+    /// Set the [viewport][crate::pso::Viewport] parameters for the rasterizer.
     ///
     /// Each viewport passed corresponds to the viewport with the same index,
     /// starting from an offset index `first_viewport`.
@@ -289,13 +287,16 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     unsafe fn set_depth_bias(&mut self, depth_bias: pso::DepthBias);
 
     /// Begins recording commands for a render pass on the given framebuffer.
-    /// `render_area` is the section of the framebuffer to render,
-    /// `clear_values` is an iterator of `ClearValueRaw`'s to use to use for
-    /// `clear_*` commands, one for each attachment of the render pass
-    /// that has a clear operation.
-    /// `first_subpass` specifies, for the first subpass, whether the
-    /// rendering commands are provided inline or whether the render
-    /// pass is composed of subpasses.
+    ///
+    /// # Arguments
+    ///
+    /// * `render_area` - section of the framebuffer to render.
+    /// * `clear_values` - iterator of [clear values][crate::command::ClearValue]
+    ///   to use to use for `clear_*` commands, one for each attachment of the render pass
+    ///   that has a clear operation.
+    /// * `first_subpass` - specifies, for the first subpass, whether the
+    ///   rendering commands are provided inline or whether the render
+    ///   pass is composed of subpasses.
     unsafe fn begin_render_pass<T>(
         &mut self,
         render_pass: &B::RenderPass,

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -5,10 +5,39 @@
     unused_import_braces,
     unused_qualifications
 )]
-#![deny(missing_debug_implementations, missing_docs, unused)]
+#![deny(
+    intra_doc_link_resolution_failure,
+    missing_debug_implementations,
+    missing_docs,
+    unused
+)]
 
 //! Low-level graphics abstraction for Rust. Mostly operates on data, not types.
 //! Designed for use by libraries and higher-level abstractions only.
+//!
+//! This crate provides a [hardware abstraction layer][hal] for [graphics adapters][gpus],
+//! for both compute and graphics operations. The API design is heavily inspired by
+//! the [Vulkan API](https://www.khronos.org/vulkan/), and borrows some of the terminology.
+//!
+//! [hal]: https://en.wikipedia.org/wiki/Hardware_abstraction
+//! [gpus]: https://en.wikipedia.org/wiki/Video_card
+//!
+//! # Usage
+//!
+//! Most of the functionality is implemented in separate crates, one for each backend.
+//! This crate only exposes a few generic traits and structures. You can import
+//! all the necessary traits through the [`prelude`][prelude] module.
+//!
+//! The first step to using `gfx-hal` is to initialize one of the available
+//! [backends][Backend], by creating an [`Instance`][Instance]. Then proceed by
+//! [enumerating][Instance::enumerate_adapters] the available
+//! [graphics adapters][adapter::Adapter] and querying their available
+//! [features][Features] and [queues][queue::family::QueueFamily].
+//!
+//! You can use the [`open`][adapter::PhysicalDevice::open] method on a
+//! [`PhysicalDevice`][adapter::PhysicalDevice] to get a [logical device
+//! handle][device::Device], from which you can manage all the other device-specific
+//! resources.
 
 #[macro_use]
 extern crate bitflags;
@@ -35,17 +64,17 @@ pub mod query;
 pub mod queue;
 pub mod window;
 
-/// Prelude module re-exports all the traits necessary to use gfx-hal.
+/// Prelude module re-exports all the traits necessary to use `gfx-hal`.
 pub mod prelude {
     pub use crate::{
-        adapter::PhysicalDevice as _,
-        command::CommandBuffer as _,
-        device::Device as _,
-        pool::CommandPool as _,
-        pso::DescriptorPool as _,
-        queue::{CommandQueue as _, QueueFamily as _},
-        window::{PresentationSurface as _, Surface as _, Swapchain as _},
-        Instance as _,
+        adapter::PhysicalDevice,
+        command::CommandBuffer,
+        device::Device,
+        pool::CommandPool,
+        pso::DescriptorPool,
+        queue::{CommandQueue, QueueFamily},
+        window::{PresentationSurface, Surface, Swapchain},
+        Instance,
     };
 }
 
@@ -66,7 +95,11 @@ bitflags! {
     //TODO: add a feature for non-normalized samplers
     //TODO: add a feature for mutable comparison samplers
     /// Features that the device supports.
+    ///
     /// These only include features of the core interface and not API extensions.
+    ///
+    /// Can be obtained from a [physical device][adapter::PhysicalDevice] by calling
+    /// [`features`][adapter::PhysicalDevice::features].
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct Features: u128 {
         /// Bit mask of Vulkan Core features.
@@ -383,7 +416,7 @@ pub enum IndexType {
 
 /// Error creating an instance of a backend on the platform that
 /// doesn't support this backend.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct UnsupportedBackend;
 
 /// An instantiated backend.
@@ -397,32 +430,57 @@ pub struct UnsupportedBackend;
 /// # extern crate gfx_backend_empty;
 /// # extern crate gfx_hal;
 /// use gfx_backend_empty as backend;
-/// use gfx_hal as hal;
+/// use gfx_hal::Instance;
 ///
 /// // Create a concrete instance of our backend (this is backend-dependent and may be more
 /// // complicated for some backends).
-/// let instance = backend::Instance;
+/// let instance = backend::Instance::create("My App", 1).unwrap();
 /// // We can get a list of the available adapters, which are either physical graphics
 /// // devices, or virtual adapters. Because we are using the dummy `empty` backend,
 /// // there will be nothing in this list.
-/// for (idx, adapter) in hal::Instance::enumerate_adapters(&instance).iter().enumerate() {
+/// for (idx, adapter) in instance.enumerate_adapters().iter().enumerate() {
 ///     println!("Adapter {}: {:?}", idx, adapter.info);
 /// }
 /// ```
 pub trait Instance<B: Backend>: Any + Send + Sync + Sized {
     /// Create a new instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - name of the application using the API.
+    /// * `version` - free form representation of the application's version.
+    ///
+    /// This metadata is passed further down the graphics stack.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Err` variant if the requested backend [is not supported
+    /// on the current platform][UnsupportedBackend].
     fn create(name: &str, version: u32) -> Result<Self, UnsupportedBackend>;
-    /// Return all available adapters.
+
+    /// Return all available [graphics adapters][adapter::Adapter].
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<B>>;
-    /// Create a new surface.
+
+    /// Create a new [surface][window::Surface].
+    ///
+    /// Surfaces can be used to render to windows.
+    ///
+    /// # Safety
+    ///
+    /// This method can cause undefined behavior if `raw_window_handle` isn't
+    /// a handle to a valid window for the current platform.
     unsafe fn create_surface(
         &self,
-        _: &impl raw_window_handle::HasRawWindowHandle,
+        raw_window_handle: &impl raw_window_handle::HasRawWindowHandle,
     ) -> Result<B::Surface, window::InitError>;
-    /// Destroy a surface.
+
+    /// Destroy a surface, freeing the resources associated with it and
+    /// releasing it from this graphics API.
     ///
-    /// The surface shouldn't be destroyed before the attached
-    /// swapchain is destroyed.
+    /// # Safety
+    ///
+    /// The surface shouldn't be destroyed before the attached swapchain
+    /// is destroyed, otherwise crashes or undefined behavior could occur.
     unsafe fn destroy_surface(&self, surface: B::Surface);
 }
 
@@ -447,45 +505,74 @@ impl<T> Extend<T> for PseudoVec<T> {
     }
 }
 
-/// The `Backend` trait wraps together all the types needed
-/// for a graphics backend. Each backend module, such as OpenGL
-/// or Metal, will implement this trait with its own concrete types.
-#[allow(missing_docs)]
+/// Wraps together all the types needed for a graphics backend.
+///
+/// Each backend module, such as OpenGL or Metal, will implement this trait
+/// with its own concrete types.
 pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send + Sync {
+    /// The corresponding [instance][Instance] type for this backend.
     type Instance: Instance<Self>;
+    /// The corresponding [physical device][adapter::PhysicalDevice] type for this backend.
     type PhysicalDevice: adapter::PhysicalDevice<Self>;
+    /// The corresponding [logical device][device::Device] type for this backend.
     type Device: device::Device<Self>;
 
+    /// The corresponding [surface][window::PresentationSurface] type for this backend.
     type Surface: window::PresentationSurface<Self>;
+    /// The corresponding [swapchain][window::Swapchain] type for this backend.
     type Swapchain: window::Swapchain<Self>;
 
+    /// The corresponding [queue family][queue::QueueFamily] type for this backend.
     type QueueFamily: queue::QueueFamily;
+    /// The corresponding [command queue][queue::CommandQueue] type for this backend.
     type CommandQueue: queue::CommandQueue<Self>;
+    /// The corresponding [command buffer][command::CommandBuffer] type for this backend.
     type CommandBuffer: command::CommandBuffer<Self>;
 
+    /// The corresponding shader module type for this backend.
     type ShaderModule: fmt::Debug + Any + Send + Sync;
+    /// The corresponding render pass type for this backend.
     type RenderPass: fmt::Debug + Any + Send + Sync;
+    /// The corresponding framebuffer type for this backend.
     type Framebuffer: fmt::Debug + Any + Send + Sync;
 
+    /// The corresponding memory type for this backend.
     type Memory: fmt::Debug + Any + Send + Sync;
+    /// The corresponding [command pool][pool::CommandPool] type for this backend.
     type CommandPool: pool::CommandPool<Self>;
 
+    /// The corresponding buffer type for this backend.
     type Buffer: fmt::Debug + Any + Send + Sync;
+    /// The corresponding buffer view type for this backend.
     type BufferView: fmt::Debug + Any + Send + Sync;
+    /// The corresponding image type for this backend.
     type Image: fmt::Debug + Any + Send + Sync;
+    /// The corresponding image view type for this backend.
     type ImageView: fmt::Debug + Any + Send + Sync;
+    /// The corresponding sampler type for this backend.
     type Sampler: fmt::Debug + Any + Send + Sync;
 
+    /// The corresponding compute pipeline type for this backend.
     type ComputePipeline: fmt::Debug + Any + Send + Sync;
+    /// The corresponding graphics pipeline type for this backend.
     type GraphicsPipeline: fmt::Debug + Any + Send + Sync;
+    /// The corresponding pipeline cache type for this backend.
     type PipelineCache: fmt::Debug + Any + Send + Sync;
+    /// The corresponding pipeline layout type for this backend.
     type PipelineLayout: fmt::Debug + Any + Send + Sync;
+    /// The corresponding [descriptor pool][pso::DescriptorPool] type for this backend.
     type DescriptorPool: pso::DescriptorPool<Self>;
+    /// The corresponding descriptor set type for this backend.
     type DescriptorSet: fmt::Debug + Any + Send + Sync;
+    /// The corresponding descriptor set layout type for this backend.
     type DescriptorSetLayout: fmt::Debug + Any + Send + Sync;
 
+    /// The corresponding fence type for this backend.
     type Fence: fmt::Debug + Any + Send + Sync;
+    /// The corresponding semaphore type for this backend.
     type Semaphore: fmt::Debug + Any + Send + Sync;
+    /// The corresponding event type for this backend.
     type Event: fmt::Debug + Any + Send + Sync;
+    /// The corresponding query pool type for this backend.
     type QueryPool: fmt::Debug + Any + Send + Sync;
 }

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -1,4 +1,4 @@
-//! Types to describe the properties of memory allocated for gfx resources.
+//! Types to describe the properties of memory allocated for graphics resources.
 
 use crate::{buffer, image, queue, Backend};
 use std::ops::Range;

--- a/src/hal/src/pass.rs
+++ b/src/hal/src/pass.rs
@@ -1,9 +1,17 @@
-//! RenderPass handling.
+//! Render pass handling.
+//!
+//! A *render pass* represents a collection of
+//!
+//! - [attachments][crate::pass::Attachment]
+//! - [subpasses][crate::pass::SubpassDesc]
+//! - [dependencies][crate::pass::SubpassDependency] between the subpasses
+//!
+//! and describes how the attachments are used over the course of the subpasses.
 
 use crate::{format::Format, image, memory::Dependencies, pso::PipelineStage, Backend};
 use std::ops::Range;
 
-/// Specifies the operation which will be applied at the beginning of a subpass.
+/// Specifies the operation to be used when reading data from a subpass attachment.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum AttachmentLoadOp {
@@ -15,7 +23,7 @@ pub enum AttachmentLoadOp {
     DontCare,
 }
 
-///
+/// Specifies the operation to be used when writing data to a subpass attachment.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum AttachmentStoreOp {
@@ -71,23 +79,27 @@ impl AttachmentOps {
     }
 }
 
-/// An `Attachment` is a description of a resource provided to a render subpass.
+/// An attachment is a description of a resource provided to a render subpass.
+///
 /// It includes things such as render targets, images that were produced from
 /// previous subpasses, etc.
 #[derive(Clone, Debug, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Attachment {
-    /// Attachment format
+    /// Format of this attachment.
     ///
     /// In the most cases `format` is not `None`. It should be only used for
     /// creating dummy renderpasses, which are used as placeholder for compatible
     /// renderpasses.
     pub format: Option<Format>,
-    /// Number of samples.
+    /// Number of samples to use when loading from this attachment.
+    ///
+    /// If greater than 1, [multisampling](https://en.wikipedia.org/wiki/Multisample_anti-aliasing)
+    /// will take effect.
     pub samples: image::NumSamples,
-    /// Load and store operations of the attachment
+    /// Load and store operations of the attachment.
     pub ops: AttachmentOps,
-    /// Load and store operations of the stencil aspect, if any
+    /// Load and store operations of the stencil aspect, if any.
     #[cfg_attr(feature = "serde", serde(default = "AttachmentOps::whatever"))]
     pub stencil_ops: AttachmentOps,
     /// Initial and final image layouts of the renderpass.
@@ -95,8 +107,9 @@ pub struct Attachment {
 }
 
 impl Attachment {
-    /// Returns true if this attachment has some clear operations. This is useful
-    /// when starting a render pass, since there has to be a clear value provided.
+    /// Returns true if this attachment has some clear operations.
+    ///
+    /// Useful when starting a render pass, since there has to be a clear value provided.
     pub fn has_clears(&self) -> bool {
         self.ops.load == AttachmentLoadOp::Clear || self.stencil_ops.load == AttachmentLoadOp::Clear
     }
@@ -112,9 +125,10 @@ pub const ATTACHMENT_UNUSED: AttachmentId = !0;
 /// Index of a subpass.
 pub type SubpassId = u8;
 
-/// Expresses a dependency between multiple subpasses. This is used
-/// both to describe a source or destination subpass; data either
-/// explicitly passes from this subpass to the next or from another
+/// Expresses a dependency between multiple [subpasses][SubpassDesc].
+///
+/// This is used both to describe a source or destination subpass;
+/// data either explicitly passes from this subpass to the next or from another
 /// subpass into this one.
 #[derive(Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -132,7 +146,7 @@ pub struct SubpassDependency {
     pub flags: Dependencies,
 }
 
-/// Description of a subpass for renderpass creation.
+/// Description of a subpass for render pass creation.
 #[derive(Clone, Debug)]
 pub struct SubpassDesc<'a> {
     /// Which attachments will be used as color buffers.
@@ -144,8 +158,11 @@ pub struct SubpassDesc<'a> {
     /// Which attachments will be used as resolve destinations.
     ///
     /// The number of resolve attachments may be zero or equal to the number of color attachments.
+    ///
     /// At the end of a subpass the color attachment will be resolved to the corresponding
-    /// resolve attachment. The resolve attachment must not be multisampled.
+    /// resolve attachment.
+    ///
+    /// The resolve attachment must not be multisampled.
     pub resolves: &'a [AttachmentRef],
     /// Attachments that are not used by the subpass but must be preserved to be
     /// passed on to subsequent passes.

--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -22,17 +22,35 @@ bitflags!(
 pub trait CommandPool<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Reset the command pool and the corresponding command buffers.
     ///
-    /// # Synchronization: You may _not_ free the pool if a command buffer is still in use (pool memory still in use)
+    /// # Arguments
+    ///
+    /// * `release_resources` - if `true`, this command pool will recycle all the
+    ///   resources it own and give them back to the system.
+    ///
+    /// # Synchronization
+    ///
+    /// You may _not_ free the pool if a command buffer allocated from it
+    /// is still in use (pool memory still in use).
     unsafe fn reset(&mut self, release_resources: bool);
 
-    /// Allocate a single command buffers from the pool.
+    /// Allocate a single [command buffer][crate::command::CommandBuffer] from the pool.
+    ///
+    /// # Arguments
+    ///
+    /// * `level` - whether this command buffer is primary or secondary.
     unsafe fn allocate_one(&mut self, level: Level) -> B::CommandBuffer {
         let mut result = PseudoVec(None);
         self.allocate(1, level, &mut result);
         result.0.unwrap()
     }
 
-    /// Allocate new command buffers from the pool.
+    /// Allocate new [command buffers][crate::command::CommandBuffer] from the pool.
+    ///
+    /// # Arguments
+    ///
+    /// * `num` - how many buffers to return
+    /// * `level` - whether to allocate primary or secondary command buffers.
+    /// * `list` - an extendable list of command buffers into which to allocate.
     unsafe fn allocate<E>(&mut self, num: usize, level: Level, list: &mut E)
     where
         E: Extend<B::CommandBuffer>,
@@ -40,7 +58,7 @@ pub trait CommandPool<B: Backend>: fmt::Debug + Any + Send + Sync {
         list.extend((0 .. num).map(|_| self.allocate_one(level)));
     }
 
-    /// Free command buffers which are allocated from this pool.
+    /// Free [command buffers][crate::command::CommandBuffer] allocated from this pool.
     unsafe fn free<I>(&mut self, buffers: I)
     where
         I: IntoIterator<Item = B::CommandBuffer>;

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -18,8 +18,14 @@
 
 use std::{borrow::Borrow, fmt, iter};
 
-use crate::{buffer::SubRange, device::OutOfMemory, image::Layout,
-            pso::ShaderStageFlags, Backend, PseudoVec};
+use crate::{
+    buffer::SubRange,
+    device::OutOfMemory,
+    image::Layout,
+    pso::ShaderStageFlags,
+    Backend,
+    PseudoVec,
+};
 
 ///
 pub type DescriptorSetIndex = u16;
@@ -154,22 +160,19 @@ pub enum AllocationError {
 impl std::fmt::Display for AllocationError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AllocationError::OutOfMemory(OutOfMemory::Host) => write!(
-                fmt,
-                "Failed to allocate descriptor set: Out of host memory"
-            ),
+            AllocationError::OutOfMemory(OutOfMemory::Host) => {
+                write!(fmt, "Failed to allocate descriptor set: Out of host memory")
+            }
             AllocationError::OutOfMemory(OutOfMemory::Device) => write!(
                 fmt,
                 "Failed to allocate descriptor set: Out of device memory"
             ),
-            AllocationError::OutOfPoolMemory => write!(
-                fmt,
-                "Failed to allocate descriptor set: Out of pool memory"
-            ),
-            AllocationError::FragmentedPool => write!(
-                fmt,
-                "Failed to allocate descriptor set: Pool is fragmented"
-            ),
+            AllocationError::OutOfPoolMemory => {
+                write!(fmt, "Failed to allocate descriptor set: Out of pool memory")
+            }
+            AllocationError::FragmentedPool => {
+                write!(fmt, "Failed to allocate descriptor set: Pool is fragmented")
+            }
             AllocationError::IncompatibleLayout => write!(
                 fmt,
                 "Failed to allocate descriptor set: Incompatible layout"

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -173,9 +173,9 @@ impl fmt::Display for Stage {
 pub struct EntryPoint<'a, B: Backend> {
     /// Entry point name.
     pub entry: &'a str,
-    /// Shader module reference.
+    /// Reference to the shader module containing this entry point.
     pub module: &'a B::ShaderModule,
-    /// Specialization.
+    /// Specialization constants to be used when creating the pipeline.
     pub specialization: Specialization<'a>,
 }
 

--- a/src/hal/src/pso/specialization.rs
+++ b/src/hal/src/pso/specialization.rs
@@ -2,16 +2,7 @@
 
 use std::{borrow::Cow, ops::Range, slice};
 
-/// Specialization constant for pipelines.
-///
-/// Specialization constants allow for easy configuration of
-/// multiple similar pipelines. For example, there may be a
-/// boolean exposed to the shader that switches the specularity on/off
-/// provided via a specialization constant.
-/// That would produce separate PSO's for the "on" and "off" states
-/// but they share most of the internal stuff and are fast to produce.
-/// More importantly, they are fast to execute, since the driver
-/// can optimize out the branch on that other PSO creation.
+/// Description of a specialization constant for the pipeline.
 #[derive(Debug, Clone, Hash, PartialEq)]
 pub struct SpecializationConstant {
     /// Constant identifier in shader source.
@@ -20,12 +11,22 @@ pub struct SpecializationConstant {
     pub range: Range<u16>,
 }
 
-/// Specialization information structure.
+/// Information required for pipeline specialization.
+///
+/// Specialization allows for easy configuration of multiple similar pipelines.
+/// For example, there may be a boolean exposed to the shader that switches
+/// the [specularity](https://en.wikipedia.org/wiki/Specularity) on/off,
+/// provided via a [specialization constant][SpecializationConstant].
+///
+/// That would produce separate PSO's for the "on" and "off" states
+/// but they share most of the internal stuff and are fast to produce.
+/// More importantly, they are fast to execute, since the driver
+/// can optimize out the branch on that other PSO creation.
 #[derive(Debug, Clone)]
 pub struct Specialization<'a> {
-    /// Constant array.
+    /// Array of descriptors of specialization constants to override.
     pub constants: Cow<'a, [SpecializationConstant]>,
-    /// Raw data.
+    /// Raw data of the specialization constants
     pub data: Cow<'a, [u8]>,
 }
 
@@ -106,7 +107,7 @@ where
     }
 }
 
-/// Macro for specifying list of specialization constatns for `EntryPoint`.
+/// Macro for specifying list of specialization constants for `EntryPoint`.
 #[macro_export]
 macro_rules! spec_const_list {
     (@ $(,)?) => {

--- a/src/hal/src/query.rs
+++ b/src/hal/src/query.rs
@@ -1,7 +1,9 @@
-//! Queries are commands that can be submitted to a command buffer to record statistics or
-//! other useful values as the command buffer is running. They are often intended for profiling
-//! or other introspection, providing a mechanism for the command buffer to record data about its
-//! operation as it is running.
+//! Commands that can be used to record statistics or other useful values
+//! as the command buffer is running.
+//!
+//! They are often intended for profiling or other introspection,
+//! providing a mechanism for the command buffer to record data about its operation
+//! as it is running.
 
 use crate::device::OutOfMemory;
 use crate::Backend;

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -9,6 +9,9 @@ use std::fmt::Debug;
 /// General information about a queue family, available upon adapter discovery.
 ///
 /// Note that a backend can expose multiple queue families with the same properties.
+///
+/// Can be obtained from an [adapter][crate::adapter::Adapter] through its
+/// [`queue_families`][crate::adapter::Adapter::queue_families] field.
 pub trait QueueFamily: Debug + Any + Send + Sync {
     /// Returns the type of queues.
     fn queue_type(&self) -> QueueType;

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -57,7 +57,9 @@ impl QueueType {
 /// `1.0` (high).
 pub type QueuePriority = f32;
 
-/// Submission information for a command queue.
+/// Submission information for a [command queue][CommandQueue].
+///
+/// The submission is sent to the device through the [`submit`][CommandQueue::submit] method.
 #[derive(Debug)]
 pub struct Submission<Ic, Iw, Is> {
     /// Command buffers to submit.
@@ -68,16 +70,29 @@ pub struct Submission<Ic, Iw, Is> {
     pub signal_semaphores: Is,
 }
 
-/// `RawCommandQueue` are abstractions to the internal GPU execution engines.
-/// Commands are executed on the the device by submitting command buffers to queues.
+/// Abstraction for an internal GPU execution engine.
+///
+/// Commands are executed on the the device by submitting
+/// [command buffers][crate::command::CommandBuffer].
+///
+/// Queues can also be used for presenting to a surface
+/// (that is, flip the front buffer with the next one in the chain).
 pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Submit command buffers to queue for execution.
-    /// `fence` must be in unsignalled state, and will be signalled after all command buffers in the submission have
-    /// finished execution.
     ///
-    /// Unsafe because it's not checked that the queue can process the submitted command buffers.
-    /// Trying to submit compute commands to a graphics queue will result in undefined behavior.
-    /// Each queue implements safer wrappers according to their supported functionalities!
+    /// # Arguments
+    ///
+    /// * `submission` - information about which command buffers to submit,
+    ///   as well as what semaphores to wait for or to signal when done.
+    /// * `fence` - must be in unsignaled state, and will be signaled after
+    ///   all command buffers in the submission have finished execution.
+    ///
+    /// # Safety
+    ///
+    /// It's not checked that the queue can process the submitted command buffers.
+    ///
+    /// For example, trying to submit compute commands to a graphics queue
+    /// will result in undefined behavior.
     unsafe fn submit<'a, T, Ic, S, Iw, Is>(
         &mut self,
         submission: Submission<Ic, Iw, Is>,
@@ -110,7 +125,10 @@ pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// semaphores given in `wait_semaphores`. A given swapchain must not appear in this
     /// list more than once.
     ///
-    /// Unsafe for the same reasons as `submit()`.
+    /// # Safety
+    ///
+    /// Unsafe for the same reasons as [`submit`][CommandQueue::submit].
+    /// No checks are performed to verify that this queue supports present operations.
     unsafe fn present<'a, W, Is, S, Iw>(
         &mut self,
         swapchains: Is,
@@ -136,7 +154,7 @@ pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
         self.present::<_, _, B::Semaphore, _>(swapchains, iter::empty())
     }
 
-    /// Present the a
+    /// Present a swapchain image directly to a surface.
     unsafe fn present_surface(
         &mut self,
         surface: &mut B::Surface,
@@ -144,6 +162,6 @@ pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
         wait_semaphore: Option<&B::Semaphore>,
     ) -> Result<Option<Suboptimal>, PresentError>;
 
-    /// Wait for the queue to idle.
+    /// Wait for the queue to be idle.
     fn wait_idle(&self) -> Result<(), OutOfMemory>;
 }

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -1,17 +1,22 @@
-//! Windowing system interoperability
+//! Windowing system interoperability.
 //!
 //! Screen presentation (fullscreen or window) of images requires two objects:
 //!
-//! * [Surface](window::Surface) is the host abstraction of the native screen
-//! * [Swapchain](window::Swapchain) is the device abstraction for a surface, containing multiple presentable images
+//! * [Surface][Surface] is an abstraction of a native screen or window, for graphics use.
+//! * [Swapchain][Swapchain] is a chain of multiple images, which can be presented on
+//!   a surface.
 //!
 //! ## Window
 //!
-//! // DOC TODO
+//! `gfx-hal` does not provide any methods for creating a native window or screen.
+//! This is handled exeternally, either by managing your own window or by using a
+//! library such as [winit](https://github.com/rust-windowing/winit), and providing
+//! the [raw window handle](https://github.com/rust-windowing/raw-window-handle).
 //!
 //! ## Surface
 //!
-//! // DOC TODO
+//! Once you have a window handle, you need to [create a surface][crate::Instance::create_surface]
+//! compatible with the [instance][crate::Instance] of the graphics API you currently use.
 //!
 //! ## Swapchain
 //!


### PR DESCRIPTION
This PR improves the docs for various components of the public API. I also improved the crate-level documentation to give an overview of the device initialization flow.

The objective for me was to document everything on the "critical path". This means every item someone with no prior `gfx-hal` or Vulkan experience would require in order to do something simple, such as [rendering a triangle on screen](https://www.falseidolfactory.com/2020/04/01/intro-to-gfx-hal-part-1-drawing-a-triangle.html).