### PR TITLE
[0.6/dx11] Fix depth to depth copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   - fix matrix vertex inputs
   - fix SPIR-V entry point selection
   - fix heap selection for non-renderable textures
+  
+### backend-dx11-0.6.13 (31-10-2020)
+  - fix depth-stencil to depth-stencil copies
 
 ### backend-dx11-0.6.12 (30-10-2020)
   - fix matrix vertex inputs

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.6.12"
+version = "0.6.13"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"


### PR DESCRIPTION
This fixes depth-stencil copies on DX11. It also adds some asserts so unsupported copies properly blows up instead of silently dropping calls. This will also tell us when we may need to add some extra compute copies for things that can be copied between in vk but not DX11.