### PR TITLE
Unblock nightly builds

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,13 +1,11 @@
-# temporary disabled Nightly checks due to
-# https://github.com/rust-lang/rust/issues/79560
 status = [
   "Dependency Check",
   "iOS Stable",
   "MacOS Stable",
-  #"MacOS Nightly",
+  "MacOS Nightly",
   "Android Stable",
   "Ubuntu Stable",
-  #"Ubuntu Nightly",
+  "Ubuntu Nightly",
   "Windows Stable",
-  #"Windows Nightly",
+  "Windows Nightly",
 ]


### PR DESCRIPTION
The Rust issue resulted in rolling back the originally causing change. We are green again.