### PR TITLE
[0.6/dx] Assorted Fixes to Make BVE-Reborn Work Under DX11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 ### backend-dx12-unreleased
   - fix matrix vertex inputs
 
-### backend-dx11-unreleased
+### backend-dx11-0.6.12 (30-10-2020)
   - fix matrix vertex inputs
+  - fix `readonly` buffers in shaders with read/write bindings
+  - fix `Immediate` presentation mode
+  - stop exposing `Mailbox` presentation mode
+  - fix `surface in use` error on swapchain recreation
+  - allow creation of multisampled SRVs
 
 ### backend-dx11-0.6.11 (27-10-2020)
   - implement push constants

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.6.11"
+version = "0.6.12"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1792,7 +1792,7 @@ impl device::Device<Backend> for Device {
                     set_debug_name_with_suffix(&srv, name, " -- SRV");
                 }
 
-                Some(srv)
+                Some(srv.into_raw())
             } else {
                 None
             },
@@ -1803,7 +1803,7 @@ impl device::Device<Backend> for Device {
                     set_debug_name_with_suffix(&rtv, name, " -- RTV");
                 }
 
-                Some(rtv)
+                Some(rtv.into_raw())
             } else {
                 None
             },
@@ -1814,7 +1814,7 @@ impl device::Device<Backend> for Device {
                     set_debug_name_with_suffix(&uav, name, " -- UAV");
                 }
 
-                Some(uav)
+                Some(uav.into_raw())
             } else {
                 None
             },
@@ -1825,7 +1825,7 @@ impl device::Device<Backend> for Device {
                     set_debug_name_with_suffix(&dsv, name, " -- DSV");
                 }
 
-                Some(dsv)
+                Some(dsv.into_raw())
             } else {
                 None
             },
@@ -1837,10 +1837,11 @@ impl device::Device<Backend> for Device {
                     set_debug_name_with_suffix(&rodsv, name, " -- DSV");
                 }
 
-                Some(rodsv)
+                Some(rodsv.into_raw())
             } else {
                 None
             },
+            owned: true,
         })
     }
 
@@ -2015,12 +2016,10 @@ impl device::Device<Backend> for Device {
                         c: ptr::null_mut(),
                         t: image
                             .srv_handle
-                            .clone()
-                            .map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                            .map_or(ptr::null_mut(), |h| h as *mut _),
                         u: image
                             .uav_handle
-                            .clone()
-                            .map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                            .map_or(ptr::null_mut(), |h| h as *mut _),
                         s: ptr::null_mut(),
                     },
                     pso::Descriptor::Sampler(sampler) => RegisterData {
@@ -2034,12 +2033,10 @@ impl device::Device<Backend> for Device {
                             c: ptr::null_mut(),
                             t: image
                                 .srv_handle
-                                .clone()
-                                .map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                                .map_or(ptr::null_mut(), |h| h as *mut _),
                             u: image
                                 .uav_handle
-                                .clone()
-                                .map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                                .map_or(ptr::null_mut(), |h| h as *mut _),
                             s: sampler.sampler_handle.as_raw() as *mut _,
                         }
                     }

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -456,11 +456,24 @@ impl Device {
                     ArraySize,
                 }
             }
+            image::ViewKind::D2 if info.kind.num_samples() > 1 => {
+                desc.ViewDimension = d3dcommon::D3D11_SRV_DIMENSION_TEXTURE2DMS;
+                *unsafe { desc.u.Texture2DMS_mut() } = d3d11::D3D11_TEX2DMS_SRV {
+                    UnusedField_NothingToDefine: 0,
+                }
+            }
             image::ViewKind::D2 => {
                 desc.ViewDimension = d3dcommon::D3D11_SRV_DIMENSION_TEXTURE2D;
                 *unsafe { desc.u.Texture2D_mut() } = d3d11::D3D11_TEX2D_SRV {
                     MostDetailedMip,
                     MipLevels,
+                }
+            }
+            image::ViewKind::D2Array if info.kind.num_samples() > 1 => {
+                desc.ViewDimension = d3dcommon::D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY;
+                *unsafe { desc.u.Texture2DMSArray_mut() } = d3d11::D3D11_TEX2DMS_ARRAY_SRV {
+                    FirstArraySlice,
+                    ArraySize,
                 }
             }
             image::ViewKind::D2Array => {

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -185,13 +185,13 @@ impl Device {
 
         // See [`shader::introspect_spirv_vertex_semantic_remapping`] for details of why this is needed.
         let semantics: Vec<_> = attributes.iter().map(|attrib| {
-            match vertex_semantic_remapping.get(&attrib.location).unwrap() {
-                Some((major, minor)) => {
+            match vertex_semantic_remapping.get(&attrib.location) {
+                Some(Some((major, minor))) => {
                     let name = std::borrow::Cow::Owned(format!("TEXCOORD{}_\0", major));
                     let location = *minor;
                     (name, location)
                 }
-                None => {
+                _ => {
                     let name = std::borrow::Cow::Borrowed("TEXCOORD\0");
                     let location = attrib.location;
                     (name, location)

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -776,11 +776,7 @@ impl Device {
             Windowed: TRUE,
             // TODO:
             SwapEffect: dxgi::DXGI_SWAP_EFFECT_DISCARD,
-            Flags: if config.present_mode == window::PresentMode::IMMEDIATE {
-                dxgi::DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING
-            } else {
-                0
-            },
+            Flags: 0,
         };
 
         let dxgi_swapchain = {

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -1176,7 +1176,7 @@ impl Internal {
                     unsafe {
                         context.OMSetRenderTargets(
                             1,
-                            [attachment.rtv_handle.clone().unwrap().as_raw()].as_ptr(),
+                            [attachment.rtv_handle.unwrap()].as_ptr(),
                             ptr::null_mut(),
                         );
                     }
@@ -1265,7 +1265,7 @@ impl Internal {
                         context.OMSetRenderTargets(
                             0,
                             ptr::null_mut(),
-                            attachment.dsv_handle.clone().unwrap().as_raw(),
+                            attachment.dsv_handle.unwrap(),
                         );
                         context.PSSetShader(
                             self.ps_partial_clear_depth.as_raw(),

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 use winapi::{shared::{
-    dxgi::{IDXGIAdapter, IDXGIFactory, IDXGISwapChain, DXGI_PRESENT_ALLOW_TEARING},
+    dxgi::{IDXGIAdapter, IDXGIFactory, IDXGISwapChain},
     dxgiformat,
     minwindef::{FALSE, HMODULE, UINT},
     windef::{HWND, RECT},
@@ -877,7 +877,6 @@ impl window::Surface<Backend> for Surface {
         // TODO: _DISCARD swap effects can only have one image?
         window::SurfaceCapabilities {
             present_modes: window::PresentMode::IMMEDIATE
-                | window::PresentMode::MAILBOX
                 | window::PresentMode::FIFO,
             composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
             image_count: 1..=16,                                       // TODO:
@@ -1088,10 +1087,10 @@ impl queue::CommandQueue<Backend> for CommandQueue {
     ) -> Result<Option<window::Suboptimal>, window::PresentError> {
         let mut presentation = surface.presentation.as_mut().unwrap();
         let (interval, flags) = match presentation.mode {
-            window::PresentMode::IMMEDIATE => (0, DXGI_PRESENT_ALLOW_TEARING),
+            window::PresentMode::IMMEDIATE => (0, 0),
             //Note: this ends up not presenting anything for some reason
             //window::PresentMode::MAILBOX if !presentation.is_init => (1, DXGI_PRESENT_DO_NOT_SEQUENCE),
-            window::PresentMode::MAILBOX | window::PresentMode::FIFO => (1, 0),
+            window::PresentMode::FIFO => (1, 0),
             _ => (0, 0),
         };
         presentation.is_init = false;

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1943,17 +1943,15 @@ impl d::Device<B> for Device {
             let semantics = vertex_semantic_remapping
                 .as_ref()
                 .and_then(|map| {
-                    *map
-                        .get(&attrib.location)
-                        .unwrap()
+                    map.get(&attrib.location)
                 });
             match semantics {
-                Some((major, minor)) => {
+                Some(Some((major, minor))) => {
                     let name = std::borrow::Cow::Owned(format!("TEXCOORD{}_\0", major));
-                    let location = minor;
+                    let location = *minor;
                     (name, location)
                 }
-                None => {
+                _ => {
                     let name = std::borrow::Cow::Borrowed("TEXCOORD\0");
                     let location = attrib.location;
                     (name, location)


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/wgpu/issues/1005

PR is commit by commit etc.

Notes:
 - I have disabled `MAILBOX` right now as it was acting like FIFO. Until we can figure out a way to make it work without limiting frame rate, we can re-enable.
 - An extension of the swapchain changes will be enabling the FLIP modes on windows 8 or newer. This will also allow us to bring back ALLOW_TEARING.
 - The spirv-cross workaround had a bug where there is a panic while there were more vertex attributes than inputs to the shader.
 - I have included changes that reduce the amount of clones we make to `ImageView`s where we didn't actually need them.
 - I have chosen this method of doing borrowed image views (forgetting smart pointers) as removing the smart pointers will make a lot of code more complicated (due to helpers like `clone`, `cast`, direct method calls, etc) than raw pointers. I am not inherently opposed to switching to raw pointers, but thought this was the easier solution.

Have a couple DX12 bugs to attend to following this, so not bumping version on that yet.