### PR TITLE
[dx12] fix command list reuse

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -474,20 +474,13 @@ impl q::CommandQueue<Backend> for CommandQueue {
         synchapi::ResetEvent(self.idle_event.0);
 
         // TODO: semaphores
-        let command_buffers = submission
+        let lists = submission
             .command_buffers
             .into_iter()
-            .map(|buf| buf.borrow())
-            .collect::<SmallVec<[_; 4]>>();
-        let lists = command_buffers
-            .iter()
-            .map(|buf| buf.as_raw_list())
+            .map(|cmd_buf| cmd_buf.borrow().as_raw_list())
             .collect::<SmallVec<[_; 4]>>();
         self.raw
             .ExecuteCommandLists(lists.len() as _, lists.as_ptr());
-        for command_buffer in command_buffers {
-            command_buffer.after_submit();
-        }
 
         if let Some(fence) = fence {
             assert_eq!(winerror::S_OK, self.raw.Signal(fence.raw.as_mut_ptr(), 1));


### PR DESCRIPTION
Fixes #3439
We used to instantly return a command list into the pool upon submit() if we knew it's a one-time submit.
However, it could happen that the user would get that command list, record it, and submit before the last one has finished.
As indicated in the issue, this can't be allowed.

So this PR makes it so we keep a hold of the command list until the reset() time.