### PR TITLE
Made instructions for macOS more clear

### DIFF
--- a/info/getting_started.md
+++ b/info/getting_started.md
@@ -2,7 +2,10 @@
 
 ## macOS Dependencies
 
-Install the newest XCode from the App Store. This installs the required `metal` developer tools.
+1. Install the newest XCode from the App Store. This installs the required `metal` developer tools.
+2. Install the command line tools with `xcode-select --install`. This might do nothing on your machine.
+3. If `xcode-select --print-path` prints `/Library/Developer/CommandLineTools…`
+4. then run `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`.
 
 To run the examples, ensure [CMake is installed](https://cmake.org/install/) as it is required for `glsl-to-spirv`.
 


### PR DESCRIPTION
Without the additional steps, an error like `error: failed to run custom build command for `gfx-backend-metal v0.3.3`` may occur. Tested on a fresh install of macOS 10.15.6

Additional steps copied from comment:
https://github.com/gfx-rs/gfx/issues/2309#issuecomment-506130902
