### PR TITLE
Support unbound subresource ranges

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -101,12 +101,6 @@ const QUAD: [Vertex; 6] = [
     },
 ];
 
-const COLOR_RANGE: i::SubresourceRange = i::SubresourceRange {
-    aspects: f::Aspects::COLOR,
-    levels: 0 .. 1,
-    layers: 0 .. 1,
-};
-
 struct RendererState<B: Backend> {
     uniform_desc_pool: Option<B::DescriptorPool>,
     img_desc_pool: Option<B::DescriptorPool>,
@@ -1029,7 +1023,10 @@ impl<B: Backend> ImageState<B> {
                 i::ViewKind::D2,
                 ColorFormat::SELF,
                 f::Swizzle::NO,
-                COLOR_RANGE.clone(),
+                i::SubresourceRange {
+                    aspects: f::Aspects::COLOR,
+                    .. Default::default()
+                },
             )
             .unwrap();
 
@@ -1068,7 +1065,10 @@ impl<B: Backend> ImageState<B> {
                     .. (i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal),
                 target: &image,
                 families: None,
-                range: COLOR_RANGE.clone(),
+                range: i::SubresourceRange {
+                    aspects: f::Aspects::COLOR,
+                    .. Default::default()
+                },
             };
 
             cmd_buffer.pipeline_barrier(
@@ -1104,7 +1104,10 @@ impl<B: Backend> ImageState<B> {
                     .. (i::Access::SHADER_READ, i::Layout::ShaderReadOnlyOptimal),
                 target: &image,
                 families: None,
-                range: COLOR_RANGE.clone(),
+                range: i::SubresourceRange {
+                    aspects: f::Aspects::COLOR,
+                    .. Default::default()
+                },
             };
             cmd_buffer.pipeline_barrier(
                 pso::PipelineStage::TRANSFER .. pso::PipelineStage::FRAGMENT_SHADER,

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -75,11 +75,6 @@ const QUAD: [Vertex; 6] = [
     Vertex { a_Pos: [ -0.5,-0.33 ], a_Uv: [0.0, 0.0] },
 ];
 
-const COLOR_RANGE: i::SubresourceRange = i::SubresourceRange {
-    aspects: f::Aspects::COLOR,
-    levels: 0 .. 1,
-    layers: 0 .. 1,
-};
 
 fn main() {
     #[cfg(target_arch = "wasm32")]
@@ -444,7 +439,10 @@ where
                     i::ViewKind::D2,
                     ColorFormat::SELF,
                     Swizzle::NO,
-                    COLOR_RANGE.clone(),
+                    i::SubresourceRange {
+                        aspects: f::Aspects::COLOR,
+                        .. Default::default()
+                    },
                 )
             }
             .unwrap(),
@@ -488,7 +486,10 @@ where
                     .. (i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal),
                 target: &*image_logo,
                 families: None,
-                range: COLOR_RANGE.clone(),
+                range: i::SubresourceRange {
+                    aspects: f::Aspects::COLOR,
+                    .. Default::default()
+                },
             };
 
             cmd_buffer.pipeline_barrier(
@@ -524,7 +525,10 @@ where
                     .. (i::Access::SHADER_READ, i::Layout::ShaderReadOnlyOptimal),
                 target: &*image_logo,
                 families: None,
-                range: COLOR_RANGE.clone(),
+                range: i::SubresourceRange {
+                    aspects: f::Aspects::COLOR,
+                    .. Default::default()
+                },
             };
             cmd_buffer.pipeline_barrier(
                 PipelineStage::TRANSFER .. PipelineStage::FRAGMENT_SHADER,

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -447,13 +447,13 @@ impl Device {
         }
 
         #[allow(non_snake_case)]
-        let MostDetailedMip = info.range.levels.start as _;
+        let MostDetailedMip = info.levels.start as _;
         #[allow(non_snake_case)]
-        let MipLevels = (info.range.levels.end - info.range.levels.start) as _;
+        let MipLevels = (info.levels.end - info.levels.start) as _;
         #[allow(non_snake_case)]
-        let FirstArraySlice = info.range.layers.start as _;
+        let FirstArraySlice = info.layers.start as _;
         #[allow(non_snake_case)]
-        let ArraySize = (info.range.layers.end - info.range.layers.start) as _;
+        let ArraySize = (info.layers.end - info.layers.start) as _;
 
         match info.view_kind {
             image::ViewKind::D1 => {
@@ -537,17 +537,17 @@ impl Device {
         desc.Format = info.format;
 
         #[allow(non_snake_case)]
-        let MipSlice = info.range.levels.start as _;
+        let MipSlice = info.levels.start as _;
         #[allow(non_snake_case)]
-        let FirstArraySlice = info.range.layers.start as _;
+        let FirstArraySlice = info.layers.start as _;
         #[allow(non_snake_case)]
-        let ArraySize = (info.range.layers.end - info.range.layers.start) as _;
+        let ArraySize = (info.layers.end - info.layers.start) as _;
 
         match info.view_kind {
             image::ViewKind::D1 => {
                 desc.ViewDimension = d3d11::D3D11_UAV_DIMENSION_TEXTURE1D;
                 *unsafe { desc.u.Texture1D_mut() } = d3d11::D3D11_TEX1D_UAV {
-                    MipSlice: info.range.levels.start as _,
+                    MipSlice: info.levels.start as _,
                 }
             }
             image::ViewKind::D1Array => {
@@ -561,7 +561,7 @@ impl Device {
             image::ViewKind::D2 => {
                 desc.ViewDimension = d3d11::D3D11_UAV_DIMENSION_TEXTURE2D;
                 *unsafe { desc.u.Texture2D_mut() } = d3d11::D3D11_TEX2D_UAV {
-                    MipSlice: info.range.levels.start as _,
+                    MipSlice: info.levels.start as _,
                 }
             }
             image::ViewKind::D2Array => {
@@ -607,11 +607,11 @@ impl Device {
         desc.Format = info.format;
 
         #[allow(non_snake_case)]
-        let MipSlice = info.range.levels.start as _;
+        let MipSlice = info.levels.start as _;
         #[allow(non_snake_case)]
-        let FirstArraySlice = info.range.layers.start as _;
+        let FirstArraySlice = info.layers.start as _;
         #[allow(non_snake_case)]
-        let ArraySize = (info.range.layers.end - info.range.layers.start) as _;
+        let ArraySize = (info.layers.end - info.layers.start) as _;
 
         match info.view_kind {
             image::ViewKind::D1 => {
@@ -671,11 +671,11 @@ impl Device {
     ) -> Result<ComPtr<d3d11::ID3D11DepthStencilView>, image::ViewCreationError> {
         #![allow(non_snake_case)]
 
-        let MipSlice = info.range.levels.start as _;
-        let FirstArraySlice = info.range.layers.start as _;
-        let ArraySize = (info.range.layers.end - info.range.layers.start) as _;
-        assert_eq!(info.range.levels.start + 1, info.range.levels.end);
-        assert!(info.range.layers.end <= info.kind.num_layers());
+        let MipSlice = info.levels.start as _;
+        let FirstArraySlice = info.layers.start as _;
+        let ArraySize = (info.layers.end - info.layers.start) as _;
+        assert_eq!(info.levels.start + 1, info.levels.end);
+        assert!(info.layers.end <= info.kind.num_layers());
 
         let mut desc: d3d11::D3D11_DEPTH_STENCIL_VIEW_DESC = unsafe { mem::zeroed() };
         desc.Format = info.format;
@@ -1595,11 +1595,8 @@ impl device::Device<Backend> for Device {
                     // TODO: we should be using `uav_format` rather than `copy_uav_format`, and share
                     //       the UAVs when the formats are identical
                     format: decomposed.copy_uav.unwrap(),
-                    range: image::SubresourceRange {
-                        aspects: format::Aspects::COLOR,
-                        levels: mip .. (mip + 1),
-                        layers: 0 .. image.kind.num_layers(),
-                    },
+                    levels: mip .. (mip + 1),
+                    layers: 0 .. image.kind.num_layers(),
                 };
 
                 unordered_access_views.push(
@@ -1616,11 +1613,8 @@ impl device::Device<Backend> for Device {
                 caps: image::ViewCapabilities::empty(),
                 view_kind,
                 format: decomposed.copy_srv.unwrap(),
-                range: image::SubresourceRange {
-                    aspects: format::Aspects::COLOR,
-                    levels: 0 .. image.mip_levels,
-                    layers: 0 .. image.kind.num_layers(),
-                },
+                levels: 0 .. image.mip_levels,
+                layers: 0 .. image.kind.num_layers(),
             };
 
             let copy_srv = if !compressed {
@@ -1663,11 +1657,8 @@ impl device::Device<Backend> for Device {
                         caps: image::ViewCapabilities::empty(),
                         view_kind,
                         format: decomposed.rtv.unwrap(),
-                        range: image::SubresourceRange {
-                            aspects: format::Aspects::COLOR,
-                            levels: mip .. (mip + 1),
-                            layers: layer .. (layer + 1),
-                        },
+                        levels: mip .. (mip + 1),
+                        layers: layer .. (layer + 1),
                     };
 
                     render_target_views.push(
@@ -1689,11 +1680,8 @@ impl device::Device<Backend> for Device {
                         caps: image::ViewCapabilities::empty(),
                         view_kind,
                         format: decomposed.dsv.unwrap(),
-                        range: image::SubresourceRange {
-                            aspects: format::Aspects::COLOR,
-                            levels: mip .. (mip + 1),
-                            layers: layer .. (layer + 1),
-                        },
+                        levels: mip .. (mip + 1),
+                        layers: layer .. (layer + 1),
                     };
 
                     depth_stencil_views.push(
@@ -1728,6 +1716,8 @@ impl device::Device<Backend> for Device {
         range: image::SubresourceRange,
     ) -> Result<ImageView, image::ViewCreationError> {
         let is_array = image.kind.num_layers() > 1;
+        let num_levels = range.resolve_level_count(image.mip_levels);
+        let num_layers = range.resolve_layer_count(image.kind.num_layers());
 
         let info = ViewInfo {
             resource: image.internal.raw,
@@ -1742,7 +1732,8 @@ impl device::Device<Backend> for Device {
                 view_kind
             },
             format: conv::map_format(format).ok_or(image::ViewCreationError::BadFormat(format))?,
-            range,
+            levels: range.level_start .. range.level_start + num_levels,
+            layers: range.layer_start .. range.layer_start + num_layers,
         };
 
         let srv_info = ViewInfo {

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -247,6 +247,7 @@ pub struct ImageBound {
     pub(crate) place: Place,
     pub(crate) surface_type: format::SurfaceType,
     pub(crate) kind: image::Kind,
+    pub(crate) mip_levels: image::Level,
     pub(crate) usage: image::Usage,
     pub(crate) default_view_format: Option<DXGI_FORMAT>,
     pub(crate) view_caps: image::ViewCapabilities,
@@ -270,15 +271,6 @@ unsafe impl Send for ImageBound {}
 unsafe impl Sync for ImageBound {}
 
 impl ImageBound {
-    /// Get `SubresourceRange` of the whole image.
-    pub fn to_subresource_range(&self, aspects: format::Aspects) -> image::SubresourceRange {
-        image::SubresourceRange {
-            aspects,
-            levels: 0 .. self.descriptor.MipLevels as _,
-            layers: 0 .. self.kind.num_layers(),
-        }
-    }
-
     pub fn calc_subresource(&self, mip_level: UINT, layer: UINT, plane: UINT) -> UINT {
         mip_level
             + (layer * self.descriptor.MipLevels as UINT)
@@ -294,6 +286,7 @@ pub struct ImageUnbound {
     pub(crate) requirements: memory::Requirements,
     pub(crate) format: format::Format,
     pub(crate) kind: image::Kind,
+    pub(crate) mip_levels: image::Level,
     pub(crate) usage: image::Usage,
     pub(crate) tiling: image::Tiling,
     pub(crate) view_caps: image::ViewCapabilities,

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -172,6 +172,8 @@ pub struct Image {
     // Required for clearing operations
     pub(crate) channel: format::ChannelType,
     pub(crate) requirements: Requirements,
+    pub(crate) num_levels: i::Level,
+    pub(crate) num_layers: i::Layer,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2628,6 +2628,7 @@ impl hal::device::Device<Backend> for Device {
                 name: String::new(),
             },
             kind,
+            mip_levels,
             format_desc,
             shader_channel: base.1.into(),
             mtl_format,
@@ -2806,8 +2807,7 @@ impl hal::device::Device<Backend> for Device {
         let raw = image.like.as_texture();
         let full_range = image::SubresourceRange {
             aspects: image.format_desc.aspects,
-            levels: 0 .. raw.mipmap_level_count() as image::Level,
-            layers: 0 .. image.kind.num_layers(),
+            .. Default::default()
         };
         let mtl_type = if image.mtl_type == MTLTextureType::D2Multisample {
             if kind != image::ViewKind::D2 {
@@ -2831,12 +2831,12 @@ impl hal::device::Device<Backend> for Device {
                 mtl_format,
                 mtl_type,
                 NSRange {
-                    location: range.levels.start as _,
-                    length: (range.levels.end - range.levels.start) as _,
+                    location: range.level_start as _,
+                    length: range.resolve_level_count(image.mip_levels) as _,
                 },
                 NSRange {
-                    location: range.layers.start as _,
-                    length: (range.layers.end - range.layers.start) as _,
+                    location: range.layer_start as _,
+                    length: range.resolve_layer_count(image.kind.num_layers()) as _,
                 },
             )
         };

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -313,6 +313,7 @@ impl ImageLike {
 pub struct Image {
     pub(crate) like: ImageLike,
     pub(crate) kind: image::Kind,
+    pub(crate) mip_levels: image::Level,
     pub(crate) format_desc: FormatDesc,
     pub(crate) shader_channel: Channel,
     pub(crate) mtl_format: metal::MTLPixelFormat,

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -121,10 +121,14 @@ pub fn map_subresource_layers(sub: &image::SubresourceLayers) -> vk::ImageSubres
 pub fn map_subresource_range(range: &image::SubresourceRange) -> vk::ImageSubresourceRange {
     vk::ImageSubresourceRange {
         aspect_mask: map_image_aspects(range.aspects),
-        base_mip_level: range.levels.start as _,
-        level_count: (range.levels.end - range.levels.start) as _,
-        base_array_layer: range.layers.start as _,
-        layer_count: (range.layers.end - range.layers.start) as _,
+        base_mip_level: range.level_start as _,
+        level_count: range
+            .level_count
+            .map_or(vk::REMAINING_MIP_LEVELS, |c| c as _),
+        base_array_layer: range.layer_start as _,
+        layer_count: range
+            .layer_count
+            .map_or(vk::REMAINING_ARRAY_LAYERS, |c| c as _),
     }
 }
 

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -470,8 +470,7 @@ impl w::PresentationSurface<Backend> for Surface {
                             hal::format::Swizzle::NO,
                             hal::image::SubresourceRange {
                                 aspects: hal::format::Aspects::COLOR,
-                                layers: 0 .. 1,
-                                levels: 0 .. 1,
+                                .. Default::default()
                             },
                         )
                         .unwrap();
@@ -522,8 +521,7 @@ impl w::PresentationSurface<Backend> for Surface {
                         view: frame.view,
                         range: hal::image::SubresourceRange {
                             aspects: hal::format::Aspects::COLOR,
-                            layers: 0 .. 1,
-                            levels: 0 .. 1,
+                            .. Default::default()
                         },
                         owner: native::ImageViewOwner::Surface(FramebufferCachePtr(Arc::clone(
                             &frame.framebuffers.0,

--- a/src/hal/src/format.rs
+++ b/src/hal/src/format.rs
@@ -15,6 +15,7 @@ bitflags!(
     /// the `Rgba8Unorm` format only specifies a `COLOR` aspect,
     /// while `D32SfloatS8Uint` specifies both a depth and stencil
     /// aspect but no color.
+    #[derive(Default)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct Aspects: u8 {
         /// Color aspect.

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -205,7 +205,7 @@ pub enum LayerError {
     /// The source image kind doesn't support array slices.
     NotExpected(Kind),
     /// Selected layers are outside of the provided range.
-    OutOfBounds(Range<Layer>),
+    OutOfBounds,
 }
 
 impl std::fmt::Display for LayerError {
@@ -214,10 +214,9 @@ impl std::fmt::Display for LayerError {
             LayerError::NotExpected(kind) => {
                 write!(fmt, "Kind {{{:?}}} does not support arrays", kind)
             }
-            LayerError::OutOfBounds(layers) => write!(
+            LayerError::OutOfBounds => write!(
                 fmt,
-                "Out of bounds layers {} .. {}",
-                layers.start, layers.end
+                "Out of bounds layers"
             ),
         }
     }
@@ -325,7 +324,7 @@ impl Kind {
     }
 
     /// Count the number of mipmap levels.
-    pub fn num_levels(&self) -> Level {
+    pub fn compute_num_levels(&self) -> Level {
         use std::cmp::max;
         match *self {
             Kind::D2(_, _, _, s) if s > 1 => {
@@ -654,15 +653,49 @@ pub struct SubresourceLayers {
 }
 
 /// A subset of resources contained within an image.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SubresourceRange {
     /// Included aspects: color/depth/stencil
     pub aspects: format::Aspects,
-    /// Included mipmap levels
-    pub levels: Range<Level>,
-    /// Included array levels
-    pub layers: Range<Layer>,
+    /// First mipmap level in this subresource
+    pub level_start: Level,
+    /// Number of sequential levels in this subresource.
+    ///
+    /// A value of `None` indicates the subresource contains
+    /// all of the remaining levels.
+    pub level_count: Option<Level>,
+    /// First layer in this subresource
+    pub layer_start: Layer,
+    /// Number of sequential layers in this subresource.
+    ///
+    /// A value of `None` indicates the subresource contains
+    /// all of the remaining layers.
+    pub layer_count: Option<Layer>,
+}
+
+impl From<SubresourceLayers> for SubresourceRange {
+    fn from(sub: SubresourceLayers) -> Self {
+        SubresourceRange {
+            aspects: sub.aspects,
+            level_start: sub.level,
+            level_count: Some(1),
+            layer_start: sub.layers.start,
+            layer_count: Some(sub.layers.end - sub.layers.start),
+        }
+    }
+}
+
+impl SubresourceRange {
+    /// Resolve the concrete level count based on the total number of layers in an image.
+    pub fn resolve_level_count(&self, total: Level) -> Level {
+        self.level_count.unwrap_or(total - self.level_start)
+    }
+
+    /// Resolve the concrete layer count based on the total number of layer in an image.
+    pub fn resolve_layer_count(&self, total: Layer) -> Layer {
+        self.layer_count.unwrap_or(total - self.layer_start)
+    }
 }
 
 /// Image format properties.

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -24,12 +24,6 @@ use hal::{
 
 use crate::raw;
 
-const COLOR_RANGE: i::SubresourceRange = i::SubresourceRange {
-    aspects: f::Aspects::COLOR,
-    levels: 0 .. 1,
-    layers: 0 .. 1,
-};
-
 pub struct FetchGuard<'a, B: hal::Backend> {
     device: &'a mut B::Device,
     buffer: Option<B::Buffer>,
@@ -477,7 +471,7 @@ impl<B: hal::Backend> Scene<B> {
                             families: None,
                             range: i::SubresourceRange {
                                 aspects,
-                                ..COLOR_RANGE.clone()
+                                .. Default::default()
                             },
                         };
                         unsafe {
@@ -545,7 +539,10 @@ impl<B: hal::Backend> Scene<B> {
                                 .. (i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal),
                             families: None,
                             target: &image,
-                            range: COLOR_RANGE.clone(), //TODO
+                            range: i::SubresourceRange {
+                                aspects: f::Aspects::COLOR,
+                                .. Default::default()
+                            }, //TODO
                         };
                         unsafe {
                             init_cmd.pipeline_barrier(
@@ -581,7 +578,10 @@ impl<B: hal::Backend> Scene<B> {
                                 .. final_state,
                             families: None,
                             target: &image,
-                            range: COLOR_RANGE.clone(), //TODO
+                            range: i::SubresourceRange {
+                                aspects: f::Aspects::COLOR,
+                                .. Default::default()
+                            }, //TODO
                         };
                         unsafe {
                             init_cmd.pipeline_barrier(
@@ -602,7 +602,10 @@ impl<B: hal::Backend> Scene<B> {
                             _memory: gpu_memory,
                             kind,
                             format,
-                            range: COLOR_RANGE.clone(),
+                            range: i::SubresourceRange {
+                                aspects: f::Aspects::COLOR,
+                                .. Default::default()
+                            },
                             stable_state,
                         },
                     );
@@ -1657,7 +1660,10 @@ impl<B: hal::Backend> Scene<B> {
                     .. (i::Access::TRANSFER_READ, i::Layout::TransferSrcOptimal),
                 target: &image.handle,
                 families: None,
-                range: COLOR_RANGE.clone(), //TODO
+                range: i::SubresourceRange {
+                    aspects: f::Aspects::COLOR,
+                    .. Default::default()
+                }, //TODO
             };
             cmd_buffer.pipeline_barrier(
                 pso::PipelineStage::TOP_OF_PIPE .. pso::PipelineStage::TRANSFER,
@@ -1693,7 +1699,10 @@ impl<B: hal::Backend> Scene<B> {
                     .. image.stable_state,
                 target: &image.handle,
                 families: None,
-                range: COLOR_RANGE.clone(), //TODO
+                range: i::SubresourceRange {
+                    aspects: f::Aspects::COLOR,
+                    .. Default::default()
+                }, //TODO
             };
             cmd_buffer.pipeline_barrier(
                 pso::PipelineStage::TRANSFER .. pso::PipelineStage::BOTTOM_OF_PIPE,

--- a/work/scenes/basic.ron
+++ b/work/scenes/basic.ron
@@ -29,8 +29,10 @@
 			format: Rgba8Unorm,
 			range: (
 				aspects: (bits: 1),
-				levels: (start: 0, end: 1),
-				layers: (start: 0, end: 1),
+				level_start: 0,
+				level_count: None,
+				layer_start: 0,
+				layer_count: None,
 			),
 		),
 		"fbo": Framebuffer(

--- a/work/scenes/transfer.ron
+++ b/work/scenes/transfer.ron
@@ -158,8 +158,10 @@
 					ranges: [
 						(
 							aspects: (bits: 0x1), //COLOR
-							levels: (start: 0, end: 1),
-							layers: (start: 0, end: 1),
+							level_start: 0,
+							level_count: None,
+							layer_start: 0,
+							layer_count: None,
 						),
 					],
 				),

--- a/work/scenes/vertex-offset.ron
+++ b/work/scenes/vertex-offset.ron
@@ -1,189 +1,191 @@
 (
-    resources: {
-        "buffer.vertex": Buffer(
-            size: 48,
-            usage: (bits: 0x80), // VERTEX
-            data: "vertex-offset.raw",
-        ),
-        "image.color": Image(
-            kind: D2(1, 1, 1, 1),
-            num_levels: 1,
-            format: Rgba32Uint,
-            usage: (bits: 0x15), //COLOR_ATTACHMENT | TRANSFER_SRC (for reading back) | SAMPLED (temporary for GL)
-        ),
-        "pass": RenderPass(
-            attachments: {
-                "c": (
-                    format: Some(Rgba32Uint),
-                    samples: 1,
-                    ops: (load: Clear, store: Store),
-                    layouts: (start: General, end: General),
-                ),
-            },
-            subpasses: {
-                "main": (
-                    colors: [("c", General)],
-                    depth_stencil: None,
-                )
-            },
-            dependencies: [],
-        ),
-        "image.color.view": ImageView(
-            image: "image.color",
-            kind: D2,
-            format: Rgba32Uint,
-            range: (
-                aspects: (bits: 1),
-                levels: (start: 0, end: 1),
-                layers: (start: 0, end: 1),
-            ),
-        ),
-        "fbo": Framebuffer(
-            pass: "pass",
-            views: {
-                "c": "image.color.view"
-            },
-            extent: (
-                width: 1,
-                height: 1,
-                depth: 1,
-            ),
-        ),
-        "pipe-layout": PipelineLayout(
-            set_layouts: [],
-            push_constant_ranges: [],
-        ),
-        "shader.vertex-offset.vs": Shader("vertex-offset.vert"),
-        "shader.vertex-offset.fs": Shader("vertex-offset.frag"),
-        "pipe.vertex-offset": GraphicsPipeline(
-            shaders: (
-                vertex: "shader.vertex-offset.vs",
-                fragment: "shader.vertex-offset.fs",
-            ),
-            rasterizer: (
-                polygon_mode: Fill,
-                cull_face: (bits: 0),
-                front_face: Clockwise,
-                depth_clamping: false,
-                depth_bias: None,
-                conservative: false,
-                line_width: Static(1.0),
-            ),
-            vertex_buffers: [
-                VertexBufferDesc(
-                    binding: 0,
-                    stride: 16,
-                    rate: Vertex,
-                ),
-            ],
-            attributes: [
-                AttributeDesc(
-                    location: 0,
-                    binding: 0,
-                    element: Element(
-                        offset: 32,
-                        format: Rgba32Uint,
-                    ),
-                ),
-            ],
-            input_assembler: (
-                primitive: TriangleList,
-                with_adjacency: false,
-                restart_index: None,
-            ),
-            blender: (
-                alpha_coverage: false,
-                logic_op: None,
-                targets: [
-                    (mask: (bits: 15), blend: None),
-                ],
-            ),
-            layout: "pipe-layout",
-            subpass: (
-                parent: "pass",
-                index: 0,
-            ),
-        ),
-        "pipe.vertex-offset-overlap": GraphicsPipeline(
-            shaders: (
-                vertex: "shader.vertex-offset.vs",
-                fragment: "shader.vertex-offset.fs",
-            ),
-            rasterizer: (
-                polygon_mode: Fill,
-                cull_face: (bits: 0),
-                front_face: Clockwise,
-                depth_clamping: false,
-                depth_bias: None,
-                conservative: false,
-                line_width: Static(1.0),
-            ),
-            vertex_buffers: [
-                VertexBufferDesc(
-                    binding: 0,
-                    stride: 16,
-                    rate: Vertex,
-                ),
-            ],
-            attributes: [
-                AttributeDesc(
-                    location: 0,
-                    binding: 0,
-                    element: Element(
-                        offset: 8,
-                        format: Rgba32Uint,
-                    ),
-                ),
-            ],
-            input_assembler: (
-                primitive: TriangleList,
-                with_adjacency: false,
-                restart_index: None,
-            ),
-            blender: (
-                alpha_coverage: false,
-                logic_op: None,
-                targets: [
-                    (mask: (bits: 15), blend: None),
-                ],
-            ),
-            layout: "pipe-layout",
-            subpass: (
-                parent: "pass",
-                index: 0,
-            ),
-        ),
-    },
-    jobs: {
-        "offset-aligned": Graphics(
-            framebuffer: "fbo",
-            clear_values: [
-                Color(Float((0.0, 0.0, 0.0, 0.0))),
-            ],
-            pass: ("pass", {
-                "main": (commands: [
-                    BindPipeline("pipe.vertex-offset"),
-                    BindVertexBuffers([("buffer.vertex", (offset: 0, size: None))]),
-                    Draw(
-                        vertices: (start: 0, end: 3),
-                    ),
-                ]),
-            }),
-        ),
-        "offset-overlap": Graphics(
-            framebuffer: "fbo",
-            clear_values: [
-                Color(Float((0.0, 0.0, 0.0, 0.0))),
-            ],
-            pass: ("pass", {
-                "main": (commands: [
-                    BindPipeline("pipe.vertex-offset-overlap"),
-                    BindVertexBuffers([("buffer.vertex", (offset: 0, size: None))]),
-                    Draw(
-                        vertices: (start: 0, end: 3),
-                    ),
-                ]),
-            }),
-        ),
-    },
+	resources: {
+		"buffer.vertex": Buffer(
+			size: 48,
+			usage: (bits: 0x80), // VERTEX
+			data: "vertex-offset.raw",
+		),
+		"image.color": Image(
+			kind: D2(1, 1, 1, 1),
+			num_levels: 1,
+			format: Rgba32Uint,
+			usage: (bits: 0x15), //COLOR_ATTACHMENT | TRANSFER_SRC (for reading back) | SAMPLED (temporary for GL)
+		),
+		"pass": RenderPass(
+			attachments: {
+				"c": (
+					format: Some(Rgba32Uint),
+					samples: 1,
+					ops: (load: Clear, store: Store),
+					layouts: (start: General, end: General),
+				),
+			},
+			subpasses: {
+				"main": (
+					colors: [("c", General)],
+					depth_stencil: None,
+				)
+			},
+			dependencies: [],
+		),
+		"image.color.view": ImageView(
+			image: "image.color",
+			kind: D2,
+			format: Rgba32Uint,
+			range: (
+				aspects: (bits: 1),
+				level_start: 0,
+				level_count: None,
+				layer_start: 0,
+				layer_count: None,
+			),
+		),
+		"fbo": Framebuffer(
+			pass: "pass",
+			views: {
+				"c": "image.color.view"
+			},
+			extent: (
+				width: 1,
+				height: 1,
+				depth: 1,
+			),
+		),
+		"pipe-layout": PipelineLayout(
+			set_layouts: [],
+			push_constant_ranges: [],
+		),
+		"shader.vertex-offset.vs": Shader("vertex-offset.vert"),
+		"shader.vertex-offset.fs": Shader("vertex-offset.frag"),
+		"pipe.vertex-offset": GraphicsPipeline(
+			shaders: (
+				vertex: "shader.vertex-offset.vs",
+				fragment: "shader.vertex-offset.fs",
+			),
+			rasterizer: (
+				polygon_mode: Fill,
+				cull_face: (bits: 0),
+				front_face: Clockwise,
+				depth_clamping: false,
+				depth_bias: None,
+				conservative: false,
+				line_width: Static(1.0),
+			),
+			vertex_buffers: [
+				VertexBufferDesc(
+					binding: 0,
+					stride: 16,
+					rate: Vertex,
+				),
+			],
+			attributes: [
+				AttributeDesc(
+					location: 0,
+					binding: 0,
+					element: Element(
+						offset: 32,
+						format: Rgba32Uint,
+					),
+				),
+			],
+			input_assembler: (
+				primitive: TriangleList,
+				with_adjacency: false,
+				restart_index: None,
+			),
+			blender: (
+				alpha_coverage: false,
+				logic_op: None,
+				targets: [
+					(mask: (bits: 15), blend: None),
+				],
+			),
+			layout: "pipe-layout",
+			subpass: (
+				parent: "pass",
+				index: 0,
+			),
+		),
+		"pipe.vertex-offset-overlap": GraphicsPipeline(
+			shaders: (
+				vertex: "shader.vertex-offset.vs",
+				fragment: "shader.vertex-offset.fs",
+			),
+			rasterizer: (
+				polygon_mode: Fill,
+				cull_face: (bits: 0),
+				front_face: Clockwise,
+				depth_clamping: false,
+				depth_bias: None,
+				conservative: false,
+				line_width: Static(1.0),
+			),
+			vertex_buffers: [
+				VertexBufferDesc(
+					binding: 0,
+					stride: 16,
+					rate: Vertex,
+				),
+			],
+			attributes: [
+				AttributeDesc(
+					location: 0,
+					binding: 0,
+					element: Element(
+						offset: 8,
+						format: Rgba32Uint,
+					),
+				),
+			],
+			input_assembler: (
+				primitive: TriangleList,
+				with_adjacency: false,
+				restart_index: None,
+			),
+			blender: (
+				alpha_coverage: false,
+				logic_op: None,
+				targets: [
+					(mask: (bits: 15), blend: None),
+				],
+			),
+			layout: "pipe-layout",
+			subpass: (
+				parent: "pass",
+				index: 0,
+			),
+		),
+	},
+	jobs: {
+		"offset-aligned": Graphics(
+			framebuffer: "fbo",
+			clear_values: [
+				Color(Float((0.0, 0.0, 0.0, 0.0))),
+			],
+			pass: ("pass", {
+				"main": (commands: [
+					BindPipeline("pipe.vertex-offset"),
+					BindVertexBuffers([("buffer.vertex", (offset: 0, size: None))]),
+					Draw(
+						vertices: (start: 0, end: 3),
+					),
+				]),
+			}),
+		),
+		"offset-overlap": Graphics(
+			framebuffer: "fbo",
+			clear_values: [
+				Color(Float((0.0, 0.0, 0.0, 0.0))),
+			],
+			pass: ("pass", {
+				"main": (commands: [
+					BindPipeline("pipe.vertex-offset-overlap"),
+					BindVertexBuffers([("buffer.vertex", (offset: 0, size: None))]),
+					Draw(
+						vertices: (start: 0, end: 3),
+					),
+				]),
+			}),
+		),
+	},
 )


### PR DESCRIPTION
Fixes #3200
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Metal, DX12
