### PR TITLE
Update naga to gfx-3

### DIFF
--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -43,7 +43,7 @@ raw-window-handle = "0.3"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-2"
+tag = "gfx-3"
 #TODO: remove `spv-out` once spirv-cross is deprecated
 features = ["spv-out", "msl-out"]
 optional = true

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -33,7 +33,7 @@ inplace_it = "0.3.2"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-2"
+tag = "gfx-3"
 features = ["spv-out"]
 optional = true
 

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 [dependencies]
 bitflags = "1.0"
 mint = { version = "0.5", optional = true }
-naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-2" }
+naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-3" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"


### PR DESCRIPTION
Improves SPIR-V generation, allows wgpu to use the latest Naga.