### PR TITLE
Bump cocoa and core-graphics deps for metal backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### backend-metal-0.5.5 (19-07-2020)
+  - update cocoa to 0.22, core-graphics to 0.21
+  - added the patch version number to the metal dependency (v0.18.1).
+
 ### backend-vulkan-0.5.10 (10-07-2020)
   - skip unknown memory types
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Change Log
 
 ### backend-metal-0.5.5 (19-07-2020)
-  - update cocoa to 0.22, core-graphics to 0.21
-  - added the patch version number to the metal dependency (v0.18.1).
+  - update cocoa to 0.22, core-graphics to 0.21 and metal to 0.19.
 
 ### backend-vulkan-0.5.10 (10-07-2020)
   - skip unknown memory types

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -29,7 +29,7 @@ bitflags = "1.0"
 copyless = "0.1.4"
 log = { version = "0.4" }
 dispatch = { version = "0.2", optional = true }
-metal = { version = "0.18", features = ["private"] }
+metal = { version = "0.19", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-metal"
-version = "0.5.4"
+version = "0.5.5"
 description = "Metal API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -33,8 +33,8 @@ metal = { version = "0.18", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"
-cocoa = "0.20"
-core-graphics = "0.19"
+cocoa = "0.22"
+core-graphics = "0.21"
 smallvec = "1"
 spirv_cross = { version = "0.20", features = ["msl"] }
 parking_lot = "0.10"


### PR DESCRIPTION
This fixes build issues on macOS caused by multiple versions of cocoa
deps. core-graphics is also updated to be consistent with cocoa v0.22,
which removes a duplication.

hal-0.5 version of #3310 

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds (fails on my machine, but this perhaps should be filed in another issue)
- [x] tested examples with the following backends: `metal`
- [x] `rustfmt` run on changed code
