### PR TITLE
[0.5/dx12] essential fixes to depth views and command allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### backend-dx12-0.5.9 (14-08-2020)
+  - fix creation of depth-stencil views
+  - fix command allocator reset validation errors
+  - fix the crash on `unconfigure_swapchain`
+
 ### backend-dx11-0.5.2 (29-07-2020)
   - update libloading to 0.6
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.5.8"
+version = "0.5.9"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1510,7 +1510,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                             },
                         };
                         let rtv = rtv_pool.alloc_handle();
-                        Device::view_image_as_render_target_impl(device, rtv, view_info).unwrap();
+                        Device::view_image_as_render_target_impl(device, rtv, &view_info).unwrap();
                         self.clear_render_target_view(rtv, value.into(), &rect);
                     }
 
@@ -1555,7 +1555,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                             },
                         };
                         let dsv = dsv_pool.alloc_handle();
-                        Device::view_image_as_depth_stencil_impl(device, dsv, view_info).unwrap();
+                        Device::view_image_as_depth_stencil_impl(device, dsv, &view_info).unwrap();
                         self.clear_depth_stencil_view(dsv, depth, stencil, &rect);
                     }
 

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -342,6 +342,7 @@ pub struct CommandBuffer {
     raw: native::GraphicsCommandList,
     allocator: native::CommandAllocator,
     shared: Arc<Shared>,
+    is_active: bool,
 
     // Cache renderpasses for graphics operations
     pass_cache: Option<RenderPassCache>,
@@ -431,6 +432,7 @@ impl CommandBuffer {
             raw,
             allocator,
             shared,
+            is_active: false,
             pass_cache: None,
             cur_subpass: !0,
             gr_pipeline: PipelineCache::new(),
@@ -470,8 +472,22 @@ impl CommandBuffer {
     }
 
     fn reset(&mut self) {
+        if self
+            .pool_create_flags
+            .contains(pool::CommandPoolCreateFlags::RESET_INDIVIDUAL)
+        {
+            // Command buffer has reset semantics now and doesn't require to be in `Initial` state.
+            if self.is_active {
+                self.raw.close();
+            }
+            unsafe {
+                self.allocator.Reset()
+            };
+        }
         self.raw
             .reset(self.allocator, native::PipelineState::null());
+        self.is_active = true;
+
         self.pass_cache = None;
         self.cur_subpass = !0;
         self.gr_pipeline = PipelineCache::new();
@@ -1162,29 +1178,15 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         _info: com::CommandBufferInheritanceInfo<Backend>,
     ) {
         // TODO: Implement flags and secondary command buffers (bundles).
-        if self
-            .pool_create_flags
-            .contains(pool::CommandPoolCreateFlags::RESET_INDIVIDUAL)
-        {
-            // Command buffer has reset semantics now and doesn't require to be in `Initial` state.
-            self.allocator.Reset();
-        }
         self.reset();
     }
 
     unsafe fn finish(&mut self) {
-        self.raw.Close();
+        self.raw.close();
+        self.is_active = false;
     }
 
     unsafe fn reset(&mut self, _release_resources: bool) {
-        // Ensure that we have a bijective relation between list and allocator.
-        // This allows to modify the allocator here. Using `reset` requires this by specification.
-        assert!(self
-            .pool_create_flags
-            .contains(pool::CommandPoolCreateFlags::RESET_INDIVIDUAL));
-
-        // TODO: `release_resources` should recreate the allocator to give back all memory.
-        self.allocator.Reset();
         self.reset();
     }
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -579,7 +579,7 @@ impl Device {
     pub(crate) fn view_image_as_render_target_impl(
         device: native::Device,
         handle: d3d12::D3D12_CPU_DESCRIPTOR_HANDLE,
-        info: ViewInfo,
+        info: &ViewInfo,
     ) -> Result<(), image::ViewCreationError> {
         #![allow(non_snake_case)]
 
@@ -598,7 +598,7 @@ impl Device {
         }
         if info.range.layers.end > info.kind.num_layers() {
             return Err(image::ViewCreationError::Layer(
-                image::LayerError::OutOfBounds(info.range.layers),
+                image::LayerError::OutOfBounds(info.range.layers.clone()),
             ));
         }
 
@@ -677,7 +677,7 @@ impl Device {
 
     fn view_image_as_render_target(
         &self,
-        info: ViewInfo,
+        info: &ViewInfo,
     ) -> Result<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE, image::ViewCreationError> {
         let handle = self.rtv_pool.lock().unwrap().alloc_handle();
         Self::view_image_as_render_target_impl(self.raw, handle, info).map(|_| handle)
@@ -686,7 +686,7 @@ impl Device {
     pub(crate) fn view_image_as_depth_stencil_impl(
         device: native::Device,
         handle: d3d12::D3D12_CPU_DESCRIPTOR_HANDLE,
-        info: ViewInfo,
+        info: &ViewInfo,
     ) -> Result<(), image::ViewCreationError> {
         #![allow(non_snake_case)]
 
@@ -706,7 +706,7 @@ impl Device {
         }
         if info.range.layers.end > info.kind.num_layers() {
             return Err(image::ViewCreationError::Layer(
-                image::LayerError::OutOfBounds(info.range.layers),
+                image::LayerError::OutOfBounds(info.range.layers.clone()),
             ));
         }
 
@@ -765,7 +765,7 @@ impl Device {
 
     fn view_image_as_depth_stencil(
         &self,
-        info: ViewInfo,
+        info: &ViewInfo,
     ) -> Result<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE, image::ViewCreationError> {
         let handle = self.dsv_pool.lock().unwrap().alloc_handle();
         Self::view_image_as_depth_stencil_impl(self.raw, handle, info).map(|_| handle)
@@ -893,17 +893,8 @@ impl Device {
 
     fn view_image_as_shader_resource(
         &self,
-        mut info: ViewInfo,
+        info: &ViewInfo,
     ) -> Result<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE, image::ViewCreationError> {
-        #![allow(non_snake_case)]
-
-        // Depth-stencil formats can't be used for SRVs.
-        info.format = match info.format {
-            dxgiformat::DXGI_FORMAT_D16_UNORM => dxgiformat::DXGI_FORMAT_R16_UNORM,
-            dxgiformat::DXGI_FORMAT_D32_FLOAT => dxgiformat::DXGI_FORMAT_R32_FLOAT,
-            format => format,
-        };
-
         let desc = Self::build_image_as_shader_resource_desc(&info)?;
         let handle = self.srv_uav_pool.lock().unwrap().alloc_handle();
         unsafe {
@@ -916,7 +907,7 @@ impl Device {
 
     fn view_image_as_storage(
         &self,
-        info: ViewInfo,
+        info: &ViewInfo,
     ) -> Result<d3d12::D3D12_CPU_DESCRIPTOR_HANDLE, image::ViewCreationError> {
         #![allow(non_snake_case)]
         assert_eq!(info.range.levels.start + 1, info.range.levels.end);
@@ -933,7 +924,7 @@ impl Device {
 
         if info.range.layers.end > info.kind.num_layers() {
             return Err(image::ViewCreationError::Layer(
-                image::LayerError::OutOfBounds(info.range.layers),
+                image::LayerError::OutOfBounds(info.range.layers.clone()),
             ));
         }
         if info.kind.num_samples() > 1 {
@@ -2558,7 +2549,7 @@ impl d::Device<B> for Device {
                 let format = image_unbound.view_format.unwrap();
                 (0 .. num_layers)
                     .map(|layer| {
-                        self.view_image_as_render_target(ViewInfo {
+                        self.view_image_as_render_target(&ViewInfo {
                             format,
                             range: image::SubresourceRange {
                                 aspects: Aspects::COLOR,
@@ -2577,7 +2568,7 @@ impl d::Device<B> for Device {
                 let format = image_unbound.dsv_format.unwrap();
                 (0 .. num_layers)
                     .map(|layer| {
-                        self.view_image_as_depth_stencil(ViewInfo {
+                        self.view_image_as_depth_stencil(&ViewInfo {
                             format,
                             range: image::SubresourceRange {
                                 aspects: Aspects::DEPTH,
@@ -2596,7 +2587,7 @@ impl d::Device<B> for Device {
                 let format = image_unbound.dsv_format.unwrap();
                 (0 .. num_layers)
                     .map(|layer| {
-                        self.view_image_as_depth_stencil(ViewInfo {
+                        self.view_image_as_depth_stencil(&ViewInfo {
                             format,
                             range: image::SubresourceRange {
                                 aspects: Aspects::STENCIL,
@@ -2629,6 +2620,7 @@ impl d::Device<B> for Device {
         let is_array = image.kind.num_layers() > 1;
         let mip_levels = (range.levels.start, range.levels.end);
         let layers = (range.layers.start, range.layers.end);
+        let surface_format = format.base_format().0;
 
         let info = ViewInfo {
             resource: image.resource,
@@ -2656,24 +2648,47 @@ impl d::Device<B> for Device {
                 .usage
                 .intersects(image::Usage::SAMPLED | image::Usage::INPUT_ATTACHMENT)
             {
-                self.view_image_as_shader_resource(info.clone()).ok()
+                let info = if info.range.aspects.contains(format::Aspects::DEPTH) {
+                    conv::map_format_shader_depth(surface_format)
+                        .map(|format| ViewInfo {
+                            format,
+                            .. info.clone()
+                        })
+                } else if info.range.aspects.contains(format::Aspects::STENCIL) {
+                    // Vulkan/gfx expects stencil to be read from the R channel,
+                    // while DX12 exposes it in "G" always.
+                    let new_swizzle = conv::swizzle_rg(swizzle);
+                    conv::map_format_shader_stencil(surface_format)
+                        .map(|format| ViewInfo {
+                            format,
+                            component_mapping: conv::map_swizzle(new_swizzle),
+                            .. info.clone()
+                        })
+                } else {
+                    Some(info.clone())
+                };
+                if let Some(ref info) = info {
+                    self.view_image_as_shader_resource(&info).ok()
+                } else {
+                    None
+                }
             } else {
                 None
             },
             handle_rtv: if image.usage.contains(image::Usage::COLOR_ATTACHMENT) {
-                self.view_image_as_render_target(info.clone()).ok()
+                self.view_image_as_render_target(&info).ok()
             } else {
                 None
             },
             handle_uav: if image.usage.contains(image::Usage::STORAGE) {
-                self.view_image_as_storage(info.clone()).ok()
+                self.view_image_as_storage(&info).ok()
             } else {
                 None
             },
             handle_dsv: if image.usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT) {
-                match conv::map_format_dsv(format.base_format().0) {
+                match conv::map_format_dsv(surface_format) {
                     Some(dsv_format) => self
-                        .view_image_as_depth_stencil(ViewInfo {
+                        .view_image_as_depth_stencil(&ViewInfo {
                             format: dsv_format,
                             ..info
                         })

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -159,7 +159,10 @@ impl w::PresentationSurface<Backend> for Surface {
     }
 
     unsafe fn unconfigure_swapchain(&mut self, device: &Device) {
-        if let Some(present) = self.presentation.take() {
+        if let Some(mut present) = self.presentation.take() {
+            let _ = present.swapchain.wait(winbase::INFINITE);
+            let _ = device.wait_idle(); //TODO: this shouldn't be needed,
+            // but it complains that the queue is still used otherwise
             device.destroy_swapchain(present.swapchain);
         }
     }
@@ -171,16 +174,7 @@ impl w::PresentationSurface<Backend> for Surface {
         let present = self.presentation.as_mut().unwrap();
         let sc = &mut present.swapchain;
  
-        match synchapi::WaitForSingleObject(
-            sc.waitable,
-            (timeout_ns / 1_000_000) as u32,
-        ) {
-            winbase::WAIT_ABANDONED |
-            winbase::WAIT_FAILED => return Err(w::AcquireError::DeviceLost(hal::device::DeviceLost)),
-            winbase::WAIT_OBJECT_0 => (),
-            winerror::WAIT_TIMEOUT => return Err(w::AcquireError::Timeout),
-            hr => panic!("Unexpected wait status 0x{:X}", hr),
-        }
+        sc.wait((timeout_ns / 1_000_000) as u32)?;
 
         let index = sc.inner.GetCurrentBackBufferIndex();
         let view = r::ImageView {
@@ -219,6 +213,18 @@ impl Swapchain {
         }
         self.rtv_heap.destroy();
         self.inner
+    }
+
+    pub(crate) fn wait(&mut self, timeout_ms: u32) -> Result<(), w::AcquireError> {
+        match unsafe {
+            synchapi::WaitForSingleObject(self.waitable, timeout_ms)
+        } {
+            winbase::WAIT_ABANDONED |
+            winbase::WAIT_FAILED => Err(w::AcquireError::DeviceLost(hal::device::DeviceLost)),
+            winbase::WAIT_OBJECT_0 => Ok(()),
+            winerror::WAIT_TIMEOUT => Err(w::AcquireError::Timeout),
+            hr => panic!("Unexpected wait status 0x{:X}", hr),
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #2656
Tested on vange-rs and wgpu-rs examples
With these fixes, we run wgpu-rs stuff without validation errors, and terminate successfully :tada: 