### PR TITLE
[0.5/vk] Switch to core-graphics-types instead of core-graphics

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -34,7 +34,7 @@ raw-window-handle = "0.3"
 winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2.5"
-core-graphics = "0.19"
+core-graphics-types = "0.1"
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 x11 = { version = "2.15", features = ["xlib"], optional = true }

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -247,7 +247,7 @@ impl Instance {
     #[cfg(target_os = "macos")]
     pub fn create_surface_from_ns_view(&self, view: *mut c_void) -> Surface {
         use ash::extensions::mvk;
-        use core_graphics::{base::CGFloat, geometry::CGRect};
+        use core_graphics_types::{base::CGFloat, geometry::CGRect};
         use objc::runtime::{Object, BOOL, YES};
 
         // TODO: this logic is duplicated from gfx-backend-metal, refactor?


### PR DESCRIPTION
This reduces the likelihood of churn.

Edit: sibling of #3317 for hal-0.5