### PR TITLE
dx12: fix entry point selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### backend-dx12-unreleased
   - fix matrix vertex inputs
+  - fix SPIR-V entry point selection
 
 ### backend-dx11-unreleased
   - fix matrix vertex inputs


### PR DESCRIPTION
SPIRV-Cross translates the selected entrypoint to `main` always.
`.find(|entry_point| entry_point.name == real_name)` will fail for non-`main` entrypoints of the source spirv module. Actually we don't need to query for all the entry points as we already selected the one we want.

Tested it by modfiying one of the spirv modules in the quad examples.

PR checklist:
- [x] tested examples with the following backends:
