### PR TITLE
[0.5/metal] Remove core-graphics deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### backend-metal-0.5.5 (20-07-2020)
+  - update cocoa to 0.22 and metal to 0.19.
+  - remove core-graphics dependency
+
 ### backend-vulkan-0.5.10 (10-07-2020)
   - skip unknown memory types
 

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -29,12 +29,11 @@ bitflags = "1.0"
 copyless = "0.1.4"
 log = { version = "0.4" }
 dispatch = { version = "0.2", optional = true }
-metal = { version = "0.18", features = ["private"] }
+metal = { version = "0.19", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"
-cocoa = "0.20"
-core-graphics = "0.19"
+cocoa = "0.22"
 smallvec = "1"
 spirv_cross = { version = "0.20", features = ["msl"] }
 parking_lot = "0.10"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-metal"
-version = "0.5.4"
+version = "0.5.5"
 description = "Metal API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -65,14 +65,13 @@ use hal::{
 use range_alloc::RangeAllocator;
 
 use cocoa::foundation::NSInteger;
-use core_graphics::base::CGFloat;
-use core_graphics::geometry::CGRect;
 #[cfg(feature = "dispatch")]
 use dispatch;
 use foreign_types::ForeignTypeRef;
 use lazy_static::lazy_static;
 use metal::MTLFeatureSet;
 use metal::MTLLanguageVersion;
+use metal::{CGFloat, CGSize};
 use objc::{
     declare::ClassDecl,
     runtime::{Class, Object, Sel, BOOL, YES},
@@ -101,6 +100,40 @@ pub type GraphicsCommandPool = CommandPool;
 //TODO: investigate why exactly using `u8` here is slower (~5% total).
 /// A type representing Metal binding's resource index.
 type ResourceIndex = u32;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CGPoint {
+    pub x: CGFloat,
+    pub y: CGFloat,
+}
+
+impl CGPoint {
+    #[inline]
+    pub fn new(x: CGFloat, y: CGFloat) -> CGPoint {
+        CGPoint {
+            x,
+            y,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CGRect {
+    pub origin: CGPoint,
+    pub size: CGSize
+}
+
+impl CGRect {
+    #[inline]
+    pub fn new(origin: CGPoint, size: CGSize) -> CGRect {
+        CGRect {
+            origin,
+            size,
+        }
+    }
+}
 
 /// Method of recording one-time-submit command buffers.
 #[derive(Clone, Debug, Hash, PartialEq)]

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -9,10 +9,10 @@ use crate::{
 
 use hal::{format, image, window as w};
 
-use core_graphics::base::CGFloat;
-use core_graphics::geometry::{CGRect, CGSize};
+use crate::CGRect;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use metal;
+use metal::{CGFloat, CGSize};
 use objc::rc::autoreleasepool;
 use objc::runtime::Object;
 use parking_lot::{Mutex, MutexGuard};


### PR DESCRIPTION
https://github.com/gfx-rs/gfx/pull/3312 hal 0.5 version
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: metal
- [ ] `rustfmt` run on changed code
