### PR TITLE
[dx] Disable automatic Alt+Enter handling in DXGI

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -972,6 +972,11 @@ impl window::PresentationSurface<Backend> for Surface {
             }
         };
 
+        // Disable automatic Alt+Enter handling by DXGI.
+        const DXGI_MWA_NO_WINDOW_CHANGES: u32 = 1;
+        const DXGI_MWA_NO_ALT_ENTER: u32 = 2;
+        self.factory.MakeWindowAssociation(self.wnd_handle, DXGI_MWA_NO_WINDOW_CHANGES | DXGI_MWA_NO_ALT_ENTER);
+
         let mut resource: *mut d3d11::ID3D11Resource = ptr::null_mut();
         assert_eq!(
             winerror::S_OK,

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -173,6 +173,11 @@ impl w::PresentationSurface<Backend> for Surface {
             }
         };
 
+        // Disable automatic Alt+Enter handling by DXGI.
+        const DXGI_MWA_NO_WINDOW_CHANGES: u32 = 1;
+        const DXGI_MWA_NO_ALT_ENTER: u32 = 2;
+        self.factory.MakeWindowAssociation(self.wnd_handle, DXGI_MWA_NO_WINDOW_CHANGES | DXGI_MWA_NO_ALT_ENTER);
+
         self.presentation = Some(Presentation {
             swapchain: device.wrap_swapchain(swapchain, &config),
             format: config.format,


### PR DESCRIPTION
Fixes #3477.

Uses [IDXGIFactory::MakeWindowAssociation](https://docs.microsoft.com/en-us/windows/win32/api/dxgi/nf-dxgi-idxgifactory-makewindowassociation) to disable Alt+Enter behavior on dx11/dx12 backends.

 * winapi-rs does not have the `DXGI_MWA` constants (opened PR https://github.com/retep998/winapi-rs/pull/960). Not sure where to cram these -- for now, I put them right beside the function call.
 * Using both `DXGI_MWA_NO_WINDOW_CHANGES | DXGI_MWA_NO_ALT_ENTER`. Either of these seems to disable the Alt+Enter behavior; according to the docs, `DXGI_MWA_NO_WINDOW_CHANGES` seems more general, but I guess this is desired (DXGI shouldn't fiddle with anything automatically for consistent behavior among backends?).

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
  - dx11, dx12, vulkan