### PR TITLE
Update DX12 backend to interpret CacheCoherentUMA devices as IntegratedGpu

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -869,12 +869,24 @@ impl hal::Instance<Backend> for Instance {
                 name.to_string_lossy().into_owned()
             };
 
+            let mut features_architecture: d3d12::D3D12_FEATURE_DATA_ARCHITECTURE =
+                unsafe { mem::zeroed() };
+            assert_eq!(winerror::S_OK, unsafe {
+                device.CheckFeatureSupport(
+                    d3d12::D3D12_FEATURE_ARCHITECTURE,
+                    &mut features_architecture as *mut _ as *mut _,
+                    mem::size_of::<d3d12::D3D12_FEATURE_DATA_ARCHITECTURE>() as _,
+                )
+            });
+
             let info = adapter::AdapterInfo {
                 name: device_name,
                 vendor: desc.VendorId as usize,
                 device: desc.DeviceId as usize,
                 device_type: if (desc.Flags & dxgi::DXGI_ADAPTER_FLAG_SOFTWARE) != 0 {
                     adapter::DeviceType::VirtualGpu
+                } else if features_architecture.CacheCoherentUMA == TRUE {
+                    adapter::DeviceType::IntegratedGpu
                 } else {
                     adapter::DeviceType::DiscreteGpu
                 },
@@ -886,16 +898,6 @@ impl hal::Instance<Backend> for Instance {
                     d3d12::D3D12_FEATURE_D3D12_OPTIONS,
                     &mut features as *mut _ as *mut _,
                     mem::size_of::<d3d12::D3D12_FEATURE_DATA_D3D12_OPTIONS>() as _,
-                )
-            });
-
-            let mut features_architecture: d3d12::D3D12_FEATURE_DATA_ARCHITECTURE =
-                unsafe { mem::zeroed() };
-            assert_eq!(winerror::S_OK, unsafe {
-                device.CheckFeatureSupport(
-                    d3d12::D3D12_FEATURE_ARCHITECTURE,
-                    &mut features_architecture as *mut _ as *mut _,
-                    mem::size_of::<d3d12::D3D12_FEATURE_DATA_ARCHITECTURE>() as _,
                 )
             });
 


### PR DESCRIPTION
This slightly modifies the DX12 backend to allow for better detection of integrated gpus. 

Upstream wgpu issue with more info: https://github.com/gfx-rs/wgpu/issues/683

I decided against using `DedicatedVideoMemory` as an indicator, as my intel chip reports 130MB or so of memory that is "dedicated", despite being `CacheCoherentUMA`. I suspect this is memory that the system allocator can't get to, so is always reserved for graphics, but this is but a hunch.

I tested this on my system with 4 DX12 gpus (1080ti, 960, Intel, Virtual), and they all report back the proper values: Dedicated, Dedicated, Integrated, and Virtual respectively.