### PR TITLE
Remove `CommandBufferFlags::EMPTY`

### DIFF
--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -44,10 +44,6 @@ bitflags! {
     /// Option flags for various command buffer settings.
     #[derive(Default)]
     pub struct CommandBufferFlags: u32 {
-        // TODO: Remove once 'const fn' is stabilized: https://github.com/rust-lang/rust/issues/24111
-        /// No flags.
-        const EMPTY = 0x0;
-
         /// Says that the command buffer will be recorded, submitted only once, and then reset and re-filled
         /// for another submission.
         const ONE_TIME_SUBMIT = 0x1;


### PR DESCRIPTION
Fixes a `TODO` I've found in the code. `const fn CommandBufferFlags::empty()` can be used instead.

PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends:
  - [X] OpenGL
  - [X] Vulkan
- [X] `rustfmt` run on changed code
