### PR TITLE
[dx/master] Rollup of DX Fixes

### DIFF
--- a/src/backend/dx11/shaders/copy.hlsl
+++ b/src/backend/dx11/shaders/copy.hlsl
@@ -456,8 +456,14 @@ void cs_copy_buffer_image2d_r16(uint3 dispatch_thread_id : SV_DispatchThreadID) 
     uint src_idx = GetBufferSrc16(dispatch_thread_id);
     uint2 data = Uint32ToUint16x2(BufferCopySrc.Load(src_idx));
 
-    Image2CopyDstR[dst_idx                 ] = data.x;
-    Image2CopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
+    uint remaining_x = bounds.x - dst_idx.x;
+
+    if (remaining_x >= 2) {
+        Image2CopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
+    } 
+    if (remaining_x >= 1) {
+        Image2CopyDstR[dst_idx + uint3(0, 0, 0)] = data.x;
+    }
 }
 
 [numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
@@ -489,9 +495,16 @@ void cs_copy_buffer_image1d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID)
 
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    Image1CopyDstRg[dst_idx.xz + uint2(0, 0)] = data.xy;
-    Image1CopyDstRg[dst_idx.xz + uint2(1, 0)] = data.zw;
+    uint remaining_x = bounds.x - dst_idx.x;
+
+    if (remaining_x >= 2) {
+        Image1CopyDstRg[dst_idx.xz + uint2(1, 0)] = data.zw;
+    } 
+    if (remaining_x >= 1) {
+        Image1CopyDstRg[dst_idx.xz + uint2(0, 0)] = data.xy;
+    }
 }
+
 [numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint3 dst_idx = GetImageDst(uint3(2, 1, 0) * dispatch_thread_id);
@@ -504,8 +517,14 @@ void cs_copy_buffer_image2d_r8g8(uint3 dispatch_thread_id : SV_DispatchThreadID)
 
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    Image2CopyDstRg[dst_idx + uint3(0, 0, 0)] = data.xy;
-    Image2CopyDstRg[dst_idx + uint3(1, 0, 0)] = data.zw;
+    uint remaining_x = bounds.x - dst_idx.x;
+
+    if (remaining_x >= 2) {
+        Image2CopyDstRg[dst_idx + uint3(1, 0, 0)] = data.zw;
+    } 
+    if (remaining_x >= 1) {
+        Image2CopyDstRg[dst_idx + uint3(0, 0, 0)] = data.xy;
+    }
 }
 
 [numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
@@ -536,10 +555,20 @@ void cs_copy_buffer_image1d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint src_idx = GetBufferSrc8(dispatch_thread_id);
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    Image1CopyDstR[dst_idx.xz + uint2(0, 0)] = data.x;
-    Image1CopyDstR[dst_idx.xz + uint2(1, 0)] = data.y;
-    Image1CopyDstR[dst_idx.xz + uint2(2, 0)] = data.z;
-    Image1CopyDstR[dst_idx.xz + uint2(3, 0)] = data.w;
+    uint remaining_x = bounds.x - dst_idx.x;
+
+    if (remaining_x >= 4) {
+        Image1CopyDstR[dst_idx.xz + uint2(3, 0)] = data.w;
+    } 
+    if (remaining_x >= 3) {
+        Image1CopyDstR[dst_idx.xz + uint2(2, 0)] = data.z;
+    } 
+    if (remaining_x >= 2) {
+        Image1CopyDstR[dst_idx.xz + uint2(1, 0)] = data.y;
+    } 
+    if (remaining_x >= 1) {
+        Image1CopyDstR[dst_idx.xz + uint2(0, 0)] = data.x;
+    }
 }
 [numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
@@ -552,10 +581,20 @@ void cs_copy_buffer_image2d_r8(uint3 dispatch_thread_id : SV_DispatchThreadID) {
     uint src_idx = GetBufferSrc8(dispatch_thread_id);
     uint4 data = Uint32ToUint8x4(BufferCopySrc.Load(src_idx));
 
-    Image2CopyDstR[dst_idx + uint3(0, 0, 0)] = data.x;
-    Image2CopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
-    Image2CopyDstR[dst_idx + uint3(2, 0, 0)] = data.z;
-    Image2CopyDstR[dst_idx + uint3(3, 0, 0)] = data.w;
+    uint remaining_x = bounds.x - dst_idx.x;
+
+    if (remaining_x >= 4) {
+        Image2CopyDstR[dst_idx + uint3(3, 0, 0)] = data.w;
+    } 
+    if (remaining_x >= 3) {
+        Image2CopyDstR[dst_idx + uint3(2, 0, 0)] = data.z;
+    } 
+    if (remaining_x >= 2) {
+        Image2CopyDstR[dst_idx + uint3(1, 0, 0)] = data.y;
+    } 
+    if (remaining_x >= 1) {
+        Image2CopyDstR[dst_idx + uint3(0, 0, 0)] = data.x;
+    }
 }
 [numthreads(COPY_2D_NUM_THREAD_X, COPY_2D_NUM_THREAD_Y, 1)]
 void cs_copy_image2d_r8_buffer(uint3 dispatch_thread_id : SV_DispatchThreadID) {

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1766,7 +1766,7 @@ impl device::Device<Backend> for Device {
                     set_debug_name_with_suffix(&srv, name, " -- SRV");
                 }
 
-                Some(srv)
+                Some(srv.into_raw())
             } else {
                 None
             },
@@ -1777,7 +1777,7 @@ impl device::Device<Backend> for Device {
                     set_debug_name_with_suffix(&rtv, name, " -- RTV");
                 }
 
-                Some(rtv)
+                Some(rtv.into_raw())
             } else {
                 None
             },
@@ -1788,7 +1788,7 @@ impl device::Device<Backend> for Device {
                     set_debug_name_with_suffix(&uav, name, " -- UAV");
                 }
 
-                Some(uav)
+                Some(uav.into_raw())
             } else {
                 None
             },
@@ -1799,7 +1799,7 @@ impl device::Device<Backend> for Device {
                     set_debug_name_with_suffix(&dsv, name, " -- DSV");
                 }
 
-                Some(dsv)
+                Some(dsv.into_raw())
             } else {
                 None
             },
@@ -1811,10 +1811,11 @@ impl device::Device<Backend> for Device {
                     set_debug_name_with_suffix(&rodsv, name, " -- DSV");
                 }
 
-                Some(rodsv)
+                Some(rodsv.into_raw())
             } else {
                 None
             },
+            owned: true,
         })
     }
 
@@ -1989,12 +1990,10 @@ impl device::Device<Backend> for Device {
                         c: ptr::null_mut(),
                         t: image
                             .srv_handle
-                            .clone()
-                            .map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                            .map_or(ptr::null_mut(), |h| h as *mut _),
                         u: image
                             .uav_handle
-                            .clone()
-                            .map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                            .map_or(ptr::null_mut(), |h| h as *mut _),
                         s: ptr::null_mut(),
                     },
                     pso::Descriptor::Sampler(sampler) => RegisterData {
@@ -2008,12 +2007,10 @@ impl device::Device<Backend> for Device {
                             c: ptr::null_mut(),
                             t: image
                                 .srv_handle
-                                .clone()
-                                .map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                                .map_or(ptr::null_mut(), |h| h as *mut _),
                             u: image
                                 .uav_handle
-                                .clone()
-                                .map_or(ptr::null_mut(), |h| h.as_raw() as *mut _),
+                                .map_or(ptr::null_mut(), |h| h as *mut _),
                             s: sampler.sampler_handle.as_raw() as *mut _,
                         }
                     }

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -456,11 +456,24 @@ impl Device {
                     ArraySize,
                 }
             }
+            image::ViewKind::D2 if info.kind.num_samples() > 1 => {
+                desc.ViewDimension = d3dcommon::D3D11_SRV_DIMENSION_TEXTURE2DMS;
+                *unsafe { desc.u.Texture2DMS_mut() } = d3d11::D3D11_TEX2DMS_SRV {
+                    UnusedField_NothingToDefine: 0,
+                }
+            }
             image::ViewKind::D2 => {
                 desc.ViewDimension = d3dcommon::D3D11_SRV_DIMENSION_TEXTURE2D;
                 *unsafe { desc.u.Texture2D_mut() } = d3d11::D3D11_TEX2D_SRV {
                     MostDetailedMip,
                     MipLevels,
+                }
+            }
+            image::ViewKind::D2Array if info.kind.num_samples() > 1 => {
+                desc.ViewDimension = d3dcommon::D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY;
+                *unsafe { desc.u.Texture2DMSArray_mut() } = d3d11::D3D11_TEX2DMS_ARRAY_SRV {
+                    FirstArraySlice,
+                    ArraySize,
                 }
             }
             image::ViewKind::D2Array => {

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -185,13 +185,13 @@ impl Device {
 
         // See [`shader::introspect_spirv_vertex_semantic_remapping`] for details of why this is needed.
         let semantics: Vec<_> = attributes.iter().map(|attrib| {
-            match vertex_semantic_remapping.get(&attrib.location).unwrap() {
-                Some((major, minor)) => {
+            match vertex_semantic_remapping.get(&attrib.location) {
+                Some(Some((major, minor))) => {
                     let name = std::borrow::Cow::Owned(format!("TEXCOORD{}_\0", major));
                     let location = *minor;
                     (name, location)
                 }
-                None => {
+                _ => {
                     let name = std::borrow::Cow::Borrowed("TEXCOORD\0");
                     let location = attrib.location;
                     (name, location)

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -776,11 +776,7 @@ impl Device {
             Windowed: TRUE,
             // TODO:
             SwapEffect: dxgi::DXGI_SWAP_EFFECT_DISCARD,
-            Flags: if config.present_mode == window::PresentMode::IMMEDIATE {
-                dxgi::DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING
-            } else {
-                0
-            },
+            Flags: 0,
         };
 
         let dxgi_swapchain = {

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1173,7 +1173,7 @@ impl device::Device<Backend> for Device {
         );
 
         #[allow(non_snake_case)]
-        let MiscFlags = if buffer.bind
+        let mut MiscFlags = if buffer.bind
             & (d3d11::D3D11_BIND_SHADER_RESOURCE | d3d11::D3D11_BIND_UNORDERED_ACCESS)
             != 0
         {
@@ -1181,6 +1181,10 @@ impl device::Device<Backend> for Device {
         } else {
             0
         };
+
+        if buffer.internal.usage.contains(buffer::Usage::INDIRECT) {
+            MiscFlags |= d3d11::D3D11_RESOURCE_MISC_DRAWINDIRECT_ARGS;
+        }
 
         let initial_data = if memory.host_ptr.is_null() {
             None

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -889,7 +889,35 @@ impl device::Device<Backend> for Device {
             });
         }
 
-        //TODO: assert that res_offsets are within supported range
+        res_offsets.map_other(|data| {
+            // These use <= because this tells us the _next_ register, so maximum usage will be equal to the limit.
+            //
+            // Leave one slot for push constants
+            assert!(
+                data.c.res_index as u32 <= d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT - 1,
+                "{} bound constant buffers exceeds limit of {}",
+                data.c.res_index as u32,
+                d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT - 1,
+            );
+            assert!(
+                data.s.res_index as u32 <= d3d11::D3D11_COMMONSHADER_SAMPLER_REGISTER_COUNT,
+                "{} bound samplers exceeds limit of {}",
+                data.s.res_index as u32,
+                d3d11::D3D11_COMMONSHADER_SAMPLER_REGISTER_COUNT,
+            );
+            assert!(
+                data.t.res_index as u32 <= d3d11::D3D11_COMMONSHADER_INPUT_RESOURCE_REGISTER_COUNT,
+                "{} bound sampled textures and read-only buffers exceeds limit of {}",
+                data.t.res_index as u32,
+                d3d11::D3D11_COMMONSHADER_INPUT_RESOURCE_REGISTER_COUNT,
+            );
+            assert!(
+                data.u.res_index as u32 <= d3d11::D3D11_PS_CS_UAV_REGISTER_COUNT,
+                "{} bound storage textures and read-write buffers exceeds limit of {}",
+                data.u.res_index as u32,
+                d3d11::D3D11_PS_CS_UAV_REGISTER_COUNT,
+            );
+        });
 
         Ok(PipelineLayout { sets })
     }

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -1176,7 +1176,7 @@ impl Internal {
                     unsafe {
                         context.OMSetRenderTargets(
                             1,
-                            [attachment.rtv_handle.clone().unwrap().as_raw()].as_ptr(),
+                            [attachment.rtv_handle.unwrap()].as_ptr(),
                             ptr::null_mut(),
                         );
                     }
@@ -1265,7 +1265,7 @@ impl Internal {
                         context.OMSetRenderTargets(
                             0,
                             ptr::null_mut(),
-                            attachment.dsv_handle.clone().unwrap().as_raw(),
+                            attachment.dsv_handle.unwrap(),
                         );
                         context.PSSetShader(
                             self.ps_partial_clear_depth.as_raw(),

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -149,7 +149,6 @@ fn get_features(
         | hal::Features::NDC_Y_UP;
 
     features.set(
-        // TODO: Add indirect rendering when supported
         hal::Features::TEXTURE_DESCRIPTOR_ARRAY
         | hal::Features::FULL_DRAW_INDEX_U32
         | hal::Features::GEOMETRY_SHADER,
@@ -165,7 +164,8 @@ fn get_features(
         hal::Features::VERTEX_STORES_AND_ATOMICS
         | hal::Features::FRAGMENT_STORES_AND_ATOMICS
         | hal::Features::FORMAT_BC
-        | hal::Features::TESSELLATION_SHADER,
+        | hal::Features::TESSELLATION_SHADER
+        | hal::Features::DRAW_INDIRECT_FIRST_INSTANCE,
         feature_level >= d3dcommon::D3D_FEATURE_LEVEL_11_0
     );
 
@@ -2775,22 +2775,30 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn draw_indirect(
         &mut self,
-        _buffer: &Buffer,
-        _offset: buffer::Offset,
-        _draw_count: DrawCount,
+        buffer: &Buffer,
+        offset: buffer::Offset,
+        draw_count: DrawCount,
         _stride: u32,
     ) {
-        unimplemented!()
+        assert_eq!(draw_count, 1, "DX11 doesn't support MULTI_DRAW_INDIRECT");
+        self.context.DrawInstancedIndirect(
+            buffer.internal.raw,
+            offset as _,
+        );
     }
 
     unsafe fn draw_indexed_indirect(
         &mut self,
-        _buffer: &Buffer,
-        _offset: buffer::Offset,
-        _draw_count: DrawCount,
+        buffer: &Buffer,
+        offset: buffer::Offset,
+        draw_count: DrawCount,
         _stride: u32,
     ) {
-        unimplemented!()
+        assert_eq!(draw_count, 1, "DX11 doesn't support MULTI_DRAW_INDIRECT");
+        self.context.DrawIndexedInstancedIndirect(
+            buffer.internal.raw,
+            offset as _,
+        );
     }
 
     unsafe fn draw_indirect_count(

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -242,6 +242,8 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
         | _ => 0b1101, // Optimistic, 8xMSAA and 4xMSAA is required on all formats _but_ RGBA32 which requires 4x.
     };
 
+    let max_constant_buffers = d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT - 1;
+
     hal::Limits {
         max_image_1d_size: max_texture_uv_dimension,
         max_image_2d_size: max_texture_uv_dimension,
@@ -250,10 +252,12 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
         max_image_array_layers: max_texture_cube_dimension as _,
         max_per_stage_descriptor_samplers: d3d11::D3D11_COMMONSHADER_SAMPLER_SLOT_COUNT as _,
         // Leave top buffer for push constants
-        max_per_stage_descriptor_uniform_buffers: (d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT - 1) as _,
+        max_per_stage_descriptor_uniform_buffers: max_constant_buffers as _,
         max_per_stage_descriptor_storage_buffers: max_buffer_uav,
         max_per_stage_descriptor_storage_images: max_image_uav,
         max_per_stage_descriptor_sampled_images: d3d11::D3D11_COMMONSHADER_INPUT_RESOURCE_REGISTER_COUNT as _,
+        max_descriptor_set_uniform_buffers_dynamic: max_constant_buffers as _,
+        max_descriptor_set_storage_buffers_dynamic: 0, // TODO: Implement dynamic offsets for storage buffers
         max_texel_elements: max_texture_uv_dimension as _, //TODO
         max_patch_size: d3d11::D3D11_IA_PATCH_MAX_CONTROL_POINT_COUNT as _,
         max_viewports: d3d11::D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE as _,
@@ -294,6 +298,7 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
         optimal_buffer_copy_pitch_alignment: 1,  // TODO
         min_vertex_input_binding_stride_alignment: 1,
         max_push_constants_size: MAX_PUSH_CONSTANT_SIZE,
+        max_uniform_buffer_range: 1 << 16,
         ..hal::Limits::default() //TODO
     }
 }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 use winapi::{shared::{
-    dxgi::{IDXGIAdapter, IDXGIFactory, IDXGISwapChain, DXGI_PRESENT_ALLOW_TEARING},
+    dxgi::{IDXGIAdapter, IDXGIFactory, IDXGISwapChain},
     dxgiformat,
     minwindef::{FALSE, HMODULE, UINT},
     windef::{HWND, RECT},
@@ -888,7 +888,6 @@ impl window::Surface<Backend> for Surface {
         // TODO: _DISCARD swap effects can only have one image?
         window::SurfaceCapabilities {
             present_modes: window::PresentMode::IMMEDIATE
-                | window::PresentMode::MAILBOX
                 | window::PresentMode::FIFO,
             composite_alpha_modes: window::CompositeAlphaMode::OPAQUE, //TODO
             image_count: 1..=16,                                       // TODO:
@@ -1139,10 +1138,10 @@ impl queue::CommandQueue<Backend> for CommandQueue {
     ) -> Result<Option<window::Suboptimal>, window::PresentError> {
         let mut presentation = surface.presentation.as_mut().unwrap();
         let (interval, flags) = match presentation.mode {
-            window::PresentMode::IMMEDIATE => (0, DXGI_PRESENT_ALLOW_TEARING),
+            window::PresentMode::IMMEDIATE => (0, 0),
             //Note: this ends up not presenting anything for some reason
             //window::PresentMode::MAILBOX if !presentation.is_init => (1, DXGI_PRESENT_DO_NOT_SEQUENCE),
-            window::PresentMode::MAILBOX | window::PresentMode::FIFO => (1, 0),
+            window::PresentMode::FIFO => (1, 0),
             _ => (0, 0),
         };
         presentation.is_init = false;

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -295,6 +295,8 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
         non_coherent_atom_size: 1, // TODO
         max_sampler_anisotropy: 16.,
         optimal_buffer_copy_offset_alignment: 1, // TODO
+        // buffer -> image and image -> buffer paths use compute shaders that, at maximum, read 4 pixels from the buffer
+        // at a time, so need an alignment of at least 4.
         optimal_buffer_copy_pitch_alignment: 4,
         min_vertex_input_binding_stride_alignment: 1,
         max_push_constants_size: MAX_PUSH_CONSTANT_SIZE,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -295,7 +295,7 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
         non_coherent_atom_size: 1, // TODO
         max_sampler_anisotropy: 16.,
         optimal_buffer_copy_offset_alignment: 1, // TODO
-        optimal_buffer_copy_pitch_alignment: 1,  // TODO
+        optimal_buffer_copy_pitch_alignment: 4,
         min_vertex_input_binding_stride_alignment: 1,
         max_push_constants_size: MAX_PUSH_CONSTANT_SIZE,
         max_uniform_buffer_range: 1 << 16,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -247,7 +247,8 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
         max_image_cube_size: max_texture_cube_dimension,
         max_image_array_layers: max_texture_cube_dimension as _,
         max_per_stage_descriptor_samplers: d3d11::D3D11_COMMONSHADER_SAMPLER_SLOT_COUNT as _,
-        max_per_stage_descriptor_uniform_buffers: d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_HW_SLOT_COUNT as _,
+        // Leave top buffer for push constants
+        max_per_stage_descriptor_uniform_buffers: d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT - 1 as _,
         max_per_stage_descriptor_storage_buffers: max_buffer_uav,
         max_per_stage_descriptor_storage_images: max_image_uav,
         max_per_stage_descriptor_sampled_images: d3d11::D3D11_COMMONSHADER_INPUT_RESOURCE_REGISTER_COUNT as _,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1176,9 +1176,13 @@ impl RenderPassCache {
             .filter(|clear| clear.subpass_id == Some(self.current_subpass))
             .map(|clear| clear.raw);
 
-        cache
-            .dirty_flag
-            .insert(DirtyStateFlag::GRAPHICS_PIPELINE | DirtyStateFlag::PIPELINE_PS | DirtyStateFlag::VIEWPORTS);
+        cache.dirty_flag.insert(
+            DirtyStateFlag::GRAPHICS_PIPELINE
+                | DirtyStateFlag::DEPTH_STENCIL_STATE
+                | DirtyStateFlag::PIPELINE_PS
+                | DirtyStateFlag::VIEWPORTS
+                | DirtyStateFlag::RENDER_TARGETS_AND_UAVS,
+        );
         internal.clear_attachments(
             context,
             attachments,
@@ -1271,6 +1275,7 @@ bitflags! {
         const PIPELINE_PS = (1 << 7);
         const VIEWPORTS = (1 << 8);
         const BLEND_STATE = (1 << 9);
+        const DEPTH_STENCIL_STATE = (1 << 10);
     }
 }
 
@@ -1514,6 +1519,32 @@ impl CommandBufferState {
         }
     }
 
+    pub fn set_stencil_ref(&mut self, value: pso::StencilValue) {
+        self.stencil_ref = Some(value);
+        self.dirty_flag.insert(DirtyStateFlag::DEPTH_STENCIL_STATE);
+    }
+
+    pub fn bind_depth_stencil_state(&mut self, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
+        if !self.dirty_flag.contains(DirtyStateFlag::DEPTH_STENCIL_STATE) {
+            return;
+        }
+
+        let pipeline = match self.graphics_pipeline {
+            Some(ref pipeline) => pipeline,
+            None => return,
+        };
+
+        if let Some(ref state) = pipeline.depth_stencil_state {
+            let stencil_ref = state.stencil_ref.static_or(self.stencil_ref.unwrap_or(0));
+
+            unsafe {
+                context.OMSetDepthStencilState(state.raw.as_raw(), stencil_ref);
+            }
+        }
+
+        self.dirty_flag.remove(DirtyStateFlag::DEPTH_STENCIL_STATE)
+    }
+
     pub fn set_graphics_pipeline(&mut self, pipeline: GraphicsPipeline) {
         let prev = self.graphics_pipeline.take();
 
@@ -1553,7 +1584,7 @@ impl CommandBufferState {
             self.dirty_flag.insert(DirtyStateFlag::RENDER_TARGETS_AND_UAVS);
         }
 
-        self.dirty_flag.insert(DirtyStateFlag::GRAPHICS_PIPELINE);
+        self.dirty_flag.insert(DirtyStateFlag::GRAPHICS_PIPELINE | DirtyStateFlag::DEPTH_STENCIL_STATE);
 
         self.graphics_pipeline = Some(pipeline);
     }
@@ -1616,16 +1647,12 @@ impl CommandBufferState {
                     context.RSSetScissorRects(1, [conv::map_rect(&scissor)].as_ptr());
                 }
 
-                if let Some(ref state) = pipeline.depth_stencil_state {
-                    let stencil_ref = state.stencil_ref.static_or(0);
-
-                    context.OMSetDepthStencilState(state.raw.as_raw(), stencil_ref);
-                }
                 self.current_blend = Some(pipeline.blend_state.as_raw());
             }
         };
 
         self.bind_blend_state(context);
+        self.bind_depth_stencil_state(context);
 
         self.dirty_flag.remove(DirtyStateFlag::GRAPHICS_PIPELINE);
     }
@@ -2105,6 +2132,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         if let Some(ref pass) = self.render_pass_cache {
             self.cache.dirty_flag.insert(
                 DirtyStateFlag::GRAPHICS_PIPELINE
+                    | DirtyStateFlag::DEPTH_STENCIL_STATE
                     | DirtyStateFlag::PIPELINE_PS
                     | DirtyStateFlag::VIEWPORTS
                     | DirtyStateFlag::RENDER_TARGETS_AND_UAVS,
@@ -2223,7 +2251,8 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
     }
 
     unsafe fn set_stencil_reference(&mut self, _faces: pso::Face, value: pso::StencilValue) {
-        self.cache.stencil_ref = Some(value);
+        self.cache.set_stencil_ref(value);
+        self.cache.bind_depth_stencil_state(&self.context);
     }
 
     unsafe fn set_stencil_read_mask(&mut self, _faces: pso::Face, value: pso::StencilValue) {

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2810,7 +2810,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _max_draw_count: u32,
         _stride: u32,
     ) {
-        unimplemented!()
+        panic!("DX11 doesn't support DRAW_INDIRECT_COUNT")
     }
 
     unsafe fn draw_indexed_indirect_count(
@@ -2822,11 +2822,11 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _max_draw_count: u32,
         _stride: u32,
     ) {
-        unimplemented!()
+        panic!("DX11 doesn't support DRAW_INDIRECT_COUNT")
     }
 
     unsafe fn draw_mesh_tasks(&mut self, _: TaskCount, _: TaskCount) {
-        unimplemented!()
+        panic!("DX11 doesn't support MESH_SHADERS")
     }
 
     unsafe fn draw_mesh_tasks_indirect(
@@ -2836,7 +2836,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: hal::DrawCount,
         _: u32,
     ) {
-        unimplemented!()
+        panic!("DX11 doesn't support MESH_SHADERS")
     }
 
     unsafe fn draw_mesh_tasks_indirect_count(
@@ -2848,7 +2848,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: hal::DrawCount,
         _: u32,
     ) {
-        unimplemented!()
+        panic!("DX11 doesn't support MESH_SHADERS")
     }
 
     unsafe fn set_event(&mut self, _: &(), _: pso::PipelineStage) {

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2909,7 +2909,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         offset: u32,
         constants: &[u32],
     ) {
-        let start = offset as usize;
+        let start = (offset / 4) as usize;
         let end = start + constants.len();
 
         self.push_constant_data[start..end].copy_from_slice(constants);
@@ -2930,7 +2930,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         offset: u32,
         constants: &[u32],
     ) {
-        let start = offset as usize;
+        let start = (offset / 4) as usize;
         let end = start + constants.len();
 
         self.push_constant_data[start..end].copy_from_slice(constants);

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1932,7 +1932,8 @@ impl CommandBuffer {
                 working_buffer: Some(self.internal.working_buffer.clone()),
                 working_buffer_size: self.internal.working_buffer_size,
                 host_memory: buffer.memory_ptr,
-                sync_range: buffer.bound_range.clone(),
+                host_sync_range: buffer.bound_range.clone(),
+                buffer_sync_range: buffer.bound_range.clone(),
                 buffer: buffer.internal.raw,
             });
         }
@@ -2391,7 +2392,8 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
                             working_buffer: Some(self.internal.working_buffer.clone()),
                             working_buffer_size: self.internal.working_buffer_size,
                             host_memory: sync.host_ptr,
-                            sync_range: sync.range.clone(),
+                            host_sync_range: sync.range.clone(),
+                            buffer_sync_range: sync.range.clone(),
                             buffer: sync.device_buffer,
                         });
                     }
@@ -2571,7 +2573,8 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
                             working_buffer: Some(self.internal.working_buffer.clone()),
                             working_buffer_size: self.internal.working_buffer_size,
                             host_memory: sync.host_ptr,
-                            sync_range: sync.range.clone(),
+                            host_sync_range: sync.range.clone(),
+                            buffer_sync_range: sync.range.clone(),
                             buffer: sync.device_buffer,
                         });
                     }
@@ -2982,7 +2985,8 @@ pub struct MemoryInvalidate {
     working_buffer: Option<ComPtr<d3d11::ID3D11Buffer>>,
     working_buffer_size: u64,
     host_memory: *mut u8,
-    sync_range: Range<u64>,
+    host_sync_range: Range<u64>,
+    buffer_sync_range: Range<u64>,
     buffer: *mut d3d11::ID3D11Buffer,
 }
 
@@ -3036,8 +3040,12 @@ impl MemoryInvalidate {
         &self,
         context: &ComPtr<d3d11::ID3D11DeviceContext>,
         buffer: *mut d3d11::ID3D11Buffer,
-        range: Range<u64>,
+        host_range: Range<u64>,
+        buffer_range: Range<u64>
     ) {
+        // Range<u64> doesn't impl `len` for some bizzare reason relating to underflow
+        debug_assert_eq!(host_range.end - host_range.start, buffer_range.end - buffer_range.start);
+
         unsafe {
             context.CopySubresourceRegion(
                 self.working_buffer.clone().unwrap().as_raw() as _,
@@ -3048,40 +3056,49 @@ impl MemoryInvalidate {
                 buffer as _,
                 0,
                 &d3d11::D3D11_BOX {
-                    left: range.start as _,
+                    left: buffer_range.start as _,
                     top: 0,
                     front: 0,
-                    right: range.end as _,
+                    right: buffer_range.end as _,
                     bottom: 1,
                     back: 1,
                 },
             );
 
             // copy over to our vec
-            let dst = self.host_memory.offset(range.start as isize);
+            let dst = self.host_memory.offset(host_range.start as isize);
             let src = self.map(&context);
-            ptr::copy(src, dst, (range.end - range.start) as usize);
+            ptr::copy(src, dst, (host_range.end - host_range.start) as usize);
             self.unmap(&context);
         }
     }
 
     fn do_invalidate(&self, context: &ComPtr<d3d11::ID3D11DeviceContext>) {
         let stride = self.working_buffer_size;
-        let range = &self.sync_range;
-        let len = range.end - range.start;
+        let len = self.host_sync_range.end - self.host_sync_range.start;
         let chunks = len / stride;
         let remainder = len % stride;
 
         // we split up the copies into chunks the size of our working buffer
         for i in 0..chunks {
-            let offset = range.start + i * stride;
-            let range = offset..(offset + stride);
+            let host_offset = self.host_sync_range.start + i * stride;
+            let host_range = host_offset..(host_offset + stride);
+            let buffer_offset = self.buffer_sync_range.start + i * stride;
+            let buffer_range = buffer_offset..(buffer_offset + stride);
 
-            self.download(context, self.buffer, range);
+            self.download(context, self.buffer, host_range, buffer_range);
         }
 
         if remainder != 0 {
-            self.download(context, self.buffer, (chunks * stride)..range.end);
+            let host_offset = self.host_sync_range.start + chunks * stride;
+            let host_range = host_offset..self.host_sync_range.end;
+            let buffer_offset = self.buffer_sync_range.start + chunks * stride;
+            let buffer_range = buffer_offset..self.buffer_sync_range.end;
+
+            debug_assert!(host_range.end - host_range.start <= stride);
+            debug_assert!(buffer_range.end - buffer_range.start <= stride);
+
+            self.download(context, self.buffer, host_range, buffer_range);
         }
     }
 
@@ -3210,11 +3227,17 @@ impl Memory {
     ) {
         for (_, &(ref buffer_range, ref buffer)) in self.local_buffers.read().iter() {
             if let Some(range) = intersection(&range, &buffer_range) {
+                let buffer_start_offset = range.start - buffer_range.start;
+                let buffer_end_offset = range.end - buffer_range.start;
+
+                let buffer_sync_range = buffer_start_offset..buffer_end_offset;
+
                 MemoryInvalidate {
                     working_buffer: Some(working_buffer.clone()),
                     working_buffer_size,
                     host_memory: self.host_ptr,
-                    sync_range: range.clone(),
+                    host_sync_range: range.clone(),
+                    buffer_sync_range: buffer_sync_range,
                     buffer: buffer.raw,
                 }
                 .do_invalidate(&context);

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1045,11 +1045,12 @@ impl window::PresentationSurface<Backend> for Surface {
             view: ImageView {
                 subresource: d3d11::D3D11CalcSubresource(0, 0, 1),
                 format: present.format,
-                rtv_handle: Some(present.view.clone()),
+                rtv_handle: Some(present.view.as_raw()),
                 dsv_handle: None,
                 srv_handle: None,
                 uav_handle: None,
                 rodsv_handle: None,
+                owned: false,
             },
         };
         Ok((swapchain_image, None))
@@ -1208,9 +1209,7 @@ impl RenderPassCache {
             .map(|&(id, _)| {
                 self.framebuffer.attachments[id]
                     .rtv_handle
-                    .clone()
                     .unwrap()
-                    .as_raw()
             })
             .collect::<Vec<_>>();
         let (ds_view, rods_view) = match subpass.depth_stencil_attachment {
@@ -1218,15 +1217,11 @@ impl RenderPassCache {
                 let attachment = &self.framebuffer.attachments[id];
                 let ds_view = attachment
                     .dsv_handle
-                    .clone()
-                    .unwrap()
-                    .as_raw();
+                    .unwrap();
 
                 let rods_view = attachment
                     .rodsv_handle
-                    .clone()
-                    .unwrap()
-                    .as_raw();
+                    .unwrap();
 
                 (Some(ds_view), Some(rods_view))
             },
@@ -1252,8 +1247,8 @@ impl RenderPassCache {
             let mut resolve_resource: *mut d3d11::ID3D11Resource = ptr::null_mut();
 
             unsafe {
-                color_framebuffer.rtv_handle.as_ref().expect("Framebuffer must have COLOR_ATTACHMENT usage").GetResource(&mut color_resource as *mut *mut _);
-                resolve_framebuffer.rtv_handle.as_ref().expect("Resolve texture must have COLOR_ATTACHMENT usage").GetResource(&mut resolve_resource as *mut *mut _);
+                (&*color_framebuffer.rtv_handle.expect("Framebuffer must have COLOR_ATTACHMENT usage")).GetResource(&mut color_resource as *mut *mut _);
+                (&*resolve_framebuffer.rtv_handle.expect("Resolve texture must have COLOR_ATTACHMENT usage")).GetResource(&mut resolve_resource as *mut *mut _);
 
                 context.ResolveSubresource(
                     resolve_resource,
@@ -1262,6 +1257,9 @@ impl RenderPassCache {
                     color_framebuffer.subresource,
                     conv::map_format(color_framebuffer.format).unwrap()
                 );
+
+                (&*color_resource).Release();
+                (&*resolve_resource).Release();
             }
         }
     }
@@ -3470,15 +3468,52 @@ impl Drop for Image {
     }
 }
 
-#[derive(Clone)]
 pub struct ImageView {
     subresource: UINT,
     format: format::Format,
-    rtv_handle: Option<ComPtr<d3d11::ID3D11RenderTargetView>>,
-    srv_handle: Option<ComPtr<d3d11::ID3D11ShaderResourceView>>,
-    dsv_handle: Option<ComPtr<d3d11::ID3D11DepthStencilView>>,
-    rodsv_handle: Option<ComPtr<d3d11::ID3D11DepthStencilView>>,
-    uav_handle: Option<ComPtr<d3d11::ID3D11UnorderedAccessView>>,
+    rtv_handle: Option<*mut d3d11::ID3D11RenderTargetView>,
+    srv_handle: Option<*mut d3d11::ID3D11ShaderResourceView>,
+    dsv_handle: Option<*mut d3d11::ID3D11DepthStencilView>,
+    rodsv_handle: Option<*mut d3d11::ID3D11DepthStencilView>,
+    uav_handle: Option<*mut d3d11::ID3D11UnorderedAccessView>,
+    owned: bool,
+}
+
+impl Clone for ImageView {
+    fn clone(&self) -> Self {
+        Self {
+            subresource: self.subresource,
+            format: self.format,
+            rtv_handle: self.rtv_handle.clone(),
+            srv_handle: self.srv_handle.clone(),
+            dsv_handle: self.dsv_handle.clone(),
+            rodsv_handle: self.rodsv_handle.clone(),
+            uav_handle: self.uav_handle.clone(),
+            owned: false
+        }
+    }
+}
+
+impl Drop for ImageView {
+    fn drop(&mut self) {
+        if self.owned {
+            if let Some(rtv) = self.rtv_handle.take() {
+                unsafe { (&*rtv).Release() };
+            }
+            if let Some(srv) = self.srv_handle.take() {
+                unsafe { (&*srv).Release() };
+            }
+            if let Some(dsv) = self.dsv_handle.take() {
+                unsafe { (&*dsv).Release() };
+            }
+            if let Some(rodsv) = self.rodsv_handle.take() {
+                unsafe { (&*rodsv).Release() };
+            }
+            if let Some(uav) = self.uav_handle.take() {
+                unsafe { (&*uav).Release() };
+            }
+        }
+    }
 }
 
 impl fmt::Debug for ImageView {

--- a/src/backend/dx11/src/shader.rs
+++ b/src/backend/dx11/src/shader.rs
@@ -268,6 +268,20 @@ fn patch_spirv_resources(
             .map_err(gen_unexpected_error)?;
     }
 
+    assert!(shader_resources.push_constant_buffers.len() <= 1, "Only 1 push constant buffer is supported");
+    for push_constant_buffer in &shader_resources.push_constant_buffers {
+        ast.set_decoration(
+            push_constant_buffer.id,
+            spirv::Decoration::DescriptorSet,
+            0 // value doesn't matter, just needs a value
+        ).map_err(gen_unexpected_error)?;
+        ast.set_decoration(
+            push_constant_buffer.id,
+            spirv::Decoration::Binding,
+            d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT - 1
+        ).map_err(gen_unexpected_error)?;
+    }
+
     Ok(())
 }
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -955,7 +955,11 @@ impl Device {
         info: &ViewInfo,
     ) -> Result<descriptors_cpu::Handle, image::ViewCreationError> {
         #![allow(non_snake_case)]
-        assert_eq!(info.levels.start + 1, info.levels.end);
+
+        // Cannot make a storage image over multiple mips
+        if info.levels.start + 1 != info.levels.end {
+            return Err(image::ViewCreationError::Unsupported);
+        }
 
         let mut desc = d3d12::D3D12_UNORDERED_ACCESS_VIEW_DESC {
             Format: info.format,

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1933,17 +1933,15 @@ impl d::Device<B> for Device {
             let semantics = vertex_semantic_remapping
                 .as_ref()
                 .and_then(|map| {
-                    *map
-                        .get(&attrib.location)
-                        .unwrap()
+                    map.get(&attrib.location)
                 });
             match semantics {
-                Some((major, minor)) => {
+                Some(Some((major, minor))) => {
                     let name = std::borrow::Cow::Owned(format!("TEXCOORD{}_\0", major));
-                    let location = minor;
+                    let location = *minor;
                     (name, location)
                 }
-                None => {
+                _ => {
                     let name = std::borrow::Cow::Borrowed("TEXCOORD\0");
                     let location = attrib.location;
                     (name, location)


### PR DESCRIPTION
Got a little behind here; rolls up #3444 #3446 #3448 #3452 #3456 #3458 and #3465. 

#3449 seems to have been obsoleted by a previous change in master: https://github.com/gfx-rs/gfx/blame/fa323527758d35a3913815e62bcb0e08511f7384/src/backend/dx12/src/device.rs#L2443-L2449. Could you just validate that this change does indeed serve the same purpose?