### PR TITLE
[0.6/dx11] Fix Read-Only Depth Stencil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx11-unreleased
+  - fix read only depth stencil
+
 ### backend-dx11-0.6.5 (17-10-2020)
   - shaders are properly cleared when using a pipeline without a PS, GS, HS, or DS.
   - fix buffer to image copies with multiple layers


### PR DESCRIPTION
Depends on #3416. Commits will be rebased away once this is merged.

Fixes the water example under DX11.