### PR TITLE
Implement std::error::Error for UnsupportedBackend

### DIFF
--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -481,6 +481,15 @@ pub enum IndexType {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct UnsupportedBackend;
 
+impl fmt::Display for UnsupportedBackend {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "UnsupportedBackend")
+    }
+}
+
+impl std::error::Error for UnsupportedBackend {}
+
+
 /// An instantiated backend.
 ///
 /// Any startup the backend needs to perform will be done when creating the type that implements


### PR DESCRIPTION
```rust
let instance = gfx_backend::Instance::create("cs535", 1)?;
```
gives compiling error
```
error[E0277]: the trait bound `UnsupportedBackend: std::error::Error` is not satisfied
  --> src/hardware.rs:18:65
   |
18 |         let instance = gfx_backend::Instance::create("cs535", 1)?;
   |                                                                 ^ the trait `std::error::Error` is not implemented for `UnsupportedBackend`
   |
   = note: required because of the requirements on the impl of `From<UnsupportedBackend>` for `Box<dyn std::error::Error>`
   = note: required by `from`
```



PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
