### PR TITLE
[0.6/dx12] Improve descriptor handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### backend-dx12-0.6.10 (24-10-2020)
+  - actually free descriptor sets
+  - work around descriptor update issue on WARP
+
 ### backend-dx11-0.6.8 (23-10-2020)
   - fix buffer leak when `Memory` was reused
   - fix image leaks

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.6.9"
+version = "0.6.10"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2913,8 +2913,8 @@ impl d::Device<B> for Device {
         J: IntoIterator,
         J::Item: Borrow<pso::Descriptor<'a, B>>,
     {
-        let mut descriptor_update_pools = self.descriptor_update_pools.lock().unwrap();
-        let mut update_pool_index = 0;
+        let mut descriptor_updater = self.descriptor_updater.lock().unwrap();
+        descriptor_updater.reset();
 
         //TODO: combine destination ranges
         let mut dst_samplers = Vec::new();
@@ -2959,15 +2959,6 @@ impl d::Device<B> for Device {
                                 buffer_address + sub.offset;
                         } else {
                             // Descriptor table
-                            if update_pool_index == descriptor_update_pools.len() {
-                                let max_size = 1u64 << 12; //arbitrary
-                                descriptor_update_pools.push(descriptors_cpu::HeapLinear::new(
-                                    self.raw,
-                                    native::DescriptorHeapType::CbvSrvUav,
-                                    max_size as _,
-                                ));
-                            }
-                            let mut heap = descriptor_update_pools.pop().unwrap();
                             let size = sub.size_to(buffer.requirements.size);
 
                             if bind_info.content.contains(r::DescriptorContent::CBV) {
@@ -2983,7 +2974,7 @@ impl d::Device<B> for Device {
                                         + sub.offset,
                                     SizeInBytes: (size as u32 + mask) as u32 & !mask,
                                 };
-                                let handle = heap.alloc_handle();
+                                let handle = descriptor_updater.alloc_handle(self.raw);
                                 self.raw.CreateConstantBufferView(&desc, handle);
                                 src_cbv = Some(handle);
                             }
@@ -3001,7 +2992,7 @@ impl d::Device<B> for Device {
                                     StructureByteStride: 0,
                                     Flags: d3d12::D3D12_BUFFER_SRV_FLAG_RAW,
                                 };
-                                let handle = heap.alloc_handle();
+                                let handle = descriptor_updater.alloc_handle(self.raw);
                                 self.raw.CreateShaderResourceView(
                                     buffer.resource.as_mut_ptr(),
                                     &desc,
@@ -3023,21 +3014,7 @@ impl d::Device<B> for Device {
                                     CounterOffsetInBytes: 0,
                                     Flags: d3d12::D3D12_BUFFER_UAV_FLAG_RAW,
                                 };
-                                if heap.is_full() {
-                                    // pool is full, move to the next one
-                                    update_pool_index += 1;
-                                    let max_size = 1u64 << 12; //arbitrary
-                                    let full_heap = mem::replace(
-                                        &mut heap,
-                                        descriptors_cpu::HeapLinear::new(
-                                            self.raw,
-                                            native::DescriptorHeapType::CbvSrvUav,
-                                            max_size as _,
-                                        ),
-                                    );
-                                    descriptor_update_pools.push(full_heap);
-                                }
-                                let handle = heap.alloc_handle();
+                                let handle = descriptor_updater.alloc_handle(self.raw);
                                 self.raw.CreateUnorderedAccessView(
                                     buffer.resource.as_mut_ptr(),
                                     ptr::null_mut(),
@@ -3046,13 +3023,6 @@ impl d::Device<B> for Device {
                                 );
                                 src_uav = Some(handle);
                             }
-
-                            // always leave this block of code prepared
-                            if heap.is_full() {
-                                // pool is full, move to the next one
-                                update_pool_index += 1;
-                            }
-                            descriptor_update_pools.push(heap);
                         }
                     }
                     pso::Descriptor::Image(image, _layout) => {
@@ -3139,11 +3109,6 @@ impl d::Device<B> for Device {
                 num_samplers.as_ptr(),
                 d3d12::D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,
             );
-        }
-
-        // reset the temporary CPU-size descriptor pools
-        for buffer_desc_pool in descriptor_update_pools.iter_mut() {
-            buffer_desc_pool.clear();
         }
     }
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3163,8 +3163,8 @@ impl d::Device<B> for Device {
             if let (Some(src_range), Some(dst_range)) =
                 (src_info.view_range.as_ref(), dst_info.view_range.as_ref())
             {
-                assert!(copy.src_array_offset + copy.count <= src_range.count as usize);
-                assert!(copy.dst_array_offset + copy.count <= dst_range.count as usize);
+                assert!(copy.src_array_offset + copy.count <= src_range.handle.size as usize);
+                assert!(copy.dst_array_offset + copy.count <= dst_range.handle.size as usize);
                 src_views.push(src_range.at(copy.src_array_offset as _));
                 dst_views.push(dst_range.at(copy.dst_array_offset as _));
                 num_views.push(copy.count as u32);
@@ -3174,11 +3174,11 @@ impl d::Device<B> for Device {
                 {
                     assert!(
                         src_info.count as usize + copy.src_array_offset + copy.count
-                            <= src_range.count as usize
+                            <= src_range.handle.size as usize
                     );
                     assert!(
                         dst_info.count as usize + copy.dst_array_offset + copy.count
-                            <= dst_range.count as usize
+                            <= dst_range.handle.size as usize
                     );
                     src_views.push(src_range.at(src_info.count + copy.src_array_offset as u64));
                     dst_views.push(dst_range.at(dst_info.count + copy.dst_array_offset as u64));
@@ -3189,8 +3189,8 @@ impl d::Device<B> for Device {
                 src_info.sampler_range.as_ref(),
                 dst_info.sampler_range.as_ref(),
             ) {
-                assert!(copy.src_array_offset + copy.count <= src_range.count as usize);
-                assert!(copy.dst_array_offset + copy.count <= dst_range.count as usize);
+                assert!(copy.src_array_offset + copy.count <= src_range.handle.size as usize);
+                assert!(copy.dst_array_offset + copy.count <= dst_range.handle.size as usize);
                 src_samplers.push(src_range.at(copy.src_array_offset as _));
                 dst_samplers.push(dst_range.at(copy.dst_array_offset as _));
                 num_samplers.push(copy.count as u32);

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2734,7 +2734,10 @@ impl d::Device<B> for Device {
                 None
             },
             handle_rtv: if image.usage.contains(image::Usage::COLOR_ATTACHMENT) {
-                r::RenderTargetHandle::Pool(self.view_image_as_render_target(&info).unwrap())
+                match self.view_image_as_render_target(&info) {
+                    Ok(handle) => r::RenderTargetHandle::Pool(handle),
+                    Err(_) => r::RenderTargetHandle::None,
+                }
             } else {
                 r::RenderTargetHandle::None
             },

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2168,7 +2168,8 @@ impl d::Device<B> for Device {
             // Constant buffer view sizes need to be aligned.
             // Coupled with the offset alignment we can enforce an aligned CBV size
             // on descriptor updates.
-            size = (size + 255) & !255;
+            let mask = d3d12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT as u64 - 1;
+            size = (size + mask) & !mask;
         }
         if usage.contains(buffer::Usage::TRANSFER_DST) {
             // minimum of 1 word for the clear UAV
@@ -2975,10 +2976,12 @@ impl d::Device<B> for Device {
                                 // alignment to 256 allows us to patch the size here.
                                 // We can always enforce the size to be aligned to 256 for
                                 // CBVs without going out-of-bounds.
+                                let mask =
+                                    d3d12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1;
                                 let desc = d3d12::D3D12_CONSTANT_BUFFER_VIEW_DESC {
                                     BufferLocation: (*buffer.resource).GetGPUVirtualAddress()
                                         + sub.offset,
-                                    SizeInBytes: ((size + 0xFF) & !0xFF) as _,
+                                    SizeInBytes: (size as u32 + mask) as u32 & !mask,
                                 };
                                 let handle = heap.alloc_handle();
                                 self.raw.CreateConstantBufferView(&desc, handle);

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1163,8 +1163,8 @@ impl hal::Instance<Backend> for Instance {
                     max_vertex_input_binding_stride: d3d12::D3D12_REQ_MULTI_ELEMENT_STRUCTURE_SIZE_IN_BYTES as _,
                     max_vertex_output_components: 16, // TODO
                     min_texel_buffer_offset_alignment: 1, // TODO
-                    min_uniform_buffer_offset_alignment: 256, // Required alignment for CBVs
-                    min_storage_buffer_offset_alignment: 1, // TODO
+                    min_uniform_buffer_offset_alignment: d3d12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT as _,
+                    min_storage_buffer_offset_alignment: 4, // TODO
                     framebuffer_color_sample_counts: sample_count_mask,
                     framebuffer_depth_sample_counts: sample_count_mask,
                     framebuffer_stencil_sample_counts: sample_count_mask,

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -541,6 +541,60 @@ impl Shared {
     }
 }
 
+struct DescriptorUpdater {
+    heaps: Vec<descriptors_cpu::HeapLinear>,
+    heap_index: usize,
+    reset_heap_index: usize,
+}
+
+impl DescriptorUpdater {
+    fn new(device: native::Device) -> Self {
+        DescriptorUpdater {
+            heaps: vec![Self::create_heap(device)],
+            heap_index: 0,
+            reset_heap_index: 0,
+        }
+    }
+
+    unsafe fn destroy(&mut self) {
+        for heap in self.heaps.drain(..) {
+            heap.destroy();
+        }
+    }
+
+    fn reset(&mut self) {
+        self.reset_heap_index = self.heap_index;
+        // Note: this could clear all the heaps, but WARP has an issue with that
+        if false {
+            for heap in self.heaps.iter_mut() {
+                heap.clear();
+            }
+        }
+    }
+
+    fn create_heap(device: native::Device) -> descriptors_cpu::HeapLinear {
+        let size = 1 << 12; //arbitrary
+        descriptors_cpu::HeapLinear::new(device, native::DescriptorHeapType::CbvSrvUav, size)
+    }
+
+    fn alloc_handle(&mut self, device: native::Device) -> native::CpuDescriptor {
+        if self.heaps[self.heap_index].is_full() {
+            self.heap_index += 1;
+            if self.heap_index == self.heaps.len() {
+                self.heap_index = 0;
+            }
+            if self.heap_index == self.reset_heap_index {
+                let heap = Self::create_heap(device);
+                self.heaps.insert(self.heap_index, heap);
+                self.reset_heap_index += 1;
+            } else {
+                self.heaps[self.heap_index].clear();
+            }
+        }
+        self.heaps[self.heap_index].alloc_handle()
+    }
+}
+
 pub struct Device {
     raw: native::Device,
     private_caps: Capabilities,
@@ -552,7 +606,7 @@ pub struct Device {
     dsv_pool: Mutex<DescriptorCpuPool>,
     srv_uav_pool: Mutex<DescriptorCpuPool>,
     sampler_pool: Mutex<DescriptorCpuPool>,
-    descriptor_update_pools: Mutex<Vec<descriptors_cpu::HeapLinear>>,
+    descriptor_updater: Mutex<DescriptorUpdater>,
     // CPU/GPU descriptor heaps
     heap_srv_cbv_uav: Mutex<resource::DescriptorHeap>,
     heap_sampler: Mutex<resource::DescriptorHeap>,
@@ -633,7 +687,7 @@ impl Device {
             dsv_pool: Mutex::new(dsv_pool),
             srv_uav_pool: Mutex::new(srv_uav_pool),
             sampler_pool: Mutex::new(sampler_pool),
-            descriptor_update_pools: Mutex::new(Vec::new()),
+            descriptor_updater: Mutex::new(DescriptorUpdater::new(device)),
             heap_srv_cbv_uav: Mutex::new(heap_srv_cbv_uav),
             heap_sampler: Mutex::new(heap_sampler),
             events: Mutex::new(Vec::new()),
@@ -673,9 +727,7 @@ impl Drop for Device {
             self.srv_uav_pool.lock().unwrap().destroy();
             self.sampler_pool.lock().unwrap().destroy();
 
-            for pool in &*self.descriptor_update_pools.lock().unwrap() {
-                pool.destroy();
-            }
+            self.descriptor_updater.lock().unwrap().destroy();
 
             // Debug tracking alive objects
             let (debug_device, hr_debug) = self.raw.cast::<d3d12sdklayers::ID3D12DebugDevice>();


### PR DESCRIPTION
Can be reviewed commit-by-commit. Actually gets us to release the descriptors.
It also fixes a mistake I made in one of the previous PRs that would panic in view creation, unnecessarily.

Also works around https://github.com/gfx-rs/wgpu/issues/1002 in the following way:
  - we rotate the temporary descriptor heaps instead of resetting them every time
  - once we reach the head during rotation, we insert a new heap in

That is not a guarantee that we'll never hit this WARP issue again, but there is a high chance most apps will not notice. If there is a better workaround, I'll be happy to scrap this one.

I think the old logic was plain wrong, too: the `update_pool_index ` wasn't actually being used...