### PR TITLE
[mtl] adjust render pass compatibility check at the start of a pass

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -114,8 +114,7 @@ fn main() {
         .append_child(&winit::platform::web::WindowExtWebSys::canvas(&window))
         .unwrap();
 
-    let instance =
-        back::Instance::create("gfx-rs quad", 1).expect("Failed to create an instance!");
+    let instance = back::Instance::create("gfx-rs quad", 1).expect("Failed to create an instance!");
 
     let surface = unsafe {
         instance

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -3639,9 +3639,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         let sin = self.state.pending_subpasses.pop().unwrap();
 
         self.state.render_pso_is_compatible = match self.state.render_pso {
-            Some(ref ps) => {
-                ps.formats == sin.formats && self.state.target.samples == sin.sample_count
-            }
+            Some(ref ps) => ps.formats == sin.formats,
             None => false,
         };
         self.state.active_depth_stencil_desc = pso::DepthStencilDesc::default();


### PR DESCRIPTION
Fixes #3509
This was a regression from #3486
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: metal
