### PR TITLE
WIP: Initial stub for mesh shaders

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1255,51 +1255,59 @@ impl<B: Backend> PipelineState<B> {
                     },
                 );
 
-                let shader_entries = pso::GraphicsShaderSet {
-                    vertex: vs_entry,
-                    hull: None,
-                    domain: None,
-                    geometry: None,
-                    fragment: Some(fs_entry),
-                };
-
                 let subpass = pass::Subpass {
                     index: 0,
                     main_pass: render_pass,
                 };
 
+                let vertex_buffers = vec![
+                    pso::VertexBufferDesc {
+                        binding: 0,
+                        stride: size_of::<Vertex>() as u32,
+                        rate: pso::VertexInputRate::Vertex,
+                    }
+                ];
+
+                let attributes = vec![
+                    pso::AttributeDesc {
+                        location: 0,
+                        binding: 0,
+                        element: pso::Element {
+                            format: f::Format::Rg32Sfloat,
+                            offset: 0,
+                        },
+                    },
+                    pso::AttributeDesc {
+                        location: 1,
+                        binding: 0,
+                        element: pso::Element {
+                            format: f::Format::Rg32Sfloat,
+                            offset: 8,
+                        },
+                    },
+                ];
+
                 let mut pipeline_desc = pso::GraphicsPipelineDesc::new(
-                    shader_entries,
-                    pso::Primitive::TriangleList,
+                    pso::PrimitiveAssembler::Vertex {
+                        buffers: vertex_buffers,
+                        attributes,
+                        input_assembler: pso::InputAssemblerDesc {
+                            primitive: pso::Primitive::TriangleList,
+                            with_adjacency: false,
+                            restart_index: None,
+                        },
+                        vertex: vs_entry,
+                        geometry: None,
+                        tessellation: None,
+                    },
                     pso::Rasterizer::FILL,
+                    Some(fs_entry),
                     &pipeline_layout,
                     subpass,
                 );
                 pipeline_desc.blender.targets.push(pso::ColorBlendDesc {
                     mask: pso::ColorMask::ALL,
                     blend: Some(pso::BlendState::ALPHA),
-                });
-                pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
-                    binding: 0,
-                    stride: size_of::<Vertex>() as u32,
-                    rate: pso::VertexInputRate::Vertex,
-                });
-
-                pipeline_desc.attributes.push(pso::AttributeDesc {
-                    location: 0,
-                    binding: 0,
-                    element: pso::Element {
-                        format: f::Format::Rg32Sfloat,
-                        offset: 0,
-                    },
-                });
-                pipeline_desc.attributes.push(pso::AttributeDesc {
-                    location: 1,
-                    binding: 0,
-                    element: pso::Element {
-                        format: f::Format::Rg32Sfloat,
-                        offset: 8,
-                    },
                 });
 
                 device.create_graphics_pipeline(&pipeline_desc, None)

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -671,51 +671,60 @@ where
                     },
                 );
 
-                let shader_entries = pso::GraphicsShaderSet {
-                    vertex: vs_entry,
-                    hull: None,
-                    domain: None,
-                    geometry: None,
-                    fragment: Some(fs_entry),
-                };
-
                 let subpass = Subpass {
                     index: 0,
                     main_pass: &*render_pass,
                 };
 
+                let vertex_buffers = vec![
+                    pso::VertexBufferDesc {
+                        binding: 0,
+                        stride: mem::size_of::<Vertex>() as u32,
+                        rate: VertexInputRate::Vertex,
+                    },
+                ];
+
+                let attributes = vec![
+                    pso::AttributeDesc {
+                        location: 0,
+                        binding: 0,
+                        element: pso::Element {
+                            format: f::Format::Rg32Sfloat,
+                            offset: 0,
+                        },
+                    },
+                    pso::AttributeDesc {
+                        location: 1,
+                        binding: 0,
+                        element: pso::Element {
+                            format: f::Format::Rg32Sfloat,
+                            offset: 8,
+                        },
+                    },
+                ];
+
                 let mut pipeline_desc = pso::GraphicsPipelineDesc::new(
-                    shader_entries,
-                    pso::Primitive::TriangleList,
+                    pso::PrimitiveAssembler::Vertex {
+                        buffers: vertex_buffers,
+                        attributes,
+                        input_assembler: pso::InputAssemblerDesc {
+                            primitive: pso::Primitive::TriangleList,
+                            with_adjacency: false,
+                            restart_index: None,
+                        },
+                        vertex: vs_entry,
+                        geometry: None,
+                        tessellation: None,
+                    },
                     pso::Rasterizer::FILL,
+                    Some(fs_entry),
                     &*pipeline_layout,
                     subpass,
                 );
+
                 pipeline_desc.blender.targets.push(pso::ColorBlendDesc {
                     mask: pso::ColorMask::ALL,
                     blend: Some(pso::BlendState::ALPHA),
-                });
-                pipeline_desc.vertex_buffers.push(pso::VertexBufferDesc {
-                    binding: 0,
-                    stride: mem::size_of::<Vertex>() as u32,
-                    rate: VertexInputRate::Vertex,
-                });
-
-                pipeline_desc.attributes.push(pso::AttributeDesc {
-                    location: 0,
-                    binding: 0,
-                    element: pso::Element {
-                        format: f::Format::Rg32Sfloat,
-                        offset: 0,
-                    },
-                });
-                pipeline_desc.attributes.push(pso::AttributeDesc {
-                    location: 1,
-                    binding: 0,
-                    element: pso::Element {
-                        format: f::Format::Rg32Sfloat,
-                        offset: 8,
-                    },
                 });
 
                 unsafe { device.create_graphics_pipeline(&pipeline_desc, None) }

--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -785,6 +785,7 @@ pub fn map_stage(stage: Stage) -> spirv::ExecutionModel {
         Stage::Compute => spirv::ExecutionModel::GlCompute,
         Stage::Hull => spirv::ExecutionModel::TessellationControl,
         Stage::Domain => spirv::ExecutionModel::TessellationEvaluation,
+        Stage::Task | Stage::Mesh => panic!("{:?} shader is not supported in DirectX 11", stage),
     }
 }
 

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -41,6 +41,7 @@ use hal::{
     Limits,
     VertexCount,
     VertexOffset,
+    TaskCount,
     WorkGroupCount,
 };
 
@@ -782,12 +783,12 @@ impl window::Surface<Backend> for Surface {
         window::SurfaceCapabilities {
             present_modes: window::PresentMode::FIFO, //TODO
             composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
-            image_count: 1 ..= 16,                    // TODO:
+            image_count: 1..=16,                    // TODO:
             current_extent,
             extents: window::Extent2D {
                 width: 16,
                 height: 16,
-            } ..= window::Extent2D {
+            }..=window::Extent2D {
                 width: 4096,
                 height: 4096,
             },
@@ -2224,6 +2225,32 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _offset: buffer::Offset,
         _draw_count: DrawCount,
         _stride: u32,
+    ) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks(&mut self, _: TaskCount, _: TaskCount) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks_indirect(
+        &mut self,
+        _: &Buffer,
+        _: buffer::Offset,
+        _: hal::DrawCount,
+        _: u32,
+    ) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks_indirect_count(
+        &mut self,
+        _: &Buffer,
+        _: buffer::Offset,
+        _: &Buffer,
+        _: buffer::Offset,
+        _: hal::DrawCount,
+        _: u32,
     ) {
         unimplemented!()
     }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -16,6 +16,7 @@ use hal::{
     InstanceCount,
     VertexCount,
     VertexOffset,
+    TaskCount,
     WorkGroupCount,
 };
 
@@ -2508,6 +2509,32 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             ptr::null_mut(),
             0,
         );
+    }
+
+    unsafe fn draw_mesh_tasks(&mut self, _: TaskCount, _: TaskCount) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks_indirect(
+        &mut self,
+        _: &r::Buffer,
+        _: buffer::Offset,
+        _: hal::DrawCount,
+        _: u32,
+    ) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks_indirect_count(
+        &mut self,
+        _: &r::Buffer,
+        _: buffer::Offset,
+        _: &r::Buffer,
+        _: buffer::Offset,
+        _: DrawCount,
+        _: u32,
+    ) {
+        unimplemented!()
     }
 
     unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -641,5 +641,6 @@ pub fn map_stage(stage: pso::Stage) -> spirv::ExecutionModel {
         pso::Stage::Compute => spirv::ExecutionModel::GlCompute,
         pso::Stage::Hull => spirv::ExecutionModel::TessellationControl,
         pso::Stage::Domain => spirv::ExecutionModel::TessellationEvaluation,
+        pso::Stage::Task | pso::Stage::Mesh => panic!("{:?} shader is not yet implemented in SPIRV-Cross", stage),
     }
 }

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -84,12 +84,12 @@ impl w::Surface<Backend> for Surface {
         w::SurfaceCapabilities {
             present_modes: w::PresentMode::FIFO,                  //TODO
             composite_alpha_modes: w::CompositeAlphaMode::OPAQUE, //TODO
-            image_count: 2 ..= dxgi::DXGI_MAX_SWAP_CHAIN_BUFFERS,
+            image_count: 2..=16, // we currently use a flip effect which supports 2..=16 buffers
             current_extent,
             extents: w::Extent2D {
                 width: 16,
                 height: 16,
-            } ..= w::Extent2D {
+            }..=w::Extent2D {
                 width: 4096,
                 height: 4096,
             },

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -849,6 +849,32 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         panic!(DO_NOT_USE_MESSAGE)
     }
 
+    unsafe fn draw_mesh_tasks(&mut self, _: u32, _: u32) {
+        panic!(DO_NOT_USE_MESSAGE)
+    }
+
+    unsafe fn draw_mesh_tasks_indirect(
+        &mut self,
+        _: &(),
+        _: buffer::Offset,
+        _: hal::DrawCount,
+        _: u32,
+    ) {
+        panic!(DO_NOT_USE_MESSAGE)
+    }
+
+    unsafe fn draw_mesh_tasks_indirect_count(
+        &mut self,
+        _: &(),
+        _: buffer::Offset,
+        _: &(),
+        _: buffer::Offset,
+        _: u32,
+        _: u32,
+    ) {
+        panic!(DO_NOT_USE_MESSAGE)
+    }
+
     unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {
         panic!(DO_NOT_USE_MESSAGE)
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1484,6 +1484,31 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
+    unsafe fn draw_mesh_tasks(&mut self, _: u32, _: u32) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks_indirect(
+        &mut self,
+        _: &n::Buffer,
+        _: buffer::Offset,
+        _: hal::DrawCount,
+        _: u32,
+    ) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks_indirect_count(
+        &mut self,
+        _: &n::Buffer,
+        _: buffer::Offset,
+        _: &n::Buffer,
+        _: buffer::Offset,
+        _: u32,
+        _: u32,
+    ) {
+        unimplemented!()
+    }
     unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {
         unimplemented!()
     }

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -5,8 +5,17 @@ use glow::HasContext;
 use smallvec::SmallVec;
 
 use crate::{
-    command as com, device, info::LegacyFeatures, native, state, Backend, GlContext, Share, Starc,
-    Surface, Swapchain,
+    command as com,
+    device,
+    info::LegacyFeatures,
+    native,
+    state,
+    Backend,
+    GlContext,
+    Share,
+    Starc,
+    Surface,
+    Swapchain,
 };
 
 // State caching system for command queue.
@@ -316,8 +325,9 @@ impl CommandQueue {
             let viewports: SmallVec<[[f32; 4]; 16]> = (0..self.state.num_viewports)
                 .map(|_| [0.0, 0.0, 0.0, 0.0])
                 .collect();
-            let depth_ranges: SmallVec<[[f64; 2]; 16]> =
-                (0..self.state.num_viewports).map(|_| [0.0, 0.0]).collect();
+            let depth_ranges: SmallVec<[[f64; 2]; 16]> = (0..self.state.num_viewports)
+                .map(|_| [0.0, 0.0])
+                .collect();
             unsafe {
                 gl.viewport_f32_slice(0, viewports.len() as i32, &viewports);
                 gl.depth_range_f64_slice(0, depth_ranges.len() as i32, &depth_ranges);
@@ -329,8 +339,9 @@ impl CommandQueue {
             unsafe { gl.scissor(0, 0, 0, 0) };
         } else if self.state.num_scissors > 1 {
             // 16 viewports is a common limit set in drivers.
-            let scissors: SmallVec<[[i32; 4]; 16]> =
-                (0..self.state.num_scissors).map(|_| [0, 0, 0, 0]).collect();
+            let scissors: SmallVec<[[i32; 4]; 16]> = (0..self.state.num_scissors)
+                .map(|_| [0, 0, 0, 0])
+                .collect();
             unsafe { gl.scissor_slice(0, scissors.len() as i32, scissors.as_slice()) };
         }
     }
@@ -890,7 +901,7 @@ impl CommandQueue {
             },
             com::Command::BindPixelTargets(pts) => {
             let point = gl::DRAW_FRAMEBUFFER;
-            for i in 0 .. hal::MAX_COLOR_TARGETS {
+            for i in 0..hal::MAX_COLOR_TARGETS {
             let att = gl::COLOR_ATTACHMENT0 + i as gl::types::GLuint;
             if let Some(ref target) = pts.colors[i] {
             self.bind_target(point, att, target);
@@ -911,7 +922,10 @@ impl CommandQueue {
             com::Command::UnbindAttribute(slot) => unsafe {
             self.share.context.DisableVertexAttribArray(slot as gl::types::GLuint);
             },*/
-            com::Command::BindUniform { ref uniform, buffer } => {
+            com::Command::BindUniform {
+                ref uniform,
+                buffer,
+            } => {
                 let gl = &self.share.context;
 
                 unsafe {
@@ -956,15 +970,27 @@ impl CommandQueue {
                         }
                         glow::FLOAT_MAT2 => {
                             let data = Self::get::<[f32; 4]>(data_buf, buffer)[0];
-                            gl.uniform_matrix_2_f32_slice(Some((*uniform.location).clone()), false, &data);
+                            gl.uniform_matrix_2_f32_slice(
+                                Some((*uniform.location).clone()),
+                                false,
+                                &data,
+                            );
                         }
                         glow::FLOAT_MAT3 => {
                             let data = Self::get::<[f32; 9]>(data_buf, buffer)[0];
-                            gl.uniform_matrix_3_f32_slice(Some((*uniform.location).clone()), false, &data);
+                            gl.uniform_matrix_3_f32_slice(
+                                Some((*uniform.location).clone()),
+                                false,
+                                &data,
+                            );
                         }
                         glow::FLOAT_MAT4 => {
                             let data = Self::get::<[f32; 16]>(data_buf, buffer)[0];
-                            gl.uniform_matrix_4_f32_slice(Some((*uniform.location).clone()), false, &data);
+                            gl.uniform_matrix_4_f32_slice(
+                                Some((*uniform.location).clone()),
+                                false,
+                                &data,
+                            );
                         }
                         _ => panic!("Unsupported uniform datatype!"),
                     }

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -83,9 +83,9 @@ impl window::Surface<B> for Surface {
         window::SurfaceCapabilities {
             present_modes: window::PresentMode::FIFO, //TODO
             composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
-            image_count: 1 ..= 1,
+            image_count: 1..=1,
             current_extent: Some(extent),
-            extents: extent ..= extent,
+            extents: extent..=extent,
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
         }

--- a/src/backend/gl/src/window/wgl.rs
+++ b/src/backend/gl/src/window/wgl.rs
@@ -246,9 +246,9 @@ impl window::Surface<Backend> for Surface {
         window::SurfaceCapabilities {
             present_modes: window::PresentMode::FIFO, //TODO
             composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
-            image_count: 2 ..= 2,
+            image_count: 2..=2,
             current_extent: Some(extent),
-            extents: extent ..= extent,
+            extents: extent..=extent,
             max_image_layers: 1,
             usage: image::Usage::COLOR_ATTACHMENT | image::Usage::TRANSFER_SRC,
         }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -35,6 +35,7 @@ use hal::{
     InstanceCount,
     VertexCount,
     VertexOffset,
+    TaskCount,
     WorkGroupCount,
 };
 
@@ -4426,6 +4427,32 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             .issue_many(commands);
     }
 
+    unsafe fn draw_mesh_tasks(&mut self, _: TaskCount, _: TaskCount) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks_indirect(
+        &mut self,
+        _: &native::Buffer,
+        _: buffer::Offset,
+        _: DrawCount,
+        _: u32,
+    ) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks_indirect_count(
+        &mut self,
+        _: &native::Buffer,
+        _: buffer::Offset,
+        _: &native::Buffer,
+        _: buffer::Offset,
+        _: u32,
+        _: u32,
+    ) {
+        unimplemented!()
+    }
+
     unsafe fn set_event(&mut self, event: &native::Event, _: pso::PipelineStage) {
         self.inner
             .borrow_mut()
@@ -4652,7 +4679,10 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                     range: start .. end,
                     value: 0,
                 };
-                self.inner.borrow_mut().sink().blit_commands(iter::once(command));
+                self.inner
+                    .borrow_mut()
+                    .sink()
+                    .blit_commands(iter::once(command));
             }
         }
     }

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -994,7 +994,7 @@ impl PrivateCapabilities {
                 &[
                     MTLFeatureSet::iOS_GPUFamily4_v2,
                     MTLFeatureSet::iOS_GPUFamily5_v1,
-                ]
+                ],
             ) {
                 64 << 10
             } else if Self::supports_any(
@@ -1003,7 +1003,7 @@ impl PrivateCapabilities {
                     MTLFeatureSet::iOS_GPUFamily4_v1,
                     MTLFeatureSet::macOS_GPUFamily1_v2,
                     MTLFeatureSet::macOS_GPUFamily2_v1,
-                ]
+                ],
             ) {
                 32 << 10
             } else {

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -421,17 +421,17 @@ impl w::Surface<Backend> for Surface {
             composite_alpha_modes: w::CompositeAlphaMode::OPAQUE, //TODO
             //Note: this is hardcoded in `CAMetalLayer` documentation
             image_count: if can_set_maximum_drawables_count {
-                2 ..= 3
+                2..=3
             } else {
                 // 3 is the default in `CAMetalLayer` documentation
                 // iOS 10.3 was tested to use 3 on iphone5s
-                3 ..= 3
+                3..=3
             },
             current_extent,
             extents: w::Extent2D {
                 width: 4,
                 height: 4,
-            } ..= w::Extent2D {
+            }..=w::Extent2D {
                 width: 4096,
                 height: 4096,
             },

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -21,6 +21,7 @@ use hal::{
     InstanceCount,
     VertexCount,
     VertexOffset,
+    TaskCount,
     WorkGroupCount,
 };
 
@@ -219,7 +220,10 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             p_inheritance_info: &inheritance_info,
         };
 
-        assert_eq!(Ok(()), self.device.raw.begin_command_buffer(self.raw, &info));
+        assert_eq!(
+            Ok(()),
+            self.device.raw.begin_command_buffer(self.raw, &info)
+        );
     }
 
     unsafe fn finish(&mut self) {
@@ -233,7 +237,10 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             vk::CommandBufferResetFlags::empty()
         };
 
-        assert_eq!(Ok(()), self.device.raw.reset_command_buffer(self.raw, flags));
+        assert_eq!(
+            Ok(()),
+            self.device.raw.reset_command_buffer(self.raw, flags)
+        );
     }
 
     unsafe fn begin_render_pass<T>(
@@ -827,6 +834,32 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         self.device
             .raw
             .cmd_draw_indexed_indirect(self.raw, buffer.raw, offset, draw_count, stride)
+    }
+
+    unsafe fn draw_mesh_tasks(&mut self, _: TaskCount, _: TaskCount) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks_indirect(
+        &mut self,
+        _: &n::Buffer,
+        _: buffer::Offset,
+        _: hal::DrawCount,
+        _: u32,
+    ) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_mesh_tasks_indirect_count(
+        &mut self,
+        _: &n::Buffer,
+        _: buffer::Offset,
+        _: &n::Buffer,
+        _: buffer::Offset,
+        _: u32,
+        _: u32,
+    ) {
+        unimplemented!()
     }
 
     unsafe fn set_event(&mut self, event: &n::Event, stage_mask: pso::PipelineStage) {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -356,12 +356,10 @@ impl hal::Instance<Backend> for Instance {
                 hal::UnsupportedBackend
             })?;
 
-        let instance_layers = entry
-            .enumerate_instance_layer_properties()
-            .map_err(|e| {
-                info!("Unable to enumerate instance layers: {:?}", e);
-                hal::UnsupportedBackend
-            })?;
+        let instance_layers = entry.enumerate_instance_layer_properties().map_err(|e| {
+            info!("Unable to enumerate instance layers: {:?}", e);
+            hal::UnsupportedBackend
+        })?;
 
         // Check our extensions against the available extensions
         let extensions = SURFACE_EXTENSIONS
@@ -669,7 +667,11 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             return Err(DeviceCreationError::MissingFeature);
         }
 
-        let maintenance_level = if self.supports_extension(*KHR_MAINTENANCE1) { 1 } else { 0 };
+        let maintenance_level = if self.supports_extension(*KHR_MAINTENANCE1) {
+            1
+        } else {
+            0
+        };
         let enabled_features = conv::map_device_features(requested_features);
         let enabled_extensions = DEVICE_EXTENSIONS
             .iter()
@@ -681,13 +683,11 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                     None
                 },
             )
-            .chain(
-                match maintenance_level {
-                    0 => None,
-                    1 => Some(*KHR_MAINTENANCE1),
-                    _ => unreachable!(),
-                }
-            );
+            .chain(match maintenance_level {
+                0 => None,
+                1 => Some(*KHR_MAINTENANCE1),
+                _ => unreachable!(),
+            });
 
         // Create device
         let device_raw = {
@@ -1190,6 +1190,21 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             max_uniform_buffer_range: limits.max_uniform_buffer_range as _,
             min_memory_map_alignment: limits.min_memory_map_alignment,
             standard_sample_locations: limits.standard_sample_locations == ash::vk::TRUE,
+
+            // TODO: Implement Limits for Mesh Shaders
+            max_draw_mesh_tasks_count: 0,
+            max_task_work_group_invocations: 0,
+            max_task_work_group_size: [0; 3],
+            max_task_total_memory_size: 0,
+            max_task_output_count: 0,
+            max_mesh_work_group_invocations: 0,
+            max_mesh_work_group_size: [0; 3],
+            max_mesh_total_memory_size: 0,
+            max_mesh_output_vertices: 0,
+            max_mesh_output_primitives: 0,
+            max_mesh_multiview_view_count: 0,
+            mesh_output_per_vertex_granularity: 0,
+            mesh_output_per_primitive_granularity: 0,
         }
     }
 

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -147,12 +147,13 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
                 )
             })
             .map_err(|err| match err {
-                vk::Result::ERROR_OUT_OF_HOST_MEMORY =>
-                    pso::AllocationError::OutOfMemory(OutOfMemory::Host),
-                vk::Result::ERROR_OUT_OF_DEVICE_MEMORY =>
-                    pso::AllocationError::OutOfMemory(OutOfMemory::Device),
-                vk::Result::ERROR_OUT_OF_POOL_MEMORY =>
-                    pso::AllocationError::OutOfPoolMemory,
+                vk::Result::ERROR_OUT_OF_HOST_MEMORY => {
+                    pso::AllocationError::OutOfMemory(OutOfMemory::Host)
+                }
+                vk::Result::ERROR_OUT_OF_DEVICE_MEMORY => {
+                    pso::AllocationError::OutOfMemory(OutOfMemory::Device)
+                }
+                vk::Result::ERROR_OUT_OF_POOL_MEMORY => pso::AllocationError::OutOfPoolMemory,
                 _ => pso::AllocationError::FragmentedPool,
             })
     }

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -392,9 +392,9 @@ impl w::Surface<Backend> for Surface {
                     u | conv::map_vk_present_mode(m)
                 }),
             composite_alpha_modes: conv::map_vk_composite_alpha(caps.supported_composite_alpha),
-            image_count: caps.min_image_count ..= max_images,
+            image_count: caps.min_image_count..=max_images,
             current_extent,
-            extents: min_extent ..= max_extent,
+            extents: min_extent..=max_extent,
             max_image_layers: caps.max_image_array_layers as _,
             usage: conv::map_vk_image_usage(caps.supported_usage_flags),
         }

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -31,6 +31,7 @@ use crate::{
     InstanceCount,
     VertexCount,
     VertexOffset,
+    TaskCount,
     WorkGroupCount,
 };
 
@@ -474,6 +475,32 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         buffer: &B::Buffer,
         offset: buffer::Offset,
         draw_count: DrawCount,
+        stride: u32,
+    );
+
+    /// Dispatches `task_count` of threads. Similar to compute dispatch.
+    unsafe fn draw_mesh_tasks(&mut self, task_count: TaskCount, first_task: TaskCount);
+
+    /// Indirect version of `draw_mesh_tasks`. Analogous to `draw_indirect`, but for mesh shaders.
+    unsafe fn draw_mesh_tasks_indirect(
+        &mut self,
+        buffer: &B::Buffer,
+        offset: buffer::Offset,
+        draw_count: DrawCount,
+        stride: u32,
+    );
+
+    /// Like `draw_mesh_tasks_indirect` except that the draw count is read by
+    /// the device from a buffer during execution. The command will read an
+    /// unsigned 32-bit integer from `count_buffer` located at `count_buffer_offset`
+    /// and use this as the draw count.
+    unsafe fn draw_mesh_tasks_indirect_count(
+        &mut self,
+        buffer: &B::Buffer,
+        offset: buffer::Offset,
+        count_buffer: &B::Buffer,
+        count_buffer_offset: buffer::Offset,
+        max_draw_count: DrawCount,
         stride: u32,
     );
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -90,6 +90,8 @@ pub type InstanceCount = u32;
 pub type DrawCount = u32;
 /// Number of work groups.
 pub type WorkGroupCount = [u32; 3];
+/// Number of tasks.
+pub type TaskCount = u32;
 
 bitflags! {
     //TODO: add a feature for non-normalized samplers
@@ -240,6 +242,11 @@ bitflags! {
 
         /// Make the NDC coordinate system pointing Y up, to match D3D and Metal.
         const NDC_Y_UP = 0x01 << 80;
+
+        /// Supports task shader stage.
+        const TASK_SHADER = 0x01 << 96;
+        /// Supports mesh shader stage.
+        const MESH_SHADER = 0x02 << 96;
     }
 }
 
@@ -402,6 +409,45 @@ pub struct Limits {
 
     /// The alignment of the vertex buffer stride.
     pub min_vertex_input_binding_stride_alignment: buffer::Offset,
+
+    /// The maximum number of local workgroups that can be launched by a single draw mesh tasks command
+    pub max_draw_mesh_tasks_count: u32,
+    /// The maximum total number of task shader invocations in a single local workgroup. The product of the X, Y, and
+    /// Z sizes, as specified by the LocalSize execution mode in shader modules or by the object decorated by the
+    /// WorkgroupSize decoration, must be less than or equal to this limit.
+    pub max_task_work_group_invocations: u32,
+    /// The maximum size of a local task workgroup. These three values represent the maximum local workgroup size in
+    /// the X, Y, and Z dimensions, respectively. The x, y, and z sizes, as specified by the LocalSize execution mode
+    /// or by the object decorated by the WorkgroupSize decoration in shader modules, must be less than or equal to
+    /// the corresponding limit.
+    pub max_task_work_group_size: [u32; 3],
+    /// The maximum number of bytes that the task shader can use in total for shared and output memory combined.
+    pub max_task_total_memory_size: u32,
+    /// The maximum number of output tasks a single task shader workgroup can emit.
+    pub max_task_output_count: u32,
+    /// The maximum total number of mesh shader invocations in a single local workgroup. The product of the X, Y, and
+    /// Z sizes, as specified by the LocalSize execution mode in shader modules or by the object decorated by the
+    /// WorkgroupSize decoration, must be less than or equal to this limit.
+    pub max_mesh_work_group_invocations: u32,
+    /// The maximum size of a local mesh workgroup. These three values represent the maximum local workgroup size in
+    /// the X, Y, and Z dimensions, respectively. The x, y, and z sizes, as specified by the LocalSize execution mode
+    /// or by the object decorated by the WorkgroupSize decoration in shader modules, must be less than or equal to the
+    /// corresponding limit.
+    pub max_mesh_work_group_size: [u32; 3],
+    /// The maximum number of bytes that the mesh shader can use in total for shared and output memory combined.
+    pub max_mesh_total_memory_size: u32,
+    /// The maximum number of vertices a mesh shader output can store.
+    pub max_mesh_output_vertices: u32,
+    /// The maximum number of primitives a mesh shader output can store.
+    pub max_mesh_output_primitives: u32,
+    /// The maximum number of multi-view views a mesh shader can use.
+    pub max_mesh_multiview_view_count: u32,
+    /// The granularity with which mesh vertex outputs are allocated. The value can be used to compute the memory size
+    /// used by the mesh shader, which must be less than or equal to maxMeshTotalMemorySize.
+    pub mesh_output_per_vertex_granularity: u32,
+    /// The granularity with which mesh outputs qualified as per-primitive are allocated. The value can be used to
+    /// compute the memory size used by the mesh shader, which must be less than or equal to
+    pub mesh_output_per_primitive_granularity: u32,
 }
 
 /// An enum describing the type of an index value in a slice's index buffer

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -4,7 +4,7 @@ use crate::{
     image,
     pass,
     pso::{
-        input_assembler::{AttributeDesc, InputAssemblerDesc, Primitive, VertexBufferDesc},
+        input_assembler::{AttributeDesc, InputAssemblerDesc, VertexBufferDesc},
         output_merger::{ColorBlendDesc, DepthStencilDesc, Face},
         BasePipeline,
         EntryPoint,
@@ -56,38 +56,6 @@ pub type ColorValue = [f32; 4];
 pub type DepthValue = f32;
 /// A single value from a stencil buffer.
 pub type StencilValue = u32;
-
-/// A complete set of shaders to build a graphics pipeline.
-///
-/// All except the vertex shader are optional; omitting them
-/// passes through the inputs without change.
-///
-/// If a fragment shader is omitted, the results of fragment
-/// processing are undefined. Specifically, any fragment color
-/// outputs are considered to have undefined values, and the
-/// fragment depth is considered to be unmodified. This can
-/// be useful for depth-only rendering.
-#[derive(Clone, Debug)]
-pub struct GraphicsShaderSet<'a, B: Backend> {
-    /// A shader that outputs a vertex in a model.
-    pub vertex: EntryPoint<'a, B>,
-    /// A hull shader takes in an input patch (values representing
-    /// a small portion of a shape, which may be actual geometry or may
-    /// be parameters for creating geometry) and produces one or more
-    /// output patches.
-    pub hull: Option<EntryPoint<'a, B>>,
-    /// A shader that takes in domains produced from a hull shader's output
-    /// patches and computes actual vertex positions.
-    pub domain: Option<EntryPoint<'a, B>>,
-    /// A shader that takes given input vertexes and outputs zero
-    /// or more output vertexes.
-    pub geometry: Option<EntryPoint<'a, B>>,
-    /// A shader that outputs a value for a fragment.
-    /// Usually this value is a color that is then displayed as a
-    /// pixel on a screen.
-    pub fragment: Option<EntryPoint<'a, B>>,
-}
-
 /// Baked-in pipeline states.
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -101,22 +69,63 @@ pub struct BakedStates {
     /// Static depth bounds.
     pub depth_bounds: Option<Range<f32>>,
 }
-
+#[derive(Debug)]
+/// Primitive Assembler describes how input data are fetched in the pipeline and formed into primitives before being sent into the fragment shader.
+pub enum PrimitiveAssembler<'a, B: Backend> {
+    /// Vertex based pipeline
+    Vertex {
+        /// Vertex buffers (IA)
+        buffers: Vec<VertexBufferDesc>,
+        /// Vertex attributes (IA)
+        attributes: Vec<AttributeDesc>,
+        /// Input assembler attributes, describes how
+        /// vertices are assembled into primitives (such as triangles).
+        input_assembler: InputAssemblerDesc,
+        /// A shader that outputs a vertex in a model.
+        vertex: EntryPoint<'a, B>,
+        /// Tesselation shaders consisting of:
+        ///
+        /// 1. Hull shader: takes in an input patch (values representing
+        /// a small portion of a shape, which may be actual geometry or may
+        /// be parameters for creating geometry) and produces one or more
+        /// output patches.
+        ///
+        /// 2. Domain shader: takes in domains produced from a hull shader's output
+        /// patches and computes actual vertex positions.
+        tessellation: Option<(EntryPoint<'a, B>, EntryPoint<'a, B>)>,
+        /// A shader that takes given input vertexes and outputs zero
+        /// or more output vertexes.
+        geometry: Option<EntryPoint<'a, B>>,
+    },
+    /// Mesh shading pipeline
+    Mesh {
+        /// A shader that creates a variable amount of mesh shader
+        /// invocations.
+        task: Option<EntryPoint<'a, B>>,
+        /// A shader of which each workgroup emits zero or
+        /// more output primitives and the group of vertices and their
+        /// associated data required for each output primitive.
+        mesh: EntryPoint<'a, B>,
+    },
+}
 /// A description of all the settings that can be altered
 /// when creating a graphics pipeline.
 #[derive(Debug)]
 pub struct GraphicsPipelineDesc<'a, B: Backend> {
-    /// A set of graphics shaders to use for the pipeline.
-    pub shaders: GraphicsShaderSet<'a, B>,
+    /// Primitive assembler
+    pub primitive_assembler: PrimitiveAssembler<'a, B>,
     /// Rasterizer setup
     pub rasterizer: Rasterizer,
-    /// Vertex buffers (IA)
-    pub vertex_buffers: Vec<VertexBufferDesc>,
-    /// Vertex attributes (IA)
-    pub attributes: Vec<AttributeDesc>,
-    /// Input assembler attributes, describes how
-    /// vertices are assembled into primitives (such as triangles).
-    pub input_assembler: InputAssemblerDesc,
+    /// A shader that outputs a value for a fragment.
+    /// Usually this value is a color that is then displayed as a
+    /// pixel on a screen.
+    ///
+    /// If a fragment shader is omitted, the results of fragment
+    /// processing are undefined. Specifically, any fragment color
+    /// outputs are considered to have undefined values, and the
+    /// fragment depth is considered to be unmodified. This can
+    /// be useful for depth-only rendering.
+    pub fragment: Option<EntryPoint<'a, B>>,
     /// Description of how blend operations should be performed.
     pub blender: BlendDesc,
     /// Depth stencil (DSV)
@@ -139,18 +148,16 @@ pub struct GraphicsPipelineDesc<'a, B: Backend> {
 impl<'a, B: Backend> GraphicsPipelineDesc<'a, B> {
     /// Create a new empty PSO descriptor.
     pub fn new(
-        shaders: GraphicsShaderSet<'a, B>,
-        primitive: Primitive,
+        primitive_assembler: PrimitiveAssembler<'a, B>,
         rasterizer: Rasterizer,
+        fragment: Option<EntryPoint<'a, B>>,
         layout: &'a B::PipelineLayout,
         subpass: pass::Subpass<'a, B>,
     ) -> Self {
         GraphicsPipelineDesc {
-            shaders,
-            rasterizer,
-            vertex_buffers: Vec::new(),
-            attributes: Vec::new(),
-            input_assembler: InputAssemblerDesc::new(primitive),
+            primitive_assembler,
+            rasterizer,            
+            fragment,
             blender: BlendDesc::default(),
             depth_stencil: DepthStencilDesc::default(),
             multisampling: None,

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -910,8 +910,21 @@ impl<B: hal::Backend> Scene<B> {
                             })
                         }
                     };
+
+                    let hs = entry(&shaders.hull);
+                    let ds = entry(&shaders.domain);
+                    let tessellation = if hs.is_some() && ds.is_some() {
+                        Some((hs.unwrap(), ds.unwrap()))
+                    } else {
+                        None
+                    };
+
                     let desc = pso::GraphicsPipelineDesc {
-                        shaders: pso::GraphicsShaderSet {
+                        rasterizer: rasterizer.clone(),
+                        primitive_assembler: pso::PrimitiveAssembler::Vertex {
+                            buffers: vertex_buffers.clone(),
+                            attributes: attributes.clone(),
+                            input_assembler: input_assembler.clone(),
                             vertex: pso::EntryPoint {
                                 entry: "main",
                                 module: reshaders
@@ -919,15 +932,10 @@ impl<B: hal::Backend> Scene<B> {
                                     .expect(&format!("Missing vertex shader: {}", shaders.vertex)),
                                 specialization: pso::Specialization::default(),
                             },
-                            hull: entry(&shaders.hull),
-                            domain: entry(&shaders.domain),
+                            tessellation,
                             geometry: entry(&shaders.geometry),
-                            fragment: entry(&shaders.fragment),
                         },
-                        rasterizer: rasterizer.clone(),
-                        vertex_buffers: vertex_buffers.clone(),
-                        attributes: attributes.clone(),
-                        input_assembler: input_assembler.clone(),
+                        fragment: entry(&shaders.fragment),
                         blender: blender.clone(),
                         depth_stencil: depth_stencil.clone(),
                         baked_states: pso::BakedStates::default(), //TODO


### PR DESCRIPTION
This is my attempt at adding support for mesh shaders. 

This (first) PR only stubs the API. From my investigation, the extension is relatively simple(it effectively only adds new shaders and 3 draw commands mirroring the original ones) and seems to be the same across Direct3D and Vulkan. 

Even though the Vulkan only has NV extension so far, based on announcements of RDNA2 and DirectX Ultimate we can expect KHR version and I don't see how it could diverge in any way. Thus, both Vulkan and DX12 implementations should be trivial.

I know nothing about Metal and I am not aware of information about support for mesh shaders. At worst, they could be emulated using compute shaders but It would probably be so slow that It would be practically worthless.

Tasks:
- [x] Stub the API
- [x] Implement empty backend
- [x] Implement non-functional Vulkan backend
- [x] Implement non-functional DirectX 12 backend
- [x] Implement non-functional DirectX 11 backend
- [x] Implement non-functional Metal backend
- [x] Implement non-functional OpenGL backend
- [x] Fix examples compilation errors
- [x] Fix warden compilation errors

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends
  - [x] DX12
  - [x] Vulkan
  - [x] OpenGL
  - [ ] Metal (have no way of testing)
- [x] `rustfmt` run on changed code

Resources:
[Vulkan specification of mesh shaders](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/chap46.html#VK_NV_mesh_shader)
[DirectX specification of mesh shader](https://microsoft.github.io/DirectX-Specs/d3d/MeshShader.html)
