### PR TITLE
[dx12] command buffer markers, names for renderpasses and descriptorsets

### DIFF
--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -19,6 +19,7 @@ default = []
 name = "gfx_backend_dx12"
 
 [dependencies]
+arrayvec = "0.5"
 auxil = { path = "../../auxil/auxil", version = "0.5", package = "gfx-auxil", features = ["spirv_cross"] }
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1.1" }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1376,6 +1376,7 @@ impl d::Device<B> for Device {
             attachments: attachments.iter().cloned().collect(),
             subpasses: Vec::new(),
             post_barriers: Vec::new(),
+            raw_name: Vec::new(),
         };
 
         while let Some(sid) = sub_infos
@@ -3580,12 +3581,12 @@ impl d::Device<B> for Device {
         // ignored
     }
 
-    unsafe fn set_render_pass_name(&self, _render_pass: &mut r::RenderPass, _name: &str) {
-        // ignored
+    unsafe fn set_render_pass_name(&self, render_pass: &mut r::RenderPass, name: &str) {
+        render_pass.raw_name = wide_cstr(name);
     }
 
-    unsafe fn set_descriptor_set_name(&self, _descriptor_set: &mut r::DescriptorSet, _name: &str) {
-        // ignored
+    unsafe fn set_descriptor_set_name(&self, descriptor_set: &mut r::DescriptorSet, name: &str) {
+        descriptor_set.raw_name = wide_cstr(name);
     }
 
     unsafe fn set_descriptor_set_layout_name(

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -44,6 +44,7 @@ pub(crate) struct HeapProperties {
 // https://msdn.microsoft.com/de-de/library/windows/desktop/dn770377(v=vs.85).aspx
 // Only 16 input slots allowed.
 const MAX_VERTEX_BUFFERS: usize = 16;
+const MAX_DESCRIPTOR_SETS: usize = 8;
 
 const NUM_HEAP_PROPERTIES: usize = 3;
 
@@ -1077,8 +1078,9 @@ impl hal::Instance<Backend> for Instance {
                     Features::DRAW_INDIRECT_COUNT,
                 hints:
                     Hints::BASE_VERTEX_INSTANCE_DRAWING,
-                limits: Limits { // TODO
-                    max_bound_descriptor_sets: 8, //TODO: verify all of these not linked to constants
+                limits: Limits {
+                    //TODO: verify all of these not linked to constants
+                    max_bound_descriptor_sets: MAX_DESCRIPTOR_SETS as u16,
                     max_descriptor_set_uniform_buffers_dynamic: 8,
                     max_descriptor_set_storage_buffers_dynamic: 4,
                     max_per_stage_descriptor_sampled_images: d3d12::D3D12_COMMONSHADER_INPUT_RESOURCE_REGISTER_COUNT as _,

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -79,6 +79,7 @@ pub struct RenderPass {
     pub(crate) attachments: Vec<pass::Attachment>,
     pub(crate) subpasses: Vec<SubpassDesc>,
     pub(crate) post_barriers: Vec<BarrierDesc>,
+    pub(crate) raw_name: Vec<u16>,
 }
 
 // Indirection layer attribute -> remap -> binding.
@@ -538,6 +539,7 @@ pub struct DescriptorSet {
     pub(crate) binding_infos: Vec<DescriptorBindingInfo>,
     pub(crate) first_gpu_sampler: Option<native::GpuDescriptor>,
     pub(crate) first_gpu_view: Option<native::GpuDescriptor>,
+    pub(crate) raw_name: Vec<u16>,
 }
 
 impl fmt::Debug for DescriptorSet {
@@ -746,6 +748,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
             binding_infos,
             first_gpu_sampler,
             first_gpu_view,
+            raw_name: Vec::new(),
         })
     }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -730,7 +730,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 if requested_features.intersects(
                     Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING
                         | Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING
-                        | Features::UNSIZED_DESCRIPTOR_ARRAY
+                        | Features::UNSIZED_DESCRIPTOR_ARRAY,
                 ) {
                     vec![*KHR_MAINTENANCE3, *EXT_DESCRIPTOR_INDEXING]
                 } else {

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -88,11 +88,7 @@ pub struct RawSurface {
 }
 
 impl Instance {
-    #[cfg(all(
-        unix,
-        not(target_os = "android"),
-        not(target_os = "macos")
-    ))]
+    #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
     pub fn create_surface_from_xlib(&self, dpy: *mut vk::Display, window: vk::Window) -> Surface {
         let entry = VK_ENTRY
             .as_ref()
@@ -119,11 +115,7 @@ impl Instance {
         self.create_surface_from_vk_surface_khr(surface)
     }
 
-    #[cfg(all(
-        unix,
-        not(target_os = "android"),
-        not(target_os = "macos")
-    ))]
+    #[cfg(all(unix, not(target_os = "android"), not(target_os = "macos")))]
     pub fn create_surface_from_xcb(
         &self,
         connection: *mut vk::xcb_connection_t,


### PR DESCRIPTION
Fixes DX12 part of #3395
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx12

![Dx12markers](https://user-images.githubusercontent.com/107301/95007794-c375f480-05e1-11eb-9f77-1780dee0b922.PNG)

