### PR TITLE
[0.5/dx11] Bump libloading to 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx11-0.5.2 (29-07-2020)
+  - update libloading to 0.6
+
 ### backend-vulkan-0.5.11 (22-07-2020)
   - switch from `core-graphics` to `core-graphics-types`.
 

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.5.1"
+version = "0.5.2"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -23,7 +23,7 @@ auxil = { path = "../../auxil/auxil", version = "0.4", package = "gfx-auxil", fe
 hal = { path = "../../hal", version = "0.5", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
-libloading = "0.5"
+libloading = "0.6"
 log = { version = "0.4" }
 smallvec = "1.0"
 spirv_cross = { version = "0.20", features = ["hlsl"] }


### PR DESCRIPTION
This bumps libloading in dx11 to 0.6, this isn't a breaking change as it is all internal.

We now directly depend on both libloading 0.6 (dx11) and 0.5 (d3d12-rs), however we have indirectly depended on both (ash uses 0.6) for a while, so this is no worse. Once d3d12 gets a new release, this issue will go away.