### PR TITLE
added name setters for PipelineLayout, Graphics and Compute pipelines

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -928,9 +928,9 @@ impl device::Device<Backend> for Device {
                 ref vertex,
                 ref tessellation,
                 ref geometry,
-            } => {               
+            } => {
                 let vs = build_shader(ShaderStage::Vertex, Some(&vertex))?.unwrap();
-                let gs = build_shader(ShaderStage::Geometry, geometry.as_ref())?;  
+                let gs = build_shader(ShaderStage::Geometry, geometry.as_ref())?;
 
                 let layout = self.create_input_layout(vs.clone(), buffers, attributes, input_assembler)?;
 
@@ -961,11 +961,11 @@ impl device::Device<Backend> for Device {
             Some(self.create_pixel_shader(blob)?)
         } else {
             None
-        };  
+        };
 
         let rasterizer_state = self.create_rasterizer_state(&desc.rasterizer)?;
         let blend_state = self.create_blend_state(&desc.blender)?;
-        let depth_stencil_state = Some(self.create_depth_stencil_state(&desc.depth_stencil)?);              
+        let depth_stencil_state = Some(self.create_depth_stencil_state(&desc.depth_stencil)?);
 
         Ok(GraphicsPipeline {
             vs,
@@ -2366,6 +2366,30 @@ impl device::Device<Backend> for Device {
     unsafe fn set_descriptor_set_layout_name(
         &self,
         _descriptor_set_layout: &mut DescriptorSetLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_pipeline_layout_name(
+        &self,
+        _pipeline_layout: &mut PipelineLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_compute_pipeline_name(
+        &self,
+        _compute_pipeline: &mut ComputePipeline,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_graphics_pipeline_name(
+        &self,
+        _graphics_pipeline: &mut GraphicsPipeline,
         _name: &str,
     ) {
         // TODO

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1808,7 +1808,7 @@ impl d::Device<B> for Device {
                 Ok((shader, false)) => Ok(ShaderBc::Borrowed(shader)),
                 Err(err) => Err(pso::CreationError::Shader(err)),
             }
-        };        
+        };
 
         let vertex_buffers = Vec::new();
         let attributes = Vec::new();
@@ -1830,7 +1830,7 @@ impl d::Device<B> for Device {
 
                 (buffers, attributes, input_assembler, Some(vertex), geometry.as_ref(), hs, ds, None, None)
             },
-            pso::PrimitiveAssembler::Mesh { 
+            pso::PrimitiveAssembler::Mesh {
                 ref task,
                 ref mesh
              } => {
@@ -3612,6 +3612,30 @@ impl d::Device<B> for Device {
     unsafe fn set_descriptor_set_layout_name(
         &self,
         _descriptor_set_layout: &mut r::DescriptorSetLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_pipeline_layout_name(
+        &self,
+        _pipeline_layout: &mut r::PipelineLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_compute_pipeline_name(
+        &self,
+        _compute_pipeline: &mut r::ComputePipeline,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_graphics_pipeline_name(
+        &self,
+        _graphics_pipeline: &mut r::GraphicsPipeline,
         _name: &str,
     ) {
         // TODO

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -607,6 +607,18 @@ impl device::Device<Backend> for Device {
         layout.name = name.to_string();
     }
 
+    unsafe fn set_pipeline_layout_name(&self, _pipeline_layout: &mut (), _name: &str) {
+        unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
+    }
+
+    unsafe fn set_compute_pipeline_name(&self, _compute_pipeline: &mut (), _name: &str) {
+        unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
+    }
+
+    unsafe fn set_graphics_pipeline_name(&self, _graphics_pipeline: &mut (), _name: &str) {
+        unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
+    }
+
     unsafe fn reset_fence(&self, _: &()) -> Result<(), device::OutOfMemory> {
         Ok(())
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -2058,4 +2058,28 @@ impl d::Device<B> for Device {
     ) {
         // TODO
     }
+
+    unsafe fn set_pipeline_layout_name(
+        &self,
+        _pipeline_layout: &mut n::PipelineLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_compute_pipeline_name(
+        &self,
+        _compute_pipeline: &mut n::ComputePipeline,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_graphics_pipeline_name(
+        &self,
+        _graphics_pipeline: &mut n::GraphicsPipeline,
+        _name: &str,
+    ) {
+        // TODO
+    }
 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1418,7 +1418,7 @@ impl hal::device::Device<Backend> for Device {
                     (Some(&ts.0), Some(&ts.1))
                 } else {
                     (None, None)
-                };    
+                };
 
                 (buffers, attributes, input_assembler, vertex, geometry, hs, ds)
             }
@@ -3154,6 +3154,30 @@ impl hal::device::Device<Backend> for Device {
     unsafe fn set_descriptor_set_layout_name(
         &self,
         _descriptor_set_layout: &mut n::DescriptorSetLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_pipeline_layout_name(
+        &self,
+        _pipeline_layout: &mut n::PipelineLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_compute_pipeline_name(
+        &self,
+        _compute_pipeline: &mut n::ComputePipeline,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_graphics_pipeline_name(
+        &self,
+        _graphics_pipeline: &mut n::GraphicsPipeline,
         _name: &str,
     ) {
         // TODO

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -2305,6 +2305,38 @@ impl d::Device<B> for Device {
             name,
         )
     }
+
+    unsafe fn set_pipeline_layout_name(
+        &self,
+        pipeline_layout: &mut n::PipelineLayout,
+        name: &str,
+    ) {
+        self.set_object_name(
+            vk::ObjectType::PIPELINE_LAYOUT,
+            pipeline_layout.raw.as_raw(),
+            name,
+        )
+    }
+
+    unsafe fn set_compute_pipeline_name(
+        &self,
+        compute_pipeline: &mut n::ComputePipeline,
+        name: &str,
+    ) {
+        self.set_object_name(
+            vk::ObjectType::PIPELINE,
+            compute_pipeline.0.as_raw(),
+            name,
+        )
+    }
+
+    unsafe fn set_graphics_pipeline_name(&self, graphics_pipeline: &mut n::GraphicsPipeline, name: &str) {
+        self.set_object_name(
+            vk::ObjectType::PIPELINE,
+            graphics_pipeline.0.as_raw(),
+            name,
+        )
+    }
 }
 
 impl Device {

--- a/src/backend/webgpu/src/device.rs
+++ b/src/backend/webgpu/src/device.rs
@@ -588,4 +588,28 @@ impl hal::device::Device<Backend> for Device {
     ) {
         todo!()
     }
+
+    unsafe fn set_pipeline_layout_name(
+        &self,
+        _pipeline_layout: &mut <Backend as hal::Backend>::PipelineLayout,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_compute_pipeline_name(
+        &self,
+        _compute_pipeline: &mut <Backend as hal::Backend>::ComputePipeline,
+        _name: &str,
+    ) {
+        // TODO
+    }
+
+    unsafe fn set_graphics_pipeline_name(
+        &self,
+        _graphics_pipeline: &mut <Backend as hal::Backend>::GraphicsPipeline,
+        _name: &str,
+    ) {
+        // TODO
+    }
 }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -1007,4 +1007,25 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         descriptor_set_layout: &mut B::DescriptorSetLayout,
         name: &str,
     );
+    /// Associate a name with a pipeline layout, for easier debugging in external tools or with
+    /// validation layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_pipeline_layout_name(
+        &self,
+        pipeline_layout: &mut B::PipelineLayout,
+        name: &str,
+    );
+    /// Associate a name with a compute pipeline, for easier debugging in external tools or with
+    /// validation layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_compute_pipeline_name(
+        &self,
+        compute_pipeline: &mut B::ComputePipeline,
+        name: &str,
+    );
+    /// Associate a name with a graphics pipeline, for easier debugging in external tools or with
+    /// validation layers that can print a friendly name when referring to objects in error messages
+    unsafe fn set_graphics_pipeline_name(
+        &self,
+        graphics_pipeline: &mut B::GraphicsPipeline,
+        name: &str,
+    );
 }


### PR DESCRIPTION
Fixes #3237

PR checklist:
- [X] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: gl
- [ ] `rustfmt` run on changed code
