### PR TITLE
[0.6/dx12] Improve D3D12 limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx12-0.6.8 (16-10-2020)
+  - improve the accuracy of limits
+
 ### backend-vulkan-0.6.5 (15-10-2020)
   - support different types of descriptors in a single `DescriptorSetWrite`
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.6.7"
+version = "0.6.8"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
Helps progress #3308 towards completion. This improves the limits to better reflect reality. There are still some corner cases not covered by this, but it is much more accurate.

To derive these limits I used:
 - https://docs.microsoft.com/en-us/windows/win32/direct3d12/hardware-support
 - Various d3d constants.
 - Poking people on the directx discord to understand what should go where :)

Not ready to merge as I didn't do a version bump in case we wanted to roll this and any possible bug fixes to my bug into a single release.