### PR TITLE
[0.5/dx12] implement descriptor pool destruction, bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx12-0.5.5 (01-06-2020)
+  - implement descriptor pool destruction
+
 ### backend-dx12-0.5.4 (29-05-2020)
   - fix detection of integrated gpus
   - fix UB in `compile_shader`

--- a/src/auxil/range-alloc/Cargo.toml
+++ b/src/auxil/range-alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "range-alloc"
-version = "0.1.0"
+version = "0.1.1"
 description = "Generic range allocator used by gfx-rs backends"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/auxil/range-alloc/src/lib.rs
+++ b/src/auxil/range-alloc/src/lib.rs
@@ -28,6 +28,10 @@ where
         }
     }
 
+    pub fn initial_range(&self) -> &Range<T> {
+        &self.initial_range
+    }
+
     pub fn allocate_range(&mut self, length: T) -> Result<Range<T>, RangeAllocationError<T>> {
         assert_ne!(length + length, length);
         let mut best_fit: Option<(usize, Range<T>)> = None;

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.5.4"
+version = "0.5.5"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -21,7 +21,7 @@ name = "gfx_backend_dx12"
 [dependencies]
 auxil = { path = "../../auxil/auxil", version = "0.4", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.5", package = "gfx-hal" }
-range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
+range-alloc = { path = "../../auxil/range-alloc", version = "0.1.1" }
 bitflags = "1"
 native = { package = "d3d12", version = "0.3", features = ["libloading"] }
 log = "0.4"

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2046,6 +2046,7 @@ impl d::Device<B> for Device {
                 baked_states,
             })
         } else {
+            error!("Failed to build shader: {:x}", hr);
             Err(pso::CreationError::Other)
         }
     }
@@ -3428,9 +3429,23 @@ impl d::Device<B> for Device {
         // Just drop
     }
 
-    unsafe fn destroy_descriptor_pool(&self, _pool: r::DescriptorPool) {
-        // Just drop
-        // Allocated descriptor sets don't need to be freed beforehand.
+    unsafe fn destroy_descriptor_pool(&self, pool: r::DescriptorPool) {
+        let view_range = pool.heap_srv_cbv_uav.range_allocator.initial_range();
+        if view_range.start < view_range.end {
+            self.heap_srv_cbv_uav
+                .lock()
+                .unwrap()
+                .range_allocator
+                .free_range(view_range.clone());
+        }
+        let sampler_range = pool.heap_sampler.range_allocator.initial_range();
+        if sampler_range.start < sampler_range.end {
+            self.heap_sampler
+                .lock()
+                .unwrap()
+                .range_allocator
+                .free_range(sampler_range.clone());
+        }
     }
 
     unsafe fn destroy_descriptor_set_layout(&self, _layout: r::DescriptorSetLayout) {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -37,6 +37,7 @@ use std::{
     fmt,
     mem,
     os::windows::ffi::OsStringExt,
+    //TODO: use parking_lot
     sync::{Arc, Mutex},
 };
 

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -643,13 +643,15 @@ impl DescriptorHeapSlice {
             })
     }
 
-    /// Free handles previously given out by this `DescriptorHeapSlice`.  Do not use this with handles not given out by this `DescriptorHeapSlice`.
+    /// Free handles previously given out by this `DescriptorHeapSlice`.
+    /// Do not use this with handles not given out by this `DescriptorHeapSlice`.
     pub(crate) fn free_handles(&mut self, handle: DualHandle) {
         let start = (handle.gpu.ptr - self.start.gpu.ptr) / self.handle_size;
         let handle_range = start .. start + handle.size as u64;
         self.range_allocator.free_range(handle_range);
     }
 
+    /// Clear the allocator.
     pub(crate) fn clear(&mut self) {
         self.range_allocator.reset();
     }


### PR DESCRIPTION
This PR adds logic to free the ranges of our global heaps of views and samplers upon destruction of descriptor pools. Without this, a `wgpu` application going through `gfx-descriptor` and constantly creating and freeing a single descriptor set would quickly run out of global samplers, since `gfx-descriptor` would correspondingly create and destroy the pool.