### PR TITLE
replaced PrimitiveAssembler vecs with slices

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1289,8 +1289,8 @@ impl<B: Backend> PipelineState<B> {
 
                 let mut pipeline_desc = pso::GraphicsPipelineDesc::new(
                     pso::PrimitiveAssembler::Vertex {
-                        buffers: vertex_buffers,
-                        attributes,
+                        buffers: &vertex_buffers,
+                        attributes: &attributes,
                         input_assembler: pso::InputAssemblerDesc {
                             primitive: pso::Primitive::TriangleList,
                             with_adjacency: false,

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -706,8 +706,8 @@ where
 
                 let mut pipeline_desc = pso::GraphicsPipelineDesc::new(
                     pso::PrimitiveAssembler::Vertex {
-                        buffers: vertex_buffers,
-                        attributes,
+                        buffers: &vertex_buffers,
+                        attributes: &attributes,
                         input_assembler: pso::InputAssemblerDesc {
                             primitive: pso::Primitive::TriangleList,
                             with_adjacency: false,

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -922,8 +922,8 @@ impl device::Device<Backend> for Device {
 
         let (layout, vs, gs, hs, ds) = match desc.primitive_assembler {
             pso::PrimitiveAssembler::Vertex {
-                ref buffers,
-                ref attributes,
+                buffers,
+                attributes,
                 ref input_assembler,
                 ref vertex,
                 ref tessellation,

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1810,13 +1810,13 @@ impl d::Device<B> for Device {
             }
         };
 
-        let vertex_buffers = Vec::new();
-        let attributes = Vec::new();
+        let vertex_buffers: Vec<pso::VertexBufferDesc> = Vec::new();
+        let attributes: Vec<pso::AttributeDesc> = Vec::new();
         let input_assembler = pso::InputAssemblerDesc::new(pso::Primitive::TriangleList);
         let (vertex_buffers, attributes, input_assembler, vs, gs, hs, ds, _, _) = match desc.primitive_assembler {
             pso::PrimitiveAssembler::Vertex {
-                ref buffers,
-                ref attributes,
+                buffers,
+                attributes,
                 ref input_assembler,
                 ref vertex,
                 ref tessellation,
@@ -1834,7 +1834,7 @@ impl d::Device<B> for Device {
                 ref task,
                 ref mesh
              } => {
-                (&vertex_buffers, &attributes, &input_assembler, None, None, None, None, task.as_ref(), Some(mesh))
+                (&vertex_buffers[..], &attributes[..], &input_assembler, None, None, None, None, task.as_ref(), Some(mesh))
             },
         };
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -761,8 +761,8 @@ impl d::Device<B> for Device {
         let (vertex_buffers, desc_attributes, input_assembler, vs, gs, hs, ds) =
             match desc.primitive_assembler {
                 pso::PrimitiveAssembler::Vertex {
-                    ref buffers,
-                    ref attributes,
+                    buffers,
+                    attributes,
                     ref input_assembler,
                     ref vertex,
                     ref tessellation,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1407,8 +1407,8 @@ impl hal::device::Device<Backend> for Device {
 
         let (desc_vertex_buffers, attributes, input_assembler, vs, gs, hs, ds) = match pipeline_desc.primitive_assembler {
             pso::PrimitiveAssembler::Vertex {
-                ref buffers,
-                ref attributes,
+                buffers,
+                attributes,
                 ref input_assembler,
                 ref vertex,
                 ref tessellation,

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -75,9 +75,9 @@ pub enum PrimitiveAssembler<'a, B: Backend> {
     /// Vertex based pipeline
     Vertex {
         /// Vertex buffers (IA)
-        buffers: Vec<VertexBufferDesc>,
+        buffers: &'a [VertexBufferDesc],
         /// Vertex attributes (IA)
-        attributes: Vec<AttributeDesc>,
+        attributes: &'a [AttributeDesc],
         /// Input assembler attributes, describes how
         /// vertices are assembled into primitives (such as triangles).
         input_assembler: InputAssemblerDesc,
@@ -156,7 +156,7 @@ impl<'a, B: Backend> GraphicsPipelineDesc<'a, B> {
     ) -> Self {
         GraphicsPipelineDesc {
             primitive_assembler,
-            rasterizer,            
+            rasterizer,
             fragment,
             blender: BlendDesc::default(),
             depth_stencil: DepthStencilDesc::default(),

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -922,8 +922,8 @@ impl<B: hal::Backend> Scene<B> {
                     let desc = pso::GraphicsPipelineDesc {
                         rasterizer: rasterizer.clone(),
                         primitive_assembler: pso::PrimitiveAssembler::Vertex {
-                            buffers: vertex_buffers.clone(),
-                            attributes: attributes.clone(),
+                            buffers: &vertex_buffers,
+                            attributes: &attributes,
                             input_assembler: input_assembler.clone(),
                             vertex: pso::EntryPoint {
                                 entry: "main",


### PR DESCRIPTION
Fixes #3259
PR checklist:
- [X] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: gl vulkan (compilation only)
- [ ] `rustfmt` run on changed code
