### PR TITLE
[0.6/dx11] Increase max bound descriptor set count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx11-0.6.16 (27-11-2020)
+  - expose proper max bound descriptor set limit 
+
 ### backend-metal-0.6.5 (27-11-2020)
   - fix render pass compatibility with multi-sampled formats
 

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx11"
-version = "0.6.15"
+version = "0.6.16"
 description = "DirectX-11 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -264,6 +264,7 @@ fn get_limits(feature_level: d3dcommon::D3D_FEATURE_LEVEL) -> hal::Limits {
             d3d11::D3D11_COMMONSHADER_INPUT_RESOURCE_REGISTER_COUNT as _,
         max_descriptor_set_uniform_buffers_dynamic: max_constant_buffers as _,
         max_descriptor_set_storage_buffers_dynamic: 0, // TODO: Implement dynamic offsets for storage buffers
+        max_bound_descriptor_sets: pso::DescriptorSetIndex::MAX,
         max_texel_elements: max_texture_uv_dimension as _, //TODO
         max_patch_size: d3d11::D3D11_IA_PATCH_MAX_CONTROL_POINT_COUNT as _,
         max_viewports: d3d11::D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE as _,


### PR DESCRIPTION
Allows the latest rend3 version to run on DX11. As the DX11 backend has no actual limit to how many descriptor sets can be bound, I just set it to the max value.