### PR TITLE
[0.6/dx11] Fix Dynamic Offsets with Command List Emulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - enable alpha to coverage
   - support debug names and markers
   - fix DX11.1 device creation
+  - fix dynamic offsets with command list emulation
 
 ### backend-dx11-0.6.6 (20-10-2020)
   - fix read only depth stencil

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2250,6 +2250,16 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
                 let num_buffers = rd.count as u32;
                 let constant_buffers = set.handles.offset(rd.pool_offset as isize);
                 if let Some(ref context1) = self.context1 {
+                    // This call with offsets won't work right with command list emulation
+                    // unless we reset the first and last constant buffers to null.
+                    if self.internal.command_list_emulation {
+                        let null_cbuf = [ptr::null_mut::<d3d11::ID3D11Buffer>()];
+                        context1.VSSetConstantBuffers(start_slot, 1, &null_cbuf as *const _);
+                        if num_buffers > 1 {
+                            context1.VSSetConstantBuffers(start_slot + num_buffers - 1, 1, &null_cbuf as *const _);
+                        }
+                    }
+
                     // TODO: This should be the actual buffer length for RBA purposes,
                     //       but that information isn't easily accessible here.
                     context1.VSSetConstantBuffers1(
@@ -2287,6 +2297,16 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
                 let num_buffers = rd.count as u32;
                 let constant_buffers = set.handles.offset(rd.pool_offset as isize);
                 if let Some(ref context1) = self.context1 {
+                    // This call with offsets won't work right with command list emulation
+                    // unless we reset the first and last constant buffers to null.
+                    if self.internal.command_list_emulation {
+                        let null_cbuf = [ptr::null_mut::<d3d11::ID3D11Buffer>()];
+                        context1.PSSetConstantBuffers(start_slot, 1, &null_cbuf as *const _);
+                        if num_buffers > 1 {
+                            context1.PSSetConstantBuffers(start_slot + num_buffers - 1, 1, &null_cbuf as *const _);
+                        }
+                    }
+
                     context1.PSSetConstantBuffers1(
                         start_slot,
                         num_buffers,


### PR DESCRIPTION
This fixes a bug the shadow example had on non-nvidia platforms.