### PR TITLE
[0.6/dx11] fix cpu-visible memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### backend-dx11-0.6.3 (04-09-2020)
+  - fix cpu-visible mapping
+  - fix UAV reset count
+
 ### backend-dx11-0.6.2 (02-09-2020)
   - fix bindings filter by shader stages
   - implement copies from buffers into R8, RG8, and RGBA8 textures

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.6.2"
+version = "0.6.3"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -736,12 +736,19 @@ impl device::Device<Backend> for Device {
         mem_type: hal::MemoryTypeId,
         size: u64,
     ) -> Result<Memory, device::AllocationError> {
-        let vec = Vec::with_capacity(size as usize);
+        let properties = self.memory_properties.memory_types[mem_type.0].properties;
+        let host_ptr = if properties.contains(hal::memory::Properties::CPU_VISIBLE) {
+            let mut data = vec![0u8; size as usize];
+            let ptr = data.as_mut_ptr();
+            mem::forget(data);
+            ptr
+        } else {
+            ptr::null_mut()
+        };
         Ok(Memory {
-            properties: self.memory_properties.memory_types[mem_type.0].properties,
+            properties,
             size,
-            mapped_ptr: vec.as_ptr() as *mut _,
-            host_visible: Some(RefCell::new(vec)),
+            host_ptr,
             local_buffers: RefCell::new(Vec::new()),
             _local_images: RefCell::new(Vec::new()),
         })
@@ -1055,9 +1062,9 @@ impl device::Device<Backend> for Device {
                 uav: None,
                 usage,
             },
-            properties: memory::Properties::empty(),
             bound_range: 0..0,
-            host_ptr: ptr::null_mut(),
+            is_coherent: false,
+            memory_ptr: ptr::null_mut(),
             bind,
             requirements: memory::Requirements {
                 size,
@@ -1092,14 +1099,15 @@ impl device::Device<Backend> for Device {
             0
         };
 
-        let initial_data = memory
-            .host_visible
-            .as_ref()
-            .map(|p| d3d11::D3D11_SUBRESOURCE_DATA {
-                pSysMem: p.borrow().as_ptr().offset(offset as isize) as _,
+        let initial_data = if memory.host_ptr.is_null() {
+            None
+        } else {
+            Some(d3d11::D3D11_SUBRESOURCE_DATA {
+                pSysMem: memory.host_ptr.offset(offset as isize) as *const _,
                 SysMemPitch: 0,
                 SysMemSlicePitch: 0,
-            });
+            })
+        };
 
         //TODO: check `memory.properties.contains(memory::Properties::DEVICE_LOCAL)` ?
         let raw = {
@@ -1121,11 +1129,7 @@ impl device::Device<Backend> for Device {
             let mut buffer: *mut d3d11::ID3D11Buffer = ptr::null_mut();
             let hr = self.raw.CreateBuffer(
                 &desc,
-                if let Some(data) = initial_data {
-                    &data
-                } else {
-                    ptr::null_mut()
-                },
+                initial_data.as_ref().map_or(ptr::null_mut(), |id| id),
                 &mut buffer as *mut *mut _ as *mut *mut _,
             );
 
@@ -1149,11 +1153,7 @@ impl device::Device<Backend> for Device {
             let mut buffer: *mut d3d11::ID3D11Buffer = ptr::null_mut();
             let hr = self.raw.CreateBuffer(
                 &desc,
-                if let Some(data) = initial_data {
-                    &data
-                } else {
-                    ptr::null_mut()
-                },
+                initial_data.as_ref().map_or(ptr::null_mut(), |id| id),
                 &mut buffer as *mut *mut _ as *mut *mut _,
             );
 
@@ -1233,15 +1233,11 @@ impl device::Device<Backend> for Device {
 
         memory.bind_buffer(range.clone(), internal.clone());
 
-        let host_ptr = if let Some(vec) = &memory.host_visible {
-            vec.borrow().as_ptr() as *mut _
-        } else {
-            ptr::null_mut()
-        };
-
         buffer.internal = internal;
-        buffer.properties = memory.properties;
-        buffer.host_ptr = host_ptr;
+        buffer.is_coherent = memory
+            .properties
+            .contains(hal::memory::Properties::COHERENT);
+        buffer.memory_ptr = memory.host_ptr;
         buffer.bound_range = range;
 
         Ok(())
@@ -1338,7 +1334,7 @@ impl device::Device<Backend> for Device {
     unsafe fn bind_image_memory(
         &self,
         memory: &Memory,
-        offset: u64,
+        _offset: u64,
         image: &mut Image,
     ) -> Result<(), device::BindError> {
         use image::Usage;
@@ -1373,20 +1369,15 @@ impl device::Device<Backend> for Device {
 
         let dxgi_format = conv::map_format(image.format).unwrap();
         let decomposed = conv::DecomposedDxgiFormat::from_dxgi_format(dxgi_format);
-        let bpp = format_desc.bits as u32 / 8;
+        assert!(
+            memory.host_ptr.is_null(),
+            "Images can only be allocated from device-local memory"
+        );
+        let initial_data_ptr = ptr::null_mut();
 
-        let (view_kind, resource) = match image.kind {
+        let mut resource = ptr::null_mut();
+        let view_kind = match image.kind {
             image::Kind::D1(width, layers) => {
-                let initial_data =
-                    memory
-                        .host_visible
-                        .as_ref()
-                        .map(|_p| d3d11::D3D11_SUBRESOURCE_DATA {
-                            pSysMem: memory.mapped_ptr.offset(offset as isize) as _,
-                            SysMemPitch: 0,
-                            SysMemSlicePitch: 0,
-                        });
-
                 let desc = d3d11::D3D11_TEXTURE1D_DESC {
                     Width: width,
                     MipLevels: image.mip_levels as _,
@@ -1398,14 +1389,9 @@ impl device::Device<Backend> for Device {
                     MiscFlags: 0,
                 };
 
-                let mut resource = ptr::null_mut();
                 let hr = self.raw.CreateTexture1D(
                     &desc,
-                    if let Some(data) = initial_data {
-                        &data
-                    } else {
-                        ptr::null_mut()
-                    },
+                    initial_data_ptr,
                     &mut resource as *mut *mut _ as *mut *mut _,
                 );
 
@@ -1415,24 +1401,9 @@ impl device::Device<Backend> for Device {
                     return Err(device::BindError::WrongMemory);
                 }
 
-                (image::ViewKind::D1Array, resource)
+                image::ViewKind::D1Array
             }
             image::Kind::D2(width, height, layers, _) => {
-                let mut initial_datas = Vec::new();
-
-                for _layer in 0..layers {
-                    for level in 0..image.mip_levels {
-                        let width = image.kind.extent().at_level(level).width;
-
-                        // TODO: layer offset?
-                        initial_datas.push(d3d11::D3D11_SUBRESOURCE_DATA {
-                            pSysMem: memory.mapped_ptr.offset(offset as isize) as _,
-                            SysMemPitch: width * bpp,
-                            SysMemSlicePitch: 0,
-                        });
-                    }
-                }
-
                 let desc = d3d11::D3D11_TEXTURE2D_DESC {
                     Width: width,
                     Height: height,
@@ -1453,14 +1424,9 @@ impl device::Device<Backend> for Device {
                     },
                 };
 
-                let mut resource = ptr::null_mut();
                 let hr = self.raw.CreateTexture2D(
                     &desc,
-                    if !depth {
-                        initial_datas.as_ptr()
-                    } else {
-                        ptr::null_mut()
-                    },
+                    initial_data_ptr,
                     &mut resource as *mut *mut _ as *mut *mut _,
                 );
 
@@ -1470,19 +1436,9 @@ impl device::Device<Backend> for Device {
                     return Err(device::BindError::WrongMemory);
                 }
 
-                (image::ViewKind::D2Array, resource)
+                image::ViewKind::D2Array
             }
             image::Kind::D3(width, height, depth) => {
-                let initial_data =
-                    memory
-                        .host_visible
-                        .as_ref()
-                        .map(|_p| d3d11::D3D11_SUBRESOURCE_DATA {
-                            pSysMem: memory.mapped_ptr.offset(offset as isize) as _,
-                            SysMemPitch: width * bpp,
-                            SysMemSlicePitch: width * height * bpp,
-                        });
-
                 let desc = d3d11::D3D11_TEXTURE3D_DESC {
                     Width: width,
                     Height: height,
@@ -1495,14 +1451,9 @@ impl device::Device<Backend> for Device {
                     MiscFlags: 0,
                 };
 
-                let mut resource = ptr::null_mut();
                 let hr = self.raw.CreateTexture3D(
                     &desc,
-                    if let Some(data) = initial_data {
-                        &data
-                    } else {
-                        ptr::null_mut()
-                    },
+                    initial_data_ptr,
                     &mut resource as *mut *mut _ as *mut *mut _,
                 );
 
@@ -1512,7 +1463,7 @@ impl device::Device<Backend> for Device {
                     return Err(device::BindError::WrongMemory);
                 }
 
-                (image::ViewKind::D3, resource)
+                image::ViewKind::D3
             }
         };
 
@@ -1949,13 +1900,11 @@ impl device::Device<Backend> for Device {
         memory: &Memory,
         segment: memory::Segment,
     ) -> Result<*mut u8, device::MapError> {
-        assert_eq!(memory.host_visible.is_some(), true);
-
-        Ok(memory.mapped_ptr.offset(segment.offset as isize))
+        Ok(memory.host_ptr.offset(segment.offset as isize))
     }
 
-    unsafe fn unmap_memory(&self, memory: &Memory) {
-        assert_eq!(memory.host_visible.is_some(), true);
+    unsafe fn unmap_memory(&self, _memory: &Memory) {
+        // persistent mapping FTW
     }
 
     unsafe fn flush_mapped_memory_ranges<'a, I>(&self, ranges: I) -> Result<(), device::OutOfMemory>
@@ -2076,8 +2025,14 @@ impl device::Device<Backend> for Device {
         unimplemented!()
     }
 
-    unsafe fn free_memory(&self, memory: Memory) {
-        for (_range, internal) in memory.local_buffers.borrow_mut().iter() {
+    unsafe fn free_memory(&self, mut memory: Memory) {
+        if !memory.host_ptr.is_null() {
+            let _vec =
+                Vec::from_raw_parts(memory.host_ptr, memory.size as usize, memory.size as usize);
+            // let it drop
+            memory.host_ptr = ptr::null_mut();
+        }
+        for (_range, internal) in memory.local_buffers.borrow_mut().drain(..) {
             (*internal.raw).Release();
             if let Some(srv) = internal.srv {
                 (*srv).Release();

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -848,7 +848,10 @@ impl Internal {
         if format_desc.is_compressed() {
             // we dont really care about non-4x4 block formats..
             assert_eq!(format_desc.dim, (4, 4));
-            assert!(!src.host_ptr.is_null());
+            assert!(
+                !src.memory_ptr.is_null(),
+                "Only CPU to GPU upload of compressed texture is supported atm"
+            );
 
             for copy in regions {
                 let info = copy.borrow();
@@ -873,7 +876,7 @@ impl Internal {
                             bottom: info.image_offset.y as u32 + info.image_extent.height,
                             back: info.image_offset.z as u32 + info.image_extent.depth,
                         },
-                        src.host_ptr
+                        src.memory_ptr
                             .offset(src.bound_range.start as isize + info.buffer_offset as isize)
                             as _,
                         row_pitch,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1227,11 +1227,7 @@ impl CommandBufferState {
             context.OMSetRenderTargets(
                 self.render_target_len,
                 self.render_targets.as_ptr(),
-                if let Some(dsv) = self.depth_target {
-                    dsv
-                } else {
-                    ptr::null_mut()
-                },
+                self.depth_target.unwrap_or(ptr::null_mut()),
             );
         }
 
@@ -1411,7 +1407,7 @@ impl CommandBuffer {
             .any(|m| m.buffer == buffer.internal.raw)
         {
             self.flush_coherent_memory.push(MemoryFlush {
-                host_memory: buffer.host_ptr,
+                host_memory: buffer.memory_ptr,
                 sync_range: SyncRange::Whole,
                 buffer: buffer.internal.raw,
             });
@@ -1427,7 +1423,7 @@ impl CommandBuffer {
             self.invalidate_coherent_memory.push(MemoryInvalidate {
                 working_buffer: Some(self.internal.working_buffer.clone()),
                 working_buffer_size: self.internal.working_buffer_size,
-                host_memory: buffer.host_ptr,
+                host_memory: buffer.memory_ptr,
                 sync_range: buffer.bound_range.clone(),
                 buffer: buffer.internal.raw,
             });
@@ -1721,7 +1717,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
             let idx = i + first_binding as usize;
             let buf = buf.borrow();
 
-            if buf.properties.contains(memory::Properties::COHERENT) {
+            if buf.is_coherent {
                 self.defer_coherent_flush(buf);
             }
 
@@ -2028,7 +2024,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<command::BufferCopy>,
     {
-        if src.properties.contains(memory::Properties::COHERENT) {
+        if src.is_coherent {
             self.defer_coherent_flush(src);
         }
 
@@ -2094,7 +2090,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<command::BufferImageCopy>,
     {
-        if buffer.properties.contains(memory::Properties::COHERENT) {
+        if buffer.is_coherent {
             self.defer_coherent_flush(buffer);
         }
 
@@ -2112,7 +2108,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<command::BufferImageCopy>,
     {
-        if buffer.properties.contains(memory::Properties::COHERENT) {
+        if buffer.is_coherent {
             self.defer_coherent_invalidate(buffer);
         }
 
@@ -2306,7 +2302,7 @@ enum SyncRange {
 
 #[derive(Debug)]
 pub struct MemoryFlush {
-    host_memory: *mut u8,
+    host_memory: *const u8,
     sync_range: SyncRange,
     buffer: *mut d3d11::ID3D11Buffer,
 }
@@ -2358,11 +2354,7 @@ impl MemoryFlush {
             context.UpdateSubresource(
                 self.buffer as _,
                 0,
-                if let Some(region) = region {
-                    &region
-                } else {
-                    ptr::null_mut()
-                },
+                region.as_ref().map_or(ptr::null(), |r| r),
                 src as _,
                 0,
                 0,
@@ -2462,10 +2454,8 @@ pub struct Memory {
     properties: memory::Properties,
     size: u64,
 
-    mapped_ptr: *mut u8,
-
-    // staging buffer covering the whole memory region, if it's HOST_VISIBLE
-    host_visible: Option<RefCell<Vec<u8>>>,
+    // pointer to staging memory, if it's HOST_VISIBLE
+    host_ptr: *mut u8,
 
     // list of all buffers bound to this memory
     local_buffers: RefCell<Vec<(Range<u64>, InternalBuffer)>>,
@@ -2497,8 +2487,6 @@ impl Memory {
 
         for &(ref buffer_range, ref buffer) in self.local_buffers.borrow().iter() {
             if let Some(range) = intersection(&range, &buffer_range) {
-                let ptr = self.mapped_ptr;
-
                 // we need to handle 3 cases for updating buffers:
                 //
                 //   1. if our buffer was created as a `UNIFORM` buffer *and* other usage flags, we
@@ -2514,7 +2502,7 @@ impl Memory {
                 //
                 if buffer.usage.contains(Usage::UNIFORM) && buffer.usage != Usage::UNIFORM {
                     MemoryFlush {
-                        host_memory: unsafe { ptr.offset(buffer_range.start as _) },
+                        host_memory: unsafe { self.host_ptr.offset(buffer_range.start as _) },
                         sync_range: SyncRange::Whole,
                         buffer: buffer.raw,
                     }
@@ -2522,7 +2510,7 @@ impl Memory {
 
                     if let Some(disjoint) = buffer.disjoint_cb {
                         MemoryFlush {
-                            host_memory: unsafe { ptr.offset(buffer_range.start as _) },
+                            host_memory: unsafe { self.host_ptr.offset(buffer_range.start as _) },
                             sync_range: SyncRange::Whole,
                             buffer: disjoint,
                         }
@@ -2530,7 +2518,7 @@ impl Memory {
                     }
                 } else if buffer.usage == Usage::UNIFORM {
                     MemoryFlush {
-                        host_memory: unsafe { ptr.offset(buffer_range.start as _) },
+                        host_memory: unsafe { self.host_ptr.offset(buffer_range.start as _) },
                         sync_range: SyncRange::Whole,
                         buffer: buffer.raw,
                     }
@@ -2540,7 +2528,7 @@ impl Memory {
                     let local_len = range.end - range.start;
 
                     MemoryFlush {
-                        host_memory: unsafe { ptr.offset(range.start as _) },
+                        host_memory: unsafe { self.host_ptr.offset(range.start as _) },
                         sync_range: SyncRange::Partial(local_start..(local_start + local_len)),
                         buffer: buffer.raw,
                     }
@@ -2562,7 +2550,7 @@ impl Memory {
                 MemoryInvalidate {
                     working_buffer: Some(working_buffer.clone()),
                     working_buffer_size,
-                    host_memory: self.mapped_ptr,
+                    host_memory: self.host_ptr,
                     sync_range: range.clone(),
                     buffer: buffer.raw,
                 }
@@ -2659,9 +2647,9 @@ pub struct InternalBuffer {
 
 pub struct Buffer {
     internal: InternalBuffer,
-    properties: memory::Properties, // empty if unbound
-    host_ptr: *mut u8,              // null if unbound
-    bound_range: Range<u64>,        // 0 if unbound
+    is_coherent: bool,
+    memory_ptr: *mut u8,     // null if unbound or non-cpu-visible
+    bound_range: Range<u64>, // 0 if unbound
     requirements: memory::Requirements,
     bind: d3d11::D3D11_BIND_FLAG,
 }
@@ -3114,7 +3102,7 @@ impl CoherentBuffers {
 
             let sync_range = CoherentBufferFlushRange {
                 device_buffer: new,
-                host_ptr: buffer.host_ptr,
+                host_ptr: buffer.memory_ptr,
                 range: SyncRange::Whole,
             };
 
@@ -3131,7 +3119,7 @@ impl CoherentBuffers {
 
                 let sync_range = CoherentBufferFlushRange {
                     device_buffer: disjoint,
-                    host_ptr: buffer.host_ptr,
+                    host_ptr: buffer.memory_ptr,
                     range: SyncRange::Whole,
                 };
 
@@ -3154,7 +3142,7 @@ impl CoherentBuffers {
 
             let sync_range = CoherentBufferInvalidateRange {
                 device_buffer: new,
-                host_ptr: buffer.host_ptr,
+                host_ptr: buffer.memory_ptr,
                 range: buffer.bound_range.clone(),
             };
 

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -352,12 +352,23 @@ impl hal::Instance<Backend> for Instance {
                 memory_heaps: vec![!0, !0],
             };
 
+            let max_image_uav = 2;
+            let max_buffer_uav = d3d11::D3D11_PS_CS_UAV_REGISTER_COUNT as usize - max_image_uav;
+
             let limits = hal::Limits {
                 max_image_1d_size: d3d11::D3D11_REQ_TEXTURE1D_U_DIMENSION as _,
                 max_image_2d_size: d3d11::D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION as _,
                 max_image_3d_size: d3d11::D3D11_REQ_TEXTURE3D_U_V_OR_W_DIMENSION as _,
                 max_image_cube_size: d3d11::D3D11_REQ_TEXTURECUBE_DIMENSION as _,
                 max_image_array_layers: d3d11::D3D11_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION as _,
+                max_per_stage_descriptor_samplers: d3d11::D3D11_COMMONSHADER_SAMPLER_SLOT_COUNT
+                    as _,
+                max_per_stage_descriptor_uniform_buffers:
+                    d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_HW_SLOT_COUNT as _,
+                max_per_stage_descriptor_storage_buffers: max_buffer_uav,
+                max_per_stage_descriptor_storage_images: max_image_uav,
+                max_per_stage_descriptor_sampled_images:
+                    d3d11::D3D11_COMMONSHADER_INPUT_RESOURCE_REGISTER_COUNT as _,
                 max_texel_elements: d3d11::D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION as _, //TODO
                 max_patch_size: 0,                                                    // TODO
                 max_viewports: d3d11::D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE as _,
@@ -1814,10 +1825,11 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         let _scope = debug_scope!(&self.context, "BindGraphicsDescriptorSets");
 
         // TODO: find a better solution to invalidating old bindings..
+        let nulls = [ptr::null_mut(); d3d11::D3D11_PS_CS_UAV_REGISTER_COUNT as usize];
         self.context.CSSetUnorderedAccessViews(
             0,
-            16,
-            [ptr::null_mut(); 16].as_ptr(),
+            d3d11::D3D11_PS_CS_UAV_REGISTER_COUNT,
+            nulls.as_ptr(),
             ptr::null_mut(),
         );
 
@@ -1927,12 +1939,14 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
     {
         let _scope = debug_scope!(&self.context, "BindComputeDescriptorSets");
 
+        let nulls = [ptr::null_mut(); d3d11::D3D11_PS_CS_UAV_REGISTER_COUNT as usize];
         self.context.CSSetUnorderedAccessViews(
             0,
-            16,
-            [ptr::null_mut(); 16].as_ptr(),
+            d3d11::D3D11_PS_CS_UAV_REGISTER_COUNT,
+            nulls.as_ptr(),
             ptr::null_mut(),
         );
+
         for (set, info) in sets.into_iter().zip(&layout.sets[first_set..]) {
             let set = set.borrow();
 


### PR DESCRIPTION
Fixes running anything in release.

Tested on vange-rs 🎉 

One problem was that every memory was allocated as if it was cpu-visible, even if it wasn't supposed to be. And we used memory that was uninitialized...

Another, we had a few occasions of this evil pattern:
```rust
let some_ptr = if let Some(something) { &something } else {ptr::null()};
```
fun thing happens here because the `something` is dead right after that expression, and the pointer gets used still...