### PR TITLE
[0.6/dx11] Fix two memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### backend-dx11-0.6.8 (23-10-2020)
+  - fix buffer leak when `Memory` was reused
+  - fix image leaks
+
 ### backend-dx11-0.6.7 (22-10-2020)
   - enable alpha to coverage
   - support debug names and markers

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -28,6 +28,7 @@ libloading = "0.6"
 log = { version = "0.4" }
 smallvec = "1.0"
 spirv_cross = { version = "0.21", features = ["hlsl"] }
+thunderdome = "0.3"
 parking_lot = "0.11"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11_1", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 wio = "0.2"

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -789,7 +789,6 @@ impl device::Device<Backend> for Device {
             size,
             host_ptr,
             local_buffers: Arc::new(RwLock::new(thunderdome::Arena::new())),
-            local_images: Arc::new(RwLock::new(thunderdome::Arena::new())),
         })
     }
 
@@ -2190,9 +2189,6 @@ impl device::Device<Backend> for Device {
         for (_, (_range, mut internal)) in memory.local_buffers.write().drain() {
             internal.release_resources()
         }
-        for (_, (_range, internal)) in memory.local_images.write().drain() {
-            (*internal.raw).Release();
-        }
     }
 
     unsafe fn create_query_pool(
@@ -2260,9 +2256,8 @@ impl device::Device<Backend> for Device {
         unimplemented!()
     }
 
-    unsafe fn destroy_image(&self, _image: Image) {
-        // TODO:
-        // unimplemented!()
+    unsafe fn destroy_image(&self, mut image: Image) {
+        image.internal.release_resources();
     }
 
     unsafe fn destroy_image_view(&self, _view: ImageView) {

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2913,9 +2913,6 @@ pub struct Memory {
 
     // list of all buffers bound to this memory
     local_buffers: Arc<RwLock<LocalResourceArena<InternalBuffer>>>,
-
-    // list of all images bound to this memory
-    local_images: Arc<RwLock<LocalResourceArena<InternalImage>>>,
 }
 
 impl fmt::Debug for Memory {
@@ -3169,6 +3166,17 @@ pub struct InternalImage {
     render_target_views: Vec<ComPtr<d3d11::ID3D11RenderTargetView>>,
 
     debug_name: Option<String>
+}
+
+impl InternalImage {
+    unsafe fn release_resources(&mut self) {
+        (&*self.raw).Release();
+        self.copy_srv = None;
+        self.srv = None;
+        self.unordered_access_views.clear();
+        self.depth_stencil_views.clear();
+        self.render_target_views.clear();
+    }
 }
 
 impl fmt::Debug for InternalImage {

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -43,9 +43,9 @@ use winapi::{shared::{
 use wio::com::ComPtr;
 
 use arrayvec::ArrayVec;
-use parking_lot::{Condvar, Mutex};
+use parking_lot::{Condvar, Mutex, RwLock};
 
-use std::{borrow::Borrow, cell::RefCell, fmt, mem, ops::Range, os::raw::c_void, ptr, sync::Arc};
+use std::{borrow::Borrow, cell::RefCell, fmt, mem, ops::Range, os::raw::c_void, ptr, sync::{Arc, Weak}};
 
 macro_rules! debug_scope {
     ($context:expr, $($arg:tt)+) => ({
@@ -2895,7 +2895,9 @@ impl MemoryInvalidate {
     }
 }
 
-// Since we dont have any heaps to work with directly, everytime we bind a
+type LocalResourceArena<T> = thunderdome::Arena<(Range<u64>, T)>;
+
+// Since we dont have any heaps to work with directly, Beverytime we bind a
 // buffer/image to memory we allocate a dx11 resource and assign it a range.
 //
 // `HOST_VISIBLE` memory gets a `Vec<u8>` which covers the entire memory
@@ -2910,10 +2912,10 @@ pub struct Memory {
     host_ptr: *mut u8,
 
     // list of all buffers bound to this memory
-    local_buffers: RefCell<Vec<(Range<u64>, InternalBuffer)>>,
+    local_buffers: Arc<RwLock<LocalResourceArena<InternalBuffer>>>,
 
     // list of all images bound to this memory
-    _local_images: RefCell<Vec<(Range<u64>, InternalImage)>>,
+    local_images: Arc<RwLock<LocalResourceArena<InternalImage>>>,
 }
 
 impl fmt::Debug for Memory {
@@ -2930,14 +2932,15 @@ impl Memory {
         segment.offset..segment.size.map_or(self.size, |s| segment.offset + s)
     }
 
-    pub fn bind_buffer(&self, range: Range<u64>, buffer: InternalBuffer) {
-        self.local_buffers.borrow_mut().push((range, buffer));
+    pub fn bind_buffer(&self, range: Range<u64>, buffer: InternalBuffer) -> thunderdome::Index {
+        let mut local_buffers = self.local_buffers.write();
+        local_buffers.insert((range, buffer))
     }
 
     pub fn flush(&self, context: &ComPtr<d3d11::ID3D11DeviceContext>, range: Range<u64>) {
         use buffer::Usage;
 
-        for &(ref buffer_range, ref buffer) in self.local_buffers.borrow().iter() {
+        for (_, &(ref buffer_range, ref buffer)) in self.local_buffers.read().iter() {
             let range = match intersection(&range, &buffer_range) {
                 Some(r) => r,
                 None => continue,
@@ -2992,7 +2995,7 @@ impl Memory {
         working_buffer: ComPtr<d3d11::ID3D11Buffer>,
         working_buffer_size: u64,
     ) {
-        for &(ref buffer_range, ref buffer) in self.local_buffers.borrow().iter() {
+        for (_, &(ref buffer_range, ref buffer)) in self.local_buffers.read().iter() {
             if let Some(range) = intersection(&range, &buffer_range) {
                 MemoryInvalidate {
                     working_buffer: Some(working_buffer.clone()),
@@ -3094,11 +3097,29 @@ pub struct InternalBuffer {
     debug_name: Option<String>,
 }
 
+impl InternalBuffer {
+    unsafe fn release_resources(&mut self) {
+        (&*self.raw).Release();
+        self.raw = ptr::null_mut();
+        self.disjoint_cb.take().map(|cb| (&*cb).Release());
+        self.uav.take().map(|uav| (&*uav).Release());
+        self.srv.take().map(|srv| (&*srv).Release());
+        self.usage = buffer::Usage::empty();
+        self.debug_name = None;
+    }
+}
+
 pub struct Buffer {
     internal: InternalBuffer,
     is_coherent: bool,
     memory_ptr: *mut u8,     // null if unbound or non-cpu-visible
     bound_range: Range<u64>, // 0 if unbound
+    /// Handle to the Memory arena storing this buffer.
+    local_memory_arena: Weak<RwLock<LocalResourceArena<InternalBuffer>>>,
+    /// Index into the above memory arena.
+    ///
+    /// Once memory is bound to a buffer, this should never be None.
+    memory_index: Option<thunderdome::Index>,
     requirements: memory::Requirements,
     bind: d3d11::D3D11_BIND_FLAG,
 }


### PR DESCRIPTION
This fixes memory leaks in various wgpu examples, as well as leaks on swapchain resize.

I have used `thunderdome` as my arena which is a simple, limited-unsafe, no-deps, implementation of a generational arena. It's on the newer end, but I've been seeing people use it successfully in the community, combined to the lack of unsafe, I think it should be perfectly stable for use here. 

Will rollup master after this passes review.