### PR TITLE
[0.6/dx11] Fix multisampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### backend-dx11-unreleased
   - fix read only depth stencil
   - support dynamic uniform buffer descriptors
+  - support MSAA resolve
 
 ### backend-dx12-0.6.9 (19-10-2020)
   - implement descriptor freeing and recycling

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1662,6 +1662,7 @@ impl device::Device<Backend> for Device {
         };
 
         Ok(ImageView {
+            subresource: d3d11::D3D11CalcSubresource(0, range.layer_start as _, range.level_start as _),
             format,
             srv_handle: if image.usage.intersects(image::Usage::SAMPLED) {
                 Some(self.view_image_as_shader_resource(&srv_info)?)

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -226,6 +226,19 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
         | _ => 8,
     };
 
+    // https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11device-checkmultisamplequalitylevels#remarks
+    // for more information.
+    let max_samples = match feature_level {
+        d3dcommon::D3D_FEATURE_LEVEL_9_1
+        | d3dcommon::D3D_FEATURE_LEVEL_9_2
+        | d3dcommon::D3D_FEATURE_LEVEL_9_3
+        | d3dcommon::D3D_FEATURE_LEVEL_10_0 => 0b0001, // Conservative, MSAA isn't required.
+        d3dcommon::D3D_FEATURE_LEVEL_10_1 => 0b0101, // Optimistic, 4xMSAA is required on all formats _but_ RGBA32.
+        d3dcommon::D3D_FEATURE_LEVEL_11_0
+        | d3dcommon::D3D_FEATURE_LEVEL_11_1
+        | _ => 0b1101, // Optimistic, 8xMSAA and 4xMSAA is required on all formats _but_ RGBA32 which requires 4x.
+    };
+
     hal::Limits {
         max_image_1d_size: max_texture_uv_dimension,
         max_image_2d_size: max_texture_uv_dimension,
@@ -266,9 +279,9 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
         min_texel_buffer_offset_alignment: 1,                                     // TODO
         min_uniform_buffer_offset_alignment: 16,
         min_storage_buffer_offset_alignment: 16, // TODO
-        framebuffer_color_sample_counts: 1,      // TODO
-        framebuffer_depth_sample_counts: 1,      // TODO
-        framebuffer_stencil_sample_counts: 1,    // TODO
+        framebuffer_color_sample_counts: max_samples,
+        framebuffer_depth_sample_counts: max_samples,
+        framebuffer_stencil_sample_counts: max_samples,
         max_color_attachments,
         buffer_image_granularity: 1,
         non_coherent_atom_size: 1, // TODO


### PR DESCRIPTION
Fixes the `msaa-line` wgpu example.

Now only remains the texture-array example, and we're golden :)