### PR TITLE
[0.6/dx12] fix respecting the read-only storage flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Change Log
 
-### backend-gl-0.6.0 (2-11-2020)
-  - re-enable the GL backend for Linux, Mac, and Web
-  - migrate GL backend to use context sharing in `surfman`
-  - remove WGL and Glutin GL backends
-
-### backend-dx12-unreleased
+### backend-dx12-0.6.12 (02-11-2020)
   - fix matrix vertex inputs
   - fix SPIR-V entry point selection
   - fix heap selection for non-renderable textures
+  - fix mutable storage bindings
+
+### backend-gl-0.6.0 (02-11-2020)
+  - re-enable the GL backend for Linux, Mac, and Web
+  - migrate GL backend to use context sharing in `surfman`
+  - remove WGL and Glutin GL backends
   
 ### backend-dx11-0.6.14 (01-11-2020)
   - Fix push constants with non-zero offsets

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.6.11"
+version = "0.6.12"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -375,7 +375,7 @@ impl Device {
                 .mutable_bindings
                 .contains(&binding)
             {
-                ast.set_decoration(storage_buffer.id, spirv::Decoration::NonWritable, 0)
+                ast.set_decoration(storage_buffer.id, spirv::Decoration::NonWritable, 1)
                     .map_err(gen_unexpected_error)?
             }
         }
@@ -399,7 +399,7 @@ impl Device {
                 .mutable_bindings
                 .contains(&binding)
             {
-                ast.set_decoration(image.id, spirv::Decoration::NonWritable, 0)
+                ast.set_decoration(image.id, spirv::Decoration::NonWritable, 1)
                     .map_err(gen_unexpected_error)?
             }
         }
@@ -461,6 +461,7 @@ impl Device {
         compile_options.shader_model = shader_model;
         compile_options.vertex.invert_y = !features.contains(hal::Features::NDC_Y_UP);
         compile_options.force_zero_initialized_variables = true;
+        compile_options.nonwritable_uav_texture_as_srv = true;
         compile_options.entry_point = Some((entry_point.to_string(), conv::map_stage(stage)));
 
         let stage_flag = stage.to_flag();


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/wgpu/issues/1013
It could be a regression from spirv-cross update, although the decoration fixes imply that it shouldn't have ever worked 🤔 
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
