### PR TITLE
OpenGL Naga integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ check-backends:
 	cargo check --manifest-path=src/backend/vulkan/Cargo.toml --features "$(VULKAN_FEATURES)"
 ifeq ($(UNAME_S),Darwin)
 	cargo check --manifest-path=src/backend/metal/Cargo.toml --all-features
+else ifeq ($(OS),Windows_NT)
+	cargo check --manifest-path=src/backend/dx12/Cargo.toml --all-features
+	cargo check --manifest-path=src/backend/dx11/Cargo.toml --all-features
+else
+	cargo check --manifest-path=src/backend/gl/Cargo.toml --all-features
 endif
 
 check-wasm:

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 name = "gfx_backend_gl"
 
 [features]
-default = []
+default = ["x11"]
 
 [dependencies]
 arrayvec = "0.5"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -35,6 +35,13 @@ raw-window-handle = "0.3"
 egl = { package = "khronos-egl", version = "2.2" }
 x11 = { version = "2", features = ["xlib"], optional = true }
 
+[dependencies.naga]
+git = "https://github.com/gfx-rs/naga"
+tag = "gfx-4"
+#TODO: remove `spv-out` once spirv-cross is deprecated
+features = ["spv-out", "glsl-out"]
+optional = true
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"
 wasm-bindgen = "0.2.51"

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -306,10 +306,12 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
     }
 }
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Debug)]
 pub enum ShaderModule {
     Raw(Shader),
     Spirv(Vec<u32>),
+    #[cfg(feature = "naga")]
+    Naga(naga::Module, Vec<u32>),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Closes #3519
The meat of the issue here is to get the proper resource mapping plumbed between gfx and Naga glsl backend, and this isn't done in the PR. However, very primitive shaders that use no resources (e.g. hello-triangle) should already work.