### PR TITLE
[vk] allow different descriptors in a single write

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -451,23 +451,15 @@ where
         );
 
         unsafe {
-            device.write_descriptor_sets(vec![
-                pso::DescriptorSetWrite {
-                    set: &desc_set,
-                    binding: 0,
-                    array_offset: 0,
-                    descriptors: Some(pso::Descriptor::Image(
-                        &*image_srv,
-                        i::Layout::ShaderReadOnlyOptimal,
-                    )),
-                },
-                pso::DescriptorSetWrite {
-                    set: &desc_set,
-                    binding: 1,
-                    array_offset: 0,
-                    descriptors: Some(pso::Descriptor::Sampler(&*sampler)),
-                },
-            ]);
+            device.write_descriptor_sets(iter::once(pso::DescriptorSetWrite {
+                set: &desc_set,
+                binding: 0,
+                array_offset: 0,
+                descriptors: vec![
+                    pso::Descriptor::Image(&*image_srv, i::Layout::ShaderReadOnlyOptimal),
+                    pso::Descriptor::Sampler(&*sampler),
+                ],
+            }));
         }
 
         // copy buffer to texture


### PR DESCRIPTION
Fixes #3408
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan, metal, dx12

The quad example now uses this semantics to update all the descriptors in a single write.