### PR TITLE
[vk] fix viewport/scissor count validation error

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -65,7 +65,7 @@ lazy_static! {
         vec![
             DebugUtils::name(),
             *KHR_GET_PHYSICAL_DEVICE_PROPERTIES2,
-	]
+    ]
     };
     static ref DEVICE_EXTENSIONS: Vec<&'static CStr> = vec![extensions::khr::Swapchain::name()];
     static ref SURFACE_EXTENSIONS: Vec<&'static CStr> = vec![
@@ -449,9 +449,11 @@ impl hal::Instance<Backend> for Instance {
                     .pfn_user_callback(Some(debug_utils_messenger_callback));
                 let handle = unsafe { ext.create_debug_utils_messenger(&info, None) }.unwrap();
                 Some(DebugMessenger::Utils(ext, handle))
-            } else if cfg!(debug_assertions) && instance_extensions.iter().any(|props| unsafe {
-                CStr::from_ptr(props.extension_name.as_ptr()) == DebugReport::name()
-            }) {
+            } else if cfg!(debug_assertions)
+                && instance_extensions.iter().any(|props| unsafe {
+                    CStr::from_ptr(props.extension_name.as_ptr()) == DebugReport::name()
+                })
+            {
                 let ext = DebugReport::new(entry, &instance);
                 let info = vk::DebugReportCallbackCreateInfoEXT::builder()
                     .flags(vk::DebugReportFlagsEXT::all())


### PR DESCRIPTION
Fixes this VU reported in https://github.com/gfx-rs/wgpu/issues/1059 :
> [0.375320 ERROR]()(no module):
VALIDATION [VUID-VkPipelineViewportStateCreateInfo-viewportCount-01216 (-376016417)] : Validation Error: [ VUID-VkPipelineViewportStateCreateInfo-viewportCount-01216 ] Object 0: handle = 0x2d93dbcf100, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xe99671df | vkCreateGraphicsPipelines: The VkPhysicalDeviceFeatures::multiViewport feature is disabled, but pCreateInfos[0].pViewportState->viewportCount (=0) is not 1. The Vulkan spec states: If the multiple viewports feature is not enabled, viewportCount must be 1 (https://vulkan.lunarg.com/doc/view/1.2.141.0/windows/1.2-extensions/vkspec.html#VUID-VkPipelineViewportStateCreateInfo-viewportCount-01216)
object info: (type: DEVICE, hndl: 3132066951424)

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested on wgpu-rs examples
