### PR TITLE
Remove invalid `SubmitInfo` builder call

### DIFF
--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1487,9 +1487,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
             wait_semaphore.0
         } else {
             let signals = &[ssc.semaphore.0];
-            let submit_info = vk::SubmitInfo::builder()
-                .wait_dst_stage_mask(&[vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT])
-                .signal_semaphores(signals);
+            let submit_info = vk::SubmitInfo::builder().signal_semaphores(signals);
             self.device
                 .raw
                 .queue_submit(*self.raw, &[*submit_info], vk::Fence::null())


### PR DESCRIPTION
Fixes #3501
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
<details><summary>`make reftests` failed (should be unrelated)</summary>

```
friz64@arch /m/h/D/g/gfx (submit_info_fix)> make reftests
cd src/warden && cargo run --bin reftest --features "gl vulkan " -- local
   Compiling instant v0.1.9
   Compiling getrandom v0.1.15
   Compiling raw-window-handle v0.3.3
   Compiling log v0.4.11
   Compiling khronos-egl v2.1.1
   Compiling x11 v2.18.2
   Compiling serde v1.0.117
   Compiling thiserror v1.0.22
   Compiling spirv_cross v0.22.1
   Compiling parking_lot_core v0.8.0
   Compiling rand_core v0.5.1
   Compiling parking_lot v0.11.1
   Compiling rand_chacha v0.2.2
   Compiling rand v0.7.3
   Compiling tempfile v3.1.0
   Compiling glsl-to-spirv v0.1.7
   Compiling gfx-hal v0.6.0 (/mnt/hdd1/Documents/git-clones/gfx/src/hal)
   Compiling ron v0.6.2
   Compiling gfx-auxil v0.5.0 (/mnt/hdd1/Documents/git-clones/gfx/src/auxil/auxil)
   Compiling gfx-backend-vulkan v0.6.5 (/mnt/hdd1/Documents/git-clones/gfx/src/backend/vulkan)
   Compiling gfx-backend-gl v0.6.0 (/mnt/hdd1/Documents/git-clones/gfx/src/backend/gl)
   Compiling gfx-warden v0.1.0 (/mnt/hdd1/Documents/git-clones/gfx/src/warden)
    Finished dev [unoptimized + debuginfo] target(s) in 33.35s
     Running `/mnt/hdd1/Documents/git-clones/gfx/target/debug/reftest local`
Parsing test suite 'local'...
Testing Vulkan:
        Scene 'vertex-offset':
                Test 'offset-aligned' ...       ran: PASS
                Test 'offset-overlap' ...       ran: PASS
        Scene 'transfer':
                Test 'copy-buf-cut' ... ran: PASS
                Test 'clear-image' ...  ran: PASS
                Test 'copy-buf-image' ...       ran: PASS
                Test 'blit-image' ...   ran: PASS
                Test 'fill-whole' ...   ran: PASS
                Test 'fill-first' ...   ran: PASS
                Test 'copy-image-buf' ...       ran: PASS
                Test 'copy-image' ...   ran: PASS
                Test 'fill-last' ...    ran: PASS
                Test 'copy-buf' ...     ran: PASS
        Scene 'basic':
                Test 'pass-through' ... ran: PASS
                Test 'render-pass-clear' ...    ran: PASS
        Scene 'compute':
                Test 'fill' ... ran: PASS
        TestResults { pass: 15, skip: 0, fail: 0 }
Testing GL:
        Scene 'vertex-offset':
thread 'main' panicked at 'Error InvalidOperation executing command: CopyTextureToBuffer { src_texture: 1, texture_target: 3553, texture_format: 36249, pixel_type: 5125, dst_buffer: 3, data: BufferImageCopy { buffer_offset: 0, buffer_width: 1, buffer_height: 1, image_layers: SubresourceLayers { aspects: COLOR, level: 0, layers: 0..1 }, image_offset: Offset { x: 0, y: 0, z: 0 }, image_extent: Extent { width: 1, height: 1, depth: 1 } } }', src/backend/gl/src/queue.rs:1060:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
                Test 'offset-aligned' ...       ran: make: *** [Makefile:72: reftests] Error 101
```

</details>

- [x] tested examples with the following backends: vulkan

This should be all that's needed to fix this. The reasoning behind this change is in the issue.