### PR TITLE
[0.6] Backport spirv_cross update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Change Log
 
-### backend-dx12-0.6.3 (TBD)
-  - fix root signature indexing
+### auxil-0.6.0 (02-09-2020)
+  - update to newer version of spirv_cross to be consistent with backends
 
-### backend-metal-0.6.2 (TBD)
+### backend-dx12-0.6.3 (02-09-2020)
+  - fix root signature indexing
+  - force zero initialization for shader variables
+
+### backend-metal-0.6.2 (02-09-2020)
   - enable compatibility with iOS emulator
+  - force zero initialization for shader variables
+  - force the use of native arrays for MSL
+
+### backend-dx11-0.6.1 (02-09-2020)
+  - force zero initialization for shader variables
 
 ### backend-metal-0.6.1 (23-08-2020)
   - fix layer checks in `clear_image`

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -34,7 +34,7 @@ path = "mesh-shading/main.rs"
 image = "0.23"
 log = "0.4"
 hal = { path = "../src/hal", version = "0.6", package = "gfx-hal" }
-auxil = { path = "../src/auxil/auxil", version = "0.5", package = "gfx-auxil" }
+auxil = { path = "../src/auxil/auxil", version = "0.6", package = "gfx-auxil" }
 gfx-backend-gl = { path = "../src/backend/gl", version = "0.6", optional = true }
 gfx-backend-empty = { path = "../src/backend/empty", version = "0.6" }
 winit = { version = "0.22", features = ["web-sys"] }

--- a/src/auxil/auxil/Cargo.toml
+++ b/src/auxil/auxil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-auxil"
-version = "0.5.0"
+version = "0.6.0"
 description = "Implementation details shared between gfx-rs backends"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
 fxhash = "0.2.1"
-spirv_cross = { version = "0.20", optional = true }
+spirv_cross = { version = "0.21", optional = true }
 
 [lib]
 name = "gfx_auxil"

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.6.0"
+version = "0.6.1"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -19,14 +19,14 @@ default = []
 name = "gfx_backend_dx11"
 
 [dependencies]
-auxil = { path = "../../auxil/auxil", version = "0.5", package = "gfx-auxil", features = ["spirv_cross"] }
+auxil = { path = "../../auxil/auxil", version = "0.6", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
 libloading = "0.6"
 log = { version = "0.4" }
 smallvec = "1.0"
-spirv_cross = { version = "0.20", features = ["hlsl"] }
+spirv_cross = { version = "0.21", features = ["hlsl"] }
 parking_lot = "0.11"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 wio = "0.2"

--- a/src/backend/dx11/src/shader.rs
+++ b/src/backend/dx11/src/shader.rs
@@ -257,6 +257,7 @@ fn translate_spirv(
     let mut compile_options = hlsl::CompilerOptions::default();
     compile_options.shader_model = shader_model;
     compile_options.vertex.invert_y = !features.contains(hal::Features::NDC_Y_UP);
+    compile_options.force_zero_initialized_variables = true;
 
     //let stage_flag = stage.into();
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.6.2"
+version = "0.6.3"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -19,14 +19,14 @@ default = []
 name = "gfx_backend_dx12"
 
 [dependencies]
-auxil = { path = "../../auxil/auxil", version = "0.5", package = "gfx-auxil", features = ["spirv_cross"] }
+auxil = { path = "../../auxil/auxil", version = "0.6", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1.1" }
 bitflags = "1"
 native = { package = "d3d12", version = "0.3", features = ["libloading"] }
 log = "0.4"
 smallvec = "1"
-spirv_cross = { version = "0.20", features = ["hlsl"] }
+spirv_cross = { version = "0.21", features = ["hlsl"] }
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 raw-window-handle = "0.3"
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -411,6 +411,7 @@ impl Device {
         let mut compile_options = hlsl::CompilerOptions::default();
         compile_options.shader_model = shader_model;
         compile_options.vertex.invert_y = !features.contains(hal::Features::NDC_Y_UP);
+        compile_options.force_zero_initialized_variables = true;
 
         let stage_flag = stage.to_flag();
         let root_constant_layout = layout

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -27,11 +27,11 @@ arrayvec = "0.5"
 bitflags = "1"
 log = { version = "0.4" }
 gfx-hal = { path = "../../hal", version = "0.6" }
-auxil = { path = "../../auxil/auxil", version = "0.5", package = "gfx-auxil", features = ["spirv_cross"] }
+auxil = { path = "../../auxil/auxil", version = "0.6", package = "gfx-auxil", features = ["spirv_cross"] }
 smallvec = "1.0"
 glow = "0.4"
 parking_lot = "0.11"
-spirv_cross = { version = "0.20", features = ["glsl"] }
+spirv_cross = { version = "0.21", features = ["glsl"] }
 lazy_static = "1"
 raw-window-handle = "0.3"
 # disable this for now, the versions of glutin are jumping too fast

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -209,6 +209,7 @@ impl Device {
             }
         };
         compile_options.vertex.invert_y = !self.features.contains(hal::Features::NDC_Y_UP);
+        compile_options.force_zero_initialized_variables = true;
         debug!("SPIR-V options {:?}", compile_options);
 
         ast.set_compiler_options(&compile_options)

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-metal"
-version = "0.6.1"
+version = "0.6.2"
 description = "Metal API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"
@@ -21,7 +21,7 @@ signpost = []
 name = "gfx_backend_metal"
 
 [dependencies]
-auxil = { path = "../../auxil/auxil", version = "0.5", package = "gfx-auxil", features = ["spirv_cross"] }
+auxil = { path = "../../auxil/auxil", version = "0.6", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 arrayvec = "0.5"
@@ -35,7 +35,7 @@ objc = "0.2.5"
 block = "0.1"
 cocoa-foundation = "0.1"
 smallvec = "1"
-spirv_cross = { version = "0.20", features = ["msl"] }
+spirv_cross = { version = "0.21", features = ["msl"] }
 parking_lot = "0.11"
 storage-map = "0.3"
 lazy_static = "1"

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1286,6 +1286,8 @@ impl hal::device::Device<Backend> for Device {
         shader_compiler_options.resource_binding_overrides = res_overrides;
         shader_compiler_options.const_samplers = const_samplers;
         shader_compiler_options.enable_argument_buffers = self.shared.private_caps.argument_buffers;
+        shader_compiler_options.force_zero_initialized_variables = true;
+        shader_compiler_options.force_native_arrays = true;
         let mut shader_compiler_options_point = shader_compiler_options.clone();
         shader_compiler_options_point.enable_point_size_builtin = true;
 
@@ -1762,6 +1764,8 @@ impl hal::device::Device<Backend> for Device {
             let mut options = msl::CompilerOptions::default();
             options.enable_point_size_builtin = false;
             options.vertex.invert_y = !self.features.contains(hal::Features::NDC_Y_UP);
+            options.force_zero_initialized_variables = true;
+            options.force_native_arrays = true;
             let info = Self::compile_shader_library(
                 &self.shared.device,
                 raw_data,

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -28,7 +28,7 @@ gl = ["gfx-backend-gl"]
 #TODO: keep Warden backend-agnostic?
 
 [dependencies]
-auxil = { path = "../auxil/auxil", version = "0.5", package = "gfx-auxil" }
+auxil = { path = "../auxil/auxil", version = "0.6", package = "gfx-auxil" }
 hal = { path = "../hal", version = "0.6", package = "gfx-hal", features = ["serde"] }
 log = "0.4"
 ron = "0.6"


### PR DESCRIPTION
Backport #3356 to update spirv_cross:
- spirv_cross 0.21 enables us to use zero initialization for shader variables and use of native arrays in MSL
- increase crate versions for the dx12/dx11/metal backends and auxil