### PR TITLE
[0.5] Update spirv-cross to version 0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx11-0.5.1, backend-dx12-0.5.3, backend-gl-0.5.1, backend-metal-0.5.2 (05-06-2020)
+  - update spirv_cross to 0.20
+
 ### backend-dx12-0.5.2 (05-04-2020)
   - fix offset calculation for root descriptors
 

--- a/src/auxil/auxil/Cargo.toml
+++ b/src/auxil/auxil/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 hal = { path = "../../hal", version = "0.5", package = "gfx-hal" }
 fxhash = "0.2.1"
-spirv_cross = { version = "0.18", optional = true }
+spirv_cross = { version = "0.20", optional = true }
 
 [lib]
 name = "gfx_auxil"

--- a/src/auxil/auxil/Cargo.toml
+++ b/src/auxil/auxil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-auxil"
-version = "0.3.0"
+version = "0.4.0"
 description = "Implementation details shared between gfx-rs backends"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "1"
 libloading = "0.5"
 log = { version = "0.4" }
 smallvec = "1.0"
-spirv_cross = { version = "0.18", features = ["hlsl"] }
+spirv_cross = { version = "0.20", features = ["hlsl"] }
 parking_lot = "0.10"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 wio = "0.2"

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.5.0"
+version = "0.5.1"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -19,7 +19,7 @@ default = []
 name = "gfx_backend_dx11"
 
 [dependencies]
-auxil = { path = "../../auxil/auxil", version = "0.3", package = "gfx-auxil", features = ["spirv_cross"] }
+auxil = { path = "../../auxil/auxil", version = "0.4", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.5", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "1"
 native = { package = "d3d12", version = "0.3", features = ["libloading"] }
 log = "0.4"
 smallvec = "1"
-spirv_cross = { version = "0.18", features = ["hlsl"] }
+spirv_cross = { version = "0.20", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 raw-window-handle = "0.3"
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.5.2"
+version = "0.5.3"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -19,7 +19,7 @@ default = []
 name = "gfx_backend_dx12"
 
 [dependencies]
-auxil = { path = "../../auxil/auxil", version = "0.3", package = "gfx-auxil", features = ["spirv_cross"] }
+auxil = { path = "../../auxil/auxil", version = "0.4", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.5", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -29,7 +29,7 @@ auxil = { path = "../../auxil/auxil", version = "0.3", package = "gfx-auxil", fe
 smallvec = "1.0"
 glow = "0.4"
 parking_lot = "0.10"
-spirv_cross = { version = "0.18", features = ["glsl"] }
+spirv_cross = { version = "0.20", features = ["glsl"] }
 lazy_static = "1"
 raw-window-handle = "0.3"
 

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-gl"
-version = "0.5.0"
+version = "0.5.1"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -25,7 +25,7 @@ arrayvec = "0.5"
 bitflags = "1"
 log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.5" }
-auxil = { path = "../../auxil/auxil", version = "0.3", package = "gfx-auxil", features = ["spirv_cross"] }
+auxil = { path = "../../auxil/auxil", version = "0.4", package = "gfx-auxil", features = ["spirv_cross"] }
 smallvec = "1.0"
 glow = "0.4"
 parking_lot = "0.10"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -36,7 +36,7 @@ block = "0.1"
 cocoa = "0.20"
 core-graphics = "0.19"
 smallvec = "1"
-spirv_cross = { version = "0.18", features = ["msl"] }
+spirv_cross = { version = "0.20", features = ["msl"] }
 parking_lot = "0.10"
 storage-map = "0.2"
 lazy_static = "1"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-metal"
-version = "0.5.1"
+version = "0.5.2"
 description = "Metal API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -21,7 +21,7 @@ signpost = []
 name = "gfx_backend_metal"
 
 [dependencies]
-auxil = { path = "../../auxil/auxil", version = "0.3", package = "gfx-auxil", features = ["spirv_cross"] }
+auxil = { path = "../../auxil/auxil", version = "0.4", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.5", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 arrayvec = "0.5"


### PR DESCRIPTION
Backport #3249 to 0.5

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
