### PR TITLE
[gl] Remove WebGL hardcoded min_storage_buffer_offset_alignment value.

### DIFF
--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -356,11 +356,8 @@ pub(crate) fn query_all(
     } else {
         get_usize(gl, glow::MAX_TEXTURE_BUFFER_SIZE).unwrap_or(0)
     };
-    let min_storage_buffer_offset_alignment = if IS_WEBGL {
-        1024
-    } else {
-        get_u64(gl, glow::SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT).unwrap_or(256)
-    };
+    let min_storage_buffer_offset_alignment =
+        get_u64(gl, glow::SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT).unwrap_or(256);
 
     let mut limits = Limits {
         max_image_1d_size: max_texture_size,


### PR DESCRIPTION
PR checklist:
- [X] `make` succeeds (on macOS)
- [X] `make reftests` succeeds
- [x] tested examples with the following backends: quad example with gl backend with wasm target arch (no windows nor linux available to test gl backend there)
