### PR TITLE
[0.6/dx11] Assorted Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   - fix SPIR-V entry point selection
   - fix heap selection for non-renderable textures
   
+### backend-dx11-0.6.14 (01-11-2020)
+  - Fix push constants with non-zero offsets
+  - Fix UAVs in non-fragment shaders
+  
 ### backend-dx11-0.6.13 (31-10-2020)
   - fix depth-stencil to depth-stencil copies
 

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.6.13"
+version = "0.6.14"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2858,7 +2858,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         offset: u32,
         constants: &[u32],
     ) {
-        let start = offset as usize;
+        let start = (offset / 4) as usize;
         let end = start + constants.len();
 
         self.push_constant_data[start..end].copy_from_slice(constants);
@@ -2879,7 +2879,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         offset: u32,
         constants: &[u32],
     ) {
-        let start = offset as usize;
+        let start = (offset / 4) as usize;
         let end = start + constants.len();
 
         self.push_constant_data[start..end].copy_from_slice(constants);

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -3748,6 +3748,36 @@ impl DescriptorSetInfo {
         }
         panic!("Unable to find binding {:?}", binding_index);
     }
+
+    fn find_uav_register(
+        &self,
+        stage: ShaderStage,
+        binding_index: pso::DescriptorBinding,
+    ) -> (DescriptorContent, RegisterData<ResourceIndex>) {
+        // Look only where uavs are stored for that stage.
+        let register_stage = if stage == ShaderStage::Compute {
+            stage
+        } else {
+            ShaderStage::Fragment
+        };
+
+        let mut res_offsets = self
+            .registers
+            .map_register(|info| info.res_index as DescriptorIndex)
+            .select(register_stage);
+        for binding in self.bindings.iter() {
+            // We don't care what stage they're in, only if they are UAVs or not.
+            let content = DescriptorContent::from(binding.ty);
+            if !content.contains(DescriptorContent::UAV) {
+                continue;
+            }
+            if binding.binding == binding_index {
+                return (content, res_offsets.map(|offset| *offset as ResourceIndex));
+            }
+            res_offsets.add_content_many(content, 1);
+        }
+        panic!("Unable to find binding {:?}", binding_index);
+    }
 }
 
 /// The pipeline layout holds optimized (less api calls) ranges of objects for all descriptor sets


### PR DESCRIPTION
These are fixes exposed by a user's project.

Fixes:
 - Treat push constant offset as bytes not words
 - Properly find register numbers for UAVs in non-fragment shaders.