### PR TITLE
Bump cocoa and core-graphics deps for metal backend

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -33,8 +33,8 @@ metal = { version = "0.18", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"
-cocoa = "0.20"
-core-graphics = "0.19"
+cocoa = "0.22"
+core-graphics = "0.21"
 smallvec = "1"
 spirv_cross = { version = "0.20", features = ["msl"] }
 parking_lot = "0.10"


### PR DESCRIPTION
This fixes build issues on macOS caused by multiple versions of cocoa
dependencies. core-graphics is also updated to be consistent with cocoa v0.22,
which removes a duplication.

The build passes and test_send_sync passes with this PR on my macOS 10.15.5 machine.