### PR TITLE
[webgpu] Instance creation and device enumeration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,6 @@ script:
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export LIBRARY_PATH=$HOME/deps/usr/lib/x86_64-linux-gnu; fi
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export LD_LIBRARY_PATH=$LIBRARY_PATH; fi
   - if [[ $TARGET != "aarch64-apple-ios" ]]; then make all; else make check-backends; fi
-  - if [[ -n "$WASM" ]]; then make quad-wasm; fi
+  - if [[ -n "$WASM" ]]; then make check-wasm quad-wasm; fi
   #- if [[ $TRAVIS_OS_NAME == "linux" ]]; then make reftests-ci; fi
   - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "osx" ]]; then cd src/backend/metal && cargo check --all-features; fi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 RUST_BACKTRACE:=1
-EXCLUDES:=
+EXCLUDES:=--exclude gfx-backend-webgpu
 FEATURES_GL:=
 FEATURES_HAL:=
 FEATURES_HAL2:=
@@ -41,7 +41,7 @@ else
 endif
 
 
-.PHONY: all check check-backends quad quad-wasm test doc reftests benches shader-binaries
+.PHONY: all check check-backends check-wasm quad quad-wasm test doc reftests benches shader-binaries
 
 all: check test
 
@@ -58,6 +58,9 @@ check: check-backends
 check-backends:
 	@echo "Note: excluding \`warden\` here, since it depends on serialization"
 	cargo check --all $(CHECK_TARGET_FLAG) $(EXCLUDES) --exclude gfx-warden
+
+check-wasm:
+	cd src/backend/webgpu && RUSTFLAGS="--cfg=web_sys_unstable_apis" cargo check --target wasm32-unknown-unknown
 
 test:
 	cargo test --all $(EXCLUDES)

--- a/src/backend/webgpu/src/lib.rs
+++ b/src/backend/webgpu/src/lib.rs
@@ -1,13 +1,15 @@
 use std::borrow::Borrow;
 
 use hal::{
-    adapter::{Gpu, MemoryProperties},
+    adapter::{Adapter, AdapterInfo, DeviceType, Gpu, MemoryProperties},
     device::CreationError,
     format,
     image,
     queue::{QueueFamilyId, QueuePriority, QueueType},
     Features,
 };
+
+use wasm_bindgen_futures::JsFuture;
 
 mod command;
 mod device;
@@ -60,15 +62,19 @@ impl hal::Backend for Backend {
 }
 
 #[derive(Debug)]
-pub struct Instance;
+pub struct Instance(web_sys::Gpu);
 
 impl hal::Instance<Backend> for Instance {
     fn create(_name: &str, _version: u32) -> Result<Self, hal::UnsupportedBackend> {
-        todo!()
+        // TODO: is there any way to check for WebGPU support
+        // before accessing the `gpu` object?
+        let gpu = web_sys::window().unwrap().navigator().gpu();
+
+        Ok(Instance(gpu))
     }
 
-    fn enumerate_adapters(&self) -> Vec<hal::adapter::Adapter<Backend>> {
-        todo!()
+    fn enumerate_adapters(&self) -> Vec<Adapter<Backend>> {
+        unimplemented!("Please use `enumerate_adapters_async` on WASM")
     }
 
     unsafe fn create_surface(
@@ -83,9 +89,77 @@ impl hal::Instance<Backend> for Instance {
     }
 }
 
+impl Instance {
+    /// Enumerates the adapters available from this backend.
+    pub async fn enumerate_adapters_async(&self) -> Vec<Adapter<Backend>> {
+        let mut options = web_sys::GpuRequestAdapterOptions::new();
+
+        // Request the high-performance dedicated GPU
+        options.power_preference(web_sys::GpuPowerPreference::HighPerformance);
+        let high_performance_adapter_promise = self.0.request_adapter_with_options(&options);
+
+        // Request the low-power integrated GPU
+        options.power_preference(web_sys::GpuPowerPreference::LowPower);
+        let low_power_adapter_promise = self.0.request_adapter_with_options(&options);
+
+        let high_performance_adapter = JsFuture::from(high_performance_adapter_promise).await;
+        let low_power_adapter = JsFuture::from(low_power_adapter_promise).await;
+
+        let high_performance_adapter = future_request_adapter(high_performance_adapter);
+        let low_power_adapter = future_request_adapter(low_power_adapter);
+
+        // If the system has at least two **different** graphics adapters,
+        // we can return them and let the application choose.
+        if high_performance_adapter != low_power_adapter {
+            high_performance_adapter
+                .into_iter()
+                .chain(low_power_adapter)
+                .map(map_wgpu_adapter_to_hal_adapter)
+                .collect()
+        } else {
+            high_performance_adapter
+                .into_iter()
+                .map(map_wgpu_adapter_to_hal_adapter)
+                .collect()
+        }
+    }
+}
+
+type JsFutureResult = Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>;
+
+// This function was taken from `wgpu-rs`
+fn future_request_adapter(result: JsFutureResult) -> Option<web_sys::GpuAdapter> {
+    match result {
+        Ok(js_value) => Some(web_sys::GpuAdapter::from(js_value)),
+        Err(_) => None,
+    }
+}
+
+fn map_wgpu_adapter_to_hal_adapter(adapter: web_sys::GpuAdapter) -> Adapter<Backend> {
+    let info = AdapterInfo {
+        name: adapter.name(),
+        // WebGPU doesn't provide us with information about the adapter type
+        vendor: 0,
+        device: 0,
+        device_type: DeviceType::Other,
+    };
+    let physical_device = PhysicalDevice(adapter);
+    let queue_family = QueueFamily {};
+
+    Adapter {
+        info,
+        physical_device,
+        queue_families: vec![queue_family],
+    }
+}
+
+// WASM doesn't have threads yet
+unsafe impl std::marker::Send for Instance {}
+unsafe impl std::marker::Sync for Instance {}
+
 
 #[derive(Debug)]
-pub struct PhysicalDevice;
+pub struct PhysicalDevice(web_sys::GpuAdapter);
 
 impl hal::adapter::PhysicalDevice<Backend> for PhysicalDevice {
     unsafe fn open(
@@ -128,20 +202,25 @@ impl hal::adapter::PhysicalDevice<Backend> for PhysicalDevice {
     }
 }
 
+unsafe impl std::marker::Send for PhysicalDevice {}
+unsafe impl std::marker::Sync for PhysicalDevice {}
+
 #[derive(Debug)]
 pub struct QueueFamily;
 
+const WEBGPU_QUEUE_FAMILY_ID: QueueFamilyId = QueueFamilyId(1);
+
 impl hal::queue::QueueFamily for QueueFamily {
     fn queue_type(&self) -> QueueType {
-        todo!()
+        QueueType::General
     }
 
     fn max_queues(&self) -> usize {
-        todo!()
+        1
     }
 
     fn id(&self) -> QueueFamilyId {
-        todo!()
+        WEBGPU_QUEUE_FAMILY_ID
     }
 }
 


### PR DESCRIPTION
Add basic instance creation to the WebGPU backend. Also allows enumerating physical devices.

I've currently excluded the `WebGPU` backend from the `test` target, and added it manually to `check`.

PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `rustfmt` run on changed code
