### PR TITLE
Remove unused dependencies

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -54,7 +54,6 @@ features = [ "console", "Document", "Element", "HtmlElement", "Node", "Window" ]
 [dependencies.gfx-backend-vulkan]
 path = "../src/backend/vulkan"
 version = "0.6"
-features = ["x11"]
 optional = true
 
 [target.'cfg(unix)'.dependencies.gfx-backend-gl]

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -15,6 +15,8 @@ edition = "2018"
 [features]
 default = []
 use-rtld-next = ["shared_library"]
+xcb = []
+x11 = []
 
 [lib]
 name = "gfx_backend_vulkan"
@@ -37,6 +39,3 @@ winapi = { version = "0.3", features = ["libloaderapi", "windef", "winuser"] }
 objc = "0.2.5"
 core-graphics-types = "0.1"
 
-[target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
-x11 = { version = "2.15", features = ["xlib"], optional = true }
-xcb = { version = "0.9", optional = true }

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -15,8 +15,6 @@ edition = "2018"
 [features]
 default = []
 use-rtld-next = ["shared_library"]
-xcb = []
-x11 = []
 
 [lib]
 name = "gfx_backend_vulkan"

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -586,7 +586,6 @@ impl hal::Instance<Backend> for Instance {
                 Ok(self.create_surface_from_wayland(handle.display, handle.surface))
             }
             #[cfg(all(
-                feature = "x11",
                 unix,
                 not(target_os = "android"),
                 not(target_os = "macos"),
@@ -600,7 +599,6 @@ impl hal::Instance<Backend> for Instance {
                 Ok(self.create_surface_from_xlib(handle.display as *mut _, handle.window))
             }
             #[cfg(all(
-                feature = "xcb",
                 unix,
                 not(target_os = "android"),
                 not(target_os = "macos"),

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -89,7 +89,6 @@ pub struct RawSurface {
 
 impl Instance {
     #[cfg(all(
-        feature = "x11",
         unix,
         not(target_os = "android"),
         not(target_os = "macos")
@@ -121,7 +120,6 @@ impl Instance {
     }
 
     #[cfg(all(
-        feature = "xcb",
         unix,
         not(target_os = "android"),
         not(target_os = "macos")

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -39,7 +39,6 @@ glsl-to-spirv = { version = "0.1", optional = true }
 [dependencies.gfx-backend-vulkan]
 path = "../../src/backend/vulkan"
 version = "0.6"
-features = ["x11"]
 optional = true
 
 [target.'cfg(windows)'.dependencies.gfx-backend-dx12]


### PR DESCRIPTION
Even when built with x11 and xcb features enabled on Linux,
Vulkan backend does not use anything from x11 or xcb crates.

Fixes #issue
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan
