### PR TITLE
[0.6/dx11] Fix writes of descriptor arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
-### backend-dx11-unreleased
+### backend-dx11-0.6.6 (20-10-2020)
   - fix read only depth stencil
   - support dynamic uniform buffer descriptors
   - support MSAA resolve
+  - fix descriptor writes involving descriptor arrays
 
 ### backend-dx12-0.6.9 (19-10-2020)
   - implement descriptor freeing and recycling

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.6.5"
+version = "0.6.6"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -3307,15 +3307,15 @@ impl<T> MultiStageData<RegisterData<T>> {
 }
 
 impl MultiStageData<RegisterData<DescriptorIndex>> {
-    fn add_content(&mut self, content: DescriptorContent, stages: pso::ShaderStageFlags) {
+    fn add_content_many(&mut self, content: DescriptorContent, stages: pso::ShaderStageFlags, count: DescriptorIndex) {
         if stages.contains(pso::ShaderStageFlags::VERTEX) {
-            self.vs.add_content(content);
+            self.vs.add_content_many(content, count);
         }
         if stages.contains(pso::ShaderStageFlags::FRAGMENT) {
-            self.ps.add_content(content);
+            self.ps.add_content_many(content, count);
         }
         if stages.contains(pso::ShaderStageFlags::COMPUTE) {
-            self.cs.add_content(content);
+            self.cs.add_content_many(content, count);
         }
     }
 
@@ -3443,7 +3443,7 @@ impl DescriptorSetInfo {
             if binding.binding == binding_index {
                 return (content, res_offsets.map(|offset| *offset as ResourceIndex));
             }
-            res_offsets.add_content(content);
+            res_offsets.add_content_many(content, 1);
         }
         panic!("Unable to find binding {:?}", binding_index);
     }


### PR DESCRIPTION
Depends on #3423.

Fixes the `texture-array` wgpu example. Once this is merged, all examples should at least run on DX11, and as such I have bumped versions.

This is a surprisingly small change for how long it took me to understand the code :)

I have added some comments to help explain a bit more how the binding situation works, especially now with arrays involved.