### PR TITLE
Implement DRAW_INDIRECT_COUNT features

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2184,6 +2184,30 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
+    unsafe fn draw_indirect_count(
+        &mut self,
+        _buffer: &Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    ) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        _buffer: &Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    ) {
+        unimplemented!()
+    }
+
     unsafe fn draw_mesh_tasks(&mut self, _: TaskCount, _: TaskCount) {
         unimplemented!()
     }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -2531,6 +2531,52 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
+    unsafe fn draw_indirect_count(
+        &mut self,
+        buffer: &r::Buffer,
+        offset: buffer::Offset,
+        count_buffer: &r::Buffer,
+        count_buffer_offset: buffer::Offset,
+        max_draw_count: DrawCount,
+        stride: u32
+    ) {
+        assert_eq!(stride, 16);
+        let buffer = buffer.expect_bound();
+        let count_buffer = count_buffer.expect_bound();
+        self.set_graphics_bind_point();
+        self.raw.ExecuteIndirect(
+            self.shared.signatures.draw.as_mut_ptr(),
+            max_draw_count,
+            buffer.resource.as_mut_ptr(),
+            offset,
+            count_buffer.resource.as_mut_ptr(),
+            count_buffer_offset,
+        );
+    }
+
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        buffer: &r::Buffer,
+        offset: buffer::Offset,
+        count_buffer: &r::Buffer,
+        count_buffer_offset: buffer::Offset,
+        max_draw_count: DrawCount,
+        stride: u32
+    ) {
+        assert_eq!(stride, 20);
+        let buffer = buffer.expect_bound();
+        let count_buffer = count_buffer.expect_bound();
+        self.set_graphics_bind_point();
+        self.raw.ExecuteIndirect(
+            self.shared.signatures.draw_indexed.as_mut_ptr(),
+            max_draw_count,
+            buffer.resource.as_mut_ptr(),
+            offset,
+            count_buffer.resource.as_mut_ptr(),
+            count_buffer_offset,
+        );
+    }
+
     unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {
         unimplemented!()
     }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1077,7 +1077,8 @@ impl hal::Instance<Backend> for Instance {
                     Features::NDC_Y_UP |
                     Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING |
                     Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING |
-                    Features::UNSIZED_DESCRIPTOR_ARRAY,
+                    Features::UNSIZED_DESCRIPTOR_ARRAY |
+                    Features::DRAW_INDIRECT_COUNT,
                 hints:
                     Hints::BASE_VERTEX_INSTANCE_DRAWING,
                 limits: Limits { // TODO

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -879,7 +879,6 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: hal::VertexOffset,
         _: Range<hal::InstanceCount>,
     ) {
-        unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
     unsafe fn draw_indirect(
@@ -889,7 +888,6 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: hal::DrawCount,
         _: u32,
     ) {
-        unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
     unsafe fn draw_indexed_indirect(
@@ -899,7 +897,28 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: hal::DrawCount,
         _: u32,
     ) {
-        unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
+    }
+
+    unsafe fn draw_indirect_count(
+        &mut self,
+        _: &Buffer,
+        _: hal::buffer::Offset,
+        _: &Buffer,
+        _: hal::buffer::Offset,
+        _: u32,
+        _: u32,
+    ) {
+    }
+
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        _: &Buffer,
+        _: hal::buffer::Offset,
+        _: &Buffer,
+        _: hal::buffer::Offset,
+        _: u32,
+        _: u32,
+    ) {
     }
 
     unsafe fn draw_mesh_tasks(&mut self, _: u32, _: u32) {

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1499,6 +1499,30 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
+    unsafe fn draw_indirect_count(
+        &mut self,
+        _buffer: &n::Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &n::Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    ) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        _buffer: &n::Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &n::Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    ) {
+        unimplemented!()
+    }
+
     unsafe fn draw_mesh_tasks(&mut self, _: u32, _: u32) {
         unimplemented!()
     }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -4359,6 +4359,30 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             .issue_many(commands);
     }
 
+    unsafe fn draw_indirect_count(
+        &mut self,
+        _buffer: &native::Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &native::Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    ) {
+        unimplemented!()
+    }
+
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        _buffer: &native::Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &native::Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    ) {
+        unimplemented!()
+    }
+
     unsafe fn draw_mesh_tasks(&mut self, _: TaskCount, _: TaskCount) {
         unimplemented!()
     }

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -25,7 +25,7 @@ byteorder = "1"
 log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
-ash = "0.30"
+ash = "0.31"
 hal = { path = "../../hal", version = "0.5", package = "gfx-hal" }
 smallvec = "1.0"
 raw-window-handle = "0.3"

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -896,7 +896,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
     }
 
     unsafe fn draw_mesh_tasks(&mut self, task_count: TaskCount, first_task: TaskCount) {
-        self.device.mesh_fn.as_ref()
+        self.device.extension_fns.mesh_shaders.as_ref()
             .expect("Draw command not supported. You must request feature MESH_SHADER.")
             .cmd_draw_mesh_tasks(self.raw, task_count, first_task);
     }
@@ -908,7 +908,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         draw_count: hal::DrawCount,
         stride: u32,
     ) {
-        self.device.mesh_fn.as_ref()
+        self.device.extension_fns.mesh_shaders.as_ref()
             .expect("Draw command not supported. You must request feature MESH_SHADER.")
             .cmd_draw_mesh_tasks_indirect(self.raw, buffer.raw, offset, draw_count, stride);
     }
@@ -922,9 +922,43 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         max_draw_count: DrawCount,
         stride: u32,
     ) {
-        self.device.mesh_fn.as_ref()
+        self.device.extension_fns.mesh_shaders.as_ref()
             .expect("Draw command not supported. You must request feature MESH_SHADER.")
             .cmd_draw_mesh_tasks_indirect_count(self.raw, buffer.raw, offset, count_buffer.raw, count_buffer_offset, max_draw_count, stride);
+    }
+
+    unsafe fn draw_indirect_count(
+        &mut self,
+        buffer: &n::Buffer,
+        offset: buffer::Offset,
+        count_buffer: &n::Buffer,
+        count_buffer_offset: buffer::Offset,
+        max_draw_count: DrawCount,
+        stride: u32
+    ) {
+        self.device
+            .extension_fns
+            .draw_indirect_count
+            .as_ref()
+            .expect("Feature DRAW_INDIRECT_COUNT must be enabled to call draw_indirect_count")
+            .cmd_draw_indirect_count(self.raw, buffer.raw, offset, count_buffer.raw, count_buffer_offset, max_draw_count, stride);
+    }
+
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        buffer: &n::Buffer,
+        offset: buffer::Offset,
+        count_buffer: &n::Buffer,
+        count_buffer_offset: buffer::Offset,
+        max_draw_count: DrawCount,
+        stride: u32
+    ) {
+        self.device
+            .extension_fns
+            .draw_indirect_count
+            .as_ref()
+            .expect("Feature DRAW_INDIRECT_COUNT must be enabled to call draw_indexed_indirect_count")
+            .cmd_draw_indexed_indirect_count(self.raw, buffer.raw, offset, count_buffer.raw, count_buffer_offset, max_draw_count, stride);
     }
 
     unsafe fn set_event(&mut self, event: &n::Event, stage_mask: pso::PipelineStage) {

--- a/src/backend/webgpu/src/command.rs
+++ b/src/backend/webgpu/src/command.rs
@@ -427,6 +427,30 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         todo!()
     }
 
+    unsafe fn draw_indirect_count(
+        &mut self,
+        _buffer: &<Backend as hal::Backend>::Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &<Backend as hal::Backend>::Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    ) {
+        todo!()
+    }
+
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        _buffer: &<Backend as hal::Backend>::Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &<Backend as hal::Backend>::Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    ) {
+        todo!()
+    }
+
     unsafe fn draw_mesh_tasks(&mut self, _task_count: TaskCount, _first_task: TaskCount) {
         todo!()
     }

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -494,6 +494,42 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         stride: u32,
     );
 
+    /// Functions identically to `draw_indirect()`, except the amount of draw
+    /// calls are specified by the u32 in `count_buffer` at `count_buffer_offset`.
+    /// There is a limit of `max_draw_count` invocations.
+    ///
+    /// Each draw command in the buffer is a series of 4 `u32` values specifying,
+    /// in order, the number of vertices to draw, the number of instances to draw,
+    /// the index of the first vertex to draw, and the instance ID of the first
+    /// instance to draw.
+    unsafe fn draw_indirect_count(
+        &mut self,
+        _buffer: &B::Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &B::Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    );
+
+    /// Functions identically to `draw_indexed_indirect()`, except the amount of draw
+    /// calls are specified by the u32 in `count_buffer` at `count_buffer_offset`.
+    /// There is a limit of `max_draw_count` invocations.
+    ///
+    /// Each draw command in the buffer is a series of 5 values specifying,
+    /// in order, the number of indices, the number of instances, the first index,
+    /// the vertex offset, and the first instance.  All are `u32`'s except
+    /// the vertex offset, which is an `i32`.
+    unsafe fn draw_indexed_indirect_count(
+        &mut self,
+        _buffer: &B::Buffer,
+        _offset: buffer::Offset,
+        _count_buffer: &B::Buffer,
+        _count_buffer_offset: buffer::Offset,
+        _max_draw_count: u32,
+        _stride: u32
+    );
+
     /// Dispatches `task_count` of threads. Similar to compute dispatch.
     unsafe fn draw_mesh_tasks(&mut self, task_count: TaskCount, first_task: TaskCount);
 

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -240,6 +240,8 @@ bitflags! {
         const STORAGE_TEXTURE_DESCRIPTOR_INDEXING = 0x0400_0000_0000_0000;
         /// Allow descriptor arrays to be unsized in shaders
         const UNSIZED_DESCRIPTOR_ARRAY = 0x0800_0000_0000_0000;
+        /// Enable draw_indirect_count and draw_indexed_indirect_count
+        const DRAW_INDIRECT_COUNT = 0x1000_0000_0000_0000;
 
         /// Support triangle fan primitive topology.
         const TRIANGLE_FAN = 0x0001 << 64;


### PR DESCRIPTION
Forward-ports #3279 to master. The default impl in the hal was removed in favor of stub impls in all the backends. Addtionally the mesh shader function machinery was combined with the machinery #3279 adds to get extension pointers.