### PR TITLE
[dx12] fix resource tier-1 handling of render targets

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2433,14 +2433,12 @@ impl d::Device<B> for Device {
 
         let alloc_info = self.raw.clone().GetResourceAllocationInfo(0, 1, &desc);
 
-        // Image usages which require RT/DS heap due to internal implementation.
-        let target_usage = image::Usage::COLOR_ATTACHMENT
-            | image::Usage::DEPTH_STENCIL_ATTACHMENT
-            | image::Usage::TRANSFER_DST;
-
+        // Image flags which require RT/DS heap due to internal implementation.
+        let target_flags = d3d12::D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET
+            | d3d12::D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
         let type_mask_shift = if self.private_caps.heterogeneous_resource_heaps {
             MEM_TYPE_UNIVERSAL_SHIFT
-        } else if usage.intersects(target_usage) {
+        } else if desc.Flags & target_flags != 0 {
             MEM_TYPE_TARGET_SHIFT
         } else {
             MEM_TYPE_IMAGE_SHIFT

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -49,7 +49,7 @@ const NUM_HEAP_PROPERTIES: usize = 3;
 
 // Memory types are grouped according to the supported resources.
 // Grouping is done to circumvent the limitations of heap tier 1 devices.
-// Devices with Tier 1 will expose `BuffersOnl`, `ImageOnly` and `TargetOnly`.
+// Devices with Tier 1 will expose `BuffersOnly`, `ImageOnly` and `TargetOnly`.
 // Devices with Tier 2 or higher will only expose `Universal`.
 enum MemoryGroup {
     Universal = 0,


### PR DESCRIPTION
Fixes a case where we request `TRANSFER_DST` without `COLOR_ATTACHMENT` on an image that has a non-renderable format, when running on Resource Tier-1 hardware.
