### PR TITLE
Remove outdated entry point assertions

### DIFF
--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -407,12 +407,10 @@ impl Device {
     ) -> n::Shader {
         match *point.module {
             n::ShaderModule::Raw(raw) => {
-                assert_eq!(point.entry, "main");
                 debug!("Can't remap bindings for raw shaders. Assuming they are already rebound.");
                 raw
             }
             n::ShaderModule::Spirv(ref spirv) => {
-                assert_eq!(point.entry, "main");
                 let mut ast = self.parse_spirv(spirv).unwrap();
 
                 spirv_cross_specialize_ast(&mut ast, &point.specialization).unwrap();


### PR DESCRIPTION
Running the quad sample the gfx-backend-gl backend works, but running the hello-triangle from the wgpu-rs project by creating the wgpu::Instance with wgpu::BackendBit::GL panics with:

```
     Running `target/debug/examples/hello-triangle`
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `"vs_main"`,
 right: `"main"`', /path/to/home/.cargo/git/checkouts/gfx-e86e7f3ebdbc4218/f1398d2/src/backend/gl/src/device.rs:399:9
```

Current PR fixes this, by removing outdated assertions as per comment here:
https://github.com/gfx-rs/gfx/pull/3520#discussion_r537818829