### PR TITLE
[0.6/dx11] Fix UAV bindings 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### backend-dx11-0.6.10 (26-10-2020)
+  - fix dynamic offsets in compute shaders with command list emulation
+  - fix creation of multisampled depth-stencil views
+  - fix binding of read/write storage buffers/images when rendering to a output attachment
+
 ### backend-metal-0.6.4, backend-dx12-0.6.11, backend-dx11-0.6.9 (26-10-2020)
   - fix entry point selection to choose the correct entry point (instead of a default) when multiple entry points exist
 

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.6.9"
+version = "0.6.10"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1873,7 +1873,18 @@ impl device::Device<Backend> for Device {
 
         for binding in bindings.iter() {
             let content = DescriptorContent::from(binding.ty);
-            total.add_content_many(content, binding.stage_flags, binding.count as _);
+            // If this binding is used by the graphics pipeline and is a UAV, it belongs to the "Output Merger"
+            // stage, so we only put them in the fragment stage to save redundant descriptor allocations.
+            let stage_flags =
+                if content.contains(DescriptorContent::UAV)
+                    && binding.stage_flags.intersects(pso::ShaderStageFlags::ALL - pso::ShaderStageFlags::COMPUTE) {
+                let mut stage_flags = pso::ShaderStageFlags::FRAGMENT;
+                stage_flags.set(pso::ShaderStageFlags::COMPUTE, binding.stage_flags.contains(pso::ShaderStageFlags::COMPUTE));
+                stage_flags
+            } else {
+                binding.stage_flags
+            };
+            total.add_content_many(content, stage_flags, binding.count as _);
         }
 
         bindings.sort_by_key(|a| a.binding);
@@ -1995,10 +2006,20 @@ impl device::Device<Backend> for Device {
                         .assign_stages(&offsets, binding.stage_flags, handles.t);
                 };
                 if content.contains(DescriptorContent::UAV) {
+                    // If this binding is used by the graphics pipeline and is a UAV, it belongs to the "Output Merger"
+                    // stage, so we only put them in the fragment stage to save redundant descriptor allocations.
+                    let stage_flags = if binding.stage_flags.intersects(pso::ShaderStageFlags::ALL - pso::ShaderStageFlags::COMPUTE) {
+                        let mut stage_flags = pso::ShaderStageFlags::FRAGMENT;
+                        stage_flags.set(pso::ShaderStageFlags::COMPUTE, binding.stage_flags.contains(pso::ShaderStageFlags::COMPUTE));
+                        stage_flags
+                    } else {
+                        binding.stage_flags
+                    };
+
                     let offsets = mapping.map_other(|map| map.u);
                     write
                         .set
-                        .assign_stages(&offsets, binding.stage_flags, handles.u);
+                        .assign_stages(&offsets, stage_flags, handles.u);
                 };
                 if content.contains(DescriptorContent::SAMPLER) {
                     let offsets = mapping.map_other(|map| map.s);

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1211,7 +1211,7 @@ impl RenderPassCache {
 
 bitflags! {
     struct DirtyStateFlag : u32 {
-        const RENDER_TARGETS = (1 << 1);
+        const RENDER_TARGETS_AND_UAVS = (1 << 1);
         const VERTEX_BUFFERS = (1 << 2);
         const GRAPHICS_PIPELINE = (1 << 3);
         const PIPELINE_GS = (1 << 4);
@@ -1228,6 +1228,8 @@ pub struct CommandBufferState {
 
     render_target_len: u32,
     render_targets: [*mut d3d11::ID3D11RenderTargetView; 8],
+    uav_len: u32,
+    uavs: [*mut d3d11::ID3D11UnorderedAccessView; d3d11::D3D11_PS_CS_UAV_REGISTER_COUNT as _],
     depth_target: Option<*mut d3d11::ID3D11DepthStencilView>,
     readonly_depth_target: Option<*mut d3d11::ID3D11DepthStencilView>,
     depth_target_read_only: bool,
@@ -1265,6 +1267,8 @@ impl CommandBufferState {
             dirty_flag: DirtyStateFlag::empty(),
             render_target_len: 0,
             render_targets: [ptr::null_mut(); 8],
+            uav_len: 0,
+            uavs: [ptr::null_mut(); 8],
             depth_target: None,
             readonly_depth_target: None,
             depth_target_read_only: false,
@@ -1286,6 +1290,7 @@ impl CommandBufferState {
 
     fn clear(&mut self) {
         self.render_target_len = 0;
+        self.uav_len = 0;
         self.depth_target = None;
         self.readonly_depth_target = None;
         self.depth_target_read_only = false;
@@ -1324,6 +1329,10 @@ impl CommandBufferState {
     }
 
     pub fn bind_vertex_buffers(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
+        if !self.dirty_flag.contains(DirtyStateFlag::VERTEX_BUFFERS) {
+            return;
+        }
+
         if let Some(binding_count) = self.max_bindings {
             if self.vertex_buffers.len() >= binding_count as usize
                 && self.vertex_strides.len() >= binding_count as usize
@@ -1351,6 +1360,10 @@ impl CommandBufferState {
     }
 
     pub fn bind_viewports(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
+        if !self.dirty_flag.contains(DirtyStateFlag::VIEWPORTS) {
+            return;
+        }
+
         if let Some(ref pipeline) = self.graphics_pipeline {
             if let Some(ref viewport) = pipeline.baked_states.viewport {
                 unsafe {
@@ -1384,25 +1397,43 @@ impl CommandBufferState {
         self.depth_target = depth_target;
         self.readonly_depth_target = readonly_depth_target;
 
-        self.dirty_flag.insert(DirtyStateFlag::RENDER_TARGETS);
+        self.dirty_flag.insert(DirtyStateFlag::RENDER_TARGETS_AND_UAVS);
     }
 
     pub fn bind_render_targets(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
+        if !self.dirty_flag.contains(DirtyStateFlag::RENDER_TARGETS_AND_UAVS) {
+            return;
+        }
+
         let depth_target = if self.depth_target_read_only {
             self.readonly_depth_target
         } else {
             self.depth_target
         }.unwrap_or(ptr::null_mut());
 
+        let uav_start_index = d3d11::D3D11_PS_CS_UAV_REGISTER_COUNT - self.uav_len;
+
         unsafe {
-            context.OMSetRenderTargets(
-                self.render_target_len,
-                self.render_targets.as_ptr(),
-                depth_target,
-            );
+            if self.uav_len > 0 {
+                context.OMSetRenderTargetsAndUnorderedAccessViews(
+                    self.render_target_len,
+                    self.render_targets.as_ptr(),
+                    depth_target,
+                    uav_start_index,
+                    self.uav_len,
+                    &self.uavs[uav_start_index as usize] as *const *mut _,
+                    ptr::null(),
+                )
+            } else {
+                context.OMSetRenderTargets(
+                    self.render_target_len,
+                    self.render_targets.as_ptr(),
+                    depth_target,
+                )
+            };
         }
 
-        self.dirty_flag.remove(DirtyStateFlag::RENDER_TARGETS);
+        self.dirty_flag.remove(DirtyStateFlag::RENDER_TARGETS_AND_UAVS);
     }
 
     pub fn set_blend_factor(&mut self, factor: [f32; 4]) {
@@ -1468,7 +1499,7 @@ impl CommandBufferState {
 
         if self.depth_target_read_only != depth_target_read_only {
             self.depth_target_read_only = depth_target_read_only;
-            self.dirty_flag.insert(DirtyStateFlag::RENDER_TARGETS);
+            self.dirty_flag.insert(DirtyStateFlag::RENDER_TARGETS_AND_UAVS);
         }
 
         self.dirty_flag.insert(DirtyStateFlag::GRAPHICS_PIPELINE);
@@ -1477,6 +1508,10 @@ impl CommandBufferState {
     }
 
     pub fn bind_graphics_pipeline(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
+        if !self.dirty_flag.contains(DirtyStateFlag::GRAPHICS_PIPELINE) {
+            return;
+        }
+
         if let Some(ref pipeline) = self.graphics_pipeline {
             self.vertex_strides.clear();
             self.vertex_strides.extend(&pipeline.strides);
@@ -1545,21 +1580,10 @@ impl CommandBufferState {
     }
 
     pub fn bind(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
-        if self.dirty_flag.contains(DirtyStateFlag::RENDER_TARGETS) {
-            self.bind_render_targets(context);
-        }
-
-        if self.dirty_flag.contains(DirtyStateFlag::GRAPHICS_PIPELINE) {
-            self.bind_graphics_pipeline(context);
-        }
-
-        if self.dirty_flag.contains(DirtyStateFlag::VERTEX_BUFFERS) {
-            self.bind_vertex_buffers(context);
-        }
-
-        if self.dirty_flag.contains(DirtyStateFlag::VIEWPORTS) {
-            self.bind_viewports(context);
-        }
+        self.bind_render_targets(context);
+        self.bind_graphics_pipeline(context);
+        self.bind_vertex_buffers(context);
+        self.bind_viewports(context);
     }
 }
 
@@ -2032,7 +2056,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
                 DirtyStateFlag::GRAPHICS_PIPELINE
                     | DirtyStateFlag::PIPELINE_PS
                     | DirtyStateFlag::VIEWPORTS
-                    | DirtyStateFlag::RENDER_TARGETS,
+                    | DirtyStateFlag::RENDER_TARGETS_AND_UAVS,
             );
             self.internal
                 .clear_attachments(&self.context, clears, rects, pass);
@@ -2336,7 +2360,22 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
                     set.handles.offset(rd.pool_offset as isize) as *const *mut _,
                 );
             }
+
+            // UAVs going to the graphics pipeline are always treated as pixel shader bindings.
+            if let Some(rd) = info.registers.ps.u.as_some() {
+            	// We bind UAVs in inverse order from the top to prevent invalidation
+            	// when the render target count changes.
+                for idx in (0..(rd.count)).rev() {
+                    let ptr = (*set.handles.offset(rd.pool_offset as isize + idx as isize)).0;
+                    let uav_register = d3d11::D3D11_PS_CS_UAV_REGISTER_COUNT - 1 - rd.res_index as u32 - idx as u32;
+                    self.cache.uavs[uav_register as usize] = ptr as *mut _;
+                }
+                self.cache.uav_len = (rd.res_index + rd.count) as u32;
+                self.cache.dirty_flag.insert(DirtyStateFlag::RENDER_TARGETS_AND_UAVS);
+            }
         }
+
+        self.cache.bind_render_targets(&self.context);
     }
 
     unsafe fn bind_compute_pipeline(&mut self, pipeline: &ComputePipeline) {
@@ -3642,7 +3681,7 @@ impl CoherentBuffers {
 
 /// Newtype around a common interface that all bindable resources inherit from.
 #[derive(Debug, Copy, Clone)]
-#[repr(C)]
+#[repr(transparent)]
 struct Descriptor(*mut d3d11::ID3D11DeviceChild);
 
 bitflags! {
@@ -3676,13 +3715,10 @@ impl From<pso::DescriptorType> for DescriptorContent {
                     with_sampler: false,
                 },
             }
-            | Dt::Image {
-                ty: Idt::Storage { read_only: true },
-            }
             | Dt::InputAttachment => DescriptorContent::SRV,
             Dt::Image {
-                ty: Idt::Storage { read_only: false },
-            } => DescriptorContent::SRV | DescriptorContent::UAV,
+                ty: Idt::Storage { .. },
+            } => DescriptorContent::UAV,
             Dt::Buffer {
                 ty: Bdt::Uniform,
                 format:
@@ -3706,7 +3742,7 @@ impl From<pso::DescriptorType> for DescriptorContent {
                     Bdf::Structured {
                         dynamic_offset: true,
                     },
-            } => DescriptorContent::SRV | DescriptorContent::UAV | DescriptorContent::DYNAMIC,
+            } => DescriptorContent::UAV | DescriptorContent::DYNAMIC,
             Dt::Buffer {
                 ty: Bdt::Storage { read_only: true },
                 ..
@@ -3714,7 +3750,7 @@ impl From<pso::DescriptorType> for DescriptorContent {
             Dt::Buffer {
                 ty: Bdt::Storage { read_only: false },
                 ..
-            } => DescriptorContent::SRV | DescriptorContent::UAV,
+            } => DescriptorContent::UAV,
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/wgpu/issues/997 and assorted issues discovered when fixing that.

This PR should be reviewed commit by commit and each commit is freestanding.

A note about the general arch of the UAV changes. This moves us more towards a "lazy state changes" model. ~~While vulkan discorages this, the DX11 driver is likely doing this anyway. We currently do a lot of redundant state changes (and the calculations to figure them out) due to the differences in binding model, so moving lazy should help eliminate this. More major changes are out of scope of this PR.~~ Discussed on matrix pros/cons of this approach, and this part is no longer relevant.

I will actually PR master after this PR this time ;)