### PR TITLE
Update spirv_cross to 0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### backend-dx12-0.6.3 backend-dx11-0.6.1 backend-metal-0.6.2 auxil-0.5.1 (31-08-2020)
+  - update spirv_cross to 0.21:
+    - force zero initialization in all generated shaders
+    - force the use of native arrays for MSL
+
 ### backend-metal-0.6.1 (23-08-2020)
   - fix layer checks in `clear_image`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-metal-0.6.1 (23-08-2020)
+  - fix layer checks in `clear_image`
+
 ### backend-dx12-0.6.2 (19-08-2020)
   - enable multisampling and object labels
 

--- a/src/auxil/auxil/Cargo.toml
+++ b/src/auxil/auxil/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
 fxhash = "0.2.1"
-spirv_cross = { version = "0.20", optional = true }
+spirv_cross = { version = "0.21", optional = true }
 
 [lib]
 name = "gfx_auxil"

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "1"
 libloading = "0.6"
 log = { version = "0.4" }
 smallvec = "1.0"
-spirv_cross = { version = "0.20", features = ["hlsl"] }
+spirv_cross = { version = "0.21", features = ["hlsl"] }
 parking_lot = "0.11"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 wio = "0.2"

--- a/src/backend/dx11/src/shader.rs
+++ b/src/backend/dx11/src/shader.rs
@@ -257,6 +257,7 @@ fn translate_spirv(
     let mut compile_options = hlsl::CompilerOptions::default();
     compile_options.shader_model = shader_model;
     compile_options.vertex.invert_y = !features.contains(hal::Features::NDC_Y_UP);
+    compile_options.force_zero_initialized_variables = true;
 
     //let stage_flag = stage.into();
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "1"
 native = { package = "d3d12", version = "0.3", features = ["libloading"] }
 log = "0.4"
 smallvec = "1"
-spirv_cross = { version = "0.20", features = ["hlsl"] }
+spirv_cross = { version = "0.21", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 raw-window-handle = "0.3"
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -411,6 +411,7 @@ impl Device {
         let mut compile_options = hlsl::CompilerOptions::default();
         compile_options.shader_model = shader_model;
         compile_options.vertex.invert_y = !features.contains(hal::Features::NDC_Y_UP);
+        compile_options.force_zero_initialized_variables = true;
 
         let stage_flag = stage.to_flag();
         let root_constant_layout = layout

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -29,7 +29,7 @@ auxil = { path = "../../auxil/auxil", version = "0.5", package = "gfx-auxil", fe
 smallvec = "1.0"
 glow = "0.4"
 parking_lot = "0.11"
-spirv_cross = { version = "0.20", features = ["glsl"] }
+spirv_cross = { version = "0.21", features = ["glsl"] }
 lazy_static = "1"
 raw-window-handle = "0.3"
 # disable this for now, the versions of glutin are jumping too fast.

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -209,6 +209,7 @@ impl Device {
             }
         };
         compile_options.vertex.invert_y = !self.features.contains(hal::Features::NDC_Y_UP);
+        compile_options.force_zero_initialized_variables = true;
         debug!("SPIR-V options {:?}", compile_options);
 
         ast.set_compiler_options(&compile_options)

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -35,7 +35,7 @@ objc = "0.2.5"
 block = "0.1"
 cocoa-foundation = "0.1"
 smallvec = "1"
-spirv_cross = { version = "0.20", features = ["msl"] }
+spirv_cross = { version = "0.21", features = ["msl"] }
 parking_lot = "0.11"
 storage-map = "0.3"
 lazy_static = "1"

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1284,6 +1284,8 @@ impl hal::device::Device<Backend> for Device {
         shader_compiler_options.resource_binding_overrides = res_overrides;
         shader_compiler_options.const_samplers = const_samplers;
         shader_compiler_options.enable_argument_buffers = self.shared.private_caps.argument_buffers;
+        shader_compiler_options.force_zero_initialized_variables = true;
+        shader_compiler_options.force_native_arrays = true;
         let mut shader_compiler_options_point = shader_compiler_options.clone();
         shader_compiler_options_point.enable_point_size_builtin = true;
 
@@ -1760,6 +1762,8 @@ impl hal::device::Device<Backend> for Device {
             let mut options = msl::CompilerOptions::default();
             options.enable_point_size_builtin = false;
             options.vertex.invert_y = !self.features.contains(hal::Features::NDC_Y_UP);
+            options.force_zero_initialized_variables = true;
+            options.force_native_arrays = true;
             let info = Self::compile_shader_library(
                 &self.shared.device,
                 raw_data,


### PR DESCRIPTION
spirv_cross 0.21 exposes `force_zero_initialized_variables` for GLSL/HLSL/MSL and `force_native_arrays` for MSL. I think we can probably enable both of these options unconditionally in gfx and wgpu.

(I'll backport this into 0.6 once we accept these changes)

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: metal, gl
