### PR TITLE
Allow DX12 Backend to work with strides of 0

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -2477,7 +2477,9 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         draw_count: DrawCount,
         stride: u32,
     ) {
-        assert_eq!(stride, 16);
+        if stride != 0 {
+            assert_eq!(stride, 16);
+        }
         let buffer = buffer.expect_bound();
         self.set_graphics_bind_point();
         self.raw.ExecuteIndirect(
@@ -2497,7 +2499,9 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         draw_count: DrawCount,
         stride: u32,
     ) {
-        assert_eq!(stride, 20);
+        if stride != 0 {
+            assert_eq!(stride, 20);
+        }
         let buffer = buffer.expect_bound();
         self.set_graphics_bind_point();
         self.raw.ExecuteIndirect(
@@ -2519,7 +2523,9 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         max_draw_count: DrawCount,
         stride: u32
     ) {
-        assert_eq!(stride, 16);
+        if stride != 0 {
+            assert_eq!(stride, 16);
+        }
         let buffer = buffer.expect_bound();
         let count_buffer = count_buffer.expect_bound();
         self.set_graphics_bind_point();
@@ -2542,7 +2548,9 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         max_draw_count: DrawCount,
         stride: u32
     ) {
-        assert_eq!(stride, 20);
+        if stride != 0 {
+            assert_eq!(stride, 20);
+        }
         let buffer = buffer.expect_bound();
         let count_buffer = count_buffer.expect_bound();
         self.set_graphics_bind_point();


### PR DESCRIPTION
So this fixes the problem https://github.com/gfx-rs/wgpu/pull/754 was working around, but found a much more interesting problem:

- DX12 _must_ have a stride of 16/20, the value of the stride is ignored other than the assert. This isn't a problem from the wgpu perspective (we assume tightly packed), but would have issues for gfx-portability.