### PR TITLE
Monocodus config

### DIFF
--- a/.monocodus
+++ b/.monocodus
@@ -1,0 +1,5 @@
+rust:
+  formatter:
+    name: rustfmt
+    ignore_paths:
+      - ".*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### backend-vulkan-0.5.4 (27-04-2020)
+  - gracefully detect when the driver supports it but hardware does not
+
+### backend-vulkan-0.5.3 (25-04-2020)
+  - switch to `VK_LAYER_KHRONOS_validation`
+
 ### backend-vulkan-0.5.2 (01-04-2020)
   - fix support for `AMD_NEGATIVE_VIEWPORT_HEIGHT`
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -351,11 +351,17 @@ impl hal::Instance<Backend> for Instance {
 
         let instance_extensions = entry
             .enumerate_instance_extension_properties()
-            .expect("Unable to enumerate instance extensions");
+            .map_err(|e| {
+                info!("Unable to enumerate instance extensions: {:?}", e);
+                hal::UnsupportedBackend
+            })?;
 
         let instance_layers = entry
             .enumerate_instance_layer_properties()
-            .expect("Unable to enumerate instance layers");
+            .map_err(|e| {
+                info!("Unable to enumerate instance layers: {:?}", e);
+                hal::UnsupportedBackend
+            })?;
 
         // Check our extensions against the available extensions
         let extensions = SURFACE_EXTENSIONS
@@ -369,7 +375,7 @@ impl hal::Instance<Backend> for Instance {
                     })
                     .map(|_| ext)
                     .or_else(|| {
-                        warn!("Unable to find extension: {}", ext.to_string_lossy());
+                        info!("Unable to find extension: {}", ext.to_string_lossy());
                         None
                     })
             })


### PR DESCRIPTION
Includes #3233
It's spammy right now. We should re-enable rustfmt spam after we format the code base and clear up the config.