### PR TITLE
[dx12] Add support for PresentMode::IMMEDIATE

### DIFF
--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.4"
 parking_lot = "0.11"
 smallvec = "1"
 spirv_cross = { version = "0.22", features = ["hlsl"] }
-winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
+winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_5","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 raw-window-handle = "0.3"
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1085,6 +1085,11 @@ impl Device {
         //TODO: proper error type?
         let non_srgb_format = conv::map_format_nosrgb(config.format).unwrap();
 
+        let mut flags = dxgi::DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
+        if config.present_mode.contains(w::PresentMode::IMMEDIATE) {
+            flags |= dxgi::DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+        }
+
         // TODO: double-check values
         let desc = dxgi1_2::DXGI_SWAP_CHAIN_DESC1 {
             AlphaMode: dxgi1_2::DXGI_ALPHA_MODE_IGNORE,
@@ -1092,7 +1097,7 @@ impl Device {
             Width: config.extent.width,
             Height: config.extent.height,
             Format: non_srgb_format,
-            Flags: dxgi::DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT,
+            Flags: flags,
             BufferUsage: dxgitype::DXGI_USAGE_RENDER_TARGET_OUTPUT,
             SampleDesc: dxgitype::DXGI_SAMPLE_DESC {
                 Count: 1,


### PR DESCRIPTION
Add support for `PresentMode::IMMEDIATE` in the DX12 backend by using the "allow tearing" swap chain feature of DXGI.

Tested on a modified `quad` example on all three vendors, both in windowed and winit's `ExclusiveFullscreen` mode.

PR checklist:
- [ ] `make` succeeds (on *nix) - not applicable
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: `dx12`
