### PR TITLE
[0.5] Implement Descriptor Indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### hal-0.5.2 backend-dx12-0.5.7 backend-metal-0.5.4 backend-vulkan-0.5.8 (12-06-2020)
+  - add descriptor indexing features and enable on supported backends
+
 ### hal-0.5.1 backend-dx12-0.5.6 backend-metal-0.5.3 backend-vulkan-0.5.7 (10-06-2020)
   - add TEXTURE_DESCRIPTOR_ARRAY feature and enable on supported backends
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.5.6"
+version = "0.5.7"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -20,7 +20,7 @@ name = "gfx_backend_dx12"
 
 [dependencies]
 auxil = { path = "../../auxil/auxil", version = "0.4", package = "gfx-auxil", features = ["spirv_cross"] }
-hal = { path = "../../hal", version = "0.5.1", package = "gfx-hal" }
+hal = { path = "../../hal", version = "0.5.2", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1.1" }
 bitflags = "1"
 native = { package = "d3d12", version = "0.3", features = ["libloading"] }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -117,6 +117,7 @@ pub(crate) enum CommandSignature {
 pub(crate) fn compile_shader(
     stage: pso::Stage,
     shader_model: hlsl::ShaderModel,
+    features: &hal::Features,
     entry: &str,
     code: &[u8],
 ) -> Result<native::Blob, d::ShaderError> {
@@ -137,6 +138,13 @@ pub(crate) fn compile_shader(
     let mut shader_data = native::Blob::null();
     let mut error = native::Blob::null();
     let entry = ffi::CString::new(entry).unwrap();
+    let mut compile_flags = d3dcompiler::D3DCOMPILE_ENABLE_STRICTNESS;
+    if cfg!(debug_assertions) {
+        compile_flags |= d3dcompiler::D3DCOMPILE_DEBUG;
+    }
+    if features.contains(hal::Features::UNSIZED_DESCRIPTOR_ARRAY) {
+        compile_flags |= d3dcompiler::D3DCOMPILE_ENABLE_UNBOUNDED_DESCRIPTOR_TABLES;
+    }
     let hr = unsafe {
         d3dcompiler::D3DCompile(
             code.as_ptr() as *const _,
@@ -146,7 +154,7 @@ pub(crate) fn compile_shader(
             ptr::null_mut(),
             entry.as_ptr() as *const _,
             full_stage.as_ptr() as *const i8,
-            1,
+            compile_flags,
             0,
             shader_data.mut_void() as *mut *mut _,
             error.mut_void() as *mut *mut _,
@@ -487,6 +495,7 @@ impl Device {
                         let shader = compile_shader(
                             stage,
                             shader_model,
+                            features,
                             &entry_point.name,
                             shader_code.as_bytes(),
                         )?;
@@ -505,7 +514,7 @@ impl Device {
         code: &[u8],
     ) -> Result<r::ShaderModule, d::ShaderError> {
         let mut shader_map = BTreeMap::new();
-        let blob = compile_shader(stage, hlsl::ShaderModel::V5_1, hlsl_entry, code)?;
+        let blob = compile_shader(stage, hlsl::ShaderModel::V5_1, &self.features, hlsl_entry, code)?;
         shader_map.insert(entry_point.into(), blob);
         Ok(r::ShaderModule::Compiled(shader_map))
     }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1093,7 +1093,10 @@ impl hal::Instance<Backend> for Instance {
                     Features::SAMPLER_ANISOTROPY |
                     Features::TEXTURE_DESCRIPTOR_ARRAY |
                     Features::SAMPLER_MIRROR_CLAMP_EDGE |
-                    Features::NDC_Y_UP,
+                    Features::NDC_Y_UP |
+                    Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING |
+                    Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING |
+                    Features::UNSIZED_DESCRIPTOR_ARRAY,
                 hints:
                     Hints::BASE_VERTEX_INSTANCE_DRAWING,
                 limits: Limits { // TODO

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-metal"
-version = "0.5.3"
+version = "0.5.4"
 description = "Metal API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -22,7 +22,7 @@ name = "gfx_backend_metal"
 
 [dependencies]
 auxil = { path = "../../auxil/auxil", version = "0.4", package = "gfx-auxil", features = ["spirv_cross"] }
-hal = { path = "../../hal", version = "0.5.1", package = "gfx-hal" }
+hal = { path = "../../hal", version = "0.5.2", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 arrayvec = "0.5"
 bitflags = "1.0"

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -443,7 +443,9 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             }
             | hal::Features::SHADER_CLIP_DISTANCE
             | if self.shared.private_caps.msl_version >= metal::MTLLanguageVersion::V2_0 {
-                hal::Features::TEXTURE_DESCRIPTOR_ARRAY
+                hal::Features::TEXTURE_DESCRIPTOR_ARRAY |
+                hal::Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING |
+                hal::Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING
             } else {
                 hal::Features::empty()
             }

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-vulkan"
-version = "0.5.7"
+version = "0.5.8"
 description = "Vulkan API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -26,7 +26,7 @@ log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
 ash = "0.30"
-hal = { path = "../../hal", version = "0.5.1", package = "gfx-hal" }
+hal = { path = "../../hal", version = "0.5.2", package = "gfx-hal" }
 smallvec = "1.0"
 raw-window-handle = "0.3"
 

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -389,84 +389,99 @@ pub fn map_buffer_features(features: vk::FormatFeatureFlags) -> format::BufferFe
     format::BufferFeature::from_bits_truncate(features.as_raw())
 }
 
-pub fn map_device_features(features: Features) -> vk::PhysicalDeviceFeatures {
-    // vk::PhysicalDeviceFeatures is a struct composed of Bool32's while
-    // Features is a bitfield so we need to map everything manually
-    vk::PhysicalDeviceFeatures::builder()
-        .robust_buffer_access(features.contains(Features::ROBUST_BUFFER_ACCESS))
-        .full_draw_index_uint32(features.contains(Features::FULL_DRAW_INDEX_U32))
-        .image_cube_array(features.contains(Features::IMAGE_CUBE_ARRAY))
-        .independent_blend(features.contains(Features::INDEPENDENT_BLENDING))
-        .geometry_shader(features.contains(Features::GEOMETRY_SHADER))
-        .tessellation_shader(features.contains(Features::TESSELLATION_SHADER))
-        .sample_rate_shading(features.contains(Features::SAMPLE_RATE_SHADING))
-        .dual_src_blend(features.contains(Features::DUAL_SRC_BLENDING))
-        .logic_op(features.contains(Features::LOGIC_OP))
-        .multi_draw_indirect(features.contains(Features::MULTI_DRAW_INDIRECT))
-        .draw_indirect_first_instance(features.contains(Features::DRAW_INDIRECT_FIRST_INSTANCE))
-        .depth_clamp(features.contains(Features::DEPTH_CLAMP))
-        .depth_bias_clamp(features.contains(Features::DEPTH_BIAS_CLAMP))
-        .fill_mode_non_solid(features.contains(Features::NON_FILL_POLYGON_MODE))
-        .depth_bounds(features.contains(Features::DEPTH_BOUNDS))
-        .wide_lines(features.contains(Features::LINE_WIDTH))
-        .large_points(features.contains(Features::POINT_SIZE))
-        .alpha_to_one(features.contains(Features::ALPHA_TO_ONE))
-        .multi_viewport(features.contains(Features::MULTI_VIEWPORTS))
-        .sampler_anisotropy(features.contains(Features::SAMPLER_ANISOTROPY))
-        .texture_compression_etc2(features.contains(Features::FORMAT_ETC2))
-        .texture_compression_astc_ldr(features.contains(Features::FORMAT_ASTC_LDR))
-        .texture_compression_bc(features.contains(Features::FORMAT_BC))
-        .occlusion_query_precise(features.contains(Features::PRECISE_OCCLUSION_QUERY))
-        .pipeline_statistics_query(features.contains(Features::PIPELINE_STATISTICS_QUERY))
-        .vertex_pipeline_stores_and_atomics(features.contains(Features::VERTEX_STORES_AND_ATOMICS))
-        .fragment_stores_and_atomics(features.contains(Features::FRAGMENT_STORES_AND_ATOMICS))
-        .shader_tessellation_and_geometry_point_size(
-            features.contains(Features::SHADER_TESSELLATION_AND_GEOMETRY_POINT_SIZE),
-        )
-        .shader_image_gather_extended(features.contains(Features::SHADER_IMAGE_GATHER_EXTENDED))
-        .shader_storage_image_extended_formats(
-            features.contains(Features::SHADER_STORAGE_IMAGE_EXTENDED_FORMATS),
-        )
-        .shader_storage_image_multisample(
-            features.contains(Features::SHADER_STORAGE_IMAGE_MULTISAMPLE),
-        )
-        .shader_storage_image_read_without_format(
-            features.contains(Features::SHADER_STORAGE_IMAGE_READ_WITHOUT_FORMAT),
-        )
-        .shader_storage_image_write_without_format(
-            features.contains(Features::SHADER_STORAGE_IMAGE_WRITE_WITHOUT_FORMAT),
-        )
-        .shader_uniform_buffer_array_dynamic_indexing(
-            features.contains(Features::SHADER_UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING),
-        )
-        .shader_sampled_image_array_dynamic_indexing(
-            features.contains(Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING),
-        )
-        .shader_storage_buffer_array_dynamic_indexing(
-            features.contains(Features::SHADER_STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING),
-        )
-        .shader_storage_image_array_dynamic_indexing(
-            features.contains(Features::SHADER_STORAGE_IMAGE_ARRAY_DYNAMIC_INDEXING),
-        )
-        .shader_clip_distance(features.contains(Features::SHADER_CLIP_DISTANCE))
-        .shader_cull_distance(features.contains(Features::SHADER_CULL_DISTANCE))
-        .shader_float64(features.contains(Features::SHADER_FLOAT64))
-        .shader_int64(features.contains(Features::SHADER_INT64))
-        .shader_int16(features.contains(Features::SHADER_INT16))
-        .shader_resource_residency(features.contains(Features::SHADER_RESOURCE_RESIDENCY))
-        .shader_resource_min_lod(features.contains(Features::SHADER_RESOURCE_MIN_LOD))
-        .sparse_binding(features.contains(Features::SPARSE_BINDING))
-        .sparse_residency_buffer(features.contains(Features::SPARSE_RESIDENCY_BUFFER))
-        .sparse_residency_image2_d(features.contains(Features::SPARSE_RESIDENCY_IMAGE_2D))
-        .sparse_residency_image3_d(features.contains(Features::SPARSE_RESIDENCY_IMAGE_3D))
-        .sparse_residency2_samples(features.contains(Features::SPARSE_RESIDENCY_2_SAMPLES))
-        .sparse_residency4_samples(features.contains(Features::SPARSE_RESIDENCY_4_SAMPLES))
-        .sparse_residency8_samples(features.contains(Features::SPARSE_RESIDENCY_8_SAMPLES))
-        .sparse_residency16_samples(features.contains(Features::SPARSE_RESIDENCY_16_SAMPLES))
-        .sparse_residency_aliased(features.contains(Features::SPARSE_RESIDENCY_ALIASED))
-        .variable_multisample_rate(features.contains(Features::VARIABLE_MULTISAMPLE_RATE))
-        .inherited_queries(features.contains(Features::INHERITED_QUERIES))
-        .build()
+pub(crate) fn map_device_features(features: Features) -> crate::DeviceCreationFeatures {
+    crate::DeviceCreationFeatures {
+        // vk::PhysicalDeviceFeatures is a struct composed of Bool32's while
+        // Features is a bitfield so we need to map everything manually
+        core: vk::PhysicalDeviceFeatures::builder()
+            .robust_buffer_access(features.contains(Features::ROBUST_BUFFER_ACCESS))
+            .full_draw_index_uint32(features.contains(Features::FULL_DRAW_INDEX_U32))
+            .image_cube_array(features.contains(Features::IMAGE_CUBE_ARRAY))
+            .independent_blend(features.contains(Features::INDEPENDENT_BLENDING))
+            .geometry_shader(features.contains(Features::GEOMETRY_SHADER))
+            .tessellation_shader(features.contains(Features::TESSELLATION_SHADER))
+            .sample_rate_shading(features.contains(Features::SAMPLE_RATE_SHADING))
+            .dual_src_blend(features.contains(Features::DUAL_SRC_BLENDING))
+            .logic_op(features.contains(Features::LOGIC_OP))
+            .multi_draw_indirect(features.contains(Features::MULTI_DRAW_INDIRECT))
+            .draw_indirect_first_instance(features.contains(Features::DRAW_INDIRECT_FIRST_INSTANCE))
+            .depth_clamp(features.contains(Features::DEPTH_CLAMP))
+            .depth_bias_clamp(features.contains(Features::DEPTH_BIAS_CLAMP))
+            .fill_mode_non_solid(features.contains(Features::NON_FILL_POLYGON_MODE))
+            .depth_bounds(features.contains(Features::DEPTH_BOUNDS))
+            .wide_lines(features.contains(Features::LINE_WIDTH))
+            .large_points(features.contains(Features::POINT_SIZE))
+            .alpha_to_one(features.contains(Features::ALPHA_TO_ONE))
+            .multi_viewport(features.contains(Features::MULTI_VIEWPORTS))
+            .sampler_anisotropy(features.contains(Features::SAMPLER_ANISOTROPY))
+            .texture_compression_etc2(features.contains(Features::FORMAT_ETC2))
+            .texture_compression_astc_ldr(features.contains(Features::FORMAT_ASTC_LDR))
+            .texture_compression_bc(features.contains(Features::FORMAT_BC))
+            .occlusion_query_precise(features.contains(Features::PRECISE_OCCLUSION_QUERY))
+            .pipeline_statistics_query(features.contains(Features::PIPELINE_STATISTICS_QUERY))
+            .vertex_pipeline_stores_and_atomics(features.contains(Features::VERTEX_STORES_AND_ATOMICS))
+            .fragment_stores_and_atomics(features.contains(Features::FRAGMENT_STORES_AND_ATOMICS))
+            .shader_tessellation_and_geometry_point_size(
+                features.contains(Features::SHADER_TESSELLATION_AND_GEOMETRY_POINT_SIZE),
+            )
+            .shader_image_gather_extended(features.contains(Features::SHADER_IMAGE_GATHER_EXTENDED))
+            .shader_storage_image_extended_formats(
+                features.contains(Features::SHADER_STORAGE_IMAGE_EXTENDED_FORMATS),
+            )
+            .shader_storage_image_multisample(
+                features.contains(Features::SHADER_STORAGE_IMAGE_MULTISAMPLE),
+            )
+            .shader_storage_image_read_without_format(
+                features.contains(Features::SHADER_STORAGE_IMAGE_READ_WITHOUT_FORMAT),
+            )
+            .shader_storage_image_write_without_format(
+                features.contains(Features::SHADER_STORAGE_IMAGE_WRITE_WITHOUT_FORMAT),
+            )
+            .shader_uniform_buffer_array_dynamic_indexing(
+                features.contains(Features::SHADER_UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING),
+            )
+            .shader_sampled_image_array_dynamic_indexing(
+                features.contains(Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING),
+            )
+            .shader_storage_buffer_array_dynamic_indexing(
+                features.contains(Features::SHADER_STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING),
+            )
+            .shader_storage_image_array_dynamic_indexing(
+                features.contains(Features::SHADER_STORAGE_IMAGE_ARRAY_DYNAMIC_INDEXING),
+            )
+            .shader_clip_distance(features.contains(Features::SHADER_CLIP_DISTANCE))
+            .shader_cull_distance(features.contains(Features::SHADER_CULL_DISTANCE))
+            .shader_float64(features.contains(Features::SHADER_FLOAT64))
+            .shader_int64(features.contains(Features::SHADER_INT64))
+            .shader_int16(features.contains(Features::SHADER_INT16))
+            .shader_resource_residency(features.contains(Features::SHADER_RESOURCE_RESIDENCY))
+            .shader_resource_min_lod(features.contains(Features::SHADER_RESOURCE_MIN_LOD))
+            .sparse_binding(features.contains(Features::SPARSE_BINDING))
+            .sparse_residency_buffer(features.contains(Features::SPARSE_RESIDENCY_BUFFER))
+            .sparse_residency_image2_d(features.contains(Features::SPARSE_RESIDENCY_IMAGE_2D))
+            .sparse_residency_image3_d(features.contains(Features::SPARSE_RESIDENCY_IMAGE_3D))
+            .sparse_residency2_samples(features.contains(Features::SPARSE_RESIDENCY_2_SAMPLES))
+            .sparse_residency4_samples(features.contains(Features::SPARSE_RESIDENCY_4_SAMPLES))
+            .sparse_residency8_samples(features.contains(Features::SPARSE_RESIDENCY_8_SAMPLES))
+            .sparse_residency16_samples(features.contains(Features::SPARSE_RESIDENCY_16_SAMPLES))
+            .sparse_residency_aliased(features.contains(Features::SPARSE_RESIDENCY_ALIASED))
+            .variable_multisample_rate(features.contains(Features::VARIABLE_MULTISAMPLE_RATE))
+            .inherited_queries(features.contains(Features::INHERITED_QUERIES))
+            .build(),
+        descriptor_indexing: if features.intersects(
+            Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING
+                | Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING
+                | Features::UNSIZED_DESCRIPTOR_ARRAY
+        ) {
+            Some(
+                vk::PhysicalDeviceDescriptorIndexingFeaturesEXT::builder()
+                    .shader_sampled_image_array_non_uniform_indexing(features.contains(Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING))
+                    .shader_storage_image_array_non_uniform_indexing(features.contains(Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING))
+                    .runtime_descriptor_array(features.contains(Features::UNSIZED_DESCRIPTOR_ARRAY))
+                    .build()
+            )
+        } else { None }
+    }
 }
 
 pub fn map_memory_ranges<'a, I>(ranges: I) -> SmallVec<[vk::MappedMemoryRange; 4]>

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -2040,7 +2040,7 @@ impl d::Device<B> for Device {
         config: SwapchainConfig,
         provided_old_swapchain: Option<w::Swapchain>,
     ) -> Result<(w::Swapchain, Vec<n::Image>), hal::window::CreationError> {
-        let functor = khr::Swapchain::new(&surface.raw.instance.0, &self.shared.raw);
+        let functor = khr::Swapchain::new(&surface.raw.instance.inner, &self.shared.raw);
 
         let old_swapchain = match provided_old_swapchain {
             Some(osc) => osc.raw,
@@ -2273,7 +2273,7 @@ impl d::Device<B> for Device {
 impl Device {
     unsafe fn set_object_name(&self, object_type: vk::ObjectType, object_handle: u64, name: &str) {
         let instance = &self.shared.instance;
-        if let Some(DebugMessenger::Utils(ref debug_utils_ext, _)) = instance.1 {
+        if let Some(DebugMessenger::Utils(ref debug_utils_ext, _)) = instance.debug_messenger {
             // Append a null terminator to the string while avoiding allocating memory
             static mut NAME_BUF: [u8; 64] = [0u8; 64];
             std::ptr::copy_nonoverlapping(

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -61,9 +61,10 @@ lazy_static! {
         vec![
             DebugUtils::name(),
             DebugReport::name(),
+            *KHR_GET_PHYSICAL_DEVICE_PROPERTIES2,
         ]
     } else {
-        vec![]
+        vec![*KHR_GET_PHYSICAL_DEVICE_PROPERTIES2]
     };
     static ref DEVICE_EXTENSIONS: Vec<&'static CStr> = vec![extensions::khr::Swapchain::name()];
     static ref SURFACE_EXTENSIONS: Vec<&'static CStr> = vec![
@@ -88,6 +89,10 @@ lazy_static! {
         CStr::from_bytes_with_nul(b"VK_KHR_maintenance1\0").unwrap();
     static ref KHR_SAMPLER_MIRROR_MIRROR_CLAMP_TO_EDGE : &'static CStr =
         CStr::from_bytes_with_nul(b"VK_KHR_sampler_mirror_clamp_to_edge\0").unwrap();
+    static ref KHR_GET_PHYSICAL_DEVICE_PROPERTIES2: &'static CStr =
+        CStr::from_bytes_with_nul(b"VK_KHR_get_physical_device_properties2\0").unwrap();
+    static ref EXT_DESCRIPTOR_INDEXING: &'static CStr =
+        CStr::from_bytes_with_nul(b"VK_EXT_descriptor_indexing\0").unwrap();
 }
 
 #[cfg(not(feature = "use-rtld-next"))]
@@ -109,7 +114,11 @@ lazy_static! {
         );
 }
 
-pub struct RawInstance(ash::Instance, Option<DebugMessenger>);
+pub struct RawInstance {
+    inner: ash::Instance,
+    debug_messenger: Option<DebugMessenger>,
+    get_physical_device_properties: Option<vk::KhrGetPhysicalDeviceProperties2Fn>,
+}
 
 pub enum DebugMessenger {
     Utils(DebugUtils, vk::DebugUtilsMessengerEXT),
@@ -121,7 +130,7 @@ impl Drop for RawInstance {
         unsafe {
             #[cfg(debug_assertions)]
             {
-                match self.1 {
+                match self.debug_messenger {
                     Some(DebugMessenger::Utils(ref ext, callback)) => {
                         ext.destroy_debug_utils_messenger(callback, None)
                     }
@@ -132,7 +141,7 @@ impl Drop for RawInstance {
                 }
             }
 
-            self.0.destroy_instance(None);
+            self.inner.destroy_instance(None);
         }
     }
 }
@@ -424,6 +433,15 @@ impl hal::Instance<Backend> for Instance {
             })?
         };
 
+        let get_physical_device_properties = extensions
+            .iter()
+            .find(|&&ext| ext == *KHR_GET_PHYSICAL_DEVICE_PROPERTIES2)
+            .map(|_| {
+                vk::KhrGetPhysicalDeviceProperties2Fn::load(|name| unsafe {
+                    std::mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+                })
+            });
+
         #[cfg(debug_assertions)]
         let debug_messenger = {
             // make sure VK_EXT_debug_utils is available
@@ -463,13 +481,13 @@ impl hal::Instance<Backend> for Instance {
         let debug_messenger = None;
 
         Ok(Instance {
-            raw: Arc::new(RawInstance(instance, debug_messenger)),
+            raw: Arc::new(RawInstance{ inner: instance, debug_messenger, get_physical_device_properties }),
             extensions,
         })
     }
 
     fn enumerate_adapters(&self) -> Vec<adapter::Adapter<Backend>> {
-        let devices = match unsafe { self.raw.0.enumerate_physical_devices() } {
+        let devices = match unsafe { self.raw.inner.enumerate_physical_devices() } {
             Ok(devices) => devices,
             Err(err) => {
                 error!("Could not enumerate physical devices! {}", err);
@@ -481,8 +499,8 @@ impl hal::Instance<Backend> for Instance {
             .into_iter()
             .map(|device| {
                 let extensions =
-                    unsafe { self.raw.0.enumerate_device_extension_properties(device) }.unwrap();
-                let properties = unsafe { self.raw.0.get_physical_device_properties(device) };
+                    unsafe { self.raw.inner.enumerate_device_extension_properties(device) }.unwrap();
+                let properties = unsafe { self.raw.inner.get_physical_device_properties(device) };
                 let info = adapter::AdapterInfo {
                     name: unsafe {
                         CStr::from_ptr(properties.device_name.as_ptr())
@@ -513,7 +531,7 @@ impl hal::Instance<Backend> for Instance {
                 };
                 let queue_families = unsafe {
                     self.raw
-                        .0
+                        .inner
                         .get_physical_device_queue_family_properties(device)
                         .into_iter()
                         .enumerate()
@@ -641,6 +659,11 @@ impl fmt::Debug for PhysicalDevice {
     }
 }
 
+pub struct DeviceCreationFeatures {
+    core: vk::PhysicalDeviceFeatures,
+    descriptor_indexing: Option<vk::PhysicalDeviceDescriptorIndexingFeaturesEXT>,
+}
+
 impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
     unsafe fn open(
         &self,
@@ -664,7 +687,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         }
 
         let maintenance_level = if self.supports_extension(*KHR_MAINTENANCE1) { 1 } else { 0 };
-        let enabled_features = conv::map_device_features(requested_features);
+        let mut enabled_features = conv::map_device_features(requested_features);
         let enabled_extensions = DEVICE_EXTENSIONS
             .iter()
             .cloned()
@@ -689,20 +712,18 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 
             let str_pointers = cstrings.iter().map(|s| s.as_ptr()).collect::<Vec<_>>();
 
-            let info = vk::DeviceCreateInfo {
-                s_type: vk::StructureType::DEVICE_CREATE_INFO,
-                p_next: ptr::null(),
-                flags: vk::DeviceCreateFlags::empty(),
-                queue_create_info_count: family_infos.len() as u32,
-                p_queue_create_infos: family_infos.as_ptr(),
-                enabled_layer_count: 0,
-                pp_enabled_layer_names: ptr::null(),
-                enabled_extension_count: str_pointers.len() as u32,
-                pp_enabled_extension_names: str_pointers.as_ptr(),
-                p_enabled_features: &enabled_features,
+            let info = vk::DeviceCreateInfo::builder()
+                .queue_create_infos(&family_infos)
+                .enabled_extension_names(&str_pointers)
+                .enabled_features(&enabled_features.core);
+
+            let info = if let Some(ref mut descriptor_indexing) = enabled_features.descriptor_indexing {
+                info.push_next(descriptor_indexing)
+            } else {
+                info
             };
 
-            match self.instance.0.create_device(self.handle, &info, None) {
+            match self.instance.inner.create_device(self.handle, &info, None) {
                 Ok(device) => device,
                 Err(e) => {
                     return Err(match e {
@@ -726,7 +747,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         let swapchain_fn = vk::KhrSwapchainFn::load(|name| {
             mem::transmute(
                 self.instance
-                    .0
+                    .inner
                     .get_device_proc_addr(device_raw.handle(), name.as_ptr()),
             )
         });
@@ -767,7 +788,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 
     fn format_properties(&self, format: Option<format::Format>) -> format::Properties {
         let properties = unsafe {
-            self.instance.0.get_physical_device_format_properties(
+            self.instance.inner.get_physical_device_format_properties(
                 self.handle,
                 format.map_or(vk::Format::UNDEFINED, conv::map_format),
             )
@@ -789,7 +810,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         view_caps: image::ViewCapabilities,
     ) -> Option<image::FormatProperties> {
         let format_properties = unsafe {
-            self.instance.0.get_physical_device_image_format_properties(
+            self.instance.inner.get_physical_device_image_format_properties(
                 self.handle,
                 conv::map_format(format),
                 match dimensions {
@@ -827,7 +848,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
     fn memory_properties(&self) -> adapter::MemoryProperties {
         let mem_properties = unsafe {
             self.instance
-                .0
+                .inner
                 .get_physical_device_memory_properties(self.handle)
         };
         let memory_heaps = mem_properties.memory_heaps
@@ -895,7 +916,25 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 || self.properties.device_id & info::intel::DEVICE_SKY_LAKE_MASK
                     == info::intel::DEVICE_SKY_LAKE_MASK);
 
-        let features = unsafe { self.instance.0.get_physical_device_features(self.handle) };
+        let mut descriptor_indexing_features = None;
+        let features = if let Some(ref get_device_properties) = self.instance.get_physical_device_properties {
+            let features = vk::PhysicalDeviceFeatures::builder().build();
+            let mut features2 = vk::PhysicalDeviceFeatures2KHR::builder().features(features).build();
+
+            // Add extension infos to the p_next chain
+            if self.supports_extension(*EXT_DESCRIPTOR_INDEXING) {
+                descriptor_indexing_features = Some(vk::PhysicalDeviceDescriptorIndexingFeaturesEXT::builder().build());
+
+                let mut_ref = descriptor_indexing_features.as_mut().unwrap();
+                mut_ref.p_next = mem::replace(&mut features2.p_next, mut_ref as *mut _ as *mut _);
+            }
+
+            unsafe { get_device_properties.get_physical_device_features2_khr(self.handle, &mut features2 as *mut _); }
+            features2.features
+        } else {
+            unsafe { self.instance.inner.get_physical_device_features(self.handle) }
+        };
+
         let mut bits = Features::empty()
             | Features::TRIANGLE_FAN
             | Features::SEPARATE_STENCIL_REF_VALUES
@@ -909,6 +948,18 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         }
         if self.supports_extension(*KHR_SAMPLER_MIRROR_MIRROR_CLAMP_TO_EDGE) {
             bits |= Features::SAMPLER_MIRROR_CLAMP_EDGE;
+        }
+        // This will only be some if the extension exists
+        if let Some(ref desc_indexing) = descriptor_indexing_features {
+            if desc_indexing.shader_sampled_image_array_non_uniform_indexing != 0 {
+                bits |= Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING;
+            }
+            if desc_indexing.shader_storage_image_array_non_uniform_indexing != 0 {
+                bits |= Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING;
+            }
+            if desc_indexing.runtime_descriptor_array != 0 {
+                bits |= Features::UNSIZED_DESCRIPTOR_ARRAY;
+            }
         }
 
         if features.robust_buffer_access != 0 {
@@ -1266,7 +1317,7 @@ impl Drop for RawDevice {
 
 impl RawDevice {
     fn debug_messenger(&self) -> Option<&DebugMessenger> {
-        self.instance.1.as_ref()
+        self.instance.debug_messenger.as_ref()
     }
 
     fn map_viewport(&self, rect: &hal::pso::Viewport) -> vk::Viewport {

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -112,7 +112,7 @@ impl Instance {
         }
 
         let surface = {
-            let xlib_loader = khr::XlibSurface::new(entry, &self.raw.0);
+            let xlib_loader = khr::XlibSurface::new(entry, &self.raw.inner);
             let info = vk::XlibSurfaceCreateInfoKHR {
                 s_type: vk::StructureType::XLIB_SURFACE_CREATE_INFO_KHR,
                 p_next: ptr::null(),
@@ -148,7 +148,7 @@ impl Instance {
         }
 
         let surface = {
-            let xcb_loader = khr::XcbSurface::new(entry, &self.raw.0);
+            let xcb_loader = khr::XcbSurface::new(entry, &self.raw.inner);
             let info = vk::XcbSurfaceCreateInfoKHR {
                 s_type: vk::StructureType::XCB_SURFACE_CREATE_INFO_KHR,
                 p_next: ptr::null(),
@@ -179,7 +179,7 @@ impl Instance {
         }
 
         let surface = {
-            let w_loader = khr::WaylandSurface::new(entry, &self.raw.0);
+            let w_loader = khr::WaylandSurface::new(entry, &self.raw.inner);
             let info = vk::WaylandSurfaceCreateInfoKHR {
                 s_type: vk::StructureType::WAYLAND_SURFACE_CREATE_INFO_KHR,
                 p_next: ptr::null(),
@@ -201,7 +201,7 @@ impl Instance {
             .expect("Unable to load Vulkan entry points");
 
         let surface = {
-            let loader = khr::AndroidSurface::new(entry, &self.raw.0);
+            let loader = khr::AndroidSurface::new(entry, &self.raw.inner);
             let info = vk::AndroidSurfaceCreateInfoKHR {
                 s_type: vk::StructureType::ANDROID_SURFACE_CREATE_INFO_KHR,
                 p_next: ptr::null(),
@@ -233,7 +233,7 @@ impl Instance {
                 hinstance: hinstance as *mut _,
                 hwnd: hwnd as *mut _,
             };
-            let win32_loader = khr::Win32Surface::new(entry, &self.raw.0);
+            let win32_loader = khr::Win32Surface::new(entry, &self.raw.inner);
             unsafe {
                 win32_loader
                     .create_win32_surface(&info, None)
@@ -286,7 +286,7 @@ impl Instance {
         }
 
         let surface = {
-            let mac_os_loader = mvk::MacOSSurface::new(entry, &self.raw.0);
+            let mac_os_loader = mvk::MacOSSurface::new(entry, &self.raw.inner);
             let info = vk::MacOSSurfaceCreateInfoMVK {
                 s_type: vk::StructureType::MACOS_SURFACE_CREATE_INFO_M,
                 p_next: ptr::null(),
@@ -309,7 +309,7 @@ impl Instance {
             .as_ref()
             .expect("Unable to load Vulkan entry points");
 
-        let functor = khr::Surface::new(entry, &self.raw.0);
+        let functor = khr::Surface::new(entry, &self.raw.inner);
 
         let raw = Arc::new(RawSurface {
             handle: surface,

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-hal"
-version = "0.5.1"
+version = "0.5.2"
 description = "gfx-rs hardware abstraction layer"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -62,7 +62,7 @@ bitflags! {
     /// These only include features of the core interface and not API extensions.
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct Features: u128 {
-        /// Bit mask of Vulkan Core features.
+        /// Bit mask of Vulkan Core/Extension features.
         const CORE_MASK = 0xFFFF_FFFF_FFFF_FFFF;
         /// Bit mask of Vulkan Portability features.
         const PORTABILITY_MASK  = 0x0000_FFFF_0000_0000_0000_0000;
@@ -190,6 +190,12 @@ bitflags! {
         const TEXTURE_DESCRIPTOR_ARRAY = 0x0080_0000_0000_0000;
         /// Support for
         const SAMPLER_MIRROR_CLAMP_EDGE = 0x0100_0000_0000_0000;
+        /// Allow indexing sampled texture descriptor arrays with dynamically non-uniform data
+        const SAMPLED_TEXTURE_DESCRIPTOR_INDEXING = 0x0200_0000_0000_0000;
+        /// Allow indexing storage texture descriptor arrays with dynamically non-uniform data
+        const STORAGE_TEXTURE_DESCRIPTOR_INDEXING = 0x0400_0000_0000_0000;
+        /// Allow descriptor arrays to be unsized in shaders
+        const UNSIZED_DESCRIPTOR_ARRAY = 0x0800_0000_0000_0000;
 
         /// Support triangle fan primitive topology.
         const TRIANGLE_FAN = 0x0001 << 64;
@@ -201,7 +207,7 @@ bitflags! {
         const SAMPLER_MIP_LOD_BIAS = 0x0008 << 64;
 
         /// Make the NDC coordinate system pointing Y up, to match D3D and Metal.
-        const NDC_Y_UP = 0x01 << 80;
+        const NDC_Y_UP = 0x0001 << 80;
     }
 }
 


### PR DESCRIPTION
This implements the gfx-hal component of supporting descriptor indexing.

Main actions:
 - Add features to hal
 - Enable appropriate features on metal
 - Enable features on DX12 with additional compiler flag if needed
 - Wire up enabling extensions to Vulkan.

Remaining Questions:
 - This PR isn't finished, but my main concern is how to get the struct of function pointers from `Instance::create`, through `PhysicalDevice` so it can get to `PhysicalDevice::features` where it needs to be. I sorta just stuck it in the structs, but if you have a better idea, please do suggest.
 - Any other vulkan advice/tips appreciated. 
 - I need to properly detect when optional instance extensions aren't supported.
 - Remove the horrible duplication of the extension name... somehow.