### PR TITLE
Add Naga dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,32 +74,25 @@ jobs:
           - os: macos-10.15
             name: MacOS Stable
             channel: stable
-            additional_command: cd src/backend/metal && cargo check --all-features
           - os: macos-10.15
             name: MacOS Nightly
             channel: nightly
-            additional_command:
           - os: ubuntu-18.04
             name: Ubuntu Stable
             channel: stable
-            additional_command:
           - os: ubuntu-18.04
             name: Ubuntu Nightly
             channel: nightly
-            additional_command:
           - os: ubuntu-18.04
             name: Web Assembly
             channel: nightly
             target: wasm32-unknown-unknown
-            additional_command:
           - os: windows-2019
             name: Windows Stable
             channel: stable
-            additional_command:
           - os: windows-2019
             name: Windows Nightly
             channel: nightly
-            additional_command:
     steps:
       - uses: actions/checkout@v2
       - if: matrix.channel == 'nightly'
@@ -119,6 +112,3 @@ jobs:
       #- if: matrix.channel == 'stable'
       #  run: rustup component add clippy
       - run: make all
-      - if: matrix.additional_command != ''
-        name: Check extra features
-        run: ${{ matrix.additional_command }}

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ check: check-backends
 
 check-backends:
 	cargo check --all $(CHECK_TARGET_FLAG) $(EXCLUDES) --exclude gfx-warden
+ifeq ($(UNAME_S),Darwin)
+	cargo check --manifest-path=src/backend/metal/Cargo.toml --all-features
+endif
 
 check-wasm:
 	cd src/backend/webgpu && RUSTFLAGS="--cfg=web_sys_unstable_apis" cargo check --target wasm32-unknown-unknown

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -41,10 +41,10 @@ lazy_static = "1"
 raw-window-handle = "0.3"
 
 [dependencies.naga]
-#path = "../../../../naga"
 git = "https://github.com/gfx-rs/naga"
-rev = "0893d912be268298ae2ed784beb541a23b9d6b31"
-features = ["spv-in", "msl-out"]
+tag = "gfx-1"
+#TODO: remove `spv-out` once spirv-cross is deprecated
+features = ["spv-in", "spv-out", "msl-out"]
 optional = true
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1830,6 +1830,23 @@ impl hal::device::Device<Backend> for Device {
         })
     }
 
+    #[cfg(feature = "naga")]
+    unsafe fn create_shader_module_from_naga(
+        &self,
+        module: naga::Module,
+    ) -> Result<n::ShaderModule, d::ShaderError> {
+        use naga::back::spv;
+        let mut flags = spv::WriterFlags::empty();
+        if cfg!(debug_assertions) {
+            flags |= spv::WriterFlags::DEBUG;
+        }
+        let spv = spv::Writer::new(&module.header, flags).write(&module);
+        Ok(n::ShaderModule {
+            spv,
+            naga: Some(module),
+        })
+    }
+
     unsafe fn create_sampler(
         &self,
         info: &image::SamplerDesc,

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 [dependencies]
 bitflags = "1.0"
 mint = { version = "0.5", optional = true }
+naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-1" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -396,6 +396,14 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// [graphics pipelines][crate::pso::GraphicsPipelineDesc].
     unsafe fn create_shader_module(&self, spirv: &[u32]) -> Result<B::ShaderModule, ShaderError>;
 
+    /// Create a new shader module from the `naga` module.
+    unsafe fn create_shader_module_from_naga(
+        &self,
+        _module: naga::Module,
+    ) -> Result<B::ShaderModule, ShaderError> {
+        Err(ShaderError::Unsupported)
+    }
+
     /// Destroy a shader module module
     ///
     /// A shader module can be destroyed while pipelines created using its shaders are still in use.

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -46,9 +46,7 @@ extern crate bitflags;
 #[macro_use]
 extern crate serde;
 
-use std::any::Any;
-use std::fmt;
-use std::hash::Hash;
+use std::{any::Any, fmt, hash::Hash};
 
 pub mod adapter;
 pub mod buffer;


### PR DESCRIPTION
By exposing Naga in gfx-hal we'll be able to have wgpu and gfx communicate the shaders without going through SPIR-V.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:

The controversial part here is that Naga is not optional. I tried to think of pros and cons.
Cons:
- Naga needs more work anyway, it's not ready yet
- Naga in gfx-hal isn't needed for any libraries that only depend on the gfx-hal, and do not care about Naga

Pros:
- Naga *will* need to be ready at some point, replacing SPIRV-Cross. And it will need to be available for wgpu interop, so we might as well skip the stage where it's optional in the gfx-hal.
- Naga by itself without features is super lightweight, it shouldn't affect the libraries too much. All the frontends and backends are gated by features.
- The end user app will need to depend on gfx-hal backends, and probably not the Vulkan backend alone. So in the end those backends would require Naga anyway to do their translation (currently, only Metal backend supports this, optionally).
- It's annoying in Cargo to say that `naga` dep is optional in a backend, in addition to requiring `naga` dep in the gfx-hal. This would require renaming the feature in the backend to be something else.

Unresolved question: how do we nicely specify Naga revision? It's needed everywhere: in gfx-hal, in each backend, in wgpu, etc, and all of them need to agree. We can't simply re-export Naga from gfx-hal, since every client will need to enable some of the features (i.e. Metal backend enables "mtl-out", `wgpu` enables "wgsl-in", etc).

One way to proceed is to just use the revisions. It's a bit clunky, since for the reader a revision is just a random set of symbols.
Another interesting way is to have tags in the Naga repo, and depend on those tags. E.g. it could be called `gfx-1`, `gfx-2`, etc, monotonically, as we update Naga dependency through the stack. I think that could work fine, at least better than with revisions only.