### PR TITLE
Refactor border color, add feature for comparison mutable samplers

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -144,8 +144,10 @@ fn get_features(
         | hal::Features::FULL_DRAW_INDEX_U32
         | hal::Features::FORMAT_BC
         | hal::Features::INSTANCE_RATE
-        | hal::Features::SAMPLER_MIP_LOD_BIAS
         | hal::Features::SAMPLER_MIRROR_CLAMP_EDGE
+        | hal::Features::SAMPLER_MIP_LOD_BIAS
+        | hal::Features::SAMPLER_BORDER_COLOR
+        | hal::Features::MUTABLE_COMPARISON_SAMPLER
         | hal::Features::NDC_Y_UP
 }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1063,6 +1063,8 @@ impl hal::Instance<Backend> for Instance {
                     Features::FORMAT_BC |
                     Features::INSTANCE_RATE |
                     Features::SAMPLER_MIP_LOD_BIAS |
+                    Features::SAMPLER_BORDER_COLOR |
+                    Features::MUTABLE_COMPARISON_SAMPLER |
                     Features::SAMPLER_ANISOTROPY |
                     Features::TEXTURE_DESCRIPTOR_ARRAY |
                     Features::SAMPLER_MIRROR_CLAMP_EDGE |

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -393,7 +393,6 @@ impl Device {
 pub(crate) unsafe fn set_sampler_info<SetParamFloat, SetParamFloatVec, SetParamInt>(
     info: &i::SamplerDesc,
     features: &hal::Features,
-    legacy_features: &LegacyFeatures,
     mut set_param_float: SetParamFloat,
     mut set_param_float_vec: SetParamFloatVec,
     mut set_param_int: SetParamInt,
@@ -421,7 +420,7 @@ pub(crate) unsafe fn set_sampler_info<SetParamFloat, SetParamFloatVec, SetParamI
     if features.contains(hal::Features::SAMPLER_MIP_LOD_BIAS) {
         set_param_float(glow::TEXTURE_LOD_BIAS, info.lod_bias.0);
     }
-    if legacy_features.contains(LegacyFeatures::SAMPLER_BORDER_COLOR) {
+    if features.contains(hal::Features::SAMPLER_BORDER_COLOR) {
         let mut border: [f32; 4] = info.border.into();
         set_param_float_vec(glow::TEXTURE_BORDER_COLOR, &mut border);
     }
@@ -1097,7 +1096,6 @@ impl d::Device<B> for Device {
         set_sampler_info(
             &info,
             &self.features,
-            &self.share.legacy_features,
             |a, b| gl.sampler_parameter_f32(name, a, b),
             |a, b| gl.sampler_parameter_f32_slice(name, a, b),
             |a, b| gl.sampler_parameter_i32(name, a, b),

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -242,12 +242,10 @@ bitflags! {
         const COPY_BUFFER = 0x00000800;
         /// Support separation of textures and samplers.
         const SAMPLER_OBJECTS = 0x00001000;
-        /// Support setting border texel colors.
-        const SAMPLER_BORDER_COLOR = 0x00002000;
         /// Support explicit layouts in shader.
-        const EXPLICIT_LAYOUTS_IN_SHADER = 0x00004000;
+        const EXPLICIT_LAYOUTS_IN_SHADER = 0x00002000;
         /// Support instanced input rate on attribute binding.
-        const INSTANCED_ATTRIBUTE_BINDING = 0x00008000;
+        const INSTANCED_ATTRIBUTE_BINDING = 0x00004000;
     }
 }
 
@@ -398,7 +396,7 @@ pub(crate) fn query_all(
         }
     }
 
-    let mut features = Features::NDC_Y_UP;
+    let mut features = Features::NDC_Y_UP | Features::MUTABLE_COMPARISON_SAMPLER;
     let mut legacy = LegacyFeatures::empty();
 
     if info.is_supported(&[
@@ -417,6 +415,9 @@ pub(crate) fn query_all(
     if info.is_supported(&[Core(3, 3)]) {
         // TODO: extension
         features |= Features::SAMPLER_MIP_LOD_BIAS;
+    }
+    if info.is_supported(&[Core(2, 1)]) {
+        features |= Features::SAMPLER_BORDER_COLOR;
     }
     if info.is_supported(&[Core(4, 4), Ext("ARB_texture_mirror_clamp_to_edge")]) {
         features |= Features::SAMPLER_MIRROR_CLAMP_EDGE;
@@ -475,10 +476,6 @@ pub(crate) fn query_all(
     }
     if info.is_supported(&[Core(3, 3), Es(3, 0), Ext("GL_ARB_sampler_objects")]) {
         legacy |= LegacyFeatures::SAMPLER_OBJECTS;
-    }
-    if info.is_supported(&[Core(3, 3)]) {
-        // TODO: extension
-        legacy |= LegacyFeatures::SAMPLER_BORDER_COLOR;
     }
     if info.is_supported(&[Core(3, 3), Es(3, 0)]) {
         legacy |= LegacyFeatures::INSTANCED_ATTRIBUTE_BINDING;

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -860,7 +860,6 @@ impl CommandQueue {
                 device::set_sampler_info(
                     &sinfo,
                     &self.features,
-                    &self.share.legacy_features,
                     |a, b| gl.tex_parameter_f32(textype, a, b),
                     |a, b| gl.tex_parameter_f32_slice(textype, a, &b),
                     |a, b| gl.tex_parameter_i32(textype, a, b),

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -1165,6 +1165,14 @@ pub fn map_wrap_mode(wrap: image::WrapMode) -> MTLSamplerAddressMode {
     }
 }
 
+pub fn map_border_color(border_color: image::BorderColor) -> MTLSamplerBorderColor {
+    match border_color {
+        image::BorderColor::TransparentBlack => MTLSamplerBorderColor::TransparentBlack,
+        image::BorderColor::OpaqueBlack => MTLSamplerBorderColor::OpaqueBlack,
+        image::BorderColor::OpaqueWhite => MTLSamplerBorderColor::OpaqueWhite,
+    }
+}
+
 pub fn map_extent(extent: image::Extent) -> MTLSize {
     MTLSize {
         width: extent.width as _,

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -520,6 +520,11 @@ const MUTABLE_COMPARISON_SAMPLER_SUPPORT: &[MTLFeatureSet] = &[
     MTLFeatureSet::macOS_GPUFamily2_v1,
 ];
 
+const SAMPLER_CLAMP_TO_BORDER_SUPPORT: &[MTLFeatureSet] = &[
+    MTLFeatureSet::macOS_GPUFamily1_v2,
+    MTLFeatureSet::macOS_GPUFamily2_v1,
+];
+
 const ASTC_PIXEL_FORMAT_FEATURES: &[MTLFeatureSet] = &[
     MTLFeatureSet::iOS_GPUFamily2_v1,
     MTLFeatureSet::iOS_GPUFamily3_v1,
@@ -680,6 +685,7 @@ struct PrivateCapabilities {
     argument_buffers: bool,
     shared_textures: bool,
     mutable_comparison_samplers: bool,
+    sampler_clamp_to_border: bool,
     base_instance: bool,
     base_vertex_instance_drawing: bool,
     dual_source_blending: bool,
@@ -825,6 +831,7 @@ impl PrivateCapabilities {
                 &device,
                 MUTABLE_COMPARISON_SAMPLER_SUPPORT,
             ),
+            sampler_clamp_to_border: Self::supports_any(&device, SAMPLER_CLAMP_TO_BORDER_SUPPORT),
             base_instance: Self::supports_any(&device, BASE_INSTANCE_SUPPORT),
             base_vertex_instance_drawing: Self::supports_any(&device, BASE_VERTEX_INSTANCE_SUPPORT),
             dual_source_blending: Self::supports_any(&device, DUAL_SOURCE_BLEND_SUPPORT),

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -223,12 +223,11 @@ pub fn map_wrap(wrap: image::WrapMode) -> vk::SamplerAddressMode {
     }
 }
 
-pub fn map_border_color(col: image::PackedColor) -> Option<vk::BorderColor> {
-    match col.0 {
-        0x00000000 => Some(vk::BorderColor::FLOAT_TRANSPARENT_BLACK),
-        0xFF000000 => Some(vk::BorderColor::FLOAT_OPAQUE_BLACK),
-        0xFFFFFFFF => Some(vk::BorderColor::FLOAT_OPAQUE_WHITE),
-        _ => None,
+pub fn map_border_color(border_color: image::BorderColor) -> vk::BorderColor {
+    match border_color {
+        image::BorderColor::TransparentBlack => vk::BorderColor::FLOAT_TRANSPARENT_BLACK,
+        image::BorderColor::OpaqueBlack => vk::BorderColor::FLOAT_OPAQUE_BLACK,
+        image::BorderColor::OpaqueWhite => vk::BorderColor::FLOAT_OPAQUE_WHITE,
     }
 }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1326,13 +1326,7 @@ impl d::Device<B> for Device {
             compare_op: conv::map_comparison(desc.comparison.unwrap_or(Comparison::Never)),
             min_lod: desc.lod_range.start.0,
             max_lod: desc.lod_range.end.0,
-            border_color: match conv::map_border_color(desc.border) {
-                Some(bc) => bc,
-                None => {
-                    error!("Unsupported border color {:x}", desc.border.0);
-                    vk::BorderColor::FLOAT_TRANSPARENT_BLACK
-                }
-            },
+            border_color: conv::map_border_color(desc.border),
             unnormalized_coordinates: if desc.normalized { vk::FALSE } else { vk::TRUE },
         };
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1030,6 +1030,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             | Features::TRIANGLE_FAN
             | Features::SEPARATE_STENCIL_REF_VALUES
             | Features::SAMPLER_MIP_LOD_BIAS
+            | Features::SAMPLER_BORDER_COLOR
+            | Features::MUTABLE_COMPARISON_SAMPLER
             | Features::TEXTURE_DESCRIPTOR_ARRAY;
 
         if self.supports_extension(*AMD_NEGATIVE_VIEWPORT_HEIGHT)

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -493,6 +493,28 @@ impl Into<[f32; 4]> for PackedColor {
     }
 }
 
+/// The border color for `WrapMode::Border` wrap mode.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum BorderColor {
+    ///
+    TransparentBlack,
+    ///
+    OpaqueBlack,
+    ///
+    OpaqueWhite,
+}
+
+impl Into<[f32; 4]> for BorderColor {
+    fn into(self) -> [f32; 4] {
+        match self {
+            BorderColor::TransparentBlack => [0.0, 0.0, 0.0, 0.0],
+            BorderColor::OpaqueBlack => [0.0, 0.0, 0.0, 1.0],
+            BorderColor::OpaqueWhite => [1.0, 1.0, 1.0, 1.0],
+        }
+    }
+}
+
 /// Specifies how to sample from an image.  These are all the parameters
 /// available that alter how the GPU goes from a coordinate in an image
 /// to producing an actual value from the texture, including filtering/
@@ -519,7 +541,7 @@ pub struct SamplerDesc {
     /// Comparison mode, used primary for a shadow map.
     pub comparison: Option<Comparison>,
     /// Border color is used when one of the wrap modes is set to border.
-    pub border: PackedColor,
+    pub border: BorderColor,
     /// Specifies whether the texture coordinates are normalized.
     pub normalized: bool,
     /// Anisotropic filtering.
@@ -540,7 +562,7 @@ impl SamplerDesc {
             lod_bias: Lod(0.0),
             lod_range: Lod::RANGE.clone(),
             comparison: None,
-            border: PackedColor(0),
+            border: BorderColor::TransparentBlack,
             normalized: true,
             anisotropy_clamp: None,
         }

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -251,6 +251,10 @@ bitflags! {
         const INSTANCE_RATE = 0x0004 << 64;
         /// Support non-zero mipmap bias on samplers.
         const SAMPLER_MIP_LOD_BIAS = 0x0008 << 64;
+        /// Support sampler wrap mode that clamps to border.
+        const SAMPLER_BORDER_COLOR = 0x0010 << 64;
+        /// Can create comparison samplers in regular descriptor sets.
+        const MUTABLE_COMPARISON_SAMPLER = 0x0020 << 64;
 
         /// Make the NDC coordinate system pointing Y up, to match D3D and Metal.
         const NDC_Y_UP = 0x0001 << 80;


### PR DESCRIPTION
Contributes towards #3346
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:

cc @jshrake (related to https://github.com/gfx-rs/wgpu/pull/891)