### PR TITLE
[dx12] Fix `set_command_buffer_name`

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3616,7 +3616,10 @@ impl d::Device<B> for Device {
 
     unsafe fn set_command_buffer_name(&self, command_buffer: &mut cmd::CommandBuffer, name: &str) {
         let cwstr = wide_cstr(name);
-        command_buffer.raw.SetName(cwstr.as_ptr());
+        if !command_buffer.raw.is_null() {
+            command_buffer.raw.SetName(cwstr.as_ptr());
+        }
+        command_buffer.raw_name = cwstr;
     }
 
     unsafe fn set_semaphore_name(&self, semaphore: &mut r::Semaphore, name: &str) {


### PR DESCRIPTION
`CommandBuffer.raw` is null when the command buffer is not recording, so
we have to store the name and set it later in `CommandBuffer::begin`.

Fixes water and texture-arrays `wgpu-rs` examples: https://github.com/gfx-rs/wgpu/issues/1059
PR checklist:
- [ ] `make` succeeds (on *nix) - not applicable
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: water and texture-arrays from wgpu-rs with dx12 backend
