### PR TITLE
d3d12: Fix offset calculation for root descriptors that was causing root signature data to be overwritten

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -143,7 +143,8 @@ impl UserData {
         }
     }
 
-    /// Update root constant values. Changes are marked as dirty.
+    /// Write root constant values into the user data, overwriting virtual memory
+    /// range [offset..offset + data.len()]. Changes are marked as dirty.
     fn set_constants(&mut self, offset: usize, data: &[u32]) {
         assert!(offset + data.len() <= ROOT_SIGNATURE_SIZE);
         // Each root constant occupies one DWORD
@@ -153,7 +154,8 @@ impl UserData {
         }
     }
 
-    /// Update descriptor table. Changes are marked as dirty.
+    /// Write a SRV/CBV/UAV descriptor table into the user data, overwriting virtual
+    /// memory range [offset..offset + 1]. Changes are marked as dirty.
     fn set_srv_cbv_uav_table(&mut self, offset: usize, table_start: u32) {
         assert!(offset < ROOT_SIGNATURE_SIZE);
         // A descriptor table occupies one DWORD
@@ -161,7 +163,8 @@ impl UserData {
         self.dirty_mask |= 1u64 << offset;
     }
 
-    /// Update descriptor table. Changes are marked as dirty.
+    /// Write a sampler descriptor table into the user data, overwriting virtual
+    /// memory range [offset..offset + 1]. Changes are marked as dirty.
     fn set_sampler_table(&mut self, offset: usize, table_start: u32) {
         assert!(offset < ROOT_SIGNATURE_SIZE);
         // A descriptor table occupies one DWORD
@@ -169,13 +172,15 @@ impl UserData {
         self.dirty_mask |= 1u64 << offset;
     }
 
-    ///
+    /// Write a CBV root descriptor into the user data, overwriting virtual
+    /// memory range [offset..offset + 2]. Changes are marked as dirty.
     fn set_descriptor_cbv(&mut self, offset: usize, buffer: u64) {
         assert!(offset + 1 < ROOT_SIGNATURE_SIZE);
+        // A root descriptor occupies two DWORDs
         self.data[offset] = RootElement::DescriptorCbv { buffer };
         self.data[offset + 1] = RootElement::DescriptorPlaceholder;
-        self.dirty_mask |= 0b1u64 << offset;
-        self.dirty_mask |= 0b1u64 << offset + 1;
+        self.dirty_mask |= 1u64 << offset;
+        self.dirty_mask |= 1u64 << offset + 1;
     }
 
     fn is_dirty(&self) -> bool {


### PR DESCRIPTION
Fixes #3243

Root descriptors were always given offset 0, regardless of any other descriptors that were present. This caused whatever user data that was at offset 0 and 1 to get overwritten (in my case, it was a SRV descriptor with an image, then a sampler descriptor, resulting in no image being rendered). 

`bind_descriptor_sets` expects a certain ordering for the descriptors within each set: 
SRV/CBV/UAV descriptors, in one table
Sampler descriptors, in one table
Root descriptors

`create_pipeline_layout` didn't follow this contract (looks like it was meant to, though), resulting in the offset mixup. I just re-arranged it a bit to ensure that tables are added first, so that the `root_offset` was correct by the end of the method and the `RootDescriptor` could be created with it.

I also touched up some documentation, hope that is ok. I am new to directx, did a lot of digging in the [documentation ](https://docs.microsoft.com/en-us/windows/win32/direct3d12/example-root-signatures) but it's possible I screwed something up big time here. Let me know.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: `quad`, `compute` on directX. Although these don't use dynamic descriptor sets, so I have just been using my own game project as a test bed.
- [ ] `rustfmt` run on changed code (I did this and it changed a ton of already existing formatting, is this still desired?)
