### PR TITLE
[0.5] Mock empty backend descriptor set functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-empty-0.5.2 (06-07-2020)
+  - mock descriptor set creation functions
+
 ### backend-empty-0.5.1 (30-06-2020)
   - start turning the empty backend into a mock instead of always panicking
   - mock memory creation and buffer and image creation functions

--- a/src/backend/empty/Cargo.toml
+++ b/src/backend/empty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-empty"
-version = "0.5.1"
+version = "0.5.2"
 description = "Empty backend for gfx-rs"
 license = "MIT OR Apache-2.0"
 authors = ["The Gfx-rs Developers"]

--- a/src/backend/empty/src/buffer.rs
+++ b/src/backend/empty/src/buffer.rs
@@ -1,7 +1,7 @@
 #[derive(Debug)]
 pub struct Buffer {
     /// Size of this buffer
-    pub size: u64,
+    pub(crate) size: u64,
 }
 
 impl Buffer {

--- a/src/backend/empty/src/descriptor.rs
+++ b/src/backend/empty/src/descriptor.rs
@@ -1,0 +1,42 @@
+use hal::pso;
+use log::debug;
+
+/// Dummy descriptor pool.
+#[derive(Debug)]
+pub struct DescriptorPool;
+
+impl pso::DescriptorPool<crate::Backend> for DescriptorPool {
+    unsafe fn allocate_set(
+        &mut self,
+        _layout: &DescriptorSetLayout,
+    ) -> Result<DescriptorSet, pso::AllocationError> {
+        Ok(DescriptorSet {
+            name: String::new(),
+        })
+    }
+
+    unsafe fn free_sets<I>(&mut self, descriptor_sets: I)
+    where
+        I: IntoIterator<Item = DescriptorSet>,
+    {
+        for _ in descriptor_sets {
+            // Let the descriptor set drop
+        }
+    }
+
+    unsafe fn reset(&mut self) {
+        debug!("Resetting descriptor pool");
+    }
+}
+
+#[derive(Debug)]
+pub struct DescriptorSetLayout {
+    /// User-defined name for this descriptor set layout
+    pub(crate) name: String,
+}
+
+#[derive(Debug)]
+pub struct DescriptorSet {
+    /// User-defined name for this descriptor set
+    pub(crate) name: String,
+}


### PR DESCRIPTION
More work on #3278, with the intent to follow up with fuzz testing for the `gfx-descriptor` crate. 