### PR TITLE
[mtl] fix panic with fill_buffer when using offset and size

### DIFF
--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2625,7 +2625,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
 
         let end = sub.size.map_or(base_range.end, |s| {
             assert_eq!(s % WORD_ALIGNMENT, 0);
-            base_range.start + s
+            start + s
         });
 
         if (data & 0xFF) * 0x0101_0101 == data {


### PR DESCRIPTION
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] ~tested examples with the following backends:~ no examples use CommandBuffer::fill_buffer
- [ ] `rustfmt` run on changed code
