### PR TITLE
Use thiserror and refactor errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### hal-unreleased
+  - use `thiserror` for errors
+  - error variants and a few names are refactored
+
 ### backend-dx12-unreleased
   - fix SPIR-V entry point selection
 

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -230,7 +230,7 @@ impl<B: Backend> RendererState<B> {
         const IMAGE_LOGO: &'static [u8] = include_bytes!("data/logo.png");
         let img = image::load(Cursor::new(&IMAGE_LOGO[..]), image::ImageFormat::Png)
             .unwrap()
-            .to_rgba();
+            .to_rgba8();
 
         let mut staging_pool = device
             .borrow()

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -356,7 +356,7 @@ where
 
         let img = image::load(Cursor::new(&img_data[..]), image::ImageFormat::Png)
             .unwrap()
-            .to_rgba();
+            .to_rgba8();
         let (width, height) = img.dimensions();
         let kind = i::Kind::D2(width as i::Size, height as i::Size, 1, 1);
         let row_alignment_mask = limits.optimal_buffer_copy_pitch_alignment as u32 - 1;

--- a/src/auxil/auxil/src/lib.rs
+++ b/src/auxil/auxil/src/lib.rs
@@ -1,9 +1,6 @@
-use std::{io, slice};
 #[cfg(feature = "spirv_cross")]
-use {
-    hal::{device::ShaderError, pso},
-    spirv_cross::spirv,
-};
+use spirv_cross::spirv;
+use std::{io, slice};
 
 /// Fast hash map used internally.
 pub type FastHashMap<K, V> =
@@ -101,18 +98,18 @@ pub fn read_spirv<R: io::Read + io::Seek>(mut x: R) -> io::Result<Vec<u32>> {
 #[cfg(feature = "spirv_cross")]
 pub fn spirv_cross_specialize_ast<T>(
     ast: &mut spirv::Ast<T>,
-    specialization: &pso::Specialization,
-) -> Result<(), ShaderError>
+    specialization: &hal::pso::Specialization,
+) -> Result<(), String>
 where
     T: spirv::Target,
     spirv::Ast<T>: spirv::Compile<T> + spirv::Parse<T>,
 {
-    let spec_constants = ast.get_specialization_constants().map_err(|err| {
-        ShaderError::CompilationFailed(match err {
+    let spec_constants = ast
+        .get_specialization_constants()
+        .map_err(|err| match err {
             spirv_cross::ErrorCode::CompilationError(msg) => msg,
             spirv_cross::ErrorCode::Unhandled => "Unexpected specialization constant error".into(),
-        })
-    })?;
+        })?;
 
     for spec_constant in spec_constants {
         if let Some(constant) = specialization
@@ -128,13 +125,11 @@ where
                 .fold(0u64, |u, &b| (u << 8) + b as u64);
 
             ast.set_scalar_constant(spec_constant.id, value)
-                .map_err(|err| {
-                    ShaderError::CompilationFailed(match err {
-                        spirv_cross::ErrorCode::CompilationError(msg) => msg,
-                        spirv_cross::ErrorCode::Unhandled => {
-                            "Unexpected specialization constant error".into()
-                        }
-                    })
+                .map_err(|err| match err {
+                    spirv_cross::ErrorCode::CompilationError(msg) => msg,
+                    spirv_cross::ErrorCode::Unhandled => {
+                        "Unexpected specialization constant error".into()
+                    }
                 })?;
         }
     }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -954,7 +954,7 @@ impl window::PresentationSurface<Backend> for Surface {
         &mut self,
         device: &device::Device,
         config: window::SwapchainConfig,
-    ) -> Result<(), window::CreationError> {
+    ) -> Result<(), window::SwapchainError> {
         assert!(image::Usage::COLOR_ATTACHMENT.contains(config.image_usage));
 
         let swapchain = match self.presentation.take() {
@@ -974,7 +974,7 @@ impl window::PresentationSurface<Backend> for Surface {
                 );
                 if result != winerror::S_OK {
                     error!("ResizeBuffers failed with 0x{:x}", result as u32);
-                    return Err(window::CreationError::WindowInUse(hal::device::WindowInUse));
+                    return Err(window::SwapchainError::WindowInUse);
                 }
                 present.swapchain
             }

--- a/src/backend/dx11/src/shader.rs
+++ b/src/backend/dx11/src/shader.rs
@@ -9,27 +9,29 @@ use winapi::{
 use wio::com::ComPtr;
 
 use auxil::{spirv_cross_specialize_ast, ShaderStage};
-use hal::{device, pso};
+use hal::pso;
 
 use crate::{conv, Backend, PipelineLayout};
 
 /// Emit error during shader module creation. Used if we don't expect an error
 /// but might panic due to an exception in SPIRV-Cross.
-fn gen_unexpected_error(err: SpirvErrorCode) -> device::ShaderError {
+fn gen_unexpected_error(err: SpirvErrorCode) -> pso::CreationError {
     let msg = match err {
         SpirvErrorCode::CompilationError(msg) => msg,
         SpirvErrorCode::Unhandled => "Unexpected error".into(),
     };
-    device::ShaderError::CompilationFailed(msg)
+    error!("SPIR-V unexpected error {:?}", msg);
+    pso::CreationError::Other
 }
 
 /// Emit error during shader module creation. Used if we execute an query command.
-fn gen_query_error(err: SpirvErrorCode) -> device::ShaderError {
+fn gen_query_error(err: SpirvErrorCode) -> pso::CreationError {
     let msg = match err {
         SpirvErrorCode::CompilationError(msg) => msg,
         SpirvErrorCode::Unhandled => "Unknown query error".into(),
     };
-    device::ShaderError::CompilationFailed(msg)
+    error!("SPIR-V query error {:?}", msg);
+    pso::CreationError::Other
 }
 
 /// Introspects the input attributes of given SPIR-V shader and returns an optional vertex semantic remapping.
@@ -45,7 +47,7 @@ fn gen_query_error(err: SpirvErrorCode) -> device::ShaderError {
 /// This workaround also exists under the same name in the DX12 backend.
 pub(crate) fn introspect_spirv_vertex_semantic_remapping(
     raw_data: &[u32],
-) -> Result<auxil::FastHashMap<u32, Option<(u32, u32)>>, device::ShaderError> {
+) -> Result<auxil::FastHashMap<u32, Option<(u32, u32)>>, pso::CreationError> {
     // This is inefficient as we already parse it once before. This is a temporary workaround only called
     // on vertex shaders. If this becomes permanent or shows up in profiles, deduplicate these as first course of action.
     let ast = parse_spirv(raw_data)?;
@@ -74,19 +76,21 @@ pub(crate) fn introspect_spirv_vertex_semantic_remapping(
             {
                 for col in 0..columns {
                     if let Some(_) = map.insert(idx + col, Some((idx, col))) {
-                        return Err(device::ShaderError::CompilationFailed(format!(
+                        error!(
                             "Shader has overlapping input attachments at location {}",
                             idx
-                        )));
+                        );
+                        return Err(pso::CreationError::Other);
                     }
                 }
             }
             _ => {
                 if let Some(_) = map.insert(idx, None) {
-                    return Err(device::ShaderError::CompilationFailed(format!(
+                    error!(
                         "Shader has overlapping input attachments at location {}",
                         idx
-                    )));
+                    );
+                    return Err(pso::CreationError::Other);
                 }
             }
         }
@@ -101,9 +105,10 @@ pub(crate) fn compile_spirv_entrypoint(
     source: &pso::EntryPoint<Backend>,
     layout: &PipelineLayout,
     features: &hal::Features,
-) -> Result<Option<ComPtr<d3dcommon::ID3DBlob>>, device::ShaderError> {
+) -> Result<Option<ComPtr<d3dcommon::ID3DBlob>>, pso::CreationError> {
     let mut ast = parse_spirv(raw_data)?;
-    spirv_cross_specialize_ast(&mut ast, &source.specialization)?;
+    spirv_cross_specialize_ast(&mut ast, &source.specialization)
+        .map_err(pso::CreationError::InvalidSpecialization)?;
 
     patch_spirv_resources(&mut ast, stage, layout)?;
     let shader_model = hlsl::ShaderModel::V5_0;
@@ -123,20 +128,13 @@ pub(crate) fn compile_spirv_entrypoint(
 
     // TODO: opt: don't query *all* entry points.
     let entry_points = ast.get_entry_points().map_err(gen_query_error)?;
-    entry_points
+    let ep = entry_points
         .iter()
         .find(|entry_point| entry_point.name == real_name)
-        .ok_or(device::ShaderError::MissingEntryPoint(source.entry.into()))
-        .and_then(|entry_point| {
-            let stage = conv::map_execution_model(entry_point.execution_model);
-            let shader = compile_hlsl_shader(
-                stage,
-                shader_model,
-                &entry_point.name,
-                shader_code.as_bytes(),
-            )?;
-            Ok(Some(unsafe { ComPtr::from_raw(shader) }))
-        })
+        .ok_or(pso::CreationError::MissingEntryPoint(source.entry.into()))?;
+    let stage = conv::map_execution_model(ep.execution_model);
+    let shader = compile_hlsl_shader(stage, shader_model, &ep.name, shader_code.as_bytes())?;
+    Ok(Some(unsafe { ComPtr::from_raw(shader) }))
 }
 
 pub(crate) fn compile_hlsl_shader(
@@ -144,7 +142,7 @@ pub(crate) fn compile_hlsl_shader(
     shader_model: hlsl::ShaderModel,
     entry: &str,
     code: &[u8],
-) -> Result<*mut d3dcommon::ID3DBlob, device::ShaderError> {
+) -> Result<*mut d3dcommon::ID3DBlob, pso::CreationError> {
     let stage_str = {
         let stage = match stage {
             ShaderStage::Vertex => "vs",
@@ -192,30 +190,34 @@ pub(crate) fn compile_hlsl_shader(
             let slice = slice::from_raw_parts(pointer as *const u8, size as usize);
             String::from_utf8_lossy(slice).into_owned()
         };
-
-        Err(device::ShaderError::CompilationFailed(message))
+        error!("D3DCompile error {:x}: {}", hr, message);
+        Err(pso::CreationError::Other)
     } else {
         Ok(blob)
     }
 }
 
-fn parse_spirv(raw_data: &[u32]) -> Result<spirv::Ast<hlsl::Target>, device::ShaderError> {
+fn parse_spirv(raw_data: &[u32]) -> Result<spirv::Ast<hlsl::Target>, pso::CreationError> {
     let module = spirv::Module::from_words(raw_data);
 
-    spirv::Ast::parse(&module).map_err(|err| {
-        let msg = match err {
-            SpirvErrorCode::CompilationError(msg) => msg,
-            SpirvErrorCode::Unhandled => "Unknown parsing error".into(),
-        };
-        device::ShaderError::CompilationFailed(msg)
-    })
+    match spirv::Ast::parse(&module) {
+        Ok(ast) => Ok(ast),
+        Err(err) => {
+            let msg = match err {
+                SpirvErrorCode::CompilationError(msg) => msg,
+                SpirvErrorCode::Unhandled => "Unknown parsing error".into(),
+            };
+            error!("SPIR-V parsing failed: {:?}", msg);
+            Err(pso::CreationError::Other)
+        }
+    }
 }
 
 fn patch_spirv_resources(
     ast: &mut spirv::Ast<hlsl::Target>,
     stage: ShaderStage,
     layout: &PipelineLayout,
-) -> Result<(), device::ShaderError> {
+) -> Result<(), pso::CreationError> {
     // we remap all `layout(binding = n, set = n)` to a flat space which we get from our
     // `PipelineLayout` which knows of all descriptor set layouts
 
@@ -367,7 +369,7 @@ fn translate_spirv(
     stage: ShaderStage,
     features: &hal::Features,
     entry_point: &str,
-) -> Result<String, device::ShaderError> {
+) -> Result<String, pso::CreationError> {
     let mut compile_options = hlsl::CompilerOptions::default();
     compile_options.shader_model = shader_model;
     compile_options.vertex.invert_y = !features.contains(hal::Features::NDC_Y_UP);
@@ -400,6 +402,7 @@ fn translate_spirv(
             SpirvErrorCode::CompilationError(msg) => msg,
             SpirvErrorCode::Unhandled => "Unknown compile error".into(),
         };
-        device::ShaderError::CompilationFailed(msg)
+        error!("SPIR-V compile failed: {:?}", msg);
+        pso::CreationError::Other
     })
 }

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -59,7 +59,7 @@ impl Surface {
                 expected_index,
                 image.index
             );
-            return Err(w::PresentError::OutOfDate);
+            return Err(w::OutOfDate.into());
         }
 
         let (interval, flags) = match present.mode {
@@ -171,7 +171,7 @@ impl w::PresentationSurface<Backend> for Surface {
         &mut self,
         device: &Device,
         config: w::SwapchainConfig,
-    ) -> Result<(), w::CreationError> {
+    ) -> Result<(), w::SwapchainError> {
         assert!(i::Usage::COLOR_ATTACHMENT.contains(config.image_usage));
 
         let swapchain = match self.presentation.take() {
@@ -198,7 +198,7 @@ impl w::PresentationSurface<Backend> for Surface {
                 );
                 if result != winerror::S_OK {
                     error!("ResizeBuffers failed with 0x{:x}", result as u32);
-                    return Err(w::CreationError::WindowInUse(hal::device::WindowInUse));
+                    return Err(w::SwapchainError::WindowInUse);
                 }
                 inner
             }
@@ -340,7 +340,7 @@ impl Swapchain {
                 Err(w::AcquireError::DeviceLost(hal::device::DeviceLost))
             }
             winbase::WAIT_OBJECT_0 => Ok(()),
-            winerror::WAIT_TIMEOUT => Err(w::AcquireError::Timeout),
+            winerror::WAIT_TIMEOUT => Err(w::AcquireError::NotReady { timeout: true }),
             hr => panic!("Unexpected wait status 0x{:X}", hr),
         }
     }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -442,7 +442,7 @@ impl device::Device<Backend> for Device {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn get_event_status(&self, _: &()) -> Result<bool, device::OomOrDeviceLost> {
+    unsafe fn get_event_status(&self, _: &()) -> Result<bool, device::WaitError> {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -469,7 +469,7 @@ impl device::Device<Backend> for Device {
         _: &mut [u8],
         _: hal::buffer::Offset,
         _: query::ResultFlags,
-    ) -> Result<bool, device::OomOrDeviceLost> {
+    ) -> Result<bool, device::WaitError> {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -596,7 +596,7 @@ impl device::Device<Backend> for Device {
         Ok(())
     }
 
-    unsafe fn wait_for_fence(&self, _: &(), _: u64) -> Result<bool, device::OomOrDeviceLost> {
+    unsafe fn wait_for_fence(&self, _: &(), _: u64) -> Result<bool, device::WaitError> {
         Ok(true)
     }
 }
@@ -1090,7 +1090,7 @@ impl window::PresentationSurface<Backend> for Surface {
         &mut self,
         _: &Device,
         _: window::SwapchainConfig,
-    ) -> Result<(), window::CreationError> {
+    ) -> Result<(), window::SwapchainError> {
         Ok(())
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -82,7 +82,7 @@ impl Device {
             ShaderStage::Geometry => glow::GEOMETRY_SHADER,
             ShaderStage::Fragment => glow::FRAGMENT_SHADER,
             ShaderStage::Compute if can_compute => glow::COMPUTE_SHADER,
-            _ => return Err(d::ShaderError::UnsupportedStage(stage.to_flag())),
+            _ => return Err(d::ShaderError::Unsupported),
         };
 
         let name = unsafe { gl.create_shader(target) }.unwrap();
@@ -897,9 +897,8 @@ impl d::Device<B> for Device {
                     warn!("\tLog: {}", log);
                 }
             } else {
-                return Err(pso::CreationError::Shader(
-                    d::ShaderError::CompilationFailed(log),
-                ));
+                error!("\tLog: {}", log);
+                return Err(pso::CreationError::Other);
             }
 
             name
@@ -1153,7 +1152,7 @@ impl d::Device<B> for Device {
             .contains(LegacyFeatures::CONSTANT_BUFFER)
             && usage.contains(buffer::Usage::UNIFORM)
         {
-            return Err(buffer::CreationError::UnsupportedUsage { usage });
+            return Err(buffer::CreationError::UnsupportedUsage(usage));
         }
 
         Ok(n::Buffer::Unbound { size, usage })
@@ -1732,7 +1731,7 @@ impl d::Device<B> for Device {
         &self,
         fence: &n::Fence,
         timeout_ns: u64,
-    ) -> Result<bool, d::OomOrDeviceLost> {
+    ) -> Result<bool, d::WaitError> {
         // TODO:
         // This can be called by multiple objects wanting to ensure they have exclusive
         // access to a resource. How much does this call costs ? The status of the fence
@@ -1780,7 +1779,7 @@ impl d::Device<B> for Device {
         fences: I,
         wait: d::WaitFor,
         timeout_ns: u64,
-    ) -> Result<bool, d::OomOrDeviceLost>
+    ) -> Result<bool, d::WaitError>
     where
         I: IntoIterator,
         I::Item: Borrow<n::Fence>,
@@ -1836,7 +1835,7 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    unsafe fn get_event_status(&self, _event: &()) -> Result<bool, d::OomOrDeviceLost> {
+    unsafe fn get_event_status(&self, _event: &()) -> Result<bool, d::WaitError> {
         unimplemented!()
     }
 
@@ -1873,7 +1872,7 @@ impl d::Device<B> for Device {
         _data: &mut [u8],
         _stride: buffer::Offset,
         _flags: query::ResultFlags,
-    ) -> Result<bool, d::OomOrDeviceLost> {
+    ) -> Result<bool, d::WaitError> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/window/egl.rs
+++ b/src/backend/gl/src/window/egl.rs
@@ -224,7 +224,7 @@ impl w::PresentationSurface<crate::Backend> for Surface {
         &mut self,
         device: &crate::Device,
         config: w::SwapchainConfig,
-    ) -> Result<(), w::CreationError> {
+    ) -> Result<(), w::SwapchainError> {
         self.unconfigure_swapchain(device);
 
         let desc = conv::describe_format(config.format).unwrap();

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -113,7 +113,7 @@ impl window::PresentationSurface<B> for Surface {
         &mut self,
         device: &Device,
         config: window::SwapchainConfig,
-    ) -> Result<(), window::CreationError> {
+    ) -> Result<(), window::SwapchainError> {
         let gl = &device.share.context;
 
         if let Some(swapchain) = self.swapchain.take() {

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -244,7 +244,7 @@ impl w::PresentationSurface<Backend> for Surface {
         &mut self,
         device: &Device,
         config: w::SwapchainConfig,
-    ) -> Result<(), w::CreationError> {
+    ) -> Result<(), w::SwapchainError> {
         assert!(image::Usage::COLOR_ATTACHMENT.contains(config.image_usage));
         self.swapchain_format = self.configure(&device.shared, &config);
         Ok(())

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -1,11 +1,8 @@
-use ash::version::DeviceV1_0;
-use ash::vk;
+use ash::{version::DeviceV1_0, vk};
 use smallvec::SmallVec;
 use std::sync::Arc;
 
-use crate::command::CommandBuffer;
-use crate::conv;
-use crate::{Backend, RawDevice};
+use crate::{command::CommandBuffer, conv, Backend, RawDevice};
 use hal::{command, pool};
 
 #[derive(Debug)]

--- a/src/backend/webgpu/src/device.rs
+++ b/src/backend/webgpu/src/device.rs
@@ -3,7 +3,7 @@ use std::{borrow::Borrow, ops::Range};
 use hal::{
     buffer,
     device::{
-        AllocationError, BindError, DeviceLost, MapError, OomOrDeviceLost, OutOfMemory, ShaderError,
+        AllocationError, BindError, DeviceLost, MapError, OutOfMemory, ShaderError, WaitError,
     },
     format, image,
     memory::{Requirements, Segment},
@@ -418,7 +418,7 @@ impl hal::device::Device<Backend> for Device {
         &self,
         _fence: &<Backend as hal::Backend>::Fence,
         _timeout_ns: u64,
-    ) -> Result<bool, OomOrDeviceLost> {
+    ) -> Result<bool, WaitError> {
         todo!()
     }
 
@@ -427,7 +427,7 @@ impl hal::device::Device<Backend> for Device {
         _fences: I,
         _wait: hal::device::WaitFor,
         _timeout_ns: u64,
-    ) -> Result<bool, OomOrDeviceLost>
+    ) -> Result<bool, WaitError>
     where
         I: IntoIterator,
         I::Item: Borrow<<Backend as hal::Backend>::Fence>,
@@ -457,7 +457,7 @@ impl hal::device::Device<Backend> for Device {
     unsafe fn get_event_status(
         &self,
         _event: &<Backend as hal::Backend>::Event,
-    ) -> Result<bool, OomOrDeviceLost> {
+    ) -> Result<bool, WaitError> {
         todo!()
     }
 
@@ -494,7 +494,7 @@ impl hal::device::Device<Backend> for Device {
         _data: &mut [u8],
         _stride: buffer::Offset,
         _flags: query::ResultFlags,
-    ) -> Result<bool, OomOrDeviceLost> {
+    ) -> Result<bool, WaitError> {
         todo!()
     }
 

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -23,6 +23,7 @@ bitflags = "1.0"
 mint = { version = "0.5", optional = true }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
+thiserror = "1"
 
 [dev-dependencies]
 gfx-backend-empty = { path = "../backend/empty", version = "0.6" }

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -8,13 +8,13 @@
 //! for a particular GPU, generally created from an [instance][crate::Instance]
 //! of that [backend][crate::Backend].
 
-use std::{any::Any, fmt};
-
 use crate::{
     device, format, image, memory,
     queue::{QueueGroup, QueuePriority},
     Backend, Features, Hints, Limits,
 };
+
+use std::{any::Any, fmt};
 
 /// A description for a single type of memory in a heap.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -37,89 +37,27 @@ impl SubRange {
 pub type State = Access;
 
 /// Error creating a buffer.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum CreationError {
     /// Out of either host or device memory.
-    OutOfMemory(OutOfMemory),
-
+    #[error(transparent)]
+    OutOfMemory(#[from] OutOfMemory),
     /// Requested buffer usage is not supported.
     ///
     /// Older GL version don't support constant buffers or multiple usage flags.
-    UnsupportedUsage {
-        /// Unsupported usage passed on buffer creation.
-        usage: Usage,
-    },
-}
-
-impl From<OutOfMemory> for CreationError {
-    fn from(error: OutOfMemory) -> Self {
-        CreationError::OutOfMemory(error)
-    }
-}
-
-impl std::fmt::Display for CreationError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CreationError::OutOfMemory(err) => write!(fmt, "Failed to create buffer: {}", err),
-            CreationError::UnsupportedUsage { usage } => write!(
-                fmt,
-                "Failed to create buffer: Unsupported usage: {:?}",
-                usage
-            ),
-        }
-    }
-}
-
-impl std::error::Error for CreationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            CreationError::OutOfMemory(err) => Some(err),
-            _ => None,
-        }
-    }
+    #[error("Unsupported usage: {0:?}")]
+    UnsupportedUsage(Usage),
 }
 
 /// Error creating a buffer view.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum ViewCreationError {
     /// Out of either host or device memory.
-    OutOfMemory(OutOfMemory),
-
+    #[error(transparent)]
+    OutOfMemory(#[from] OutOfMemory),
     /// Buffer view format is not supported.
+    #[error("Unsupported format: {0:?}")]
     UnsupportedFormat(Option<Format>),
-}
-
-impl From<OutOfMemory> for ViewCreationError {
-    fn from(error: OutOfMemory) -> Self {
-        ViewCreationError::OutOfMemory(error)
-    }
-}
-
-impl std::fmt::Display for ViewCreationError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ViewCreationError::OutOfMemory(err) => {
-                write!(fmt, "Failed to create buffer view: {}", err)
-            }
-            ViewCreationError::UnsupportedFormat(Some(format)) => write!(
-                fmt,
-                "Failed to create buffer view: Unsupported format {:?}",
-                format
-            ),
-            ViewCreationError::UnsupportedFormat(None) => {
-                write!(fmt, "Failed to create buffer view: Unspecified format")
-            }
-        }
-    }
-}
-
-impl std::error::Error for ViewCreationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            ViewCreationError::OutOfMemory(err) => Some(err),
-            _ => None,
-        }
-    }
 }
 
 bitflags!(

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -16,8 +16,6 @@
 mod clear;
 mod structs;
 
-use std::{any::Any, borrow::Borrow, fmt, ops::Range};
-
 use crate::{
     buffer,
     image::{Filter, Layout, SubresourceRange},
@@ -25,6 +23,8 @@ use crate::{
     pass, pso, query, Backend, DrawCount, IndexCount, IndexType, InstanceCount, TaskCount,
     VertexCount, VertexOffset, WorkGroupCount,
 };
+
+use std::{any::Any, borrow::Borrow, fmt, ops::Range};
 
 pub use self::clear::*;
 pub use self::structs::*;

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -103,119 +103,66 @@ pub enum Tiling {
 }
 
 /// Pure image object creation error.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum CreationError {
     /// Out of either host or device memory.
-    OutOfMemory(device::OutOfMemory),
+    #[error(transparent)]
+    OutOfMemory(#[from] device::OutOfMemory),
     /// The format is not supported by the device.
+    #[error("Unsupported format: {0:?}")]
     Format(format::Format),
     /// The kind doesn't support a particular operation.
+    #[error("Specified kind doesn't support particular operation")]
     Kind,
     /// Failed to map a given multisampled kind to the device.
+    #[error("Specified format doesn't support specified sampling {0:}")]
     Samples(NumSamples),
     /// Unsupported size in one of the dimensions.
+    #[error("Unsupported size in one of the dimensions {0:}")]
     Size(Size),
     /// The given data has a different size than the target image slice.
+    #[error("The given data has a different size ({0:}) than the target image slice")]
     Data(usize),
     /// The mentioned usage mode is not supported
+    #[error("Unsupported usage: {0:?}")]
     Usage(Usage),
-}
-
-impl From<device::OutOfMemory> for CreationError {
-    fn from(error: device::OutOfMemory) -> Self {
-        CreationError::OutOfMemory(error)
-    }
-}
-
-impl std::fmt::Display for CreationError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CreationError::OutOfMemory(err) => write!(fmt, "Failed to create image: {}", err),
-            CreationError::Format(format) => write!(fmt, "Failed to create image: Unsupported format: {:?}", format),
-            CreationError::Kind => write!(fmt, "Failed to create image: Specified kind doesn't support particular operation"), // Room for improvement.
-            CreationError::Samples(samples) => write!(fmt, "Failed to create image: Specified format doesn't support specified sampling {}", samples),
-            CreationError::Size(size) => write!(fmt, "Failed to create image: Unsupported size in one of the dimensions {}", size),
-            CreationError::Data(data) => write!(fmt, "Failed to create image: The given data has a different size {{{}}} than the target image slice", data), // Actually nothing emits this.
-            CreationError::Usage(usage) => write!(fmt, "Failed to create image: Unsupported usage: {:?}", usage),
-        }
-    }
-}
-
-impl std::error::Error for CreationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            CreationError::OutOfMemory(err) => Some(err),
-            _ => None,
-        }
-    }
 }
 
 /// Error creating an `ImageView`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum ViewCreationError {
+    /// Out of either Host or Device memory
+    #[error(transparent)]
+    OutOfMemory(#[from] device::OutOfMemory),
     /// The required usage flag is not present in the image.
+    #[error("Specified usage flags are not present in the image {0:?}")]
     Usage(Usage),
     /// Selected mip level doesn't exist.
+    #[error("Selected level doesn't exist in the image {0:}")]
     Level(Level),
     /// Selected array layer doesn't exist.
-    Layer(LayerError),
+    #[error(transparent)]
+    Layer(#[from] LayerError),
     /// An incompatible format was requested for the view.
+    #[error("Incompatible format: {0:?}")]
     BadFormat(format::Format),
     /// An incompatible view kind was requested for the view.
+    #[error("Incompatible kind: {0:?}")]
     BadKind(ViewKind),
-    /// Out of either Host or Device memory
-    OutOfMemory(device::OutOfMemory),
     /// The backend refused for some reason.
+    #[error("Implementation specific error occurred")]
     Unsupported,
 }
 
-impl From<device::OutOfMemory> for ViewCreationError {
-    fn from(error: device::OutOfMemory) -> Self {
-        ViewCreationError::OutOfMemory(error)
-    }
-}
-
-impl std::fmt::Display for ViewCreationError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ViewCreationError::Usage(usage) => write!(fmt, "Failed to create image view: Specified usage flags are not present in the image {:?}", usage),
-            ViewCreationError::Level(level) => write!(fmt, "Failed to create image view: Selected level doesn't exist in the image {}", level),
-            ViewCreationError::Layer(err) => write!(fmt, "Failed to create image view: {}", err),
-            ViewCreationError::BadFormat(format) => write!(fmt, "Failed to create image view: Incompatible format {:?}", format),
-            ViewCreationError::BadKind(kind) => write!(fmt, "Failed to create image view: Incompatible kind {:?}", kind),
-            ViewCreationError::OutOfMemory(err) => write!(fmt, "Failed to create image view: {}", err),
-            ViewCreationError::Unsupported => write!(fmt, "Failed to create image view: Implementation specific error occurred"),
-        }
-    }
-}
-
-impl std::error::Error for ViewCreationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            ViewCreationError::OutOfMemory(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
 /// An error associated with selected image layer.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum LayerError {
     /// The source image kind doesn't support array slices.
+    #[error("Source image doesn't support view kind {0:?}")]
     NotExpected(Kind),
     /// Selected layers are outside of the provided range.
+    #[error("Selected layers are out of bounds")]
     OutOfBounds,
-}
-
-impl std::fmt::Display for LayerError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LayerError::NotExpected(kind) => {
-                write!(fmt, "Kind {{{:?}}} does not support arrays", kind)
-            }
-            LayerError::OutOfBounds => write!(fmt, "Out of bounds layers"),
-        }
-    }
 }
 
 /// How to [filter](https://en.wikipedia.org/wiki/Texture_filtering) the

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -478,16 +478,9 @@ pub enum IndexType {
 
 /// Error creating an instance of a backend on the platform that
 /// doesn't support this backend.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("Backend is not supported on this platform")]
 pub struct UnsupportedBackend;
-
-impl fmt::Display for UnsupportedBackend {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "UnsupportedBackend")
-    }
-}
-
-impl std::error::Error for UnsupportedBackend {}
 
 /// An instantiated backend.
 ///

--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -1,10 +1,8 @@
 //! Command pools
 
-use crate::command::Level;
-use crate::{Backend, PseudoVec};
+use crate::{command::Level, Backend, PseudoVec};
 
-use std::any::Any;
-use std::fmt;
+use std::{any::Any, fmt};
 
 bitflags!(
     /// Command pool creation flags.

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -16,48 +16,26 @@ pub use self::{
 };
 
 /// Error types happening upon PSO creation on the device side.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum CreationError {
     /// Unknown other error.
+    #[error("Implementation specific error occurred")]
     Other,
     /// Unsupported pipeline on hardware or implementation. Example: mesh shaders on DirectX 11.
+    #[error("Pipeline kind is not supported")]
     UnsupportedPipeline,
     /// Invalid subpass (not part of renderpass).
+    #[error("Invalid subpass: {0:?}")]
     InvalidSubpass(pass::SubpassId),
-    /// Shader compilation error.
-    Shader(device::ShaderError),
+    /// The shader is missing an entry point.
+    #[error("Invalid entry point: {0:}")]
+    MissingEntryPoint(String),
+    /// The specialization values are incorrect.
+    #[error("Specialization failed: {0:}")]
+    InvalidSpecialization(String),
     /// Out of either host or device memory.
-    OutOfMemory(device::OutOfMemory),
-}
-
-impl From<device::OutOfMemory> for CreationError {
-    fn from(err: device::OutOfMemory) -> Self {
-        CreationError::OutOfMemory(err)
-    }
-}
-
-impl std::fmt::Display for CreationError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CreationError::OutOfMemory(err) => write!(fmt, "Failed to create pipeline: {}", err),
-            CreationError::Other => write!(fmt, "Failed to create pipeline: Unsupported usage: Implementation specific error occurred"),
-            CreationError::UnsupportedPipeline => write!(fmt, "Failed to create pipeline: pipeline type is not supported"),
-            CreationError::InvalidSubpass(subpass) => write!(fmt, "Failed to create pipeline: Invalid subpass: {}", subpass),
-            CreationError::Shader(err) => write!(fmt, "Failed to create pipeline: {}", err),
-        }
-    }
-}
-
-impl std::error::Error for CreationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            CreationError::OutOfMemory(err) => Some(err),
-            CreationError::Shader(err) => Some(err),
-            CreationError::InvalidSubpass(_) => None,
-            CreationError::Other => None,
-            CreationError::UnsupportedPipeline => None,
-        }
-    }
+    #[error(transparent)]
+    OutOfMemory(#[from] device::OutOfMemory),
 }
 
 bitflags!(

--- a/src/hal/src/query.rs
+++ b/src/hal/src/query.rs
@@ -5,37 +5,20 @@
 //! providing a mechanism for the command buffer to record data about its operation
 //! as it is running.
 
-use crate::device::OutOfMemory;
-use crate::Backend;
+use crate::{device::OutOfMemory, Backend};
 
 /// A query identifier.
 pub type Id = u32;
 
 /// Query creation error.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum CreationError {
     /// Out of either host or device memory.
-    OutOfMemory(OutOfMemory),
-
+    #[error(transparent)]
+    OutOfMemory(#[from] OutOfMemory),
     /// Query type unsupported.
+    #[error("Unsupported type: {0:?}")]
     Unsupported(Type),
-}
-
-impl From<OutOfMemory> for CreationError {
-    fn from(error: OutOfMemory) -> Self {
-        CreationError::OutOfMemory(error)
-    }
-}
-
-impl std::fmt::Display for CreationError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CreationError::OutOfMemory(err) => write!(fmt, "Failed to create query: {}", err),
-            CreationError::Unsupported(ty) => {
-                write!(fmt, "Failed to create query: Unsupported type: {:?}", ty)
-            }
-        }
-    }
 }
 
 /// A `Query` object has a particular identifier and saves its results to a given `QueryPool`.

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -1,10 +1,8 @@
 //! Queue family and groups.
 
-use crate::queue::QueueType;
-use crate::Backend;
+use crate::{queue::QueueType, Backend};
 
-use std::any::Any;
-use std::fmt::Debug;
+use std::{any::Any, fmt::Debug};
 
 /// General information about a queue family, available upon adapter discovery.
 ///

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -70,71 +70,26 @@ pub const DEFAULT_USAGE: image::Usage = image::Usage::COLOR_ATTACHMENT;
 /// Default image count for the swapchain.
 pub const DEFAULT_IMAGE_COUNT: SwapImageIndex = 3;
 
-/// Error occurred during swapchain creation.
-#[derive(Clone, Debug, PartialEq)]
-pub enum CreationError {
+/// Error occurred caused surface to be lost.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[error("Surface lost")]
+pub struct SurfaceLost;
+
+/// Error occurred during swapchain configuration.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+pub enum SwapchainError {
     /// Out of either host or device memory.
-    OutOfMemory(device::OutOfMemory),
+    #[error(transparent)]
+    OutOfMemory(#[from] device::OutOfMemory),
     /// Device is lost
-    DeviceLost(device::DeviceLost),
+    #[error(transparent)]
+    DeviceLost(#[from] device::DeviceLost),
     /// Surface is lost
-    SurfaceLost(device::SurfaceLost),
+    #[error(transparent)]
+    SurfaceLost(#[from] SurfaceLost),
     /// Window in use
-    WindowInUse(device::WindowInUse),
-}
-
-impl From<device::OutOfMemory> for CreationError {
-    fn from(error: device::OutOfMemory) -> Self {
-        CreationError::OutOfMemory(error)
-    }
-}
-
-impl From<device::DeviceLost> for CreationError {
-    fn from(error: device::DeviceLost) -> Self {
-        CreationError::DeviceLost(error)
-    }
-}
-
-impl From<device::SurfaceLost> for CreationError {
-    fn from(error: device::SurfaceLost) -> Self {
-        CreationError::SurfaceLost(error)
-    }
-}
-
-impl From<device::WindowInUse> for CreationError {
-    fn from(error: device::WindowInUse) -> Self {
-        CreationError::WindowInUse(error)
-    }
-}
-
-impl std::fmt::Display for CreationError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CreationError::OutOfMemory(err) => {
-                write!(fmt, "Failed to create or configure swapchain: {}", err)
-            }
-            CreationError::DeviceLost(err) => {
-                write!(fmt, "Failed to create or configure swapchain: {}", err)
-            }
-            CreationError::SurfaceLost(err) => {
-                write!(fmt, "Failed to create or configure swapchain: {}", err)
-            }
-            CreationError::WindowInUse(err) => {
-                write!(fmt, "Failed to create or configure swapchain: {}", err)
-            }
-        }
-    }
-}
-
-impl std::error::Error for CreationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            CreationError::OutOfMemory(err) => Some(err),
-            CreationError::DeviceLost(err) => Some(err),
-            CreationError::SurfaceLost(err) => Some(err),
-            CreationError::WindowInUse(err) => Some(err),
-        }
-    }
+    #[error("Window is in use")]
+    WindowInUse,
 }
 
 /// An extent describes the size of a rectangle, such as
@@ -259,7 +214,7 @@ pub trait PresentationSurface<B: Backend>: Surface<B> {
         &mut self,
         device: &B::Device,
         config: SwapchainConfig,
-    ) -> Result<(), CreationError>;
+    ) -> Result<(), SwapchainError>;
 
     /// Remove the associated swapchain from this surface.
     ///
@@ -455,109 +410,55 @@ impl SwapchainConfig {
 #[derive(Debug)]
 pub struct Suboptimal;
 
+/// Error occurred caused surface to be lost.
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[error("Swapchain is out of date and needs to be re-created")]
+pub struct OutOfDate;
+
 /// Error on acquiring the next image from a swapchain.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum AcquireError {
     /// Out of either host or device memory.
-    OutOfMemory(device::OutOfMemory),
+    #[error(transparent)]
+    OutOfMemory(#[from] device::OutOfMemory),
     /// No image was ready and no timeout was specified.
-    NotReady,
-    /// No image was ready after the specified timeout expired.
-    Timeout,
+    #[error("No image ready (timeout: {timeout:})")]
+    NotReady {
+        /// Time has ran out.
+        timeout: bool,
+    },
     /// The swapchain is no longer in sync with the surface, needs to be re-created.
-    OutOfDate,
+    #[error(transparent)]
+    OutOfDate(#[from] OutOfDate),
     /// The surface was lost, and the swapchain is no longer usable.
-    SurfaceLost(device::SurfaceLost),
+    #[error(transparent)]
+    SurfaceLost(#[from] SurfaceLost),
     /// Device is lost
-    DeviceLost(device::DeviceLost),
-}
-
-impl std::fmt::Display for AcquireError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AcquireError::OutOfMemory(err) => write!(fmt, "Failed to acqure image: {}", err),
-            AcquireError::NotReady => write!(
-                fmt,
-                "Failed to acqure image: No image ready (timeout wasn't specified)"
-            ),
-            AcquireError::Timeout => {
-                write!(fmt, "Failed to acqure image: No image ready (timeout)")
-            }
-            AcquireError::OutOfDate => write!(
-                fmt,
-                "Failed to acqure image: Swapchain is out of date and needs to be re-created"
-            ),
-            AcquireError::SurfaceLost(err) => write!(fmt, "Failed to acqure image: {}", err),
-            AcquireError::DeviceLost(err) => write!(fmt, "Failed to acqure image: {}", err),
-        }
-    }
-}
-
-impl std::error::Error for AcquireError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            AcquireError::OutOfMemory(err) => Some(err),
-            AcquireError::SurfaceLost(err) => Some(err),
-            AcquireError::DeviceLost(err) => Some(err),
-            _ => None,
-        }
-    }
+    #[error(transparent)]
+    DeviceLost(#[from] device::DeviceLost),
 }
 
 /// Error on acquiring the next image from a swapchain.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 pub enum PresentError {
     /// Out of either host or device memory.
-    OutOfMemory(device::OutOfMemory),
+    #[error(transparent)]
+    OutOfMemory(#[from] device::OutOfMemory),
     /// The swapchain is no longer in sync with the surface, needs to be re-created.
-    OutOfDate,
+    #[error(transparent)]
+    OutOfDate(#[from] OutOfDate),
     /// The surface was lost, and the swapchain is no longer usable.
-    SurfaceLost(device::SurfaceLost),
+    #[error(transparent)]
+    SurfaceLost(#[from] SurfaceLost),
     /// Device is lost
-    DeviceLost(device::DeviceLost),
-}
-
-impl std::fmt::Display for PresentError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PresentError::OutOfMemory(err) => write!(fmt, "Failed to present image: {}", err),
-            PresentError::OutOfDate => write!(
-                fmt,
-                "Failed to present image: Swapchain is out of date and needs to be re-created"
-            ),
-            PresentError::SurfaceLost(err) => write!(fmt, "Failed to present image: {}", err),
-            PresentError::DeviceLost(err) => write!(fmt, "Failed to present image: {}", err),
-        }
-    }
-}
-
-impl std::error::Error for PresentError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            PresentError::OutOfMemory(err) => Some(err),
-            PresentError::SurfaceLost(err) => Some(err),
-            PresentError::DeviceLost(err) => Some(err),
-            _ => None,
-        }
-    }
+    #[error(transparent)]
+    DeviceLost(#[from] device::DeviceLost),
 }
 
 /// Error occurred during surface creation.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum InitError {
     /// Window handle is not supported by the backend.
+    #[error("Specified window handle is unsupported")]
     UnsupportedWindowHandle,
 }
-
-impl std::fmt::Display for InitError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            InitError::UnsupportedWindowHandle => write!(
-                fmt,
-                "Failed to create surface: Specified window handle is unsupported"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for InitError {}


### PR DESCRIPTION
Makes error variants a bit more sane and structured.
Also takes advantage of `thiserror`, since that's what we settled on in `wgpu` land.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:

New code (HAL only):
> Finished dev [unoptimized + debuginfo] target(s) in 17.65s

Old code (HAL only):
> Finished dev [unoptimized + debuginfo] target(s) in 7.73s