### PR TITLE
[0.6/dx11] fix read-only buffer SRV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### backend-dx11-0.6.2 (02-09-2020)
+  - fix bindings filter by shader stages
+  - implement copies from buffers into R8, RG8, and RGBA8 textures
+  - fix read-only storage buffer support
+  - fix race condition in internal shader operations
+
 ### auxil-0.6.0 (02-09-2020)
   - update to newer version of spirv_cross to be consistent with backends
 

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.6.1"
+version = "0.6.2"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/shaders/copy.hlsl
+++ b/src/backend/dx11/shaders/copy.hlsl
@@ -136,8 +136,8 @@ ByteAddressBuffer   BufferCopySrc : register(t0);
 RWByteAddressBuffer BufferCopyDst : register(u0);
 
 RWTexture1DArray<uint>  Image1CopyDstR    : register(u0);
-RWTexture1DArray<uint>  Image1CopyDstRg   : register(u0);
-RWTexture1DArray<uint>  Image1CopyDstRgba : register(u0);
+RWTexture1DArray<uint2>  Image1CopyDstRg   : register(u0);
+RWTexture1DArray<uint4>  Image1CopyDstRgba : register(u0);
 
 Texture2DArray<uint4>   Image2CopySrc     : register(t0);
 RWTexture2DArray<uint>  Image2CopyDstR    : register(u0);

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1013,7 +1013,9 @@ impl device::Device<Backend> for Device {
         }
 
         // TODO: >=11.1
-        if usage.intersects(Usage::UNIFORM_TEXEL | Usage::STORAGE_TEXEL | Usage::TRANSFER_SRC | Usage::STORAGE) {
+        if usage.intersects(
+            Usage::UNIFORM_TEXEL | Usage::STORAGE_TEXEL | Usage::TRANSFER_SRC | Usage::STORAGE,
+        ) {
             bind |= d3d11::D3D11_BIND_SHADER_RESOURCE;
         }
 


### PR DESCRIPTION
Follow-up to #3362
Also fixes the read-only buffer SRVs.
Gets DX11 the the point of running vange-rs :tada: 
