### PR TITLE
Dx11 correctness fixes for bindings, and buffer-image copies

### DIFF
--- a/src/backend/dx11/shaders/copy.hlsl
+++ b/src/backend/dx11/shaders/copy.hlsl
@@ -135,12 +135,16 @@ uint4 Float4ToUint8x4(float4 data)
 ByteAddressBuffer   BufferCopySrc : register(t0);
 RWByteAddressBuffer BufferCopyDst : register(u0);
 
-Texture2DArray<uint4>   ImageCopySrc     : register(t0);
-RWTexture2DArray<uint>  ImageCopyDstR    : register(u0);
-RWTexture2DArray<uint2> ImageCopyDstRg   : register(u0);
-RWTexture2DArray<uint4> ImageCopyDstRgba : register(u0);
+RWTexture1DArray<uint>  Image1CopyDstR    : register(u0);
+RWTexture1DArray<uint>  Image1CopyDstRg   : register(u0);
+RWTexture1DArray<uint>  Image1CopyDstRgba : register(u0);
 
-Texture2DArray<float4>  ImageCopySrcBgra : register(t0);
+Texture2DArray<uint4>   Image2CopySrc     : register(t0);
+RWTexture2DArray<uint>  Image2CopyDstR    : register(u0);
+RWTexture2DArray<uint2> Image2CopyDstRg   : register(u0);
+RWTexture2DArray<uint4> Image2CopyDstRgba : register(u0);
+
+Texture2DArray<float4>  ImageCopy2SrcBgra : register(t0);
 
 // Image<->Image copies
 [numthreads(1, 1, 1)]
@@ -149,7 +153,7 @@ void cs_copy_image2d_r8g8_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThre
     uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
     uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
-    ImageCopyDstR[dst_idx] = Uint8x2ToUint16(ImageCopySrc[src_idx]);
+    Image2CopyDstR[dst_idx] = Uint8x2ToUint16(Image2CopySrc[src_idx]);
 }
 
 [numthreads(1, 1, 1)]
@@ -158,7 +162,7 @@ void cs_copy_image2d_r16_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThre
     uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
     uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
-    ImageCopyDstRg[dst_idx] = Uint16ToUint8x2(ImageCopySrc[src_idx]);
+    Image2CopyDstRg[dst_idx] = Uint16ToUint8x2(Image2CopySrc[src_idx]);
 }
 
 [numthreads(1, 1, 1)]
@@ -167,7 +171,7 @@ void cs_copy_image2d_r8g8b8a8_image2d_r32(uint3 dispatch_thread_id : SV_Dispatch
     uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
     uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
-    ImageCopyDstR[dst_idx] = Uint8x4ToUint32(ImageCopySrc[src_idx]);
+    Image2CopyDstR[dst_idx] = Uint8x4ToUint32(Image2CopySrc[src_idx]);
 }
 
 [numthreads(1, 1, 1)]
@@ -176,7 +180,7 @@ void cs_copy_image2d_r8g8b8a8_image2d_r16g16(uint3 dispatch_thread_id : SV_Dispa
     uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
     uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
-    ImageCopyDstRg[dst_idx] = Uint32ToUint16x2(Uint8x4ToUint32(ImageCopySrc[src_idx]));
+    Image2CopyDstRg[dst_idx] = Uint32ToUint16x2(Uint8x4ToUint32(Image2CopySrc[src_idx]));
 }
 
 [numthreads(1, 1, 1)]
@@ -185,7 +189,7 @@ void cs_copy_image2d_r16g16_image2d_r32(uint3 dispatch_thread_id : SV_DispatchTh
     uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
     uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
-    ImageCopyDstR[dst_idx] = Uint16x2ToUint32(ImageCopySrc[src_idx]);
+    Image2CopyDstR[dst_idx] = Uint16x2ToUint32(Image2CopySrc[src_idx]);
 }
 
 [numthreads(1, 1, 1)]
@@ -194,7 +198,7 @@ void cs_copy_image2d_r16g16_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_Dispa
     uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
     uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
-    ImageCopyDstRgba[dst_idx] = Uint32ToUint8x4(Uint16x2ToUint32(ImageCopySrc[src_idx]));
+    Image2CopyDstRgba[dst_idx] = Uint32ToUint8x4(Uint16x2ToUint32(Image2CopySrc[src_idx]));
 }
 
 [numthreads(1, 1, 1)]
@@ -203,7 +207,7 @@ void cs_copy_image2d_r32_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchTh
     uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
     uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
-    ImageCopyDstRg[dst_idx] = Uint32ToUint16x2(ImageCopySrc[src_idx]);
+    Image2CopyDstRg[dst_idx] = Uint32ToUint16x2(Image2CopySrc[src_idx]);
 }
 
 [numthreads(1, 1, 1)]
@@ -212,16 +216,17 @@ void cs_copy_image2d_r32_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_Dispatch
     uint3 dst_idx = GetImageCopyDst(dispatch_thread_id);
     uint3 src_idx = GetImageCopySrc(dispatch_thread_id);
 
-    ImageCopyDstRgba[dst_idx] = Uint32ToUint8x4(ImageCopySrc[src_idx]);
+    Image2CopyDstRgba[dst_idx] = Uint32ToUint8x4(Image2CopySrc[src_idx]);
 }
 
-#define COPY_NUM_THREAD_X 8
-#define COPY_NUM_THREAD_Y 8
+//#define COPY_1D_NUM_THREAD 64 //TODO
+#define COPY_2D_NUM_THREAD_X 8
+#define COPY_2D_NUM_THREAD_Y 8
 
 // Buffer<->Image copies
 
 // R32G32B32A32
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r32g32b32a32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -231,7 +236,7 @@ void cs_copy_buffer_image2d_r32g32b32a32(uint3 dispatch_thread_id : SV_DispatchT
 
     uint src_idx = GetBufferSrc128(dispatch_thread_id);
 
-    ImageCopyDstRgba[dst_idx] = uint4(
+    Image2CopyDstRgba[dst_idx] = uint4(
         BufferCopySrc.Load(src_idx),
         BufferCopySrc.Load(src_idx + 1 * 4),
         BufferCopySrc.Load(src_idx + 2 * 4),
@@ -239,7 +244,7 @@ void cs_copy_buffer_image2d_r32g32b32a32(uint3 dispatch_thread_id : SV_DispatchT
     );
 }
 
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r32g32b32a32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -247,7 +252,7 @@ void cs_copy_image2d_r32g32b32a32_buffer(uint3 dispatch_thread_id : SV_DispatchT
         return;
     }
 
-    uint4 data = ImageCopySrc[src_idx];
+    uint4 data = Image2CopySrc[src_idx];
     uint dst_idx = GetBufferDst128(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx,         data.x);
@@ -257,7 +262,7 @@ void cs_copy_image2d_r32g32b32a32_buffer(uint3 dispatch_thread_id : SV_DispatchT
 }
 
 // R32G32
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r32g32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -267,13 +272,13 @@ void cs_copy_buffer_image2d_r32g32(uint3 dispatch_thread_id : SV_DispatchThreadI
 
     uint src_idx = GetBufferSrc64(dispatch_thread_id);
 
-    ImageCopyDstRg[dst_idx] = uint2(
+    Image2CopyDstRg[dst_idx] = uint2(
         BufferCopySrc.Load(src_idx),
         BufferCopySrc.Load(src_idx + 1 * 4)
     );
 }
 
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r32g32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -281,7 +286,7 @@ void cs_copy_image2d_r32g32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadI
         return;
     }
 
-    uint2 data = ImageCopySrc[src_idx].rg;
+    uint2 data = Image2CopySrc[src_idx].rg;
     uint dst_idx = GetBufferDst64(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx        , data.x);
@@ -289,7 +294,7 @@ void cs_copy_image2d_r32g32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadI
 }
 
 // R16G16B16A16
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r16g16b16a16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -299,13 +304,13 @@ void cs_copy_buffer_image2d_r16g16b16a16(uint3 dispatch_thread_id : SV_DispatchT
 
     uint src_idx = GetBufferSrc64(dispatch_thread_id);
 
-    ImageCopyDstRgba[dst_idx] = uint4(
+    Image2CopyDstRgba[dst_idx] = uint4(
         Uint32ToUint16x2(BufferCopySrc.Load(src_idx)),
         Uint32ToUint16x2(BufferCopySrc.Load(src_idx + 1 * 4))
     );
 }
 
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r16g16b16a16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -313,7 +318,7 @@ void cs_copy_image2d_r16g16b16a16_buffer(uint3 dispatch_thread_id : SV_DispatchT
         return;
     }
 
-    uint4 data = ImageCopySrc[src_idx];
+    uint4 data = Image2CopySrc[src_idx];
     uint dst_idx = GetBufferDst64(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx,         Uint16x2ToUint32(data.xy));
@@ -321,7 +326,19 @@ void cs_copy_image2d_r16g16b16a16_buffer(uint3 dispatch_thread_id : SV_DispatchT
 }
 
 // R32
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, 1, 1)]
+void cs_copy_buffer_image1d_r32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
+    uint3 dst_idx = GetImageDst(dispatch_thread_id);
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x) {
+        return;
+    }
+
+    uint src_idx = GetBufferSrc32(dispatch_thread_id);
+
+    Image1CopyDstR[dst_idx.xz] = BufferCopySrc.Load(src_idx);
+}
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r32(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -331,10 +348,10 @@ void cs_copy_buffer_image2d_r32(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 
     uint src_idx = GetBufferSrc32(dispatch_thread_id);
 
-    ImageCopyDstR[dst_idx] = BufferCopySrc.Load(src_idx);
+    Image2CopyDstR[dst_idx] = BufferCopySrc.Load(src_idx);
 }
 
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -344,11 +361,11 @@ void cs_copy_image2d_r32_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 
     uint dst_idx = GetBufferDst32(dispatch_thread_id);
 
-    BufferCopyDst.Store(dst_idx, ImageCopySrc[src_idx].r);
+    BufferCopyDst.Store(dst_idx, Image2CopySrc[src_idx].r);
 }
 
 // R16G16
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -358,10 +375,10 @@ void cs_copy_buffer_image2d_r16g16(uint3 dispatch_thread_id : SV_DispatchThreadI
 
     uint src_idx = GetBufferSrc32(dispatch_thread_id);
 
-    ImageCopyDstRg[dst_idx] = Uint32ToUint16x2(BufferCopySrc.Load(src_idx));
+    Image2CopyDstRg[dst_idx] = Uint32ToUint16x2(BufferCopySrc.Load(src_idx));
 }
 
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r16g16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -371,11 +388,23 @@ void cs_copy_image2d_r16g16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadI
 
     uint dst_idx = GetBufferDst32(dispatch_thread_id);
 
-    BufferCopyDst.Store(dst_idx, Uint16x2ToUint32(ImageCopySrc[src_idx].xy));
+    BufferCopyDst.Store(dst_idx, Uint16x2ToUint32(Image2CopySrc[src_idx].xy));
 }
 
 // R8G8B8A8
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, 1, 1)]
+void cs_copy_buffer_image1d_r8g8b8a8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
+    uint3 dst_idx = GetImageDst(dispatch_thread_id);
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x) {
+        return;
+    }
+
+    uint src_idx = GetBufferSrc32(dispatch_thread_id);
+
+    Image1CopyDstRgba[dst_idx.xz] = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
+}
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -385,10 +414,10 @@ void cs_copy_buffer_image2d_r8g8b8a8(uint3 dispatch_thread_id : SV_DispatchThrea
 
     uint src_idx = GetBufferSrc32(dispatch_thread_id);
 
-    ImageCopyDstRgba[dst_idx] = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
+    Image2CopyDstRgba[dst_idx] = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 }
 
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8g8b8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -398,11 +427,11 @@ void cs_copy_image2d_r8g8b8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThrea
 
     uint dst_idx = GetBufferDst32(dispatch_thread_id);
 
-    BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(ImageCopySrc[src_idx]));
+    BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(Image2CopySrc[src_idx]));
 }
 
 // B8G8R8A8
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_b8g8r8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -412,11 +441,11 @@ void cs_copy_image2d_b8g8r8a8_buffer(uint3 dispatch_thread_id : SV_DispatchThrea
 
     uint dst_idx = GetBufferDst32(dispatch_thread_id);
 
-    BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(Float4ToUint8x4(ImageCopySrcBgra[src_idx].bgra)));
+    BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(Float4ToUint8x4(ImageCopy2SrcBgra[src_idx].bgra)));
 }
 
 // R16
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -427,11 +456,11 @@ void cs_copy_buffer_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThreadID) 
     uint src_idx = GetBufferSrc16(dispatch_thread_id);
     uint2 data = Uint32ToUint16x2(BufferCopySrc.Load(src_idx));
 
-    ImageCopyDstR[dst_idx                 ] = data.x;
-    ImageCopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
+    Image2CopyDstR[dst_idx                 ] = data.x;
+    Image2CopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
 }
 
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(uint3(2, 1, 0) * dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -441,14 +470,29 @@ void cs_copy_image2d_r16_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) 
 
     uint dst_idx = GetBufferDst16(dispatch_thread_id);
 
-    uint upper = ImageCopySrc[src_idx].r;
-    uint lower = ImageCopySrc[src_idx + uint3(1, 0, 0)].r;
+    uint upper = Image2CopySrc[src_idx].r;
+    uint lower = Image2CopySrc[src_idx + uint3(1, 0, 0)].r;
 
     BufferCopyDst.Store(dst_idx, Uint16x2ToUint32(uint2(upper, lower)));
 }
 
 // R8G8
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, 1, 1)]
+void cs_copy_buffer_image1d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
+    uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x) {
+        return;
+    }
+
+    uint src_idx = GetBufferSrc16(dispatch_thread_id);
+
+    uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
+
+    Image1CopyDstRg[dst_idx.xz + uint2(0, 0)] = data.xy;
+    Image1CopyDstRg[dst_idx.xz + uint2(1, 0)] = data.zw;
+}
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -460,11 +504,11 @@ void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID)
 
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    ImageCopyDstRg[dst_idx                 ] = data.xy;
-    ImageCopyDstRg[dst_idx + uint3(1, 0, 0)] = data.zw;
+    Image2CopyDstRg[dst_idx + uint3(0, 0, 0)] = data.xy;
+    Image2CopyDstRg[dst_idx + uint3(1, 0, 0)] = data.zw;
 }
 
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8g8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(uint3(2, 1, 0) * dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -474,14 +518,30 @@ void cs_copy_image2d_r8g8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID)
 
     uint dst_idx = GetBufferDst16(dispatch_thread_id);
 
-    uint2 lower = ImageCopySrc[src_idx].xy;
-    uint2 upper = ImageCopySrc[src_idx + uint3(1, 0, 0)].xy;
+    uint2 lower = Image2CopySrc[src_idx].xy;
+    uint2 upper = Image2CopySrc[src_idx + uint3(1, 0, 0)].xy;
 
     BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(uint4(lower.x, lower.y, upper.x, upper.y)));
 }
 
 // R8
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, 1, 1)]
+void cs_copy_buffer_image1d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
+    uint3 dst_idx = GetImageDst(uint3(4, 1, 0) * dispatch_thread_id);
+    uint3 bounds = GetDestBounds();
+    if (dst_idx.x >= bounds.x) {
+        return;
+    }
+
+    uint src_idx = GetBufferSrc8(dispatch_thread_id);
+    uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
+
+    Image1CopyDstR[dst_idx.xz + uint2(0, 0)] = data.x;
+    Image1CopyDstR[dst_idx.xz + uint2(1, 0)] = data.y;
+    Image1CopyDstR[dst_idx.xz + uint2(2, 0)] = data.z;
+    Image1CopyDstR[dst_idx.xz + uint2(3, 0)] = data.w;
+}
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(uint3(4, 1, 0) * dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -492,13 +552,12 @@ void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint src_idx = GetBufferSrc8(dispatch_thread_id);
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    ImageCopyDstR[dst_idx              ] = data.x;
-    ImageCopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
-    ImageCopyDstR[dst_idx + uint3(2, 0, 0)] = data.z;
-    ImageCopyDstR[dst_idx + uint3(3, 0, 0)] = data.w;
+    Image2CopyDstR[dst_idx + uint3(0, 0, 0)] = data.x;
+    Image2CopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
+    Image2CopyDstR[dst_idx + uint3(2, 0, 0)] = data.z;
+    Image2CopyDstR[dst_idx + uint3(3, 0, 0)] = data.w;
 }
-
-[numthreads(COPY_NUM_THREAD_X, COPY_NUM_THREAD_Y, 1)]
+[numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 src_idx = GetImageSrc(uint3(4, 1, 0) * dispatch_thread_id);
     uint3 bounds = GetDestBounds();
@@ -509,9 +568,9 @@ void cs_copy_image2d_r8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint dst_idx = GetBufferDst8(dispatch_thread_id);
 
     BufferCopyDst.Store(dst_idx, Uint8x4ToUint32(uint4(
-        ImageCopySrc[src_idx].r,
-        ImageCopySrc[src_idx + uint3(1, 0, 0)].r,
-        ImageCopySrc[src_idx + uint3(2, 0, 0)].r,
-        ImageCopySrc[src_idx + uint3(3, 0, 0)].r
+        Image2CopySrc[src_idx].r,
+        Image2CopySrc[src_idx + uint3(1, 0, 0)].r,
+        Image2CopySrc[src_idx + uint3(2, 0, 0)].r,
+        Image2CopySrc[src_idx + uint3(3, 0, 0)].r
     )));
 }

--- a/src/backend/dx11/shaders/copy.hlsl
+++ b/src/backend/dx11/shaders/copy.hlsl
@@ -136,8 +136,8 @@ ByteAddressBuffer   BufferCopySrc : register(t0);
 RWByteAddressBuffer BufferCopyDst : register(u0);
 
 RWTexture1DArray<uint>  Image1CopyDstR    : register(u0);
-RWTexture1DArray<uint>  Image1CopyDstRg   : register(u0);
-RWTexture1DArray<uint>  Image1CopyDstRgba : register(u0);
+RWTexture1DArray<uint2>  Image1CopyDstRg   : register(u0);
+RWTexture1DArray<uint4>  Image1CopyDstRgba : register(u0);
 
 Texture2DArray<uint4>   Image2CopySrc     : register(t0);
 RWTexture2DArray<uint>  Image2CopyDstR    : register(u0);

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -46,7 +46,7 @@ pub struct Device {
     pub(crate) context: ComPtr<d3d11::ID3D11DeviceContext>,
     features: hal::Features,
     memory_properties: MemoryProperties,
-    pub(crate) internal: internal::Internal,
+    internal: Arc<internal::Internal>,
 }
 
 impl fmt::Debug for Device {
@@ -80,7 +80,7 @@ impl Device {
             context,
             features,
             memory_properties,
-            internal: internal::Internal::new(&device),
+            internal: Arc::new(internal::Internal::new(&device)),
         }
     }
 
@@ -754,7 +754,7 @@ impl device::Device<Backend> for Device {
         // TODO:
         Ok(CommandPool {
             device: self.raw.clone(),
-            internal: self.internal.clone(),
+            internal: Arc::clone(&self.internal),
         })
     }
 

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -238,6 +238,7 @@ impl Device {
                 vertex_strides,
             })
         } else {
+            error!("CreateInputLayout error 0x{:X}", hr);
             Err(pso::CreationError::Other)
         }
     }

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -1,4 +1,4 @@
-use auxil::ShaderStage;
+use auxil::{FastHashMap, ShaderStage};
 use hal::{command, image, pso};
 
 use winapi::{
@@ -14,6 +14,7 @@ use wio::com::ComPtr;
 
 use std::{borrow::Borrow, mem, ptr};
 
+use parking_lot::Mutex;
 use smallvec::SmallVec;
 use spirv_cross;
 
@@ -68,15 +69,45 @@ struct PartialClearInfo {
 const COPY_THREAD_GROUP_X: u32 = 8;
 const COPY_THREAD_GROUP_Y: u32 = 8;
 
+#[derive(Clone, Debug)]
+struct ComputeCopyBuffer {
+    d1_from_buffer: Option<ComPtr<d3d11::ID3D11ComputeShader>>,
+    // Buffer -> Image2D
+    d2_from_buffer: Option<ComPtr<d3d11::ID3D11ComputeShader>>,
+    // Image2D -> Buffer
+    d2_into_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
+    scale: (u32, u32),
+}
+
+#[derive(Debug)]
+struct ConstantBuffer {
+    buffer: ComPtr<d3d11::ID3D11Buffer>,
+}
+
+impl ConstantBuffer {
+    unsafe fn update<T>(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>, data: T) {
+        let mut mapped = mem::zeroed::<d3d11::D3D11_MAPPED_SUBRESOURCE>();
+        let hr = context.Map(
+            self.buffer.as_raw() as _,
+            0,
+            d3d11::D3D11_MAP_WRITE_DISCARD,
+            0,
+            &mut mapped,
+        );
+        assert_eq!(winerror::S_OK, hr);
+
+        ptr::copy(&data, mapped.pData as _, 1);
+
+        context.Unmap(self.buffer.as_raw() as _, 0);
+    }
+}
+
 // Holds everything we need for fallback implementations of features that are not in DX.
-//
-// TODO: maybe get rid of `Clone`? there's _a lot_ of refcounts here and it is used as a singleton
-//       anyway :s
 //
 // TODO: make struct fields more modular and group them up in structs depending on if it is a
 //       fallback version or not (eg. Option<PartialClear>), should make struct definition and
 //       `new` function smaller
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Internal {
     // partial clearing
     vs_partial_clear: ComPtr<d3d11::ID3D11VertexShader>,
@@ -100,41 +131,15 @@ pub struct Internal {
     ps_blit_2d_float: ComPtr<d3d11::ID3D11PixelShader>,
 
     // Image<->Image not covered by `CopySubresourceRegion`
-    cs_copy_image2d_r8g8_image2d_r16: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r16_image2d_r8g8: ComPtr<d3d11::ID3D11ComputeShader>,
-
-    cs_copy_image2d_r8g8b8a8_image2d_r32: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r8g8b8a8_image2d_r16g16: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r16g16_image2d_r32: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r16g16_image2d_r8g8b8a8: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r32_image2d_r16g16: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r32_image2d_r8g8b8a8: ComPtr<d3d11::ID3D11ComputeShader>,
-
-    // Image -> Buffer
-    cs_copy_image2d_r32g32b32a32_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r32g32_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r16g16b16a16_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r32_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r16g16_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r8g8b8a8_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r16_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r8g8_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_r8_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_image2d_b8g8r8a8_buffer: ComPtr<d3d11::ID3D11ComputeShader>,
-
-    // Buffer -> Image
-    cs_copy_buffer_image2d_r32g32b32a32: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_buffer_image2d_r32g32: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_buffer_image2d_r16g16b16a16: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_buffer_image2d_r32: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_buffer_image2d_r16g16: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_buffer_image2d_r8g8b8a8: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_buffer_image2d_r16: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_buffer_image2d_r8g8: ComPtr<d3d11::ID3D11ComputeShader>,
-    cs_copy_buffer_image2d_r8: ComPtr<d3d11::ID3D11ComputeShader>,
+    cs_copy_image_shaders: FastHashMap<
+        (dxgiformat::DXGI_FORMAT, dxgiformat::DXGI_FORMAT),
+        ComPtr<d3d11::ID3D11ComputeShader>,
+    >,
+    // Image -> Buffer and Buffer -> Image shaders
+    cs_copy_buffer_shaders: FastHashMap<dxgiformat::DXGI_FORMAT, ComputeCopyBuffer>,
 
     // internal constant buffer that is used by internal shaders
-    internal_buffer: ComPtr<d3d11::ID3D11Buffer>,
+    internal_buffer: Mutex<ConstantBuffer>,
 
     // public buffer that is used as intermediate storage for some operations (memory invalidation)
     pub working_buffer: ComPtr<d3d11::ID3D11Buffer>,
@@ -364,6 +369,224 @@ impl Internal {
         let copy_shaders = include_bytes!("../shaders/copy.hlsl");
         let blit_shaders = include_bytes!("../shaders/blit.hlsl");
 
+        let mut cs_copy_image_shaders = FastHashMap::default();
+        cs_copy_image_shaders.insert(
+            (
+                dxgiformat::DXGI_FORMAT_R8G8_UINT,
+                dxgiformat::DXGI_FORMAT_R16_UINT,
+            ),
+            compile_cs(device, copy_shaders, "cs_copy_image2d_r8g8_image2d_r16"),
+        );
+        cs_copy_image_shaders.insert(
+            (
+                dxgiformat::DXGI_FORMAT_R16_UINT,
+                dxgiformat::DXGI_FORMAT_R8G8_UINT,
+            ),
+            compile_cs(device, copy_shaders, "cs_copy_image2d_r16_image2d_r8g8"),
+        );
+        cs_copy_image_shaders.insert(
+            (
+                dxgiformat::DXGI_FORMAT_R8G8B8A8_UINT,
+                dxgiformat::DXGI_FORMAT_R32_UINT,
+            ),
+            compile_cs(device, copy_shaders, "cs_copy_image2d_r8g8b8a8_image2d_r32"),
+        );
+        cs_copy_image_shaders.insert(
+            (
+                dxgiformat::DXGI_FORMAT_R8G8B8A8_UINT,
+                dxgiformat::DXGI_FORMAT_R16G16_UINT,
+            ),
+            compile_cs(
+                device,
+                copy_shaders,
+                "cs_copy_image2d_r8g8b8a8_image2d_r16g16",
+            ),
+        );
+        cs_copy_image_shaders.insert(
+            (
+                dxgiformat::DXGI_FORMAT_R16G16_UINT,
+                dxgiformat::DXGI_FORMAT_R32_UINT,
+            ),
+            compile_cs(device, copy_shaders, "cs_copy_image2d_r16g16_image2d_r32"),
+        );
+        cs_copy_image_shaders.insert(
+            (
+                dxgiformat::DXGI_FORMAT_R16G16_UINT,
+                dxgiformat::DXGI_FORMAT_R8G8B8A8_UINT,
+            ),
+            compile_cs(
+                device,
+                copy_shaders,
+                "cs_copy_image2d_r16g16_image2d_r8g8b8a8",
+            ),
+        );
+        cs_copy_image_shaders.insert(
+            (
+                dxgiformat::DXGI_FORMAT_R32_UINT,
+                dxgiformat::DXGI_FORMAT_R16G16_UINT,
+            ),
+            compile_cs(device, copy_shaders, "cs_copy_image2d_r32_image2d_r16g16"),
+        );
+        cs_copy_image_shaders.insert(
+            (
+                dxgiformat::DXGI_FORMAT_R32_UINT,
+                dxgiformat::DXGI_FORMAT_R8G8B8A8_UINT,
+            ),
+            compile_cs(device, copy_shaders, "cs_copy_image2d_r32_image2d_r8g8b8a8"),
+        );
+
+        let mut cs_copy_buffer_shaders = FastHashMap::default();
+        cs_copy_buffer_shaders.insert(
+            dxgiformat::DXGI_FORMAT_R32G32B32A32_UINT,
+            ComputeCopyBuffer {
+                d1_from_buffer: None,
+                d2_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image2d_r32g32b32a32",
+                )),
+                d2_into_buffer: compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_image2d_r32g32b32a32_buffer",
+                ),
+                scale: (1, 1),
+            },
+        );
+        cs_copy_buffer_shaders.insert(
+            dxgiformat::DXGI_FORMAT_R32G32_UINT,
+            ComputeCopyBuffer {
+                d1_from_buffer: None,
+                d2_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image2d_r32g32",
+                )),
+                d2_into_buffer: compile_cs(device, copy_shaders, "cs_copy_image2d_r32g32_buffer"),
+                scale: (1, 1),
+            },
+        );
+        cs_copy_buffer_shaders.insert(
+            dxgiformat::DXGI_FORMAT_R32_UINT,
+            ComputeCopyBuffer {
+                d1_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image1d_r32",
+                )),
+                d2_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image2d_r32",
+                )),
+                d2_into_buffer: compile_cs(device, copy_shaders, "cs_copy_image2d_r32_buffer"),
+                scale: (1, 1),
+            },
+        );
+        cs_copy_buffer_shaders.insert(
+            dxgiformat::DXGI_FORMAT_R16G16B16A16_UINT,
+            ComputeCopyBuffer {
+                d1_from_buffer: None,
+                d2_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image2d_r16g16b16a16",
+                )),
+                d2_into_buffer: compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_image2d_r16g16b16a16_buffer",
+                ),
+                scale: (1, 1),
+            },
+        );
+        cs_copy_buffer_shaders.insert(
+            dxgiformat::DXGI_FORMAT_R16G16_UINT,
+            ComputeCopyBuffer {
+                d1_from_buffer: None,
+                d2_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image2d_r16g16",
+                )),
+                d2_into_buffer: compile_cs(device, copy_shaders, "cs_copy_image2d_r16g16_buffer"),
+                scale: (1, 1),
+            },
+        );
+        cs_copy_buffer_shaders.insert(
+            dxgiformat::DXGI_FORMAT_R16_UINT,
+            ComputeCopyBuffer {
+                d1_from_buffer: None,
+                d2_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image2d_r16",
+                )),
+                d2_into_buffer: compile_cs(device, copy_shaders, "cs_copy_image2d_r16_buffer"),
+                scale: (2, 1),
+            },
+        );
+        cs_copy_buffer_shaders.insert(
+            dxgiformat::DXGI_FORMAT_B8G8R8A8_UNORM,
+            ComputeCopyBuffer {
+                d1_from_buffer: None,
+                d2_from_buffer: None,
+                d2_into_buffer: compile_cs(device, copy_shaders, "cs_copy_image2d_b8g8r8a8_buffer"),
+                scale: (1, 1),
+            },
+        );
+        cs_copy_buffer_shaders.insert(
+            dxgiformat::DXGI_FORMAT_R8G8B8A8_UINT,
+            ComputeCopyBuffer {
+                d1_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image1d_r8g8b8a8",
+                )),
+                d2_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image2d_r8g8b8a8",
+                )),
+                d2_into_buffer: compile_cs(device, copy_shaders, "cs_copy_image2d_r8g8b8a8_buffer"),
+                scale: (1, 1),
+            },
+        );
+        cs_copy_buffer_shaders.insert(
+            dxgiformat::DXGI_FORMAT_R8G8_UINT,
+            ComputeCopyBuffer {
+                d1_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image1d_r8g8",
+                )),
+                d2_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image2d_r8g8",
+                )),
+                d2_into_buffer: compile_cs(device, copy_shaders, "cs_copy_image2d_r8g8_buffer"),
+                scale: (2, 1),
+            },
+        );
+        cs_copy_buffer_shaders.insert(
+            dxgiformat::DXGI_FORMAT_R8_UINT,
+            ComputeCopyBuffer {
+                d1_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image1d_r8",
+                )),
+                d2_from_buffer: Some(compile_cs(
+                    device,
+                    copy_shaders,
+                    "cs_copy_buffer_image2d_r8",
+                )),
+                d2_into_buffer: compile_cs(device, copy_shaders, "cs_copy_image2d_r8_buffer"),
+                scale: (4, 1),
+            },
+        );
+
         Internal {
             vs_partial_clear: compile_vs(device, clear_shaders, "vs_partial_clear"),
             ps_partial_clear_float: compile_ps(device, clear_shaders, "ps_partial_clear_float"),
@@ -384,183 +607,48 @@ impl Internal {
             ps_blit_2d_int: compile_ps(device, blit_shaders, "ps_blit_2d_int"),
             ps_blit_2d_float: compile_ps(device, blit_shaders, "ps_blit_2d_float"),
 
-            cs_copy_image2d_r8g8_image2d_r16: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r8g8_image2d_r16",
-            ),
-            cs_copy_image2d_r16_image2d_r8g8: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r16_image2d_r8g8",
-            ),
+            cs_copy_image_shaders,
+            cs_copy_buffer_shaders,
 
-            cs_copy_image2d_r8g8b8a8_image2d_r32: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r8g8b8a8_image2d_r32",
-            ),
-            cs_copy_image2d_r8g8b8a8_image2d_r16g16: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r8g8b8a8_image2d_r16g16",
-            ),
-            cs_copy_image2d_r16g16_image2d_r32: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r16g16_image2d_r32",
-            ),
-            cs_copy_image2d_r16g16_image2d_r8g8b8a8: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r16g16_image2d_r8g8b8a8",
-            ),
-            cs_copy_image2d_r32_image2d_r16g16: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r32_image2d_r16g16",
-            ),
-            cs_copy_image2d_r32_image2d_r8g8b8a8: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r32_image2d_r8g8b8a8",
-            ),
-
-            cs_copy_image2d_r32g32b32a32_buffer: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r32g32b32a32_buffer",
-            ),
-            cs_copy_image2d_r32g32_buffer: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r32g32_buffer",
-            ),
-            cs_copy_image2d_r16g16b16a16_buffer: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r16g16b16a16_buffer",
-            ),
-            cs_copy_image2d_r32_buffer: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r32_buffer",
-            ),
-            cs_copy_image2d_r16g16_buffer: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r16g16_buffer",
-            ),
-            cs_copy_image2d_r8g8b8a8_buffer: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r8g8b8a8_buffer",
-            ),
-            cs_copy_image2d_r16_buffer: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r16_buffer",
-            ),
-            cs_copy_image2d_r8g8_buffer: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r8g8_buffer",
-            ),
-            cs_copy_image2d_r8_buffer: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_r8_buffer",
-            ),
-            cs_copy_image2d_b8g8r8a8_buffer: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_image2d_b8g8r8a8_buffer",
-            ),
-
-            cs_copy_buffer_image2d_r32g32b32a32: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_buffer_image2d_r32g32b32a32",
-            ),
-            cs_copy_buffer_image2d_r32g32: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_buffer_image2d_r32g32",
-            ),
-            cs_copy_buffer_image2d_r16g16b16a16: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_buffer_image2d_r16g16b16a16",
-            ),
-            cs_copy_buffer_image2d_r32: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_buffer_image2d_r32",
-            ),
-            cs_copy_buffer_image2d_r16g16: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_buffer_image2d_r16g16",
-            ),
-            cs_copy_buffer_image2d_r8g8b8a8: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_buffer_image2d_r8g8b8a8",
-            ),
-            cs_copy_buffer_image2d_r16: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_buffer_image2d_r16",
-            ),
-            cs_copy_buffer_image2d_r8g8: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_buffer_image2d_r8g8",
-            ),
-            cs_copy_buffer_image2d_r8: compile_cs(
-                device,
-                copy_shaders,
-                "cs_copy_buffer_image2d_r8",
-            ),
-
-            internal_buffer,
+            internal_buffer: Mutex::new(ConstantBuffer {
+                buffer: internal_buffer,
+            }),
             working_buffer,
             working_buffer_size: working_buffer_size as _,
         }
     }
 
-    fn map(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>) -> *mut u8 {
-        let mut mapped = unsafe { mem::zeroed::<d3d11::D3D11_MAPPED_SUBRESOURCE>() };
-        let hr = unsafe {
-            context.Map(
-                self.internal_buffer.as_raw() as _,
-                0,
-                d3d11::D3D11_MAP_WRITE_DISCARD,
-                0,
-                &mut mapped,
-            )
-        };
-
-        assert_eq!(winerror::S_OK, hr);
-
-        mapped.pData as _
-    }
-
-    fn unmap(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
-        unsafe {
-            context.Unmap(self.internal_buffer.as_raw() as _, 0);
-        }
-    }
-
-    fn update_image(
-        &mut self,
+    pub fn copy_image_2d<T>(
+        &self,
         context: &ComPtr<d3d11::ID3D11DeviceContext>,
-        info: &command::ImageCopy,
-    ) {
-        unsafe {
-            ptr::copy(
-                &BufferImageCopyInfo {
-                    image: ImageCopy {
+        src: &Image,
+        dst: &Image,
+        regions: T,
+    ) where
+        T: IntoIterator,
+        T::Item: Borrow<command::ImageCopy>,
+    {
+        let key = (
+            src.decomposed_format.copy_srv.unwrap(),
+            dst.decomposed_format.copy_srv.unwrap(),
+        );
+        if let Some(shader) = self.cs_copy_image_shaders.get(&key) {
+            // Some formats cant go through default path, since they cant
+            // be cast between formats of different component types (eg.
+            // Rg16 <-> Rgba8)
+
+            // TODO: subresources
+            let srv = src.internal.copy_srv.clone().unwrap().as_raw();
+            let mut const_buf = self.internal_buffer.lock();
+
+            unsafe {
+                context.CSSetShader(shader.as_raw(), ptr::null_mut(), 0);
+                context.CSSetConstantBuffers(0, 1, &const_buf.buffer.as_raw());
+                context.CSSetShaderResources(0, 1, [srv].as_ptr());
+
+                for region in regions.into_iter() {
+                    let info = region.borrow();
+                    let image = ImageCopy {
                         src: [
                             info.src_offset.x as _,
                             info.src_offset.y as _,
@@ -573,209 +661,14 @@ impl Internal {
                             info.dst_offset.z as _,
                             0,
                         ],
-                    },
-                    ..mem::zeroed()
-                },
-                self.map(context) as *mut _,
-                1,
-            )
-        };
-
-        self.unmap(context);
-    }
-
-    fn update_buffer_image(
-        &mut self,
-        context: &ComPtr<d3d11::ID3D11DeviceContext>,
-        info: &command::BufferImageCopy,
-        image: &Image,
-    ) {
-        let size = image.kind.extent();
-
-        unsafe {
-            ptr::copy(
-                &BufferImageCopyInfo {
-                    buffer_image: BufferImageCopy {
-                        buffer_offset: info.buffer_offset as _,
-                        buffer_size: [info.buffer_width, info.buffer_height],
-                        _padding: 0,
-                        image_offset: [
-                            info.image_offset.x as _,
-                            info.image_offset.y as _,
-                            (info.image_offset.z + info.image_layers.layers.start as i32) as _,
-                            0,
-                        ],
-                        image_extent: [
-                            info.image_extent.width,
-                            info.image_extent.height,
-                            info.image_extent.depth,
-                            0,
-                        ],
-                        image_size: [size.width, size.height, size.depth, 0],
-                    },
-                    ..mem::zeroed()
-                },
-                self.map(context) as *mut _,
-                1,
-            )
-        };
-
-        self.unmap(context);
-    }
-
-    fn update_blit(
-        &mut self,
-        context: &ComPtr<d3d11::ID3D11DeviceContext>,
-        src: &Image,
-        info: &command::ImageBlit,
-    ) {
-        let (sx, dx) = if info.dst_bounds.start.x > info.dst_bounds.end.x {
-            (
-                info.src_bounds.end.x,
-                info.src_bounds.start.x - info.src_bounds.end.x,
-            )
-        } else {
-            (
-                info.src_bounds.start.x,
-                info.src_bounds.end.x - info.src_bounds.start.x,
-            )
-        };
-        let (sy, dy) = if info.dst_bounds.start.y > info.dst_bounds.end.y {
-            (
-                info.src_bounds.end.y,
-                info.src_bounds.start.y - info.src_bounds.end.y,
-            )
-        } else {
-            (
-                info.src_bounds.start.y,
-                info.src_bounds.end.y - info.src_bounds.start.y,
-            )
-        };
-        let image::Extent { width, height, .. } = src.kind.level_extent(info.src_subresource.level);
-
-        unsafe {
-            ptr::copy(
-                &BlitInfo {
-                    offset: [sx as f32 / width as f32, sy as f32 / height as f32],
-                    extent: [dx as f32 / width as f32, dy as f32 / height as f32],
-                    z: 0f32, // TODO
-                    level: info.src_subresource.level as _,
-                },
-                self.map(context) as *mut _,
-                1,
-            )
-        };
-
-        self.unmap(context);
-    }
-
-    fn update_clear_color(
-        &mut self,
-        context: &ComPtr<d3d11::ID3D11DeviceContext>,
-        value: command::ClearColor,
-    ) {
-        unsafe {
-            ptr::copy(
-                &PartialClearInfo {
-                    data: mem::transmute(value),
-                },
-                self.map(context) as *mut _,
-                1,
-            )
-        };
-
-        self.unmap(context);
-    }
-
-    fn update_clear_depth_stencil(
-        &mut self,
-        context: &ComPtr<d3d11::ID3D11DeviceContext>,
-        depth: Option<f32>,
-        stencil: Option<u32>,
-    ) {
-        unsafe {
-            ptr::copy(
-                &PartialClearInfo {
-                    data: [
-                        mem::transmute(depth.unwrap_or(0f32)),
-                        stencil.unwrap_or(0),
-                        0,
-                        0,
-                    ],
-                },
-                self.map(context) as *mut _,
-                1,
-            );
-        }
-
-        self.unmap(context);
-    }
-
-    fn find_image_copy_shader(
-        &self,
-        src: &Image,
-        dst: &Image,
-    ) -> Option<*mut d3d11::ID3D11ComputeShader> {
-        use dxgiformat::*;
-
-        let src_format = src.decomposed_format.copy_srv.unwrap();
-        let dst_format = dst.decomposed_format.copy_uav.unwrap();
-
-        match (src_format, dst_format) {
-            (DXGI_FORMAT_R8G8_UINT, DXGI_FORMAT_R16_UINT) => {
-                Some(self.cs_copy_image2d_r8g8_image2d_r16.as_raw())
-            }
-            (DXGI_FORMAT_R16_UINT, DXGI_FORMAT_R8G8_UINT) => {
-                Some(self.cs_copy_image2d_r16_image2d_r8g8.as_raw())
-            }
-            (DXGI_FORMAT_R8G8B8A8_UINT, DXGI_FORMAT_R32_UINT) => {
-                Some(self.cs_copy_image2d_r8g8b8a8_image2d_r32.as_raw())
-            }
-            (DXGI_FORMAT_R8G8B8A8_UINT, DXGI_FORMAT_R16G16_UINT) => {
-                Some(self.cs_copy_image2d_r8g8b8a8_image2d_r16g16.as_raw())
-            }
-            (DXGI_FORMAT_R16G16_UINT, DXGI_FORMAT_R32_UINT) => {
-                Some(self.cs_copy_image2d_r16g16_image2d_r32.as_raw())
-            }
-            (DXGI_FORMAT_R16G16_UINT, DXGI_FORMAT_R8G8B8A8_UINT) => {
-                Some(self.cs_copy_image2d_r16g16_image2d_r8g8b8a8.as_raw())
-            }
-            (DXGI_FORMAT_R32_UINT, DXGI_FORMAT_R16G16_UINT) => {
-                Some(self.cs_copy_image2d_r32_image2d_r16g16.as_raw())
-            }
-            (DXGI_FORMAT_R32_UINT, DXGI_FORMAT_R8G8B8A8_UINT) => {
-                Some(self.cs_copy_image2d_r32_image2d_r8g8b8a8.as_raw())
-            }
-            _ => None,
-        }
-    }
-
-    pub fn copy_image_2d<T>(
-        &mut self,
-        context: &ComPtr<d3d11::ID3D11DeviceContext>,
-        src: &Image,
-        dst: &Image,
-        regions: T,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ImageCopy>,
-    {
-        if let Some(shader) = self.find_image_copy_shader(src, dst) {
-            // Some formats cant go through default path, since they cant
-            // be cast between formats of different component types (eg.
-            // Rg16 <-> Rgba8)
-
-            // TODO: subresources
-            let srv = src.internal.copy_srv.clone().unwrap().as_raw();
-
-            unsafe {
-                context.CSSetShader(shader, ptr::null_mut(), 0);
-                context.CSSetConstantBuffers(0, 1, &self.internal_buffer.as_raw());
-                context.CSSetShaderResources(0, 1, [srv].as_ptr());
-
-                for region in regions.into_iter() {
-                    let info = region.borrow();
-                    self.update_image(context, &info);
+                    };
+                    const_buf.update(
+                        context,
+                        BufferImageCopyInfo {
+                            image,
+                            ..mem::zeroed()
+                        },
+                    );
 
                     let uav = dst.get_uav(info.dst_subresource.level, 0).unwrap().as_raw();
                     context.CSSetUnorderedAccessViews(0, 1, [uav].as_ptr(), ptr::null_mut());
@@ -821,37 +714,8 @@ impl Internal {
         }
     }
 
-    fn find_image_to_buffer_shader(
+    pub fn copy_image_to_buffer<T>(
         &self,
-        format: dxgiformat::DXGI_FORMAT,
-    ) -> Option<(*mut d3d11::ID3D11ComputeShader, u32, u32)> {
-        use dxgiformat::*;
-
-        match format {
-            DXGI_FORMAT_R32G32B32A32_UINT => {
-                Some((self.cs_copy_image2d_r32g32b32a32_buffer.as_raw(), 1, 1))
-            }
-            DXGI_FORMAT_R32G32_UINT => Some((self.cs_copy_image2d_r32g32_buffer.as_raw(), 1, 1)),
-            DXGI_FORMAT_R16G16B16A16_UINT => {
-                Some((self.cs_copy_image2d_r16g16b16a16_buffer.as_raw(), 1, 1))
-            }
-            DXGI_FORMAT_R32_UINT => Some((self.cs_copy_image2d_r32_buffer.as_raw(), 1, 1)),
-            DXGI_FORMAT_R16G16_UINT => Some((self.cs_copy_image2d_r16g16_buffer.as_raw(), 1, 1)),
-            DXGI_FORMAT_R8G8B8A8_UINT => {
-                Some((self.cs_copy_image2d_r8g8b8a8_buffer.as_raw(), 1, 1))
-            }
-            DXGI_FORMAT_R16_UINT => Some((self.cs_copy_image2d_r16_buffer.as_raw(), 2, 1)),
-            DXGI_FORMAT_R8G8_UINT => Some((self.cs_copy_image2d_r8g8_buffer.as_raw(), 2, 1)),
-            DXGI_FORMAT_R8_UINT => Some((self.cs_copy_image2d_r8_buffer.as_raw(), 4, 1)),
-            DXGI_FORMAT_B8G8R8A8_UNORM => {
-                Some((self.cs_copy_image2d_b8g8r8a8_buffer.as_raw(), 1, 1))
-            }
-            _ => None,
-        }
-    }
-
-    pub fn copy_image_2d_to_buffer<T>(
-        &mut self,
         context: &ComPtr<d3d11::ID3D11DeviceContext>,
         src: &Image,
         dst: &Buffer,
@@ -866,48 +730,77 @@ impl Internal {
             src.format,
             src.kind
         );
-        let (shader, scale_x, scale_y) = self
-            .find_image_to_buffer_shader(src.decomposed_format.copy_srv.unwrap())
-            .unwrap();
+        let shader = self
+            .cs_copy_buffer_shaders
+            .get(&src.decomposed_format.copy_srv.unwrap())
+            .unwrap()
+            .clone();
 
         let srv = src.internal.copy_srv.clone().unwrap().as_raw();
         let uav = dst.internal.uav.unwrap();
         let format_desc = src.format.base_format().0.desc();
         let bytes_per_texel = format_desc.bits as u32 / 8;
+        let mut const_buf = self.internal_buffer.lock();
 
         unsafe {
-            context.CSSetShader(shader, ptr::null_mut(), 0);
-            context.CSSetConstantBuffers(0, 1, &self.internal_buffer.as_raw());
+            context.CSSetShader(shader.d2_into_buffer.as_raw(), ptr::null_mut(), 0);
+            context.CSSetConstantBuffers(0, 1, &const_buf.buffer.as_raw());
 
             context.CSSetShaderResources(0, 1, [srv].as_ptr());
             context.CSSetUnorderedAccessViews(0, 1, [uav].as_ptr(), ptr::null_mut());
 
             for copy in regions {
-                let copy = copy.borrow();
-                self.update_buffer_image(context, &copy, src);
+                let info = copy.borrow();
+                let size = src.kind.extent();
+                let buffer_image = BufferImageCopy {
+                    buffer_offset: info.buffer_offset as _,
+                    buffer_size: [info.buffer_width, info.buffer_height],
+                    _padding: 0,
+                    image_offset: [
+                        info.image_offset.x as _,
+                        info.image_offset.y as _,
+                        (info.image_offset.z + info.image_layers.layers.start as i32) as _,
+                        0,
+                    ],
+                    image_extent: [
+                        info.image_extent.width,
+                        info.image_extent.height,
+                        info.image_extent.depth,
+                        0,
+                    ],
+                    image_size: [size.width, size.height, size.depth, 0],
+                };
 
-                debug_marker!(context, "{:?}", copy);
+                const_buf.update(
+                    context,
+                    BufferImageCopyInfo {
+                        buffer_image,
+                        ..mem::zeroed()
+                    },
+                );
+
+                debug_marker!(context, "{:?}", info);
 
                 context.Dispatch(
-                    ((copy.image_extent.width + (COPY_THREAD_GROUP_X - 1))
+                    ((info.image_extent.width + (COPY_THREAD_GROUP_X - 1))
                         / COPY_THREAD_GROUP_X
-                        / scale_x)
+                        / shader.scale.0)
                         .max(1),
-                    ((copy.image_extent.height + (COPY_THREAD_GROUP_X - 1))
+                    ((info.image_extent.height + (COPY_THREAD_GROUP_X - 1))
                         / COPY_THREAD_GROUP_Y
-                        / scale_y)
+                        / shader.scale.1)
                         .max(1),
                     1,
                 );
 
                 if let Some(disjoint_cb) = dst.internal.disjoint_cb {
-                    let total_size = copy.image_extent.depth
-                        * (copy.buffer_height * copy.buffer_width * bytes_per_texel);
+                    let total_size = info.image_extent.depth
+                        * (info.buffer_height * info.buffer_width * bytes_per_texel);
                     let copy_box = d3d11::D3D11_BOX {
-                        left: copy.buffer_offset as u32,
+                        left: info.buffer_offset as u32,
                         top: 0,
                         front: 0,
-                        right: copy.buffer_offset as u32 + total_size,
+                        right: info.buffer_offset as u32 + total_size,
                         bottom: 1,
                         back: 1,
                     };
@@ -915,7 +808,7 @@ impl Internal {
                     context.CopySubresourceRegion(
                         disjoint_cb as _,
                         0,
-                        copy.buffer_offset as _,
+                        info.buffer_offset as _,
                         0,
                         0,
                         dst.internal.raw as _,
@@ -931,34 +824,8 @@ impl Internal {
         }
     }
 
-    fn find_buffer_to_image_shader(
+    pub fn copy_buffer_to_image<T>(
         &self,
-        format: dxgiformat::DXGI_FORMAT,
-    ) -> Option<(*mut d3d11::ID3D11ComputeShader, u32, u32)> {
-        use dxgiformat::*;
-
-        match format {
-            DXGI_FORMAT_R32G32B32A32_UINT => {
-                Some((self.cs_copy_buffer_image2d_r32g32b32a32.as_raw(), 1, 1))
-            }
-            DXGI_FORMAT_R32G32_UINT => Some((self.cs_copy_buffer_image2d_r32g32.as_raw(), 1, 1)),
-            DXGI_FORMAT_R16G16B16A16_UINT => {
-                Some((self.cs_copy_buffer_image2d_r16g16b16a16.as_raw(), 1, 1))
-            }
-            DXGI_FORMAT_R32_UINT => Some((self.cs_copy_buffer_image2d_r32.as_raw(), 1, 1)),
-            DXGI_FORMAT_R16G16_UINT => Some((self.cs_copy_buffer_image2d_r16g16.as_raw(), 1, 1)),
-            DXGI_FORMAT_R8G8B8A8_UINT => {
-                Some((self.cs_copy_buffer_image2d_r8g8b8a8.as_raw(), 1, 1))
-            }
-            DXGI_FORMAT_R16_UINT => Some((self.cs_copy_buffer_image2d_r16.as_raw(), 2, 1)),
-            DXGI_FORMAT_R8G8_UINT => Some((self.cs_copy_buffer_image2d_r8g8.as_raw(), 2, 1)),
-            DXGI_FORMAT_R8_UINT => Some((self.cs_copy_buffer_image2d_r8.as_raw(), 4, 1)),
-            _ => None,
-        }
-    }
-
-    pub fn copy_buffer_to_image_2d<T>(
-        &mut self,
         context: &ComPtr<d3d11::ID3D11DeviceContext>,
         src: &Buffer,
         dst: &Image,
@@ -1015,20 +882,54 @@ impl Internal {
                 }
             }
         } else {
-            let (shader, scale_x, scale_y) = self
-                .find_buffer_to_image_shader(dst.decomposed_format.copy_uav.unwrap())
-                .unwrap();
+            let shader = self
+                .cs_copy_buffer_shaders
+                .get(&dst.decomposed_format.copy_uav.unwrap())
+                .unwrap()
+                .clone();
 
             let srv = src.internal.srv.unwrap();
+            let mut const_buf = self.internal_buffer.lock();
+            let shader_raw = match dst.kind {
+                image::Kind::D1(..) => shader.d1_from_buffer.unwrap().as_raw(),
+                image::Kind::D2(..) => shader.d2_from_buffer.unwrap().as_raw(),
+                image::Kind::D3(..) => panic!("Copies into 3D images are not supported"),
+            };
 
             unsafe {
-                context.CSSetShader(shader, ptr::null_mut(), 0);
-                context.CSSetConstantBuffers(0, 1, &self.internal_buffer.as_raw());
+                context.CSSetShader(shader_raw, ptr::null_mut(), 0);
+                context.CSSetConstantBuffers(0, 1, &const_buf.buffer.as_raw());
                 context.CSSetShaderResources(0, 1, [srv].as_ptr());
 
                 for copy in regions {
                     let info = copy.borrow();
-                    self.update_buffer_image(context, &info, dst);
+                    let size = dst.kind.extent();
+                    let buffer_image = BufferImageCopy {
+                        buffer_offset: info.buffer_offset as _,
+                        buffer_size: [info.buffer_width, info.buffer_height],
+                        _padding: 0,
+                        image_offset: [
+                            info.image_offset.x as _,
+                            info.image_offset.y as _,
+                            (info.image_offset.z + info.image_layers.layers.start as i32) as _,
+                            0,
+                        ],
+                        image_extent: [
+                            info.image_extent.width,
+                            info.image_extent.height,
+                            info.image_extent.depth,
+                            0,
+                        ],
+                        image_size: [size.width, size.height, size.depth, 0],
+                    };
+
+                    const_buf.update(
+                        context,
+                        BufferImageCopyInfo {
+                            buffer_image,
+                            ..mem::zeroed()
+                        },
+                    );
 
                     debug_marker!(context, "{:?}", info);
 
@@ -1049,11 +950,11 @@ impl Internal {
                     context.Dispatch(
                         ((info.image_extent.width + (COPY_THREAD_GROUP_X - 1))
                             / COPY_THREAD_GROUP_X
-                            / scale_x)
+                            / shader.scale.0)
                             .max(1),
                         ((info.image_extent.height + (COPY_THREAD_GROUP_X - 1))
                             / COPY_THREAD_GROUP_Y
-                            / scale_y)
+                            / shader.scale.1)
                             .max(1),
                         1,
                     );
@@ -1083,7 +984,7 @@ impl Internal {
     }
 
     pub fn blit_2d_image<T>(
-        &mut self,
+        &self,
         context: &ComPtr<d3d11::ID3D11DeviceContext>,
         src: &Image,
         dst: &Image,
@@ -1107,11 +1008,12 @@ impl Internal {
         let shader = self.find_blit_shader(src).unwrap();
 
         let srv = src.internal.srv.clone().unwrap().as_raw();
+        let mut const_buf = self.internal_buffer.lock();
 
         unsafe {
             context.IASetPrimitiveTopology(d3dcommon::D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
             context.VSSetShader(self.vs_blit_2d.as_raw(), ptr::null_mut(), 0);
-            context.VSSetConstantBuffers(0, 1, [self.internal_buffer.as_raw()].as_ptr());
+            context.VSSetConstantBuffers(0, 1, [const_buf.buffer.as_raw()].as_ptr());
             context.PSSetShader(shader, ptr::null_mut(), 0);
             context.PSSetShaderResources(0, 1, [srv].as_ptr());
             context.PSSetSamplers(
@@ -1125,14 +1027,47 @@ impl Internal {
             );
 
             for region in regions {
-                let region = region.borrow();
-                self.update_blit(context, src, &region);
+                let info = region.borrow();
+                let blit_info = {
+                    let (sx, dx) = if info.dst_bounds.start.x > info.dst_bounds.end.x {
+                        (
+                            info.src_bounds.end.x,
+                            info.src_bounds.start.x - info.src_bounds.end.x,
+                        )
+                    } else {
+                        (
+                            info.src_bounds.start.x,
+                            info.src_bounds.end.x - info.src_bounds.start.x,
+                        )
+                    };
+                    let (sy, dy) = if info.dst_bounds.start.y > info.dst_bounds.end.y {
+                        (
+                            info.src_bounds.end.y,
+                            info.src_bounds.start.y - info.src_bounds.end.y,
+                        )
+                    } else {
+                        (
+                            info.src_bounds.start.y,
+                            info.src_bounds.end.y - info.src_bounds.start.y,
+                        )
+                    };
+                    let image::Extent { width, height, .. } =
+                        src.kind.level_extent(info.src_subresource.level);
+                    BlitInfo {
+                        offset: [sx as f32 / width as f32, sy as f32 / height as f32],
+                        extent: [dx as f32 / width as f32, dy as f32 / height as f32],
+                        z: 0f32, // TODO
+                        level: info.src_subresource.level as _,
+                    }
+                };
+
+                const_buf.update(context, blit_info);
 
                 // TODO: more layers
                 let rtv = dst
                     .get_rtv(
-                        region.dst_subresource.level,
-                        region.dst_subresource.layers.start,
+                        info.dst_subresource.level,
+                        info.dst_subresource.layers.start,
                     )
                     .unwrap()
                     .as_raw();
@@ -1140,10 +1075,10 @@ impl Internal {
                 context.RSSetViewports(
                     1,
                     [d3d11::D3D11_VIEWPORT {
-                        TopLeftX: cmp::min(region.dst_bounds.start.x, region.dst_bounds.end.x) as _,
-                        TopLeftY: cmp::min(region.dst_bounds.start.y, region.dst_bounds.end.y) as _,
-                        Width: (region.dst_bounds.end.x - region.dst_bounds.start.x).abs() as _,
-                        Height: (region.dst_bounds.end.y - region.dst_bounds.start.y).abs() as _,
+                        TopLeftX: cmp::min(info.dst_bounds.start.x, info.dst_bounds.end.x) as _,
+                        TopLeftY: cmp::min(info.dst_bounds.start.y, info.dst_bounds.end.y) as _,
+                        Width: (info.dst_bounds.end.x - info.dst_bounds.start.x).abs() as _,
+                        Height: (info.dst_bounds.end.y - info.dst_bounds.start.y).abs() as _,
                         MinDepth: 0.0f32,
                         MaxDepth: 1.0f32,
                     }]
@@ -1159,7 +1094,7 @@ impl Internal {
     }
 
     pub fn clear_attachments<T, U>(
-        &mut self,
+        &self,
         context: &ComPtr<d3d11::ID3D11DeviceContext>,
         clears: T,
         rects: U,
@@ -1177,12 +1112,13 @@ impl Internal {
             .into_iter()
             .map(|rect| rect.borrow().clone())
             .collect();
+        let mut const_buf = self.internal_buffer.lock();
 
         unsafe {
             context.IASetPrimitiveTopology(d3dcommon::D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
             context.IASetInputLayout(ptr::null_mut());
             context.VSSetShader(self.vs_partial_clear.as_raw(), ptr::null_mut(), 0);
-            context.PSSetConstantBuffers(0, 1, [self.internal_buffer.as_raw()].as_ptr());
+            context.PSSetConstantBuffers(0, 1, [const_buf.buffer.as_raw()].as_ptr());
         }
 
         let subpass = &cache.render_pass.subpasses[cache.current_subpass as usize];
@@ -1194,7 +1130,14 @@ impl Internal {
 
             match *clear {
                 command::AttachmentClear::Color { index, value } => {
-                    self.update_clear_color(context, value);
+                    unsafe {
+                        const_buf.update(
+                            context,
+                            PartialClearInfo {
+                                data: mem::transmute(value),
+                            },
+                        )
+                    };
 
                     let attachment = {
                         let rtv_id = subpass.color_attachments[index];
@@ -1231,7 +1174,19 @@ impl Internal {
                     }
                 }
                 command::AttachmentClear::DepthStencil { depth, stencil } => {
-                    self.update_clear_depth_stencil(context, depth, stencil);
+                    unsafe {
+                        const_buf.update(
+                            context,
+                            PartialClearInfo {
+                                data: [
+                                    mem::transmute(depth.unwrap_or(0f32)),
+                                    stencil.unwrap_or(0),
+                                    0,
+                                    0,
+                                ],
+                            },
+                        )
+                    };
 
                     let attachment = {
                         let dsv_id = subpass.depth_stencil_attachment.unwrap();

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1003,7 +1003,7 @@ pub struct RenderPassCache {
 impl RenderPassCache {
     pub fn start_subpass(
         &mut self,
-        internal: &mut internal::Internal,
+        internal: &internal::Internal,
         context: &ComPtr<d3d11::ID3D11DeviceContext>,
         cache: &mut CommandBufferState,
     ) {
@@ -1349,8 +1349,7 @@ impl CommandBufferState {
 }
 
 pub struct CommandBuffer {
-    // TODO: better way of sharing
-    internal: internal::Internal,
+    internal: Arc<internal::Internal>,
     context: ComPtr<d3d11::ID3D11DeviceContext>,
     list: RefCell<Option<ComPtr<d3d11::ID3D11CommandList>>>,
 
@@ -1378,7 +1377,10 @@ unsafe impl Send for CommandBuffer {}
 unsafe impl Sync for CommandBuffer {}
 
 impl CommandBuffer {
-    fn create_deferred(device: ComPtr<d3d11::ID3D11Device>, internal: internal::Internal) -> Self {
+    fn create_deferred(
+        device: ComPtr<d3d11::ID3D11Device>,
+        internal: Arc<internal::Internal>,
+    ) -> Self {
         let mut context: *mut d3d11::ID3D11DeviceContext = ptr::null_mut();
         let hr =
             unsafe { device.CreateDeferredContext(0, &mut context as *mut *mut _ as *mut *mut _) };
@@ -1569,7 +1571,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         });
 
         if let Some(ref mut current_render_pass) = self.render_pass_cache {
-            current_render_pass.start_subpass(&mut self.internal, &self.context, &mut self.cache);
+            current_render_pass.start_subpass(&self.internal, &self.context, &mut self.cache);
         }
     }
 
@@ -1577,7 +1579,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         if let Some(ref mut current_render_pass) = self.render_pass_cache {
             // TODO: resolve msaa
             current_render_pass.next_subpass();
-            current_render_pass.start_subpass(&mut self.internal, &self.context, &mut self.cache);
+            current_render_pass.start_subpass(&self.internal, &self.context, &mut self.cache);
         }
     }
 
@@ -2099,7 +2101,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         }
 
         self.internal
-            .copy_buffer_to_image_2d(&self.context, buffer, image, regions);
+            .copy_buffer_to_image(&self.context, buffer, image, regions);
     }
 
     unsafe fn copy_image_to_buffer<T>(
@@ -2117,7 +2119,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         }
 
         self.internal
-            .copy_image_2d_to_buffer(&self.context, image, buffer, regions);
+            .copy_image_to_buffer(&self.context, image, buffer, regions);
     }
 
     unsafe fn draw(&mut self, vertices: Range<VertexCount>, instances: Range<InstanceCount>) {
@@ -2575,7 +2577,7 @@ impl Memory {
 #[derive(Debug)]
 pub struct CommandPool {
     device: ComPtr<d3d11::ID3D11Device>,
-    internal: internal::Internal,
+    internal: Arc<internal::Internal>,
 }
 
 unsafe impl Send for CommandPool {}
@@ -2587,7 +2589,7 @@ impl hal::pool::CommandPool<Backend> for CommandPool {
     }
 
     unsafe fn allocate_one(&mut self, _level: command::Level) -> CommandBuffer {
-        CommandBuffer::create_deferred(self.device.clone(), self.internal.clone())
+        CommandBuffer::create_deferred(self.device.clone(), Arc::clone(&self.internal))
     }
 
     unsafe fn free<I>(&mut self, _cbufs: I)

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -3054,6 +3054,9 @@ impl DescriptorSetInfo {
             .map_register(|info| info.res_index as DescriptorIndex)
             .select(stage);
         for binding in self.bindings.iter() {
+            if !binding.stage_flags.contains(stage.to_flag()) {
+                continue;
+            }
             let content = DescriptorContent::from(binding.ty);
             if binding.binding == binding_index {
                 return (content, res_offsets.map(|offset| *offset as ResourceIndex));


### PR DESCRIPTION
Includes #3362 and #3363 but for master
