### PR TITLE
[dx12] fix root signature indexing

### DIFF
--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -295,13 +295,13 @@ impl PipelineCache {
             None => return,
         };
 
-        for (i, &root_offset) in shared.parameter_offsets.iter().enumerate() {
+        for (root_index, &root_offset) in shared.parameter_offsets.iter().enumerate() {
             if !user_data.is_index_dirty(root_offset) {
                 continue;
             }
             match user_data.data[root_offset as usize] {
                 RootElement::Constant(_) => {
-                    let c = &shared.constants[i];
+                    let c = &shared.constants[root_index];
                     debug_assert_eq!(root_offset, c.range.start);
                     self.temp_constants.clear();
                     self.temp_constants.extend(
@@ -318,19 +318,19 @@ impl PipelineCache {
                                 }
                             }),
                     );
-                    constants_update(root_offset, &self.temp_constants);
+                    constants_update(root_index as u32, &self.temp_constants);
                 }
                 RootElement::TableSrvCbvUav(offset) => {
                     let gpu = d3d12::D3D12_GPU_DESCRIPTOR_HANDLE {
                         ptr: self.srv_cbv_uav_start + offset as u64,
                     };
-                    table_update(root_offset, gpu);
+                    table_update(root_index as u32, gpu);
                 }
                 RootElement::TableSampler(offset) => {
                     let gpu = d3d12::D3D12_GPU_DESCRIPTOR_HANDLE {
                         ptr: self.sampler_start + offset as u64,
                     };
-                    table_update(root_offset, gpu);
+                    table_update(root_index as u32, gpu);
                 }
                 RootElement::DescriptorCbv { buffer } => {
                     debug_assert!(user_data.is_index_dirty(root_offset + 1));
@@ -339,7 +339,7 @@ impl PipelineCache {
                         RootElement::DescriptorPlaceholder
                     );
 
-                    descriptor_cbv_update(root_offset, buffer);
+                    descriptor_cbv_update(root_index as u32, buffer);
                 }
                 RootElement::DescriptorPlaceholder | RootElement::Undefined => {
                     error!(

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1629,7 +1629,6 @@ impl d::Device<B> for Device {
                     )
                 };
 
-                let mut descriptors = Vec::new();
                 let mut mutable_bindings = auxil::FastHashSet::default();
 
                 // SRV/CBV/UAV descriptor tables
@@ -1688,9 +1687,6 @@ impl d::Device<B> for Device {
                         };
 
                         if content.contains(r::DescriptorContent::CBV) {
-                            descriptors.push(r::RootDescriptor {
-                                offset: root_offset as usize,
-                            });
                             parameter_offsets.push(root_offset);
                             parameters
                                 .push(native::RootParameter::cbv_descriptor(visibility, binding));
@@ -1707,7 +1703,6 @@ impl d::Device<B> for Device {
                         ty: table_type,
                         offset: root_table_offset as _,
                     },
-                    descriptors,
                     mutable_bindings,
                 }
             })

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -132,16 +132,9 @@ pub struct RootTable {
     pub offset: RootSignatureOffset,
 }
 
-#[derive(Debug, Hash)]
-pub struct RootDescriptor {
-    pub offset: RootSignatureOffset,
-}
-
 #[derive(Debug)]
 pub struct RootElement {
     pub table: RootTable,
-    //TODO: remove this or find a better way to use it
-    pub descriptors: Vec<RootDescriptor>,
     pub mutable_bindings: auxil::FastHashSet<pso::DescriptorBinding>,
 }
 

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -227,7 +227,8 @@ impl CommandQueue {
             .framebuffer_object;
 
         unsafe {
-            gl.context.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(swapchain.fbos[index as usize]));
+            gl.context
+                .bind_framebuffer(glow::READ_FRAMEBUFFER, Some(swapchain.fbos[index as usize]));
             gl.context.bind_framebuffer(
                 glow::DRAW_FRAMEBUFFER,
                 #[cfg(surfman)]

--- a/src/backend/gl/src/window/surfman.rs
+++ b/src/backend/gl/src/window/surfman.rs
@@ -94,9 +94,7 @@ impl Instance {
             .bind_surface_to_context(&mut context, surface)
             .expect("TODO");
 
-        device
-            .make_context_current(&context)
-            .expect("TODO");
+        device.make_context_current(&context).expect("TODO");
 
         // Create a surface with the given context
         Surface {


### PR DESCRIPTION
Fixes a critical problem reported in https://github.com/gfx-rs/wgpu/issues/849#issuecomment-685151553
It appears to be a regression from #3342, where I accidentally started using the root offsets where the root indices are expected. We might need to change their types to not hit this any more times (maybe in d3d12-rs even? cc @msiglreith ).
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: D3D12
