### PR TITLE
Add get_buffer_device_address extension/feature to gfx-rs (vulkan only)

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -2178,4 +2178,8 @@ impl device::Device<Backend> for Device {
     ) {
         // TODO
     }
+
+    unsafe fn get_buffer_device_address(&self, _buf: &Buffer) -> NonZeroU64 {
+        unimplemented!()
+    }
 }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3612,6 +3612,10 @@ impl d::Device<B> for Device {
         let cwstr = wide_cstr(name);
         pipeline.raw.SetName(cwstr.as_ptr());
     }
+
+    unsafe fn get_buffer_device_address(&self, _buf: &r::Buffer) -> NonZeroU64 {
+        unimplemented!()
+    }
 }
 
 #[test]

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -596,6 +596,10 @@ impl device::Device<Backend> for Device {
     unsafe fn wait_for_fence(&self, _: &(), _: u64) -> Result<bool, device::OomOrDeviceLost> {
         Ok(true)
     }
+
+    unsafe fn get_buffer_device_address(&self, _buf: &Buffer) -> std::num::NonZeroU64 {
+        unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
+    }
 }
 
 #[derive(Debug)]

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1967,4 +1967,8 @@ impl d::Device<B> for Device {
     ) {
         // TODO
     }
+
+    unsafe fn get_buffer_device_address(&self, _buf: &n::Buffer) -> std::num::NonZeroU64 {
+        unimplemented!()
+    }
 }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -3144,6 +3144,10 @@ impl hal::device::Device<Backend> for Device {
     ) {
         // TODO
     }
+
+    unsafe fn get_buffer_device_address(&self, _buf: &n::Buffer) -> std::num::NonZeroU64 {
+        unimplemented!()
+    }
 }
 
 #[test]

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -19,6 +19,7 @@ use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::{mem, ptr};
+use std::num::NonZeroU64;
 
 use crate::pool::RawCommandPool;
 use crate::{command as cmd, conv, native as n, window as w};
@@ -2260,6 +2261,22 @@ impl d::Device<B> for Device {
         name: &str,
     ) {
         self.set_object_name(vk::ObjectType::PIPELINE, graphics_pipeline.0.as_raw(), name)
+    }
+
+    unsafe fn get_buffer_device_address(&self, buf: &n::Buffer) -> NonZeroU64 {
+        let get_buffer_device_address = self
+            .shared
+            .extension_fns
+            .get_buffer_device_address
+            .expect("Feature BUFFER_DEVICE_ADDRESS must be enabled to call get_buffer_device_address");
+        
+        let address = get_buffer_device_address(
+            &self.shared.raw,
+            &vk::BufferDeviceAddressInfo::builder()
+                .buffer(buf.raw),
+        );
+
+        NonZeroU64::new(address).expect("`get_buffer_device_address` returned a null value!")
     }
 }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -15,11 +15,11 @@ use hal::{
 
 use std::borrow::Borrow;
 use std::ffi::CString;
+use std::num::NonZeroU64;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::{mem, ptr};
-use std::num::NonZeroU64;
 
 use crate::pool::RawCommandPool;
 use crate::{command as cmd, conv, native as n, window as w};
@@ -2264,16 +2264,13 @@ impl d::Device<B> for Device {
     }
 
     unsafe fn get_buffer_device_address(&self, buf: &n::Buffer) -> NonZeroU64 {
-        let get_buffer_device_address = self
-            .shared
-            .extension_fns
-            .get_buffer_device_address
-            .expect("Feature BUFFER_DEVICE_ADDRESS must be enabled to call get_buffer_device_address");
-        
+        let get_buffer_device_address = self.shared.extension_fns.get_buffer_device_address.expect(
+            "Feature BUFFER_DEVICE_ADDRESS must be enabled to call get_buffer_device_address",
+        );
+
         let address = get_buffer_device_address(
             &self.shared.raw,
-            &vk::BufferDeviceAddressInfo::builder()
-                .buffer(buf.raw),
+            &vk::BufferDeviceAddressInfo::builder().buffer(buf.raw),
         );
 
         NonZeroU64::new(address).expect("`get_buffer_device_address` returned a null value!")

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -96,8 +96,8 @@ lazy_static! {
     static ref EXT_DESCRIPTOR_INDEXING: &'static CStr =
         CStr::from_bytes_with_nul(b"VK_EXT_descriptor_indexing\0").unwrap();
     static ref MESH_SHADER: &'static CStr = MeshShader::name();
-    static ref KHR_BUFFER_DEVICE_ADDRESS: &'static CStr =
-        CStr::from_bytes_with_nul(b"VK_KHR_buffer_device_address\0").unwrap();
+    static ref EXT_BUFFER_DEVICE_ADDRESS: &'static CStr =
+        CStr::from_bytes_with_nul(b"VK_EXT_buffer_device_address\0").unwrap();
 }
 
 #[cfg(not(feature = "use-rtld-next"))]
@@ -1066,7 +1066,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         if self.supports_extension(*KHR_DRAW_INDIRECT_COUNT) {
             bits |= Features::DRAW_INDIRECT_COUNT
         }
-        if self.supports_extension(*KHR_BUFFER_DEVICE_ADDRESS) {
+        if self.supports_extension(*EXT_BUFFER_DEVICE_ADDRESS) {
             bits |= Features::BUFFER_DEVICE_ADDRESS;
         }
         // This will only be some if the extension exists

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -15,7 +15,7 @@ use ash::extensions::{
     khr::DrawIndirectCount,
 };
 use ash::extensions::{khr::Swapchain, nv::MeshShader};
-use ash::version::{DeviceV1_0, EntryV1_0, InstanceV1_0, DeviceV1_2};
+use ash::version::{DeviceV1_0, DeviceV1_2, EntryV1_0, InstanceV1_0};
 use ash::vk;
 #[cfg(not(feature = "use-rtld-next"))]
 use ash::{Entry, LoadingError};
@@ -734,7 +734,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 if requested_features.intersects(
                     Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING
                         | Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING
-                        | Features::UNSIZED_DESCRIPTOR_ARRAY
+                        | Features::UNSIZED_DESCRIPTOR_ARRAY,
                 ) {
                     vec![*KHR_MAINTENANCE3, *EXT_DESCRIPTOR_INDEXING]
                 } else {
@@ -833,11 +833,12 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             None
         };
 
-        let buffer_device_address_fn = if requested_features.contains(Features::BUFFER_DEVICE_ADDRESS) {
-            Some(ash::Device::get_buffer_device_address as _)
-        } else {
-            None
-        };
+        let buffer_device_address_fn =
+            if requested_features.contains(Features::BUFFER_DEVICE_ADDRESS) {
+                Some(ash::Device::get_buffer_device_address as _)
+            } else {
+                None
+            };
 
         let device = Device {
             shared: Arc::new(RawDevice {
@@ -1436,7 +1437,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 struct DeviceExtensionFunctions {
     mesh_shaders: Option<MeshShader>,
     draw_indirect_count: Option<DrawIndirectCount>,
-    get_buffer_device_address: Option<unsafe fn(&ash::Device, &vk::BufferDeviceAddressInfo) -> vk::DeviceAddress>,
+    get_buffer_device_address:
+        Option<unsafe fn(&ash::Device, &vk::BufferDeviceAddressInfo) -> vk::DeviceAddress>,
 }
 
 #[doc(hidden)]

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -96,8 +96,8 @@ lazy_static! {
     static ref EXT_DESCRIPTOR_INDEXING: &'static CStr =
         CStr::from_bytes_with_nul(b"VK_EXT_descriptor_indexing\0").unwrap();
     static ref MESH_SHADER: &'static CStr = MeshShader::name();
-    static ref EXT_BUFFER_DEVICE_ADDRESS: &'static CStr =
-        CStr::from_bytes_with_nul(b"VK_EXT_buffer_device_address\0").unwrap();
+    static ref KHR_BUFFER_DEVICE_ADDRESS: &'static CStr =
+        CStr::from_bytes_with_nul(b"VK_KHR_buffer_device_address\0").unwrap();
 }
 
 #[cfg(not(feature = "use-rtld-next"))]
@@ -1066,7 +1066,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         if self.supports_extension(*KHR_DRAW_INDIRECT_COUNT) {
             bits |= Features::DRAW_INDIRECT_COUNT
         }
-        if self.supports_extension(*EXT_BUFFER_DEVICE_ADDRESS) {
+        if self.supports_extension(*KHR_BUFFER_DEVICE_ADDRESS) {
             bits |= Features::BUFFER_DEVICE_ADDRESS;
         }
         // This will only be some if the extension exists

--- a/src/backend/webgpu/src/device.rs
+++ b/src/backend/webgpu/src/device.rs
@@ -586,7 +586,10 @@ impl hal::device::Device<Backend> for Device {
         // TODO
     }
 
-    unsafe fn get_buffer_device_address(&self, _buf: &<Backend as hal::Backend>::Buffer) -> std::num::NonZeroU64 {
+    unsafe fn get_buffer_device_address(
+        &self,
+        _buf: &<Backend as hal::Backend>::Buffer,
+    ) -> std::num::NonZeroU64 {
         unimplemented!()
     }
 }

--- a/src/backend/webgpu/src/device.rs
+++ b/src/backend/webgpu/src/device.rs
@@ -585,4 +585,8 @@ impl hal::device::Device<Backend> for Device {
     ) {
         // TODO
     }
+
+    unsafe fn get_buffer_device_address(&self, _buf: &<Backend as hal::Backend>::Buffer) -> std::num::NonZeroU64 {
+        unimplemented!()
+    }
 }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -15,6 +15,7 @@ use std::any::Any;
 use std::borrow::Borrow;
 use std::ops::Range;
 use std::{fmt, iter};
+use std::num::NonZeroU64;
 
 use crate::{
     buffer, format, image,
@@ -994,4 +995,9 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         graphics_pipeline: &mut B::GraphicsPipeline,
         name: &str,
     );
+    /// Query a 64-bit buffer device address value through which buffer memory can be accessed in a shader.
+    unsafe fn get_buffer_device_address(
+        &self,
+        buf: &B::Buffer,
+    ) -> NonZeroU64;
 }

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -13,9 +13,9 @@
 
 use std::any::Any;
 use std::borrow::Borrow;
+use std::num::NonZeroU64;
 use std::ops::Range;
 use std::{fmt, iter};
-use std::num::NonZeroU64;
 
 use crate::{
     buffer, format, image,
@@ -996,8 +996,5 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         name: &str,
     );
     /// Query a 64-bit buffer device address value through which buffer memory can be accessed in a shader.
-    unsafe fn get_buffer_device_address(
-        &self,
-        buf: &B::Buffer,
-    ) -> NonZeroU64;
+    unsafe fn get_buffer_device_address(&self, buf: &B::Buffer) -> NonZeroU64;
 }

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -242,6 +242,8 @@ bitflags! {
         const UNSIZED_DESCRIPTOR_ARRAY = 0x0800_0000_0000_0000;
         /// Enable draw_indirect_count and draw_indexed_indirect_count
         const DRAW_INDIRECT_COUNT = 0x1000_0000_0000_0000;
+        /// Enable get_buffer_device_address
+        const BUFFER_DEVICE_ADDRESS = 0x2000_0000_0000_0000;
 
         /// Support triangle fan primitive topology.
         const TRIANGLE_FAN = 0x0001 << 64;


### PR DESCRIPTION
This adds support for using `VK_KHR_buffer_device_address` to get the device address of a buffer that can be dereferenced in a shader (through `SPV_KHR_physical_storage_buffer` and `GL_EXT_buffer_reference(2)`).

https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VK_KHR_buffer_device_address
https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_buffer_reference.txt
https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GLSL_EXT_buffer_reference2.txt

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds - fails with:
```
Testing GL:
thread 'main' panicked at 'removal index (is 0) should be < len (is 0)', src/liballoc/vec.rs:1062:13
```
- [ ] tested examples with the following backends:
    - [ ] vulkan
