### PR TITLE
[0.5] Add draw_indirect_count feature

### DIFF
--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.5.7"
+version = "0.5.8"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -20,7 +20,7 @@ name = "gfx_backend_dx12"
 
 [dependencies]
 auxil = { path = "../../auxil/auxil", version = "0.4", package = "gfx-auxil", features = ["spirv_cross"] }
-hal = { path = "../../hal", version = "0.5.2", package = "gfx-hal" }
+hal = { path = "../../hal", version = "0.5.3", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1.1" }
 bitflags = "1"
 native = { package = "d3d12", version = "0.3", features = ["libloading"] }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -2510,6 +2510,52 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         );
     }
 
+    unsafe fn draw_indirect_count(
+        &mut self,
+        buffer: &r::Buffer,
+        offset: buffer::Offset,
+        count_buffer: &r::Buffer,
+        count_buffer_offset: buffer::Offset,
+        max_draw_count: DrawCount,
+        stride: u32
+    ) {
+        assert_eq!(stride, 16);
+        let buffer = buffer.expect_bound();
+        let count_buffer = count_buffer.expect_bound();
+        self.set_graphics_bind_point();
+        self.raw.ExecuteIndirect(
+            self.shared.signatures.draw.as_mut_ptr(),
+            max_draw_count,
+            buffer.resource.as_mut_ptr(),
+            offset,
+            count_buffer.resource.as_mut_ptr(),
+            count_buffer_offset,
+        );
+    }
+
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        buffer: &r::Buffer,
+        offset: buffer::Offset,
+        count_buffer: &r::Buffer,
+        count_buffer_offset: buffer::Offset,
+        max_draw_count: DrawCount,
+        stride: u32
+    ) {
+        assert_eq!(stride, 20);
+        let buffer = buffer.expect_bound();
+        let count_buffer = count_buffer.expect_bound();
+        self.set_graphics_bind_point();
+        self.raw.ExecuteIndirect(
+            self.shared.signatures.draw_indexed.as_mut_ptr(),
+            max_draw_count,
+            buffer.resource.as_mut_ptr(),
+            offset,
+            count_buffer.resource.as_mut_ptr(),
+            count_buffer_offset,
+        );
+    }
+
     unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {
         unimplemented!()
     }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1096,7 +1096,8 @@ impl hal::Instance<Backend> for Instance {
                     Features::NDC_Y_UP |
                     Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING |
                     Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING |
-                    Features::UNSIZED_DESCRIPTOR_ARRAY,
+                    Features::UNSIZED_DESCRIPTOR_ARRAY |
+                    Features::DRAW_INDIRECT_COUNT,
                 hints:
                     Hints::BASE_VERTEX_INSTANCE_DRAWING,
                 limits: Limits { // TODO

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-vulkan"
-version = "0.5.8"
+version = "0.5.9"
 description = "Vulkan API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -26,7 +26,7 @@ log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
 ash = "0.31"
-hal = { path = "../../hal", version = "0.5.2", package = "gfx-hal" }
+hal = { path = "../../hal", version = "0.5.3", package = "gfx-hal" }
 smallvec = "1.0"
 raw-window-handle = "0.3"
 

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -25,7 +25,7 @@ byteorder = "1"
 log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
-ash = "0.30"
+ash = "0.31"
 hal = { path = "../../hal", version = "0.5.2", package = "gfx-hal" }
 smallvec = "1.0"
 raw-window-handle = "0.3"

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -829,6 +829,40 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             .cmd_draw_indexed_indirect(self.raw, buffer.raw, offset, draw_count, stride)
     }
 
+    unsafe fn draw_indirect_count(
+        &mut self,
+        buffer: &n::Buffer,
+        offset: buffer::Offset,
+        count_buffer: &n::Buffer,
+        count_buffer_offset: buffer::Offset,
+        max_draw_count: DrawCount,
+        stride: u32
+    ) {
+        self.device
+            .extension_fns
+            .draw_indirect_count
+            .as_ref()
+            .expect("Feature DRAW_INDIRECT_COUNT must be enabled to call draw_indirect_count")
+            .cmd_draw_indirect_count(self.raw, buffer.raw, offset, count_buffer.raw, count_buffer_offset, max_draw_count, stride);
+    }
+
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        buffer: &n::Buffer,
+        offset: buffer::Offset,
+        count_buffer: &n::Buffer,
+        count_buffer_offset: buffer::Offset,
+        max_draw_count: DrawCount,
+        stride: u32
+    ) {
+        self.device
+            .extension_fns
+            .draw_indirect_count
+            .as_ref()
+            .expect("Feature DRAW_INDIRECT_COUNT must be enabled to call draw_indexed_indirect_count")
+            .cmd_draw_indexed_indirect_count(self.raw, buffer.raw, offset, count_buffer.raw, count_buffer_offset, max_draw_count, stride);
+    }
+
     unsafe fn set_event(&mut self, event: &n::Event, stage_mask: pso::PipelineStage) {
         self.device.raw.cmd_set_event(
             self.raw,

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-hal"
-version = "0.5.2"
+version = "0.5.3"
 description = "gfx-rs hardware abstraction layer"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -480,6 +480,46 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         stride: u32,
     );
 
+    /// Functions identically to `draw_indirect()`, except the amount of draw
+    /// calls are specified by the u32 in `count_buffer` at `count_buffer_offset`.
+    /// There is a limit of `max_draw_count` invocations.
+    ///
+    /// Each draw command in the buffer is a series of 4 `u32` values specifying,
+    /// in order, the number of vertices to draw, the number of instances to draw,
+    /// the index of the first vertex to draw, and the instance ID of the first
+    /// instance to draw.
+    unsafe fn draw_indirect_count(
+        &mut self,
+        _buffer: &B::Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &B::Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    ) {
+        unimplemented!("Backend doesn't support draw_indirect_count");
+    }
+
+    /// Functions identically to `draw_indexed_indirect()`, except the amount of draw
+    /// calls are specified by the u32 in `count_buffer` at `count_buffer_offset`.
+    /// There is a limit of `max_draw_count` invocations.
+    ///
+    /// Each draw command in the buffer is a series of 5 values specifying,
+    /// in order, the number of indices, the number of instances, the first index,
+    /// the vertex offset, and the first instance.  All are `u32`'s except
+    /// the vertex offset, which is an `i32`.
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        _buffer: &B::Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &B::Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    ) {
+        unimplemented!("Backend doesn't support draw_indexed_indirect_count");
+    }
+
     /// Signals an event once all specified stages of the shader pipeline have completed.
     unsafe fn set_event(&mut self, event: &B::Event, stages: pso::PipelineStage);
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -196,6 +196,8 @@ bitflags! {
         const STORAGE_TEXTURE_DESCRIPTOR_INDEXING = 0x0400_0000_0000_0000;
         /// Allow descriptor arrays to be unsized in shaders
         const UNSIZED_DESCRIPTOR_ARRAY = 0x0800_0000_0000_0000;
+        /// Enable draw_indirect_count and draw_indexed_indirect_count
+        const DRAW_INDIRECT_COUNT = 0x1000_0000_0000_0000;
 
         /// Support triangle fan primitive topology.
         const TRIANGLE_FAN = 0x0001 << 64;


### PR DESCRIPTION
gfx-hal work for https://github.com/gfx-rs/wgpu/issues/742. I would not merge this until I've finished the wgpu work and prove that it works on both dx12 and vulkan, but it can be reviewed now :)

This adds two methods to a gfx-hal trait, so I added them with a default `unimplemented!()` implementation so it is a non-breaking change. When this is ported forward to master, the functions will just exist as is.

This adds support for this feature on DX12 and Vulkan (through `VK_KHR_draw_indirect_count`). Metal is possible as discussed in the wgpu issue, but I don't have access to a development mac, so I couldn't do the work on it, at least right now. GL 4.6 also seems to support this though `glMultiDrawIndexedIndirectCount`, but that's a problem to solve once the GL backend is sorted.