### PR TITLE
[0.6/dx12] Fix Panic When Creating Texture View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx12-0.6.13 (03-11-2020)
+  - fix panic when creating unused multi-mip storage view
+
 ### backend-dx12-0.6.12 (02-11-2020)
   - fix matrix vertex inputs
   - fix SPIR-V entry point selection

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.6.12"
+version = "0.6.13"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -952,7 +952,11 @@ impl Device {
         info: &ViewInfo,
     ) -> Result<descriptors_cpu::Handle, image::ViewCreationError> {
         #![allow(non_snake_case)]
-        assert_eq!(info.levels.start + 1, info.levels.end);
+
+        // Cannot make a storage image over multiple mips
+        if info.levels.start + 1 != info.levels.end {
+            return Err(image::ViewCreationError::Unsupported);
+        }
 
         let mut desc = d3d12::D3D12_UNORDERED_ACCESS_VIEW_DESC {
             Format: info.format,


### PR DESCRIPTION
Fixes last issue preventing bve-reborn from running on DX12.

I'll forward port my pending changes after this merges.