### PR TITLE
[0.6/dx12] fix alpha blend factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx12-0.6.6 (05-10-2020)
+  - allow color blend factors to be used on alpha channel
+
 ### backend-dx12-0.6.5 (04-10-2020)
   - implement command buffer markers
   - debug names for render passes and descriptor sets

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -32,9 +32,7 @@ use range_alloc::RangeAllocator;
 
 use winapi::{
     shared::{
-        dxgi::{
-            IDXGIAdapter, IDXGIFactory, IDXGISwapChain, DXGI_PRESENT_ALLOW_TEARING,
-        },
+        dxgi::{IDXGIAdapter, IDXGIFactory, IDXGISwapChain, DXGI_PRESENT_ALLOW_TEARING},
         dxgiformat,
         minwindef::{FALSE, HMODULE, UINT},
         windef::{HWND, RECT},
@@ -991,8 +989,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
             window::PresentMode::IMMEDIATE => (0, DXGI_PRESENT_ALLOW_TEARING),
             //Note: this ends up not presenting anything for some reason
             //window::PresentMode::MAILBOX if !presentation.is_init => (1, DXGI_PRESENT_DO_NOT_SEQUENCE),
-            window::PresentMode::MAILBOX |
-            window::PresentMode::FIFO => (1, 0),
+            window::PresentMode::MAILBOX | window::PresentMode::FIFO => (1, 0),
             _ => (0, 0),
         };
         presentation.is_init = false;

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.6.5"
+version = "0.6.6"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -301,14 +301,18 @@ pub fn map_rasterizer(rasterizer: &pso::Rasterizer, multisample: bool) -> D3D12_
     }
 }
 
-fn map_factor(factor: pso::Factor) -> D3D12_BLEND {
+fn map_factor(factor: pso::Factor, is_alpha: bool) -> D3D12_BLEND {
     use hal::pso::Factor::*;
     match factor {
         Zero => D3D12_BLEND_ZERO,
         One => D3D12_BLEND_ONE,
+        SrcColor if is_alpha => D3D12_BLEND_SRC_ALPHA,
         SrcColor => D3D12_BLEND_SRC_COLOR,
+        OneMinusSrcColor if is_alpha => D3D12_BLEND_INV_SRC_ALPHA,
         OneMinusSrcColor => D3D12_BLEND_INV_SRC_COLOR,
+        DstColor if is_alpha => D3D12_BLEND_DEST_ALPHA,
         DstColor => D3D12_BLEND_DEST_COLOR,
+        OneMinusDstColor if is_alpha => D3D12_BLEND_INV_DEST_ALPHA,
         OneMinusDstColor => D3D12_BLEND_INV_DEST_COLOR,
         SrcAlpha => D3D12_BLEND_SRC_ALPHA,
         OneMinusSrcAlpha => D3D12_BLEND_INV_SRC_ALPHA,
@@ -318,21 +322,34 @@ fn map_factor(factor: pso::Factor) -> D3D12_BLEND {
         OneMinusConstColor | OneMinusConstAlpha => D3D12_BLEND_INV_BLEND_FACTOR,
         SrcAlphaSaturate => D3D12_BLEND_SRC_ALPHA_SAT,
         Src1Color => D3D12_BLEND_SRC1_COLOR,
+        Src1Color if is_alpha => D3D12_BLEND_SRC1_ALPHA,
         OneMinusSrc1Color => D3D12_BLEND_INV_SRC1_COLOR,
+        OneMinusSrc1Color if is_alpha => D3D12_BLEND_INV_SRC1_ALPHA,
         Src1Alpha => D3D12_BLEND_SRC1_ALPHA,
         OneMinusSrc1Alpha => D3D12_BLEND_INV_SRC1_ALPHA,
     }
 }
 
-fn map_blend_op(operation: pso::BlendOp) -> (D3D12_BLEND_OP, D3D12_BLEND, D3D12_BLEND) {
+fn map_blend_op(
+    operation: pso::BlendOp,
+    is_alpha: bool,
+) -> (D3D12_BLEND_OP, D3D12_BLEND, D3D12_BLEND) {
     use hal::pso::BlendOp::*;
     match operation {
-        Add { src, dst } => (D3D12_BLEND_OP_ADD, map_factor(src), map_factor(dst)),
-        Sub { src, dst } => (D3D12_BLEND_OP_SUBTRACT, map_factor(src), map_factor(dst)),
+        Add { src, dst } => (
+            D3D12_BLEND_OP_ADD,
+            map_factor(src, is_alpha),
+            map_factor(dst, is_alpha),
+        ),
+        Sub { src, dst } => (
+            D3D12_BLEND_OP_SUBTRACT,
+            map_factor(src, is_alpha),
+            map_factor(dst, is_alpha),
+        ),
         RevSub { src, dst } => (
             D3D12_BLEND_OP_REV_SUBTRACT,
-            map_factor(src),
-            map_factor(dst),
+            map_factor(src, is_alpha),
+            map_factor(dst, is_alpha),
         ),
         Min => (D3D12_BLEND_OP_MIN, D3D12_BLEND_ZERO, D3D12_BLEND_ZERO),
         Max => (D3D12_BLEND_OP_MAX, D3D12_BLEND_ZERO, D3D12_BLEND_ZERO),
@@ -341,7 +358,7 @@ fn map_blend_op(operation: pso::BlendOp) -> (D3D12_BLEND_OP, D3D12_BLEND, D3D12_
 
 pub fn map_render_targets(
     color_targets: &[pso::ColorBlendDesc],
-) -> [D3D12_RENDER_TARGET_BLEND_DESC; 8] {
+) -> [D3D12_RENDER_TARGET_BLEND_DESC; D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT as usize] {
     let dummy_target = D3D12_RENDER_TARGET_BLEND_DESC {
         BlendEnable: FALSE,
         LogicOpEnable: FALSE,
@@ -354,13 +371,13 @@ pub fn map_render_targets(
         LogicOp: D3D12_LOGIC_OP_CLEAR,
         RenderTargetWriteMask: 0,
     };
-    let mut targets = [dummy_target; 8];
+    let mut targets = [dummy_target; D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT as usize];
 
     for (target, color_desc) in targets.iter_mut().zip(color_targets.iter()) {
         target.RenderTargetWriteMask = color_desc.mask.bits() as UINT8;
         if let Some(ref blend) = color_desc.blend {
-            let (color_op, color_src, color_dst) = map_blend_op(blend.color);
-            let (alpha_op, alpha_src, alpha_dst) = map_blend_op(blend.alpha);
+            let (color_op, color_src, color_dst) = map_blend_op(blend.color, false);
+            let (alpha_op, alpha_src, alpha_dst) = map_blend_op(blend.alpha, true);
             target.BlendEnable = TRUE;
             target.BlendOp = color_op;
             target.SrcBlend = color_src;


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/wgpu/issues/953
This is a part of Vulkan semantics that needs mapping. In D3D12 it's not legal to use the COLOR factors on alpha, but in Vulkan 
it's fine.