### PR TITLE
[0.6/dx12] refactor pipeline layouts and descriptor binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx12-0.6.1 (18-08-2020)
+  - fix descriptor binding
+
 ### backend-vulkan-0.6.1 (17-08-2020)
   - fix Android build
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.6.0"
+version = "0.6.1"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
Fixes the current breakage of the wgpu-rs shadow example on dx12.

The problem was the last fix being incomplete. We switched from parameter iteration into root offset iteration in `flush*`.
But we didn't advance the root offset on bindings that are non-dirty (as well as invalid bindings).

This PR moves the common parts about pipelines and layouts into a separate structure. It also explicitly stores a root offset per parameter, as well as the total number of root slots. That allows us to make the `flush*` function robust, and also moves it to be a method of `PipelineCache`.