### PR TITLE
Refactor bind_index_buffer API

### DIFF
--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -4,8 +4,8 @@ use hal::{
     image,
     pso::{
         BlendDesc, BlendOp, ColorBlendDesc, Comparison, DepthBias, DepthStencilDesc, Face, Factor,
-        FrontFace, InputAssemblerDesc, Multisampling, PolygonMode, Rasterizer, Rect, Sided, State, StencilFace,
-        StencilOp, StencilValue, Viewport
+        FrontFace, InputAssemblerDesc, Multisampling, PolygonMode, Rasterizer, Rect, Sided, State,
+        StencilFace, StencilOp, StencilValue, Viewport,
     },
     IndexType,
 };
@@ -510,7 +510,10 @@ fn map_cull_mode(mode: Face) -> D3D11_CULL_MODE {
     }
 }
 
-pub(crate) fn map_rasterizer_desc(desc: &Rasterizer, multisampling_desc: &Option<Multisampling>) -> D3D11_RASTERIZER_DESC {
+pub(crate) fn map_rasterizer_desc(
+    desc: &Rasterizer,
+    multisampling_desc: &Option<Multisampling>,
+) -> D3D11_RASTERIZER_DESC {
     let bias = match desc.depth_bias {
         //TODO: support dynamic depth bias
         Some(State::Static(db)) => db,
@@ -644,7 +647,10 @@ fn map_blend_targets(
     targets
 }
 
-pub(crate) fn map_blend_desc(desc: &BlendDesc, multisampling: &Option<Multisampling>) -> D3D11_BLEND_DESC {
+pub(crate) fn map_blend_desc(
+    desc: &BlendDesc,
+    multisampling: &Option<Multisampling>,
+) -> D3D11_BLEND_DESC {
     D3D11_BLEND_DESC {
         AlphaToCoverageEnable: multisampling.as_ref().map_or(false, |m| m.alpha_coverage) as _,
         IndependentBlendEnable: TRUE,
@@ -728,8 +734,8 @@ pub(crate) fn map_depth_stencil_desc(
         None => unsafe { mem::zeroed() },
     };
 
-    let stencil_read_only = write_mask == 0 ||
-        (front.StencilDepthFailOp == D3D11_STENCIL_OP_KEEP
+    let stencil_read_only = write_mask == 0
+        || (front.StencilDepthFailOp == D3D11_STENCIL_OP_KEEP
             && front.StencilFailOp == D3D11_STENCIL_OP_KEEP
             && front.StencilPassOp == D3D11_STENCIL_OP_KEEP
             && back.StencilDepthFailOp == D3D11_STENCIL_OP_KEEP
@@ -753,7 +759,7 @@ pub(crate) fn map_depth_stencil_desc(
             BackFace: back,
         },
         stencil_ref,
-        read_only
+        read_only,
     )
 }
 

--- a/src/backend/dx11/src/debug.rs
+++ b/src/backend/dx11/src/debug.rs
@@ -27,7 +27,9 @@ impl DebugScope {
             }
         }
 
-        let annotation = context.cast::<d3d11_1::ID3DUserDefinedAnnotation>().unwrap();
+        let annotation = context
+            .cast::<d3d11_1::ID3DUserDefinedAnnotation>()
+            .unwrap();
         let msg: &OsStr = name.as_ref();
         let msg: Vec<u16> = msg.to_wide_null();
 
@@ -55,7 +57,9 @@ pub fn debug_marker(context: &ComPtr<d3d11::ID3D11DeviceContext>, name: &str) {
         }
     }
 
-    let annotation = context.cast::<d3d11_1::ID3DUserDefinedAnnotation>().unwrap();
+    let annotation = context
+        .cast::<d3d11_1::ID3DUserDefinedAnnotation>()
+        .unwrap();
     let msg: &OsStr = name.as_ref();
     let msg: Vec<u16> = msg.to_wide_null();
 
@@ -79,7 +83,11 @@ pub fn verify_debug_ascii(name: &str) -> bool {
 /// SetPrivateData will copy the data internally so the data doesn't need to live.
 pub fn set_debug_name(resource: &d3d11::ID3D11DeviceChild, name: &str) {
     unsafe {
-        resource.SetPrivateData((&d3dcommon::WKPDID_D3DDebugObjectName) as *const _, name.len() as _, name.as_ptr() as *const _);
+        resource.SetPrivateData(
+            (&d3dcommon::WKPDID_D3DDebugObjectName) as *const _,
+            name.len() as _,
+            name.as_ptr() as *const _,
+        );
     }
 }
 
@@ -89,10 +97,18 @@ pub fn set_debug_name(resource: &d3d11::ID3D11DeviceChild, name: &str) {
 ///
 /// The given string will be mutated to add the suffix, then restored to it's original state.
 /// This saves an allocation. SetPrivateData will copy the data internally so the data doesn't need to live.
-pub fn set_debug_name_with_suffix(resource: &d3d11::ID3D11DeviceChild, name: &mut String, suffix: &str) {
+pub fn set_debug_name_with_suffix(
+    resource: &d3d11::ID3D11DeviceChild,
+    name: &mut String,
+    suffix: &str,
+) {
     name.push_str(suffix);
     unsafe {
-        resource.SetPrivateData((&d3dcommon::WKPDID_D3DDebugObjectName) as *const _, name.len() as _, name.as_ptr() as *const _);
+        resource.SetPrivateData(
+            (&d3dcommon::WKPDID_D3DDebugObjectName) as *const _,
+            name.len() as _,
+            name.as_ptr() as *const _,
+        );
     }
     name.drain((name.len() - suffix.len())..);
 }

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -11,18 +11,25 @@ use winapi::{
 
 use wio::com::ComPtr;
 
-use std::{borrow::Borrow, fmt, mem, ops::Range, ptr, sync::{Arc, Weak}};
+use std::{
+    borrow::Borrow,
+    fmt, mem,
+    ops::Range,
+    ptr,
+    sync::{Arc, Weak},
+};
 
 use parking_lot::{Condvar, Mutex, RwLock};
 
 use crate::{
-    conv, internal, shader, Backend, Buffer, BufferView, CommandBuffer, CommandPool,
-    ComputePipeline, DescriptorContent, DescriptorIndex, DescriptorPool, DescriptorSet,
-    DescriptorSetInfo, DescriptorSetLayout, Fence, Framebuffer, GraphicsPipeline, Image, ImageView,
-    InternalBuffer, InternalImage, Memory, MultiStageData, PipelineLayout, QueryPool, RawFence,
+    conv,
+    debug::{set_debug_name, set_debug_name_with_suffix, verify_debug_ascii},
+    internal, shader, Backend, Buffer, BufferView, CommandBuffer, CommandPool, ComputePipeline,
+    DescriptorContent, DescriptorIndex, DescriptorPool, DescriptorSet, DescriptorSetInfo,
+    DescriptorSetLayout, Fence, Framebuffer, GraphicsPipeline, Image, ImageView, InternalBuffer,
+    InternalImage, Memory, MultiStageData, PipelineLayout, QueryPool, RawFence,
     RegisterAccumulator, RegisterData, RenderPass, ResourceIndex, Sampler, Semaphore, ShaderModule,
     SubpassDesc, ViewInfo,
-    debug::{set_debug_name_with_suffix, set_debug_name, verify_debug_ascii},
 };
 
 //TODO: expose coherent type 0x2 when it's properly supported
@@ -96,7 +103,7 @@ impl Device {
     fn create_rasterizer_state(
         &self,
         rasterizer_desc: &pso::Rasterizer,
-        multisampling_desc: &Option<pso::Multisampling>
+        multisampling_desc: &Option<pso::Multisampling>,
     ) -> Result<ComPtr<d3d11::ID3D11RasterizerState>, pso::CreationError> {
         let mut rasterizer = ptr::null_mut();
         let desc = conv::map_rasterizer_desc(rasterizer_desc, multisampling_desc);
@@ -136,10 +143,7 @@ impl Device {
     fn create_depth_stencil_state(
         &self,
         depth_desc: &pso::DepthStencilDesc,
-    ) -> Result<
-        DepthStencilState,
-        pso::CreationError,
-    > {
+    ) -> Result<DepthStencilState, pso::CreationError> {
         let mut depth = ptr::null_mut();
         let (desc, stencil_ref, read_only) = conv::map_depth_stencil_desc(depth_desc);
 
@@ -150,9 +154,9 @@ impl Device {
 
         if winerror::SUCCEEDED(hr) {
             Ok(DepthStencilState {
-                raw: unsafe{ ComPtr::from_raw(depth) },
+                raw: unsafe { ComPtr::from_raw(depth) },
                 stencil_ref,
-                read_only
+                read_only,
             })
         } else {
             Err(pso::CreationError::Other)
@@ -184,20 +188,23 @@ impl Device {
         }
 
         // See [`shader::introspect_spirv_vertex_semantic_remapping`] for details of why this is needed.
-        let semantics: Vec<_> = attributes.iter().map(|attrib| {
-            match vertex_semantic_remapping.get(&attrib.location) {
-                Some(Some((major, minor))) => {
-                    let name = std::borrow::Cow::Owned(format!("TEXCOORD{}_\0", major));
-                    let location = *minor;
-                    (name, location)
-                }
-                _ => {
-                    let name = std::borrow::Cow::Borrowed("TEXCOORD\0");
-                    let location = attrib.location;
-                    (name, location)
-                }
-            }
-        }).collect();
+        let semantics: Vec<_> = attributes
+            .iter()
+            .map(
+                |attrib| match vertex_semantic_remapping.get(&attrib.location) {
+                    Some(Some((major, minor))) => {
+                        let name = std::borrow::Cow::Owned(format!("TEXCOORD{}_\0", major));
+                        let location = *minor;
+                        (name, location)
+                    }
+                    _ => {
+                        let name = std::borrow::Cow::Borrowed("TEXCOORD\0");
+                        let location = attrib.location;
+                        (name, location)
+                    }
+                },
+            )
+            .collect();
 
         let input_elements = attributes
             .iter()
@@ -628,7 +635,9 @@ impl Device {
             image::ViewKind::D2 => {
                 if info.kind.num_samples() > 1 {
                     desc.ViewDimension = d3d11::D3D11_RTV_DIMENSION_TEXTURE2DMS;
-                    *unsafe { desc.u.Texture2DMS_mut() } = d3d11::D3D11_TEX2DMS_RTV { UnusedField_NothingToDefine: 0 }
+                    *unsafe { desc.u.Texture2DMS_mut() } = d3d11::D3D11_TEX2DMS_RTV {
+                        UnusedField_NothingToDefine: 0,
+                    }
                 } else {
                     desc.ViewDimension = d3d11::D3D11_RTV_DIMENSION_TEXTURE2D;
                     *unsafe { desc.u.Texture2D_mut() } = d3d11::D3D11_TEX2D_RTV { MipSlice }
@@ -921,7 +930,8 @@ impl device::Device<Backend> for Device {
             //
             // Leave one slot for push constants
             assert!(
-                data.c.res_index as u32 <= d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT - 1,
+                data.c.res_index as u32
+                    <= d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT - 1,
                 "{} bound constant buffers exceeds limit of {}",
                 data.c.res_index as u32,
                 d3d11::D3D11_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT - 1,
@@ -1010,8 +1020,13 @@ impl device::Device<Backend> for Device {
                 let vs = build_shader(ShaderStage::Vertex, Some(&vertex))?.unwrap();
                 let gs = build_shader(ShaderStage::Geometry, geometry.as_ref())?;
 
-                let layout =
-                    self.create_input_layout(vs.clone(), buffers, attributes, input_assembler, vertex_semantic_remapping)?;
+                let layout = self.create_input_layout(
+                    vs.clone(),
+                    buffers,
+                    attributes,
+                    input_assembler,
+                    vertex_semantic_remapping,
+                )?;
 
                 let vs = self.create_vertex_shader(vs)?;
                 let gs = if let Some(blob) = gs {
@@ -1045,7 +1060,8 @@ impl device::Device<Backend> for Device {
             None
         };
 
-        let rasterizer_state = self.create_rasterizer_state(&desc.rasterizer, &desc.multisampling)?;
+        let rasterizer_state =
+            self.create_rasterizer_state(&desc.rasterizer, &desc.multisampling)?;
         let blend_state = self.create_blend_state(&desc.blender, &desc.multisampling)?;
         let depth_stencil_state = Some(self.create_depth_stencil_state(&desc.depth_stencil)?);
 
@@ -1366,7 +1382,7 @@ impl device::Device<Backend> for Device {
             srv,
             uav,
             usage: buffer.internal.usage,
-            debug_name: buffer.internal.debug_name.take()
+            debug_name: buffer.internal.debug_name.take(),
         };
         let range = offset..offset + buffer.requirements.size;
 
@@ -1671,7 +1687,10 @@ impl device::Device<Backend> for Device {
                         .map_err(|_| device::BindError::WrongMemory)?;
 
                     if let Some(ref name) = image.internal.debug_name {
-                        set_debug_name(&rtv, &format!("{} -- RTV Mip {} Layer {}", name, mip, layer));
+                        set_debug_name(
+                            &rtv,
+                            &format!("{} -- RTV Mip {} Layer {}", name, mip, layer),
+                        );
                     }
 
                     render_target_views.push(rtv);
@@ -1695,11 +1714,14 @@ impl device::Device<Backend> for Device {
                     };
 
                     let dsv = self
-                            .view_image_as_depth_stencil(&view, None)
-                            .map_err(|_| device::BindError::WrongMemory)?;
+                        .view_image_as_depth_stencil(&view, None)
+                        .map_err(|_| device::BindError::WrongMemory)?;
 
                     if let Some(ref name) = image.internal.debug_name {
-                        set_debug_name(&dsv, &format!("{} -- DSV Mip {} Layer {}", name, mip, layer));
+                        set_debug_name(
+                            &dsv,
+                            &format!("{} -- DSV Mip {} Layer {}", name, mip, layer),
+                        );
                     }
 
                     depth_stencil_views.push(dsv);
@@ -1724,7 +1746,7 @@ impl device::Device<Backend> for Device {
             unordered_access_views,
             depth_stencil_views,
             render_target_views,
-            debug_name: image.internal.debug_name.take()
+            debug_name: image.internal.debug_name.take(),
         };
 
         image.decomposed_format = decomposed;
@@ -1770,7 +1792,11 @@ impl device::Device<Backend> for Device {
         let mut debug_name = image.internal.debug_name.clone();
 
         Ok(ImageView {
-            subresource: d3d11::D3D11CalcSubresource(0, range.layer_start as _, range.level_start as _),
+            subresource: d3d11::D3D11CalcSubresource(
+                0,
+                range.layer_start as _,
+                range.level_start as _,
+            ),
             format,
             srv_handle: if image.usage.intersects(image::Usage::SAMPLED) {
                 let srv = self.view_image_as_shader_resource(&srv_info)?;
@@ -1817,8 +1843,8 @@ impl device::Device<Backend> for Device {
                 None
             },
             rodsv_handle: if image.usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT) {
-                let rodsv = self.view_image_as_depth_stencil(&info, Some(image.format.is_stencil()))?;
-
+                let rodsv =
+                    self.view_image_as_depth_stencil(&info, Some(image.format.is_stencil()))?;
 
                 if let Some(ref mut name) = debug_name {
                     set_debug_name_with_suffix(&rodsv, name, " -- DSV");
@@ -1917,11 +1943,16 @@ impl device::Device<Backend> for Device {
             let content = DescriptorContent::from(binding.ty);
             // If this binding is used by the graphics pipeline and is a UAV, it belongs to the "Output Merger"
             // stage, so we only put them in the fragment stage to save redundant descriptor allocations.
-            let stage_flags =
-                if content.contains(DescriptorContent::UAV)
-                    && binding.stage_flags.intersects(pso::ShaderStageFlags::ALL - pso::ShaderStageFlags::COMPUTE) {
+            let stage_flags = if content.contains(DescriptorContent::UAV)
+                && binding
+                    .stage_flags
+                    .intersects(pso::ShaderStageFlags::ALL - pso::ShaderStageFlags::COMPUTE)
+            {
                 let mut stage_flags = pso::ShaderStageFlags::FRAGMENT;
-                stage_flags.set(pso::ShaderStageFlags::COMPUTE, binding.stage_flags.contains(pso::ShaderStageFlags::COMPUTE));
+                stage_flags.set(
+                    pso::ShaderStageFlags::COMPUTE,
+                    binding.stage_flags.contains(pso::ShaderStageFlags::COMPUTE),
+                );
                 stage_flags
             } else {
                 binding.stage_flags
@@ -1976,7 +2007,8 @@ impl device::Device<Backend> for Device {
 
             // If we're skipping array indices in the current binding, we need to add them to get the correct binding offset
             if array_index > 0 {
-                let binding: &pso::DescriptorSetLayoutBinding = &write.set.layout.bindings[binding_index];
+                let binding: &pso::DescriptorSetLayoutBinding =
+                    &write.set.layout.bindings[binding_index];
                 let content = DescriptorContent::from(binding.ty);
                 mapping.add_content_many(content, binding.stage_flags, array_index as _);
             }
@@ -1987,7 +2019,8 @@ impl device::Device<Backend> for Device {
             // When we hit the end of an array of descriptors and there are still descriptors left
             // over, we will spill into writing the next binding.
             for descriptor in write.descriptors {
-                let binding: &pso::DescriptorSetLayoutBinding = &write.set.layout.bindings[binding_index];
+                let binding: &pso::DescriptorSetLayoutBinding =
+                    &write.set.layout.bindings[binding_index];
 
                 let handles = match *descriptor.borrow() {
                     pso::Descriptor::Buffer(buffer, ref _sub) => RegisterData {
@@ -2001,12 +2034,8 @@ impl device::Device<Backend> for Device {
                     },
                     pso::Descriptor::Image(image, _layout) => RegisterData {
                         c: ptr::null_mut(),
-                        t: image
-                            .srv_handle
-                            .map_or(ptr::null_mut(), |h| h as *mut _),
-                        u: image
-                            .uav_handle
-                            .map_or(ptr::null_mut(), |h| h as *mut _),
+                        t: image.srv_handle.map_or(ptr::null_mut(), |h| h as *mut _),
+                        u: image.uav_handle.map_or(ptr::null_mut(), |h| h as *mut _),
                         s: ptr::null_mut(),
                     },
                     pso::Descriptor::Sampler(sampler) => RegisterData {
@@ -2018,12 +2047,8 @@ impl device::Device<Backend> for Device {
                     pso::Descriptor::CombinedImageSampler(image, _layout, sampler) => {
                         RegisterData {
                             c: ptr::null_mut(),
-                            t: image
-                                .srv_handle
-                                .map_or(ptr::null_mut(), |h| h as *mut _),
-                            u: image
-                                .uav_handle
-                                .map_or(ptr::null_mut(), |h| h as *mut _),
+                            t: image.srv_handle.map_or(ptr::null_mut(), |h| h as *mut _),
+                            u: image.uav_handle.map_or(ptr::null_mut(), |h| h as *mut _),
                             s: sampler.sampler_handle.as_raw() as *mut _,
                         }
                     }
@@ -2046,18 +2071,22 @@ impl device::Device<Backend> for Device {
                 if content.contains(DescriptorContent::UAV) {
                     // If this binding is used by the graphics pipeline and is a UAV, it belongs to the "Output Merger"
                     // stage, so we only put them in the fragment stage to save redundant descriptor allocations.
-                    let stage_flags = if binding.stage_flags.intersects(pso::ShaderStageFlags::ALL - pso::ShaderStageFlags::COMPUTE) {
+                    let stage_flags = if binding
+                        .stage_flags
+                        .intersects(pso::ShaderStageFlags::ALL - pso::ShaderStageFlags::COMPUTE)
+                    {
                         let mut stage_flags = pso::ShaderStageFlags::FRAGMENT;
-                        stage_flags.set(pso::ShaderStageFlags::COMPUTE, binding.stage_flags.contains(pso::ShaderStageFlags::COMPUTE));
+                        stage_flags.set(
+                            pso::ShaderStageFlags::COMPUTE,
+                            binding.stage_flags.contains(pso::ShaderStageFlags::COMPUTE),
+                        );
                         stage_flags
                     } else {
                         binding.stage_flags
                     };
 
                     let offsets = mapping.map_other(|map| map.u);
-                    write
-                        .set
-                        .assign_stages(&offsets, stage_flags, handles.u);
+                    write.set.assign_stages(&offsets, stage_flags, handles.u);
                 };
                 if content.contains(DescriptorContent::SAMPLER) {
                     let offsets = mapping.map_other(|map| map.s);
@@ -2439,8 +2468,16 @@ impl device::Device<Backend> for Device {
         let mut name = name.to_string();
 
         set_debug_name_with_suffix(&graphics_pipeline.blend_state, &mut name, " -- Blend State");
-        set_debug_name_with_suffix(&graphics_pipeline.rasterizer_state, &mut name, " -- Rasterizer State");
-        set_debug_name_with_suffix(&graphics_pipeline.input_layout, &mut name, " -- Input Layout");
+        set_debug_name_with_suffix(
+            &graphics_pipeline.rasterizer_state,
+            &mut name,
+            " -- Rasterizer State",
+        );
+        set_debug_name_with_suffix(
+            &graphics_pipeline.input_layout,
+            &mut name,
+            " -- Input Layout",
+        );
         if let Some(ref dss) = graphics_pipeline.depth_stencil_state {
             set_debug_name_with_suffix(&dss.raw, &mut name, " -- Depth Stencil State");
         }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -1954,16 +1954,21 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         }
     }
 
-    unsafe fn bind_index_buffer(&mut self, ibv: buffer::IndexBufferView<Backend>) {
-        let buffer = ibv.buffer.expect_bound();
-        let format = match ibv.index_type {
+    unsafe fn bind_index_buffer(
+        &mut self,
+        buffer: &r::Buffer,
+        sub: buffer::SubRange,
+        ty: IndexType,
+    ) {
+        let buffer = buffer.expect_bound();
+        let format = match ty {
             IndexType::U16 => dxgiformat::DXGI_FORMAT_R16_UINT,
             IndexType::U32 => dxgiformat::DXGI_FORMAT_R32_UINT,
         };
         let location = buffer.resource.gpu_virtual_address();
         self.raw.set_index_buffer(
-            location + ibv.range.offset,
-            ibv.range.size_to(buffer.requirements.size) as u32,
+            location + sub.offset,
+            sub.size_to(buffer.requirements.size) as u32,
             format,
         );
     }

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -176,7 +176,10 @@ impl w::PresentationSurface<Backend> for Surface {
         // Disable automatic Alt+Enter handling by DXGI.
         const DXGI_MWA_NO_WINDOW_CHANGES: u32 = 1;
         const DXGI_MWA_NO_ALT_ENTER: u32 = 2;
-        self.factory.MakeWindowAssociation(self.wnd_handle, DXGI_MWA_NO_WINDOW_CHANGES | DXGI_MWA_NO_ALT_ENTER);
+        self.factory.MakeWindowAssociation(
+            self.wnd_handle,
+            DXGI_MWA_NO_WINDOW_CHANGES | DXGI_MWA_NO_ALT_ENTER,
+        );
 
         self.presentation = Some(Presentation {
             swapchain: device.wrap_swapchain(swapchain, &config),

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -728,7 +728,12 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn bind_index_buffer(&mut self, _: hal::buffer::IndexBufferView<Backend>) {
+    unsafe fn bind_index_buffer(
+        &mut self,
+        _: &Buffer,
+        _: hal::buffer::SubRange,
+        _: hal::IndexType,
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -906,11 +906,15 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!()
     }
 
-    unsafe fn bind_index_buffer(&mut self, ibv: buffer::IndexBufferView<Backend>) {
-        let (raw_buffer, range) = ibv.buffer.as_bound();
+    unsafe fn bind_index_buffer(
+        &mut self,
+        buffer: &n::Buffer,
+        sub: buffer::SubRange,
+        ty: hal::IndexType,
+    ) {
+        let (raw_buffer, parent_range) = buffer.as_bound();
 
-        self.cache.index_type_range =
-            Some((ibv.index_type, crate::resolve_sub_range(&ibv.range, range)));
+        self.cache.index_type_range = Some((ty, crate::resolve_sub_range(&sub, parent_range)));
         self.data.push_cmd(Command::BindIndexBuffer(raw_buffer));
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1092,10 +1092,7 @@ impl d::Device<B> for Device {
 
             if let Err(err) = self.share.check() {
                 //TODO: attachments have been consumed
-                panic!(
-                    "Error creating FBO: {:?} for {:?}", /* with attachments {:?}"*/
-                    err, pass /*, attachments*/
-                );
+                panic!("Error creating FBO: {:?} for {:?}", err, pass);
             }
 
             Some(name)

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -3380,13 +3380,18 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         retained_textures.extend(dst_cubish);
     }
 
-    unsafe fn bind_index_buffer(&mut self, view: buffer::IndexBufferView<Backend>) {
-        let (raw, range) = view.buffer.as_bound();
-        assert!(range.start + view.range.offset + view.range.size.unwrap_or(0) <= range.end); // conservative
+    unsafe fn bind_index_buffer(
+        &mut self,
+        buffer: &native::Buffer,
+        sub: buffer::SubRange,
+        ty: IndexType,
+    ) {
+        let (raw, range) = buffer.as_bound();
+        assert!(range.start + sub.offset + sub.size.unwrap_or(0) <= range.end); // conservative
         self.state.index_buffer = Some(IndexBuffer {
             buffer: AsNative::from(raw),
-            offset: (range.start + view.range.offset) as _,
-            stride: match view.index_type {
+            offset: (range.start + sub.offset) as _,
+            stride: match ty {
                 IndexType::U16 => 2,
                 IndexType::U32 => 4,
             },

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1846,14 +1846,16 @@ impl hal::device::Device<Backend> for Device {
         Ok(n::ShaderModule {
             spv: raw_data.to_vec(),
             #[cfg(feature = "naga")]
-            naga: match naga::front::spv::Parser::new(raw_data.iter().cloned(), &Default::default()).parse() {
+            naga: match naga::front::spv::Parser::new(raw_data.iter().cloned(), &Default::default())
+                .parse()
+            {
                 Ok(module) => match naga::proc::Validator::new().validate(&module) {
                     Ok(()) => Some(module),
                     Err(e) => {
                         warn!("Naga validation failed: {:?}", e);
                         None
                     }
-                }
+                },
                 Err(e) => {
                     warn!("Naga parsing failed: {:?}", e);
                     None

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -1,11 +1,6 @@
-use ash::version::DeviceV1_0;
-use ash::vk;
+use ash::{version::DeviceV1_0, vk};
 use smallvec::SmallVec;
-use std::borrow::Borrow;
-use std::ffi::CString;
-use std::ops::Range;
-use std::sync::Arc;
-use std::{mem, slice};
+use std::{borrow::Borrow, ffi::CString, mem, ops::Range, slice, sync::Arc};
 
 use inplace_it::inplace_or_alloc_array;
 
@@ -14,8 +9,8 @@ use hal::{
     buffer, command as com,
     format::Aspects,
     image::{Filter, Layout, SubresourceRange},
-    memory, pso, query, DrawCount, IndexCount, InstanceCount, TaskCount, VertexCount, VertexOffset,
-    WorkGroupCount,
+    memory, pso, query, DrawCount, IndexCount, IndexType, InstanceCount, TaskCount, VertexCount,
+    VertexOffset, WorkGroupCount,
 };
 
 #[derive(Debug)]
@@ -525,12 +520,17 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         });
     }
 
-    unsafe fn bind_index_buffer(&mut self, ibv: buffer::IndexBufferView<Backend>) {
+    unsafe fn bind_index_buffer(
+        &mut self,
+        buffer: &n::Buffer,
+        sub: buffer::SubRange,
+        ty: IndexType,
+    ) {
         self.device.raw.cmd_bind_index_buffer(
             self.raw,
-            ibv.buffer.raw,
-            ibv.range.offset,
-            conv::map_index_type(ibv.index_type),
+            buffer.raw,
+            sub.offset,
+            conv::map_index_type(ty),
         );
     }
 

--- a/src/backend/webgpu/src/command.rs
+++ b/src/backend/webgpu/src/command.rs
@@ -13,7 +13,8 @@ use hal::{
     pso, query,
     queue::Submission,
     window::{PresentError, PresentationSurface, Suboptimal, SwapImageIndex},
-    DrawCount, IndexCount, InstanceCount, TaskCount, VertexCount, VertexOffset, WorkGroupCount,
+    DrawCount, IndexCount, IndexType, InstanceCount, TaskCount, VertexCount, VertexOffset,
+    WorkGroupCount,
 };
 
 use crate::Backend;
@@ -192,7 +193,12 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         todo!()
     }
 
-    unsafe fn bind_index_buffer(&mut self, _view: buffer::IndexBufferView<Backend>) {
+    unsafe fn bind_index_buffer(
+        &mut self,
+        _buffer: &<Backend as hal::Backend>::Buffer,
+        _sub: buffer::SubRange,
+        _ty: IndexType,
+    ) {
         todo!()
     }
 

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -5,7 +5,7 @@
 //! They can be used as shader resources, vertex buffers, index buffers or for
 //! specifying the action commands for indirect execution.
 
-use crate::{device, format, Backend, IndexType};
+use crate::{device::OutOfMemory, format::Format};
 
 /// An offset inside a buffer, in bytes.
 pub type Offset = u64;
@@ -40,7 +40,7 @@ pub type State = Access;
 #[derive(Clone, Debug, PartialEq)]
 pub enum CreationError {
     /// Out of either host or device memory.
-    OutOfMemory(device::OutOfMemory),
+    OutOfMemory(OutOfMemory),
 
     /// Requested buffer usage is not supported.
     ///
@@ -51,8 +51,8 @@ pub enum CreationError {
     },
 }
 
-impl From<device::OutOfMemory> for CreationError {
-    fn from(error: device::OutOfMemory) -> Self {
+impl From<OutOfMemory> for CreationError {
+    fn from(error: OutOfMemory) -> Self {
         CreationError::OutOfMemory(error)
     }
 }
@@ -83,14 +83,14 @@ impl std::error::Error for CreationError {
 #[derive(Clone, Debug, PartialEq)]
 pub enum ViewCreationError {
     /// Out of either host or device memory.
-    OutOfMemory(device::OutOfMemory),
+    OutOfMemory(OutOfMemory),
 
     /// Buffer view format is not supported.
-    UnsupportedFormat(Option<format::Format>),
+    UnsupportedFormat(Option<Format>),
 }
 
-impl From<device::OutOfMemory> for ViewCreationError {
-    fn from(error: device::OutOfMemory) -> Self {
+impl From<OutOfMemory> for ViewCreationError {
+    fn from(error: OutOfMemory) -> Self {
         ViewCreationError::OutOfMemory(error)
     }
 }
@@ -190,17 +190,3 @@ bitflags!(
         const MEMORY_WRITE = 0x10000;
     }
 );
-
-/// Index buffer view for `bind_index_buffer`.
-///
-/// Defines a buffer slice used for acquiring the indices on draw commands.
-/// Indices are used to lookup vertex indices in the vertex buffers.
-#[derive(Debug)]
-pub struct IndexBufferView<'a, B: Backend> {
-    /// The buffer to bind.
-    pub buffer: &'a B::Buffer,
-    /// The subrange of the buffer.
-    pub range: SubRange,
-    /// The type of the table elements (`u16` or `u32`).
-    pub index_type: IndexType,
-}

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -16,17 +16,14 @@
 mod clear;
 mod structs;
 
-use std::any::Any;
-use std::borrow::Borrow;
-use std::fmt;
-use std::ops::Range;
+use std::{any::Any, borrow::Borrow, fmt, ops::Range};
 
-use crate::image::{Filter, Layout, SubresourceRange};
-use crate::memory::{Barrier, Dependencies};
-use crate::{buffer, pass, pso, query};
 use crate::{
-    Backend, DrawCount, IndexCount, InstanceCount, TaskCount, VertexCount, VertexOffset,
-    WorkGroupCount,
+    buffer,
+    image::{Filter, Layout, SubresourceRange},
+    memory::{Barrier, Dependencies},
+    pass, pso, query, Backend, DrawCount, IndexCount, IndexType, InstanceCount, TaskCount,
+    VertexCount, VertexOffset, WorkGroupCount,
 };
 
 pub use self::clear::*;
@@ -192,7 +189,12 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
 
     /// Bind the index buffer view, making it the "current" one that draw commands
     /// will operate on.
-    unsafe fn bind_index_buffer(&mut self, view: buffer::IndexBufferView<B>);
+    unsafe fn bind_index_buffer(
+        &mut self,
+        buffer: &B::Buffer,
+        sub: buffer::SubRange,
+        ty: IndexType,
+    );
 
     /// Bind the vertex buffer set, making it the "current" one that draw commands
     /// will operate on.

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -1314,16 +1314,16 @@ impl<B: hal::Backend> Scene<B> {
                                     ref range,
                                     index_type,
                                 } => {
-                                    let view = b::IndexBufferView {
-                                        buffer: &resources
-                                            .buffers
-                                            .get(buffer)
-                                            .expect(&format!("Missing index buffer: {}", buffer))
-                                            .handle,
-                                        range: range.clone(),
+                                    let buffer = &resources
+                                        .buffers
+                                        .get(buffer)
+                                        .expect(&format!("Missing index buffer: {}", buffer))
+                                        .handle;
+                                    command_buf.bind_index_buffer(
+                                        buffer,
+                                        range.clone(),
                                         index_type,
-                                    };
-                                    command_buf.bind_index_buffer(view);
+                                    );
                                 }
                                 Dc::BindVertexBuffers(ref buffers) => {
                                     let buffers_raw = buffers.iter().map(|&(ref name, ref sub)| {


### PR DESCRIPTION
Makes it more consistent with `bind_vertex_buffers`, and also removes one more type from gfx-hal.
Also fixes #3483 
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
