### PR TITLE
[vk/0.6] Properly enable VK_KHR_maintenance3 when VK_EXT_descriptor_indexing is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-vulkan-0.6.3 (30-09-2020)
+  - enable VK_KHR_maintenance3 when VK_EXT_descriptor_indexing is enabled
+
 ### backend-dx12-0.6.4 backend-vulkan-0.6.2 backend-metal-0.6.3 (23-09-2020)
   - fix descriptor indexing features
 

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-vulkan"
-version = "0.6.2"
+version = "0.6.3"
 description = "Vulkan API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -85,6 +85,8 @@ lazy_static! {
         CStr::from_bytes_with_nul(b"VK_AMD_negative_viewport_height\0").unwrap();
     static ref KHR_MAINTENANCE1: &'static CStr =
         CStr::from_bytes_with_nul(b"VK_KHR_maintenance1\0").unwrap();
+    static ref KHR_MAINTENANCE3: &'static CStr =
+        CStr::from_bytes_with_nul(b"VK_KHR_maintenance3\0").unwrap();
     static ref KHR_SAMPLER_MIRROR_MIRROR_CLAMP_TO_EDGE : &'static CStr =
         CStr::from_bytes_with_nul(b"VK_KHR_sampler_mirror_clamp_to_edge\0").unwrap();
     static ref KHR_GET_PHYSICAL_DEVICE_PROPERTIES2: &'static CStr =
@@ -732,9 +734,9 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                         | Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING
                         | Features::UNSIZED_DESCRIPTOR_ARRAY
                 ) {
-                    Some(*EXT_DESCRIPTOR_INDEXING)
+                    vec![*KHR_MAINTENANCE3, *EXT_DESCRIPTOR_INDEXING]
                 } else {
-                    None
+                    vec![]
                 },
             )
             .chain(


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/wgpu/issues/946. DI requires maintence3, so we shouldn't need to check if it exists.