### PR TITLE
[dx12] fix and refactor the samplers

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2890,13 +2890,7 @@ impl d::Device<B> for Device {
         let mut descriptor_update_pools = self.descriptor_update_pools.lock();
         let mut update_pool_index = 0;
 
-        //TODO: combine destination ranges
-        let mut dst_samplers = Vec::new();
-        let mut dst_views = Vec::new();
-        let mut src_samplers = Vec::new();
-        let mut src_views = Vec::new();
-        let mut num_samplers = Vec::new();
-        let mut num_views = Vec::new();
+        let mut accum = descriptors_cpu::MultiCopyAccumulator::default();
         debug!("write_descriptor_sets");
 
         for write in write_iter {
@@ -3068,15 +3062,17 @@ impl d::Device<B> for Device {
 
                 if let Some(handle) = src_cbv {
                     trace!("\tcbv offset {}", offset);
-                    src_views.push(handle);
-                    dst_views.push(bind_info.view_range.as_ref().unwrap().at(offset));
-                    num_views.push(1);
+                    accum.src_views.add(handle, 1);
+                    accum
+                        .dst_views
+                        .add(bind_info.view_range.as_ref().unwrap().at(offset), 1);
                 }
                 if let Some(handle) = src_srv {
                     trace!("\tsrv offset {}", offset);
-                    src_views.push(handle);
-                    dst_views.push(bind_info.view_range.as_ref().unwrap().at(offset));
-                    num_views.push(1);
+                    accum.src_views.add(handle, 1);
+                    accum
+                        .dst_views
+                        .add(bind_info.view_range.as_ref().unwrap().at(offset), 1);
                 }
                 if let Some(handle) = src_uav {
                     let uav_offset = if bind_info.content.contains(r::DescriptorContent::SRV) {
@@ -3085,9 +3081,10 @@ impl d::Device<B> for Device {
                         offset
                     };
                     trace!("\tuav offset {}", uav_offset);
-                    src_views.push(handle);
-                    dst_views.push(bind_info.view_range.as_ref().unwrap().at(uav_offset));
-                    num_views.push(1);
+                    accum.src_views.add(handle, 1);
+                    accum
+                        .dst_views
+                        .add(bind_info.view_range.as_ref().unwrap().at(uav_offset), 1);
                 }
 
                 offset += 1;
@@ -3095,38 +3092,13 @@ impl d::Device<B> for Device {
 
             if sampler_offset != base_sampler_offset {
                 drop(desc_samplers);
-                write.set.update_samplers(
-                    &self.heap_sampler.0,
-                    &self.heap_sampler.1,
-                    &mut src_samplers,
-                    &mut dst_samplers,
-                    &mut num_samplers,
-                );
+                write
+                    .set
+                    .update_samplers(&self.heap_sampler.0, &self.heap_sampler.1, &mut accum);
             }
         }
 
-        if !num_views.is_empty() {
-            self.raw.clone().CopyDescriptors(
-                dst_views.len() as u32,
-                dst_views.as_ptr(),
-                num_views.as_ptr(),
-                src_views.len() as u32,
-                src_views.as_ptr(),
-                num_views.as_ptr(),
-                d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
-            );
-        }
-        if !num_samplers.is_empty() {
-            self.raw.clone().CopyDescriptors(
-                dst_samplers.len() as u32,
-                dst_samplers.as_ptr(),
-                num_samplers.as_ptr(),
-                src_samplers.len() as u32,
-                src_samplers.as_ptr(),
-                num_samplers.as_ptr(),
-                d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,
-            );
-        }
+        accum.flush(self.raw.clone());
 
         // reset the temporary CPU-size descriptor pools
         for buffer_desc_pool in descriptor_update_pools.iter_mut() {
@@ -3139,12 +3111,7 @@ impl d::Device<B> for Device {
         I: IntoIterator,
         I::Item: Borrow<pso::DescriptorSetCopy<'a, B>>,
     {
-        let mut dst_views = Vec::new();
-        let mut dst_samplers = Vec::new();
-        let mut src_views = Vec::new();
-        let mut src_samplers = Vec::new();
-        let mut num_views = Vec::new();
-        let mut num_samplers = Vec::new();
+        let mut accum = descriptors_cpu::MultiCopyAccumulator::default();
 
         for copy_wrap in copy_iter {
             let copy = copy_wrap.borrow();
@@ -3156,9 +3123,13 @@ impl d::Device<B> for Device {
             {
                 assert!(copy.src_array_offset + copy.count <= src_range.count as usize);
                 assert!(copy.dst_array_offset + copy.count <= dst_range.count as usize);
-                src_views.push(src_range.at(copy.src_array_offset as _));
-                dst_views.push(dst_range.at(copy.dst_array_offset as _));
-                num_views.push(copy.count as u32);
+                let count = copy.count as u32;
+                accum
+                    .src_views
+                    .add(src_range.at(copy.src_array_offset as _), count);
+                accum
+                    .dst_views
+                    .add(dst_range.at(copy.dst_array_offset as _), count);
 
                 if (src_info.content & dst_info.content)
                     .contains(r::DescriptorContent::SRV | r::DescriptorContent::UAV)
@@ -3171,45 +3142,39 @@ impl d::Device<B> for Device {
                         dst_info.count as usize + copy.dst_array_offset + copy.count
                             <= dst_range.count as usize
                     );
-                    src_views.push(src_range.at(src_info.count + copy.src_array_offset as u64));
-                    dst_views.push(dst_range.at(dst_info.count + copy.dst_array_offset as u64));
-                    num_views.push(copy.count as u32);
+                    accum.src_views.add(
+                        src_range.at(src_info.count + copy.src_array_offset as u64),
+                        count,
+                    );
+                    accum.dst_views.add(
+                        dst_range.at(dst_info.count + copy.dst_array_offset as u64),
+                        count,
+                    );
                 }
             }
 
             if dst_info.content.contains(r::DescriptorContent::SAMPLER) {
+                let src_offset = copy
+                    .src_set
+                    .sampler_offset(copy.src_binding, copy.src_array_offset);
+                let dst_offset = copy
+                    .dst_set
+                    .sampler_offset(copy.dst_binding, copy.dst_array_offset);
+                let src_samplers = copy.src_set.sampler_indices.borrow();
+                let mut dst_samplers = copy.dst_set.sampler_indices.borrow_mut();
+                dst_samplers[dst_offset..dst_offset + copy.count]
+                    .copy_from_slice(&src_samplers[src_offset..src_offset + copy.count]);
+                drop(dst_samplers);
+
                 copy.dst_set.update_samplers(
                     &self.heap_sampler.0,
                     &self.heap_sampler.1,
-                    &mut src_samplers,
-                    &mut dst_samplers,
-                    &mut num_samplers,
+                    &mut accum,
                 );
             }
         }
 
-        if !num_views.is_empty() {
-            self.raw.clone().CopyDescriptors(
-                dst_views.len() as u32,
-                dst_views.as_ptr(),
-                num_views.as_ptr(),
-                src_views.len() as u32,
-                src_views.as_ptr(),
-                num_views.as_ptr(),
-                d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
-            );
-        }
-        if !num_samplers.is_empty() {
-            self.raw.clone().CopyDescriptors(
-                dst_samplers.len() as u32,
-                dst_samplers.as_ptr(),
-                num_samplers.as_ptr(),
-                src_samplers.len() as u32,
-                src_samplers.as_ptr(),
-                num_samplers.as_ptr(),
-                d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,
-            );
-        }
+        accum.flush(self.raw.clone());
     }
 
     unsafe fn map_memory(


### PR DESCRIPTION
This PR follows #3393. It combines a few closely related things around samplers:
  1. It turns out we can't copy GPU-visible descriptors into each other. We used to create samplers in the GPU-visible heap, and track the origin indices. Now we create them in a separate CPU-only pool, and only copy from there into the GPU heap.
  2. The previous PR was missing a piece of logic that would update the sampler data on a descriptor inside `copy_descriptor_sets`.
  3. From the early days, we had code duplication between descriptor copies and writes. This PR introduces a structure that manages those copy ranges and flushes them.
  4. Using copy ranges more aggressively, and non-symmetrically between the source and destination.