### PR TITLE
Sparse (tiled) resources for Vulkan and DirectX 12

### DIFF
--- a/examples/bench/main.rs
+++ b/examples/bench/main.rs
@@ -72,6 +72,7 @@ fn main() {
                 FORMAT,
                 i::Tiling::Optimal,
                 i::Usage::TRANSFER_SRC | i::Usage::TRANSFER_DST,
+                hal::memory::SparseFlags::empty(),
                 i::ViewCapabilities::empty(),
             )
             .unwrap();
@@ -101,7 +102,11 @@ fn main() {
         let buffer_size = (bytes_per_texel as u64).max(limits.non_coherent_atom_size as u64);
 
         let mut src_buffer = device
-            .create_buffer(buffer_size, hal::buffer::Usage::TRANSFER_SRC)
+            .create_buffer(
+                buffer_size,
+                hal::buffer::Usage::TRANSFER_SRC,
+                hal::memory::SparseFlags::empty(),
+            )
             .unwrap();
         let src_buffer_requirements = device.get_buffer_requirements(&src_buffer);
         let src_buffer_type = memory_properties
@@ -145,6 +150,7 @@ fn main() {
                 FORMAT,
                 i::Tiling::Optimal,
                 i::Usage::TRANSFER_DST,
+                hal::memory::SparseFlags::empty(),
                 i::ViewCapabilities::empty(),
             )
             .unwrap();

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -726,7 +726,9 @@ impl<B: Backend> BufferState<B> {
         {
             let device = &device_ptr.borrow().device;
 
-            buffer = device.create_buffer(upload_size as u64, usage).unwrap();
+            buffer = device
+                .create_buffer(upload_size as u64, usage, hal::memory::SparseFlags::empty())
+                .unwrap();
             let mem_req = device.get_buffer_requirements(&buffer);
 
             // A note about performance: Using CPU_VISIBLE memory is convenient because it can be
@@ -805,7 +807,9 @@ impl<B: Backend> BufferState<B> {
         let size: u64;
 
         {
-            buffer = device.create_buffer(upload_size, usage).unwrap();
+            buffer = device
+                .create_buffer(upload_size, usage, hal::memory::SparseFlags::empty(),)
+                .unwrap();
             let mem_reqs = device.get_buffer_requirements(&buffer);
 
             let upload_type = adapter
@@ -1032,6 +1036,7 @@ impl<B: Backend> ImageState<B> {
                 ColorFormat::SELF,
                 i::Tiling::Optimal,
                 i::Usage::TRANSFER_DST | i::Usage::SAMPLED,
+                hal::memory::SparseFlags::empty(),
                 i::ViewCapabilities::empty(),
             )
             .unwrap(); // TODO: usage

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -283,7 +283,9 @@ unsafe fn create_buffer<B: hal::Backend>(
     stride: buffer::Stride,
     len: u64,
 ) -> (B::Memory, B::Buffer, u64) {
-    let mut buffer = device.create_buffer(stride as u64 * len, usage).unwrap();
+    let mut buffer = device
+        .create_buffer(stride as u64 * len, usage, hal::memory::SparseFlags::empty())
+        .unwrap();
     let requirements = device.get_buffer_requirements(&buffer);
 
     let ty = memory_types

--- a/examples/mesh-shading/main.rs
+++ b/examples/mesh-shading/main.rs
@@ -280,7 +280,14 @@ where
             * non_coherent_alignment;
 
         let mut positions_buffer = ManuallyDrop::new(
-            unsafe { device.create_buffer(padded_buffer_len, buffer::Usage::STORAGE) }.unwrap(),
+            unsafe {
+                device.create_buffer(
+                    padded_buffer_len,
+                    buffer::Usage::STORAGE,
+                    hal::memory::SparseFlags::empty(),
+                )
+            }
+            .unwrap(),
         );
 
         let buffer_req = unsafe { device.get_buffer_requirements(&positions_buffer) };

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1107,6 +1107,7 @@ impl device::Device<Backend> for Device {
         &self,
         size: u64,
         usage: buffer::Usage,
+        _sparse: memory::SparseFlags,
     ) -> Result<Buffer, buffer::CreationError> {
         use buffer::Usage;
 
@@ -1388,6 +1389,7 @@ impl device::Device<Backend> for Device {
         format: format::Format,
         _tiling: image::Tiling,
         usage: image::Usage,
+        _sparse: memory::SparseFlags,
         view_caps: image::ViewCapabilities,
     ) -> Result<Image, image::CreationError> {
         let surface_desc = format.base_format().0.desc();
@@ -1521,10 +1523,12 @@ impl device::Device<Backend> for Device {
                     Usage: usage,
                     BindFlags: bind,
                     CPUAccessFlags: cpu,
-                    MiscFlags: if image.view_caps.contains(image::ViewCapabilities::KIND_CUBE) {
-                        d3d11::D3D11_RESOURCE_MISC_TEXTURECUBE
-                    } else {
-                        0
+                    MiscFlags: {
+                        let mut flags = 0;
+                        if image.view_caps.contains(image::ViewCapabilities::KIND_CUBE) {
+                            flags |= d3d11::D3D11_RESOURCE_MISC_TEXTURECUBE;
+                        }
+                        flags
                     },
                 };
 

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -706,7 +706,7 @@ impl Device {
         Ok(())
     }
 
-    fn view_image_as_render_target(
+    pub(crate) fn view_image_as_render_target(
         &self,
         info: &ViewInfo,
     ) -> Result<descriptors_cpu::Handle, image::ViewCreationError> {
@@ -794,7 +794,7 @@ impl Device {
         Ok(())
     }
 
-    fn view_image_as_depth_stencil(
+    pub(crate) fn view_image_as_depth_stencil(
         &self,
         info: &ViewInfo,
     ) -> Result<descriptors_cpu::Handle, image::ViewCreationError> {
@@ -1143,6 +1143,109 @@ impl Device {
             usage: config.image_usage,
             acquired_count: 0,
         }
+    }
+
+    pub(crate) fn bind_image_resource(
+        &self,
+        resource: native::WeakPtr<d3d12::ID3D12Resource>,
+        image: &mut r::Image,
+        place: r::Place,
+    ) {
+        let image_unbound = image.expect_unbound();
+        let num_layers = image_unbound.kind.num_layers();
+
+        //TODO: the clear_Xv is incomplete. We should support clearing images created without XXX_ATTACHMENT usage.
+        // for this, we need to check the format and force the `RENDER_TARGET` flag behind the user's back
+        // if the format supports being rendered into, allowing us to create clear_Xv
+        let info = ViewInfo {
+            resource,
+            kind: image_unbound.kind,
+            caps: image::ViewCapabilities::empty(),
+            view_kind: match image_unbound.kind {
+                image::Kind::D1(..) => image::ViewKind::D1Array,
+                image::Kind::D2(..) => image::ViewKind::D2Array,
+                image::Kind::D3(..) => image::ViewKind::D3,
+            },
+            format: image_unbound.desc.Format,
+            component_mapping: IDENTITY_MAPPING,
+            levels: 0..1,
+            layers: 0..0,
+        };
+        let format_properties = self
+            .format_properties
+            .resolve(image_unbound.format as usize)
+            .properties;
+        let props = match image_unbound.tiling {
+            image::Tiling::Optimal => format_properties.optimal_tiling,
+            image::Tiling::Linear => format_properties.linear_tiling,
+        };
+        let can_clear_color = image_unbound
+            .usage
+            .intersects(image::Usage::TRANSFER_DST | image::Usage::COLOR_ATTACHMENT)
+            && props.contains(format::ImageFeature::COLOR_ATTACHMENT);
+        let can_clear_depth = image_unbound
+            .usage
+            .intersects(image::Usage::TRANSFER_DST | image::Usage::DEPTH_STENCIL_ATTACHMENT)
+            && props.contains(format::ImageFeature::DEPTH_STENCIL_ATTACHMENT);
+        let aspects = image_unbound.format.surface_desc().aspects;
+
+        *image = r::Image::Bound(r::ImageBound {
+            resource,
+            place,
+            surface_type: image_unbound.format.base_format().0,
+            kind: image_unbound.kind,
+            mip_levels: image_unbound.mip_levels,
+            usage: image_unbound.usage,
+            default_view_format: image_unbound.view_format,
+            view_caps: image_unbound.view_caps,
+            descriptor: image_unbound.desc,
+            clear_cv: if aspects.contains(Aspects::COLOR) && can_clear_color {
+                let format = image_unbound.view_format.unwrap();
+                (0..num_layers)
+                    .map(|layer| {
+                        self.view_image_as_render_target(&ViewInfo {
+                            format,
+                            layers: layer..layer + 1,
+                            ..info.clone()
+                        })
+                        .unwrap()
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            },
+            clear_dv: if aspects.contains(Aspects::DEPTH) && can_clear_depth {
+                let format = image_unbound.dsv_format.unwrap();
+                (0..num_layers)
+                    .map(|layer| {
+                        self.view_image_as_depth_stencil(&ViewInfo {
+                            format,
+                            layers: layer..layer + 1,
+                            ..info.clone()
+                        })
+                        .unwrap()
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            },
+            clear_sv: if aspects.contains(Aspects::STENCIL) && can_clear_depth {
+                let format = image_unbound.dsv_format.unwrap();
+                (0..num_layers)
+                    .map(|layer| {
+                        self.view_image_as_depth_stencil(&ViewInfo {
+                            format,
+                            layers: layer..layer + 1,
+                            ..info.clone()
+                        })
+                        .unwrap()
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            },
+            requirements: image_unbound.requirements,
+        });
     }
 }
 
@@ -2229,6 +2332,7 @@ impl d::Device<B> for Device {
         &self,
         mut size: u64,
         usage: buffer::Usage,
+        _sparse: memory::SparseFlags,
     ) -> Result<r::Buffer, buffer::CreationError> {
         if usage.contains(buffer::Usage::UNIFORM) {
             // Constant buffer view sizes need to be aligned.
@@ -2452,6 +2556,7 @@ impl d::Device<B> for Device {
         format: format::Format,
         tiling: image::Tiling,
         usage: image::Usage,
+        sparse: memory::SparseFlags,
         view_caps: image::ViewCapabilities,
     ) -> Result<r::Image, image::CreationError> {
         assert!(mip_levels <= kind.compute_num_levels());
@@ -2464,15 +2569,22 @@ impl d::Device<B> for Device {
         let extent = kind.extent();
 
         let format_info = self.format_properties.resolve(format as usize);
-        let (layout, features) = match tiling {
-            image::Tiling::Optimal => (
-                d3d12::D3D12_TEXTURE_LAYOUT_UNKNOWN,
+        let (layout, features) = if sparse.contains(memory::SparseFlags::SPARSE_BINDING) {
+            (
+                d3d12::D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE,
                 format_info.properties.optimal_tiling,
-            ),
-            image::Tiling::Linear => (
-                d3d12::D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
-                format_info.properties.linear_tiling,
-            ),
+            )
+        } else {
+            match tiling {
+                image::Tiling::Optimal => (
+                    d3d12::D3D12_TEXTURE_LAYOUT_UNKNOWN,
+                    format_info.properties.optimal_tiling,
+                ),
+                image::Tiling::Linear => (
+                    d3d12::D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+                    format_info.properties.linear_tiling,
+                ),
+            }
         };
         if format_info.sample_count_mask & kind.num_samples() == 0 {
             return Err(image::CreationError::Samples(kind.num_samples()));
@@ -2592,8 +2704,6 @@ impl d::Device<B> for Device {
         offset: u64,
         image: &mut r::Image,
     ) -> Result<(), d::BindError> {
-        use self::image::Usage;
-
         let image_unbound = image.expect_unbound();
         if image_unbound.requirements.type_mask & (1 << memory.type_id) == 0 {
             error!(
@@ -2607,7 +2717,6 @@ impl d::Device<B> for Device {
         }
 
         let mut resource = native::Resource::null();
-        let num_layers = image_unbound.kind.num_layers();
 
         assert_eq!(
             winerror::S_OK,
@@ -2626,102 +2735,14 @@ impl d::Device<B> for Device {
             resource.SetName(name.as_ptr());
         }
 
-        let info = ViewInfo {
+        self.bind_image_resource(
             resource,
-            kind: image_unbound.kind,
-            caps: image::ViewCapabilities::empty(),
-            view_kind: match image_unbound.kind {
-                image::Kind::D1(..) => image::ViewKind::D1Array,
-                image::Kind::D2(..) => image::ViewKind::D2Array,
-                image::Kind::D3(..) => image::ViewKind::D3,
-            },
-            format: image_unbound.desc.Format,
-            component_mapping: IDENTITY_MAPPING,
-            levels: 0..1,
-            layers: 0..0,
-        };
-
-        //TODO: the clear_Xv is incomplete. We should support clearing images created without XXX_ATTACHMENT usage.
-        // for this, we need to check the format and force the `RENDER_TARGET` flag behind the user's back
-        // if the format supports being rendered into, allowing us to create clear_Xv
-        let format_properties = self
-            .format_properties
-            .resolve(image_unbound.format as usize)
-            .properties;
-        let props = match image_unbound.tiling {
-            image::Tiling::Optimal => format_properties.optimal_tiling,
-            image::Tiling::Linear => format_properties.linear_tiling,
-        };
-        let can_clear_color = image_unbound
-            .usage
-            .intersects(Usage::TRANSFER_DST | Usage::COLOR_ATTACHMENT)
-            && props.contains(format::ImageFeature::COLOR_ATTACHMENT);
-        let can_clear_depth = image_unbound
-            .usage
-            .intersects(Usage::TRANSFER_DST | Usage::DEPTH_STENCIL_ATTACHMENT)
-            && props.contains(format::ImageFeature::DEPTH_STENCIL_ATTACHMENT);
-        let aspects = image_unbound.format.surface_desc().aspects;
-
-        *image = r::Image::Bound(r::ImageBound {
-            resource: resource,
-            place: r::Place::Heap {
+            image,
+            r::Place::Heap {
                 raw: memory.heap.clone(),
                 offset,
             },
-            surface_type: image_unbound.format.base_format().0,
-            kind: image_unbound.kind,
-            mip_levels: image_unbound.mip_levels,
-            usage: image_unbound.usage,
-            default_view_format: image_unbound.view_format,
-            view_caps: image_unbound.view_caps,
-            descriptor: image_unbound.desc,
-            clear_cv: if aspects.contains(Aspects::COLOR) && can_clear_color {
-                let format = image_unbound.view_format.unwrap();
-                (0..num_layers)
-                    .map(|layer| {
-                        self.view_image_as_render_target(&ViewInfo {
-                            format,
-                            layers: layer..layer + 1,
-                            ..info.clone()
-                        })
-                        .unwrap()
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            },
-            clear_dv: if aspects.contains(Aspects::DEPTH) && can_clear_depth {
-                let format = image_unbound.dsv_format.unwrap();
-                (0..num_layers)
-                    .map(|layer| {
-                        self.view_image_as_depth_stencil(&ViewInfo {
-                            format,
-                            layers: layer..layer + 1,
-                            ..info.clone()
-                        })
-                        .unwrap()
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            },
-            clear_sv: if aspects.contains(Aspects::STENCIL) && can_clear_depth {
-                let format = image_unbound.dsv_format.unwrap();
-                (0..num_layers)
-                    .map(|layer| {
-                        self.view_image_as_depth_stencil(&ViewInfo {
-                            format,
-                            layers: layer..layer + 1,
-                            ..info.clone()
-                        })
-                        .unwrap()
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            },
-            requirements: image_unbound.requirements,
-        });
+        );
 
         Ok(())
     }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -49,6 +49,7 @@ use winapi::{
 };
 
 use std::{
+    borrow::{Borrow, BorrowMut},
     ffi::OsString,
     fmt,
     mem,
@@ -58,6 +59,7 @@ use std::{
 };
 
 use self::descriptors_cpu::DescriptorCpuPool;
+use crate::resource::Image;
 
 #[derive(Debug)]
 pub(crate) struct HeapProperties {
@@ -507,6 +509,155 @@ impl q::Queue<Backend> for Queue {
             .collect::<SmallVec<[_; 4]>>();
         self.raw
             .ExecuteCommandLists(lists.len() as _, lists.as_ptr());
+
+        if let Some(fence) = fence {
+            assert_eq!(winerror::S_OK, self.raw.Signal(fence.raw.as_mut_ptr(), 1));
+        }
+    }
+
+    unsafe fn bind_sparse<'a, Iw, Is, Ibi, Ib, Iii, Io, Ii>(
+        &mut self,
+        _wait_semaphores: Iw,
+        _signal_semaphores: Is,
+        _buffer_memory_binds: Ib,
+        _image_opaque_memory_binds: Io,
+        image_memory_binds: Ii,
+        device: &Device,
+        fence: Option<&resource::Fence>,
+    ) where
+        Ibi: Iterator<Item = &'a memory::SparseBind<&'a resource::Memory>>,
+        Ib: Iterator<Item = (&'a mut resource::Buffer, Ibi)>,
+        Iii: Iterator<Item = &'a memory::SparseImageBind<&'a resource::Memory>>,
+        Io: Iterator<Item = (&'a mut resource::Image, Ibi)>,
+        Ii: Iterator<Item = (&'a mut resource::Image, Iii)>,
+        Iw: Iterator<Item = &'a resource::Semaphore>,
+        Is: Iterator<Item = &'a resource::Semaphore>,
+    {
+        // Reset idle fence and event
+        // That's safe here due to exclusive access to the queue
+        self.idle_fence.signal(0);
+        synchapi::ResetEvent(self.idle_event.0);
+
+        // TODO: semaphores
+
+        for (image, binds) in image_memory_binds {
+            let image = image.borrow_mut();
+
+            let (bits, image_kind) = match image {
+                Image::Unbound(unbound) => (unbound.format.surface_desc().bits, unbound.kind),
+                Image::Bound(bound) => (bound.surface_type.desc().bits, bound.kind),
+            };
+            let block_size = match image_kind {
+                image::Kind::D1(_, _) => unimplemented!(),
+                image::Kind::D2(_, _, _, samples) => {
+                    image::get_tile_size(image::TileKind::Flat(samples), bits)
+                }
+                image::Kind::D3(_, _, _) => image::get_tile_size(image::TileKind::Volume, bits),
+            };
+
+            // TODO avoid allocations
+            let mut resource_coords = Vec::new();
+            let mut region_sizes = Vec::new();
+            let mut range_flags = Vec::new();
+            let mut heap_range_start_offsets = Vec::new();
+            let mut range_tile_counts = Vec::new();
+
+            let mut heap: *mut d3d12::ID3D12Heap = std::ptr::null_mut();
+            for bind in binds {
+                resource_coords.push(d3d12::D3D12_TILED_RESOURCE_COORDINATE {
+                    X: bind.offset.x as u32,
+                    Y: bind.offset.y as u32,
+                    Z: bind.offset.z as u32,
+                    Subresource: image.calc_subresource(
+                        bind.subresource.level as _,
+                        bind.subresource.layer as _,
+                        0,
+                    ),
+                });
+
+                // Increment one tile if the extent is not a multiple of the block size
+                // Accessing these IS unsafe, but that is also true of Vulkan as the documentation
+                // requires an extent multiple of the block size.
+                let tile_extents = (
+                    (bind.extent.width / block_size.0 as u32)
+                        + ((bind.extent.width % block_size.0 as u32) != 0) as u32,
+                    (bind.extent.height / block_size.1 as u32)
+                        + ((bind.extent.height % block_size.1 as u32) != 0) as u32,
+                    (bind.extent.depth / block_size.2 as u32)
+                        + ((bind.extent.depth % block_size.2 as u32) != 0) as u32,
+                );
+                let number_tiles = tile_extents.0 * tile_extents.1 * tile_extents.2;
+                region_sizes.push(d3d12::D3D12_TILE_REGION_SIZE {
+                    NumTiles: number_tiles,
+                    UseBox: 1,
+                    Width: tile_extents.0,
+                    Height: tile_extents.1 as u16,
+                    Depth: tile_extents.2 as u16,
+                });
+
+                if let Some((memory, memory_offset)) = bind.memory {
+                    // TODO multiple heap support
+                    // would involve multiple update tile mapping calls
+                    if heap.is_null() {
+                        heap = memory.borrow().heap.as_mut_ptr();
+                    } else if cfg!(debug_assertions) {
+                        debug_assert_eq!(heap, memory.borrow().heap.as_mut_ptr());
+                    }
+                    range_flags.push(d3d12::D3D12_TILE_RANGE_FLAG_NONE);
+                    heap_range_start_offsets.push(memory_offset as u32);
+                } else {
+                    range_flags.push(d3d12::D3D12_TILE_RANGE_FLAG_NULL);
+                    heap_range_start_offsets.push(0);
+                }
+                range_tile_counts.push(number_tiles);
+            }
+
+            match image {
+                Image::Bound(bound) => {
+                    self.raw.UpdateTileMappings(
+                        bound.resource.as_mut_ptr(),
+                        resource_coords.len() as u32,
+                        resource_coords.as_ptr(),
+                        region_sizes.as_ptr(),
+                        heap,
+                        range_flags.len() as u32,
+                        range_flags.as_ptr(),
+                        heap_range_start_offsets.as_ptr(),
+                        range_tile_counts.as_ptr(),
+                        d3d12::D3D12_TILE_MAPPING_FLAG_NONE,
+                    );
+                }
+                Image::Unbound(image_unbound) => {
+                    let mut resource = native::Resource::null();
+                    assert_eq!(
+                        winerror::S_OK,
+                        device.raw.clone().CreateReservedResource(
+                            &image_unbound.desc,
+                            d3d12::D3D12_RESOURCE_STATE_COMMON,
+                            std::ptr::null(),
+                            &d3d12::ID3D12Resource::uuidof(),
+                            resource.mut_void(),
+                        )
+                    );
+
+                    self.raw.UpdateTileMappings(
+                        resource.as_mut_ptr(),
+                        resource_coords.len() as u32,
+                        resource_coords.as_ptr(),
+                        region_sizes.as_ptr(),
+                        heap,
+                        range_flags.len() as u32,
+                        range_flags.as_ptr(),
+                        heap_range_start_offsets.as_ptr(),
+                        range_tile_counts.as_ptr(),
+                        d3d12::D3D12_TILE_MAPPING_FLAG_NONE,
+                    );
+
+                    device.bind_image_resource(resource, image, resource::Place::Swapchain {});
+                }
+            }
+        }
+        // TODO sparse buffers and opaque images iterated here
 
         if let Some(fence) = fence {
             assert_eq!(winerror::S_OK, self.raw.Signal(fence.raw.as_mut_ptr(), 1));
@@ -1141,6 +1292,21 @@ impl hal::Instance<Backend> for Instance {
                 _ => unreachable!(),
             } as _;
 
+            let mut tiled_resource_features = Features::empty();
+            if features.TiledResourcesTier >= d3d12::D3D12_TILED_RESOURCES_TIER_1 {
+                tiled_resource_features |= Features::SPARSE_BINDING;
+                tiled_resource_features |= Features::SPARSE_RESIDENCY_IMAGE_2D;
+                tiled_resource_features |= Features::SPARSE_RESIDENCY_BUFFER;
+                tiled_resource_features |= Features::SPARSE_RESIDENCY_ALIASED;
+                tiled_resource_features |= Features::SPARSE_RESIDENCY_2_SAMPLES;
+                tiled_resource_features |= Features::SPARSE_RESIDENCY_4_SAMPLES;
+                tiled_resource_features |= Features::SPARSE_RESIDENCY_8_SAMPLES;
+                tiled_resource_features |= Features::SPARSE_RESIDENCY_16_SAMPLES;
+            }
+            if features.TiledResourcesTier >= d3d12::D3D12_TILED_RESOURCES_TIER_3 {
+                tiled_resource_features |= Features::SPARSE_RESIDENCY_IMAGE_3D;
+            }
+
             let physical_device = PhysicalDevice {
                 library: Arc::clone(&self.library),
                 adapter,
@@ -1170,7 +1336,8 @@ impl hal::Instance<Backend> for Instance {
                     Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING |
                     Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING |
                     Features::UNSIZED_DESCRIPTOR_ARRAY |
-                    Features::DRAW_INDIRECT_COUNT,
+                    Features::DRAW_INDIRECT_COUNT |
+                    tiled_resource_features,
                 properties: PhysicalDeviceProperties {
                     limits: Limits {
                         //TODO: verify all of these not linked to constants

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -296,6 +296,7 @@ impl device::Device<Backend> for Device {
         &self,
         size: u64,
         _: hal::buffer::Usage,
+        _: hal::memory::SparseFlags,
     ) -> Result<Buffer, hal::buffer::CreationError> {
         Ok(Buffer::new(size))
     }
@@ -334,6 +335,7 @@ impl device::Device<Backend> for Device {
         _: format::Format,
         _: hal::image::Tiling,
         _: hal::image::Usage,
+        _: hal::memory::SparseFlags,
         _: hal::image::ViewCapabilities,
     ) -> Result<Image, hal::image::CreationError> {
         Ok(Image::new(kind))

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1264,6 +1264,7 @@ impl d::Device<B> for Device {
         &self,
         size: u64,
         usage: buffer::Usage,
+        _sparse: memory::SparseFlags,
     ) -> Result<n::Buffer, buffer::CreationError> {
         if !self
             .share
@@ -1452,6 +1453,7 @@ impl d::Device<B> for Device {
         format: Format,
         _tiling: i::Tiling,
         usage: i::Usage,
+        _sparse: memory::SparseFlags,
         _view_caps: i::ViewCapabilities,
     ) -> Result<n::Image, i::CreationError> {
         let gl = &self.share.context;

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2453,6 +2453,7 @@ impl hal::device::Device<Backend> for Device {
         &self,
         size: u64,
         usage: buffer::Usage,
+        _sparse: memory::SparseFlags,
     ) -> Result<n::Buffer, buffer::CreationError> {
         debug!("create_buffer of size {} and usage {:?}", size, usage);
         Ok(n::Buffer::Unbound {
@@ -2650,6 +2651,7 @@ impl hal::device::Device<Backend> for Device {
         format: format::Format,
         tiling: image::Tiling,
         usage: image::Usage,
+        _sparse: memory::SparseFlags,
         view_caps: image::ViewCapabilities,
     ) -> Result<n::Image, image::CreationError> {
         debug!(

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -3,7 +3,7 @@ use crate::native as n;
 use ash::vk;
 
 use hal::{
-    buffer, command, format, image,
+    buffer, command, format, image, memory,
     memory::Segment,
     pass, pso, query,
     window::{CompositeAlphaMode, PresentMode},
@@ -154,6 +154,10 @@ pub fn map_pipeline_stage(stage: pso::PipelineStage) -> vk::PipelineStageFlags {
 
 pub fn map_buffer_usage(usage: buffer::Usage) -> vk::BufferUsageFlags {
     vk::BufferUsageFlags::from_raw(usage.bits())
+}
+
+pub fn map_buffer_create_flags(sparse: memory::SparseFlags) -> vk::BufferCreateFlags {
+    vk::BufferCreateFlags::from_raw(sparse.bits())
 }
 
 pub fn map_image_usage(usage: image::Usage) -> vk::ImageUsageFlags {
@@ -516,6 +520,13 @@ pub fn map_viewport(vp: &pso::Viewport, flip_y: bool, shift_y: bool) -> vk::View
 
 pub fn map_view_capabilities(caps: image::ViewCapabilities) -> vk::ImageCreateFlags {
     vk::ImageCreateFlags::from_raw(caps.bits())
+}
+
+pub fn map_view_capabilities_sparse(
+    sparse: memory::SparseFlags,
+    caps: image::ViewCapabilities,
+) -> vk::ImageCreateFlags {
+    vk::ImageCreateFlags::from_raw(sparse.bits() | caps.bits())
 }
 
 pub fn map_present_mode(mode: PresentMode) -> vk::PresentModeKHR {

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -4,6 +4,7 @@ use inplace_it::inplace_or_alloc_from_iter;
 use smallvec::SmallVec;
 
 use hal::{
+    memory,
     memory::{Requirements, Segment},
     pool::CommandPoolCreateFlags,
     pso::VertexInputRate,
@@ -1005,9 +1006,10 @@ impl d::Device<B> for super::Device {
         &self,
         size: u64,
         usage: buffer::Usage,
+        sparse: memory::SparseFlags,
     ) -> Result<n::Buffer, buffer::CreationError> {
         let info = vk::BufferCreateInfo::builder()
-            .flags(vk::BufferCreateFlags::empty()) // TODO:
+            .flags(conv::map_buffer_create_flags(sparse))
             .size(size)
             .usage(conv::map_buffer_usage(usage))
             .sharing_mode(vk::SharingMode::EXCLUSIVE); // TODO:
@@ -1081,9 +1083,10 @@ impl d::Device<B> for super::Device {
         format: format::Format,
         tiling: image::Tiling,
         usage: image::Usage,
+        sparse: memory::SparseFlags,
         view_caps: image::ViewCapabilities,
     ) -> Result<n::Image, image::CreationError> {
-        let flags = conv::map_view_capabilities(view_caps);
+        let flags = conv::map_view_capabilities_sparse(sparse, view_caps);
         let extent = conv::map_extent(kind.extent());
         let array_layers = kind.num_layers();
         let samples = kind.num_samples();

--- a/src/backend/webgpu/src/command.rs
+++ b/src/backend/webgpu/src/command.rs
@@ -61,8 +61,8 @@ impl hal::pool::CommandPool<Backend> for CommandPool {
     }
 
     unsafe fn free<I>(&mut self, _buffers: I)
-    where
-        I: Iterator<Item = CommandBuffer>,
+        where
+            I: Iterator<Item = CommandBuffer>,
     {
         todo!()
     }
@@ -134,11 +134,11 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
     }
 
     unsafe fn clear_attachments<T, U>(&mut self, _clears: T, _rects: U)
-    where
-        T: Iterator,
-        T::Item: Borrow<AttachmentClear>,
-        U: Iterator,
-        U::Item: Borrow<pso::ClearRect>,
+        where
+            T: Iterator,
+            T::Item: Borrow<AttachmentClear>,
+            U: Iterator,
+            U::Item: Borrow<pso::ClearRect>,
     {
         todo!()
     }
@@ -182,25 +182,25 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
     }
 
     unsafe fn bind_vertex_buffers<I, T>(&mut self, _first_binding: pso::BufferIndex, _buffers: I)
-    where
-        I: Iterator<Item = (T, buffer::SubRange)>,
-        T: Borrow<<Backend as hal::Backend>::Buffer>,
+        where
+            I: Iterator<Item = (T, buffer::SubRange)>,
+            T: Borrow<<Backend as hal::Backend>::Buffer>,
     {
         todo!()
     }
 
     unsafe fn set_viewports<T>(&mut self, _first_viewport: u32, _viewports: T)
-    where
-        T: Iterator,
-        T::Item: Borrow<pso::Viewport>,
+        where
+            T: Iterator,
+            T::Item: Borrow<pso::Viewport>,
     {
         todo!()
     }
 
     unsafe fn set_scissors<T>(&mut self, _first_scissor: u32, _rects: T)
-    where
-        T: Iterator,
-        T::Item: Borrow<pso::Rect>,
+        where
+            T: Iterator,
+            T::Item: Borrow<pso::Rect>,
     {
         todo!()
     }
@@ -531,9 +531,9 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
     }
 
     unsafe fn execute_commands<'a, T, I>(&mut self, _cmd_buffers: I)
-    where
-        T: 'a + Borrow<<Backend as hal::Backend>::CommandBuffer>,
-        I: Iterator<Item = &'a T>,
+        where
+            T: 'a + Borrow<<Backend as hal::Backend>::CommandBuffer>,
+            I: Iterator<Item = &'a T>,
     {
         todo!()
     }

--- a/src/backend/webgpu/src/device.rs
+++ b/src/backend/webgpu/src/device.rs
@@ -8,7 +8,7 @@ use hal::{
     device::{
         AllocationError, BindError, DeviceLost, MapError, OutOfMemory, ShaderError, WaitError,
     },
-    format, image,
+    format, image, memory,
     memory::{Requirements, Segment},
     pass,
     pool::CommandPoolCreateFlags,
@@ -167,6 +167,7 @@ impl hal::device::Device<Backend> for Device {
         &self,
         _size: u64,
         _usage: buffer::Usage,
+        _sparse: memory::SparseFlags,
     ) -> Result<<Backend as hal::Backend>::Buffer, buffer::CreationError> {
         todo!()
     }
@@ -211,6 +212,7 @@ impl hal::device::Device<Backend> for Device {
         _format: format::Format,
         _tiling: image::Tiling,
         _usage: image::Usage,
+        _sparse: memory::SparseFlags,
         _view_caps: image::ViewCapabilities,
     ) -> Result<<Backend as hal::Backend>::Image, image::CreationError> {
         todo!()

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -88,6 +88,21 @@ bitflags!(
     }
 );
 
+bitflags!(
+    /// Buffer create flags.
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct CreateFlags: u32 {
+        /// Specifies the view will be backed using sparse memory binding.
+        const SPARSE_BINDING = 0x0000_0001;
+        /// Specifies the view can be partially backed with sparse memory binding.
+        /// Must have `SPARSE_BINDING` enabled.
+        const SPARSE_RESIDENCY = 0x0000_0002;
+        /// Specifies the view will be backed using sparse memory binding with memory bindings that
+        /// might alias other data. Must have `SPARSE_BINDING` enabled.
+        const SPARSE_ALIASED = 0x0000_0004;
+    }
+);
+
 impl Usage {
     /// Returns if the buffer can be used in transfer operations.
     pub fn can_transfer(&self) -> bool {

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -12,7 +12,7 @@
 //! and is used to actually do things.
 
 use crate::{
-    buffer, format, image,
+    buffer, format, image, memory,
     memory::{Requirements, Segment},
     pass,
     pool::CommandPoolCreateFlags,
@@ -376,6 +376,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         &self,
         size: u64,
         usage: buffer::Usage,
+        sparse: memory::SparseFlags,
     ) -> Result<B::Buffer, buffer::CreationError>;
 
     /// Get memory requirements for the buffer
@@ -419,6 +420,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         format: format::Format,
         tiling: image::Tiling,
         usage: image::Usage,
+        sparse: memory::SparseFlags,
         view_caps: image::ViewCapabilities,
     ) -> Result<B::Image, image::CreationError>;
 

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -700,6 +700,49 @@ pub struct SubresourceFootprint {
     pub depth_pitch: RawOffset,
 }
 
+/// The type of tile to check for with `get_tile_size`.
+#[derive(Debug)]
+pub enum TileKind {
+    /// A volume or 3D image tile kind.
+    Volume,
+    /// A flat or 2D image tile kind, with the number of samples for MSAA.
+    Flat(NumSamples),
+}
+
+// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#sparsememory-standard-shapes
+// https://docs.microsoft.com/en-us/windows/win32/direct3d11/texture2d-and-texture2darray-subresource-tiling
+/// Tile or block size for sparse binding
+pub fn get_tile_size(tile_kind: TileKind, texel_bits: u16) -> (u16, u16, u16) {
+    match tile_kind {
+        TileKind::Flat(samples) => {
+            let sizes = match texel_bits {
+                8 => (256, 256, 1),
+                16 => (256, 128, 1),
+                32 => (128, 128, 1),
+                64 => (128, 64, 1),
+                128 => (64, 64, 1),
+                _ => unimplemented!(),
+            };
+            match samples {
+                1 => sizes,
+                2 => (sizes.0 / 2, sizes.1, 1),
+                4 => (sizes.0 / 2, sizes.1 / 2, 1),
+                8 => (sizes.0 / 4, sizes.1 / 2, 1),
+                16 => (sizes.0 / 4, sizes.1 / 4, 1),
+                _ => unimplemented!(),
+            }
+        }
+        TileKind::Volume => match texel_bits {
+            8 => (64, 32, 32),
+            16 => (32, 32, 32),
+            32 => (32, 32, 16),
+            64 => (32, 16, 16),
+            128 => (16, 16, 16),
+            _ => unimplemented!(),
+        },
+    }
+}
+
 /// Description of a framebuffer attachment.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -128,3 +128,54 @@ impl Segment {
         size: None,
     };
 }
+
+/// Defines a single memory bind region.
+///
+/// This is used in the [`bind_sparse`][CommandQueue::bind_sparse] method to define a physical
+/// store region for a buffer.
+#[derive(Debug)]
+pub struct SparseBind<M> {
+    /// Offset into the (virtual) resource.
+    pub resource_offset: u64,
+    /// Size of the memory region to be bound.
+    pub size: u64,
+    /// Memory that the physical store is bound to, and the offset into the resource of the binding.
+    ///
+    /// Using `None` will unbind this range. Reading or writing to an unbound range is undefined
+    /// behaviour in some older hardware.
+    pub memory: Option<(M, u64)>,
+}
+
+/// Defines a single image memory bind region.
+///
+/// This is used in the [`bind_sparse`][CommandQueue::bind_sparse] method to define a physical
+/// store region for a buffer.
+#[derive(Debug)]
+pub struct SparseImageBind<M> {
+    /// Image aspect and region of interest in the image.
+    pub subresource: image::Subresource,
+    /// Coordinates of the first texel in the (virtual) image subresource to bind.
+    pub offset: image::Offset,
+    /// Extent of the (virtual) image subresource region to be bound.
+    pub extent: image::Extent,
+    /// Memory that the physical store is bound to, and the offset into the resource of the binding.
+    ///
+    /// Using `None` will unbind this range. Reading or writing to an unbound range is undefined
+    /// behaviour in some older hardware.
+    pub memory: Option<(M, u64)>,
+}
+
+bitflags!(
+    /// Sparse flags for creating images and buffers.
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct SparseFlags: u32 {
+        /// Specifies the view will be backed using sparse memory binding.
+        const SPARSE_BINDING = 0x0000_0001;
+        /// Specifies the view can be partially backed with sparse memory binding.
+        /// Must have `SPARSE_BINDING` enabled.
+        const SPARSE_RESIDENCY = 0x0000_0002;
+        /// Specifies the view will be backed using sparse memory binding with memory bindings that
+        /// might alias other data. Must have `SPARSE_BINDING` enabled.
+        const SPARSE_ALIASED = 0x0000_0004;
+    }
+);

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 use std::{any::Any, fmt};
 
 pub use self::family::{QueueFamily, QueueFamilyId, QueueGroup};
+use crate::memory::{SparseBind, SparseImageBind};
 
 /// The type of the queue, an enum encompassing `queue::Capability`
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -65,6 +66,41 @@ pub type QueuePriority = f32;
 /// Queues can also be used for presenting to a surface
 /// (that is, flip the front buffer with the next one in the chain).
 pub trait Queue<B: Backend>: fmt::Debug + Any + Send + Sync {
+    /// Sparse memory bind operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `info` - information about the memory bindings.
+    ///
+    /// # Safety
+    ///
+    /// - Defining memory as `None` will cause undefined behaviour when the
+    /// tile is read or written from in some hardware.
+    /// - The memory regions provided are not checked to be valid and matching
+    /// of the sparse resource type.
+    /// - If extents are not a multiple of the block size, additional space will be
+    /// bound, and accessing memory is unsafe.
+    unsafe fn bind_sparse<'a, Iw, Is, Ibi, Ib, Iii, Io, Ii>(
+        &mut self,
+        _wait_semaphores: Iw,
+        _signal_semaphores: Is,
+        _buffer_memory_binds: Ib,
+        _image_opaque_memory_binds: Io,
+        _image_memory_binds: Ii,
+        _device: &B::Device,
+        _fence: Option<&B::Fence>,
+    ) where
+        Ibi: Iterator<Item = &'a SparseBind<&'a B::Memory>>,
+        Ib: Iterator<Item = (&'a mut B::Buffer, Ibi)>,
+        Iii: Iterator<Item = &'a SparseImageBind<&'a B::Memory>>,
+        Io: Iterator<Item = (&'a mut B::Image, Ibi)>,
+        Ii: Iterator<Item = (&'a mut B::Image, Iii)>,
+        Iw: Iterator<Item = &'a B::Semaphore>,
+        Is: Iterator<Item = &'a B::Semaphore>,
+    {
+        unimplemented!()
+    }
+
     /// Submit command buffers to queue for execution.
     ///
     /// # Arguments

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -291,7 +291,10 @@ impl<B: hal::Backend> Scene<B> {
                     ref data,
                 } => {
                     // allocate memory
-                    let mut buffer = unsafe { device.create_buffer(size as _, usage) }.unwrap();
+                    let mut buffer = unsafe {
+                        device.create_buffer(size as _, usage, hal::memory::SparseFlags::empty())
+                    }
+                    .unwrap();
                     let requirements = unsafe { device.get_buffer_requirements(&buffer) };
                     let memory_type = memory_types
                         .iter()
@@ -333,9 +336,14 @@ impl<B: hal::Backend> Scene<B> {
                         let upload_size =
                             align(size as _, limits.optimal_buffer_copy_pitch_alignment);
                         // create upload buffer
-                        let mut upload_buffer =
-                            unsafe { device.create_buffer(upload_size, b::Usage::TRANSFER_SRC) }
-                                .unwrap();
+                        let mut upload_buffer = unsafe {
+                            device.create_buffer(
+                                upload_size,
+                                b::Usage::TRANSFER_SRC,
+                                hal::memory::SparseFlags::empty(),
+                            )
+                        }
+                        .unwrap();
                         let upload_req = unsafe { device.get_buffer_requirements(&upload_buffer) };
                         let upload_type = *upload_types
                             .iter()
@@ -421,6 +429,7 @@ impl<B: hal::Backend> Scene<B> {
                             format,
                             i::Tiling::Optimal,
                             usage,
+                            hal::memory::SparseFlags::empty(),
                             view_caps,
                         )
                     }
@@ -492,9 +501,14 @@ impl<B: hal::Backend> Scene<B> {
                         let upload_size =
                             (row_pitch as u64 * h as u64 * d as u64) / block_height as u64;
                         // create upload buffer
-                        let mut upload_buffer =
-                            unsafe { device.create_buffer(upload_size, b::Usage::TRANSFER_SRC) }
-                                .unwrap();
+                        let mut upload_buffer = unsafe {
+                            device.create_buffer(
+                                upload_size,
+                                b::Usage::TRANSFER_SRC,
+                                hal::memory::SparseFlags::empty(),
+                            )
+                        }
+                        .unwrap();
                         let upload_req = unsafe { device.get_buffer_requirements(&upload_buffer) };
                         let upload_type = *upload_types
                             .iter()
@@ -1518,8 +1532,14 @@ impl<B: hal::Backend> Scene<B> {
             limits.optimal_buffer_copy_pitch_alignment,
         );
 
-        let mut down_buffer =
-            unsafe { self.device.create_buffer(down_size, b::Usage::TRANSFER_DST) }.unwrap();
+        let mut down_buffer = unsafe {
+            self.device.create_buffer(
+                down_size,
+                b::Usage::TRANSFER_DST,
+                hal::memory::SparseFlags::empty(),
+            )
+        }
+        .unwrap();
         let down_req = unsafe { self.device.get_buffer_requirements(&down_buffer) };
         let download_type = *self
             .download_types
@@ -1637,8 +1657,14 @@ impl<B: hal::Backend> Scene<B> {
         let row_pitch = align(width_bytes, limits.optimal_buffer_copy_pitch_alignment);
         let down_size = (row_pitch * height * depth as u64) / block_height as u64;
 
-        let mut down_buffer =
-            unsafe { self.device.create_buffer(down_size, b::Usage::TRANSFER_DST) }.unwrap();
+        let mut down_buffer = unsafe {
+            self.device.create_buffer(
+                down_size,
+                b::Usage::TRANSFER_DST,
+                hal::memory::SparseFlags::empty(),
+            )
+        }
+        .unwrap();
         let down_req = unsafe { self.device.get_buffer_requirements(&down_buffer) };
         let download_type = *self
             .download_types


### PR DESCRIPTION
Progress in implementing sparse resources, listed on issue #1610

This PR adds the following:
- A `bind_sparse` method in CommandQueue based on `submit`.
- A Vulkan implementation for `bind_sparse`, making a [vkQueueBindSparse](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueBindSparse.html) call.
- A DirectX12 implementation for `bind_sparse` for images, creating a virtual resource with [CreateReservedResource](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12device-createreservedresource) if unbound and mapping it to memory with [UpdateTileMappings](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12commandqueue-updatetilemappings).
- `SPARSE_BINDING`, `SPARSE_RESIDENCY` and `SPARSE_ALIASED` view capabilities when creating images. Also sets the texture layout to `D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE` when creating images on DX12.
- A `sparselybound` feature on the `quad` example which binds the logo texture using `bind_sparse` instead of `bind_image_memory`.

Remaining additions:
- [ ] DirectX 11 implementation.
- [ ] Buffer and opaque textures in the DirectX 12 implementation.
- [ ] Setting sparse flags in buffer resources. (This will have to be a breaking change or a different buffer create method)

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan, DirectX 12, DirectX 11
