### PR TITLE
[mtl] experimental Naga support

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -40,6 +40,13 @@ storage-map = "0.3"
 lazy_static = "1"
 raw-window-handle = "0.3"
 
+[dependencies.naga]
+#path = "../../../../naga"
+git = "https://github.com/gfx-rs/naga"
+rev = "587dc01a2cc43fdf4637f1bf6d2b75b703e9f681"
+features = ["spv-in", "msl-out"]
+optional = true
+
 # This forces docs.rs to build the crate on mac, otherwise the build fails
 # and we get no docs at all.
 [package.metadata.docs.rs]

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -32,26 +32,17 @@ pub type EntryPointMap = FastHashMap<String, spirv::EntryPoint>;
 /// An index of a resource within descriptor pool.
 pub type PoolResourceIndex = u32;
 
-/// Shader module can be compiled in advance if it's resource bindings do not
-/// depend on pipeline layout, in which case the value would become `Compiled`.
-pub enum ShaderModule {
-    Compiled(ModuleInfo),
-    Raw(Vec<u32>),
+pub struct ShaderModule {
+    pub(crate) spv: Vec<u32>,
+    #[cfg(feature = "naga")]
+    pub(crate) naga: Option<naga::Module>,
 }
 
 impl fmt::Debug for ShaderModule {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ShaderModule::Compiled(_) => write!(formatter, "ShaderModule::Compiled(..)"),
-            ShaderModule::Raw(ref vec) => {
-                write!(formatter, "ShaderModule::Raw(length = {})", vec.len())
-            }
-        }
+        write!(formatter, "ShaderModule(words = {})", self.spv.len())
     }
 }
-
-unsafe impl Send for ShaderModule {}
-unsafe impl Sync for ShaderModule {}
 
 bitflags! {
     /// Subpass attachment operations.
@@ -196,6 +187,8 @@ pub struct PushConstantInfo {
 pub struct PipelineLayout {
     pub(crate) shader_compiler_options: msl::CompilerOptions,
     pub(crate) shader_compiler_options_point: msl::CompilerOptions,
+    #[cfg(feature = "naga")]
+    pub(crate) naga_options: naga::back::msl::Options,
     pub(crate) infos: Vec<DescriptorSetInfo>,
     pub(crate) total: MultiStageResourceCounters,
     pub(crate) push_constants: MultiStageData<Option<PushConstantInfo>>,


### PR DESCRIPTION
First humble steps towards #71 ...

Naga is an optional github dependency (obviously will need to be switched to crates upon release).
If it fails, we fall back to spirv-cross. Extra steps are taking to ensure that shader modules compiled by Naga and SPIRV-Cross can still link together.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Metal
