### PR TITLE
[0.6/dx11] Fix buffer to image copies of textures of <4 bytes/pixel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
   - fix SPIR-V entry point selection
   - fix heap selection for non-renderable textures
   
+### backend-dx11-0.6.15 (01-11-2020)
+  - fix buffer copy pitch alignment
+  - fix buffer to image copies writing garbage when not properly aligned
+  
 ### backend-dx11-0.6.14 (01-11-2020)
-  - Fix push constants with non-zero offsets
-  - Fix UAVs in non-fragment shaders
+  - fix push constants with non-zero offsets
+  - fix UAVs in non-fragment shaders
   
 ### backend-dx11-0.6.13 (31-10-2020)
   - fix depth-stencil to depth-stencil copies

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.6.14"
+version = "0.6.15"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/shaders/copy.hlsl
+++ b/src/backend/dx11/shaders/copy.hlsl
@@ -456,8 +456,14 @@ void cs_copy_buffer_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThreadID) 
     uint src_idx = GetBufferSrc16(dispatch_thread_id);
     uint2 data = Uint32ToUint16x2(BufferCopySrc.Load(src_idx));
 
-    Image2CopyDstR[dst_idx                 ] = data.x;
-    Image2CopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
+    uint remaining_x = bounds.x - dst_idx.x;
+
+    if (remaining_x >= 2) {
+        Image2CopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
+    } 
+    if (remaining_x >= 1) {
+        Image2CopyDstR[dst_idx + uint3(0, 0, 0)] = data.x;
+    }
 }
 
 [numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
@@ -489,9 +495,16 @@ void cs_copy_buffer_image1d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID)
 
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    Image1CopyDstRg[dst_idx.xz + uint2(0, 0)] = data.xy;
-    Image1CopyDstRg[dst_idx.xz + uint2(1, 0)] = data.zw;
+    uint remaining_x = bounds.x - dst_idx.x;
+
+    if (remaining_x >= 2) {
+        Image1CopyDstRg[dst_idx.xz + uint2(1, 0)] = data.zw;
+    } 
+    if (remaining_x >= 1) {
+        Image1CopyDstRg[dst_idx.xz + uint2(0, 0)] = data.xy;
+    }
 }
+
 [numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
@@ -504,8 +517,14 @@ void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID)
 
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    Image2CopyDstRg[dst_idx + uint3(0, 0, 0)] = data.xy;
-    Image2CopyDstRg[dst_idx + uint3(1, 0, 0)] = data.zw;
+    uint remaining_x = bounds.x - dst_idx.x;
+
+    if (remaining_x >= 2) {
+        Image2CopyDstRg[dst_idx + uint3(1, 0, 0)] = data.zw;
+    } 
+    if (remaining_x >= 1) {
+        Image2CopyDstRg[dst_idx + uint3(0, 0, 0)] = data.xy;
+    }
 }
 
 [numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
@@ -536,10 +555,20 @@ void cs_copy_buffer_image1d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint src_idx = GetBufferSrc8(dispatch_thread_id);
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    Image1CopyDstR[dst_idx.xz + uint2(0, 0)] = data.x;
-    Image1CopyDstR[dst_idx.xz + uint2(1, 0)] = data.y;
-    Image1CopyDstR[dst_idx.xz + uint2(2, 0)] = data.z;
-    Image1CopyDstR[dst_idx.xz + uint2(3, 0)] = data.w;
+    uint remaining_x = bounds.x - dst_idx.x;
+
+    if (remaining_x >= 4) {
+        Image1CopyDstR[dst_idx.xz + uint2(3, 0)] = data.w;
+    } 
+    if (remaining_x >= 3) {
+        Image1CopyDstR[dst_idx.xz + uint2(2, 0)] = data.z;
+    } 
+    if (remaining_x >= 2) {
+        Image1CopyDstR[dst_idx.xz + uint2(1, 0)] = data.y;
+    } 
+    if (remaining_x >= 1) {
+        Image1CopyDstR[dst_idx.xz + uint2(0, 0)] = data.x;
+    }
 }
 [numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
@@ -552,10 +581,20 @@ void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint src_idx = GetBufferSrc8(dispatch_thread_id);
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    Image2CopyDstR[dst_idx + uint3(0, 0, 0)] = data.x;
-    Image2CopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
-    Image2CopyDstR[dst_idx + uint3(2, 0, 0)] = data.z;
-    Image2CopyDstR[dst_idx + uint3(3, 0, 0)] = data.w;
+    uint remaining_x = bounds.x - dst_idx.x;
+
+    if (remaining_x >= 4) {
+        Image2CopyDstR[dst_idx + uint3(3, 0, 0)] = data.w;
+    } 
+    if (remaining_x >= 3) {
+        Image2CopyDstR[dst_idx + uint3(2, 0, 0)] = data.z;
+    } 
+    if (remaining_x >= 2) {
+        Image2CopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
+    } 
+    if (remaining_x >= 1) {
+        Image2CopyDstR[dst_idx + uint3(0, 0, 0)] = data.x;
+    }
 }
 [numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -294,6 +294,8 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
         non_coherent_atom_size: 1, // TODO
         max_sampler_anisotropy: 16.,
         optimal_buffer_copy_offset_alignment: 1, // TODO
+        // buffer -> image and image -> buffer paths use compute shaders that, at maximum, read 4 pixels from the buffer
+        // at a time, so need an alignment of at least 4.
         optimal_buffer_copy_pitch_alignment: 4,
         min_vertex_input_binding_stride_alignment: 1,
         max_push_constants_size: MAX_PUSH_CONSTANT_SIZE,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -294,7 +294,7 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
         non_coherent_atom_size: 1, // TODO
         max_sampler_anisotropy: 16.,
         optimal_buffer_copy_offset_alignment: 1, // TODO
-        optimal_buffer_copy_pitch_alignment: 1,  // TODO
+        optimal_buffer_copy_pitch_alignment: 4,
         min_vertex_input_binding_stride_alignment: 1,
         max_push_constants_size: MAX_PUSH_CONSTANT_SIZE,
         max_uniform_buffer_range: 1 << 16,


### PR DESCRIPTION
We had some nasty corruption as a result of alignment throwing some calculations off. This fixes the copies for all copies to textures that have less than 4 bytes per pixel.

As a future extension, a lot of the copies in that file aren't using full warps, so adjusting them to use full warps likely will be useful.