### PR TITLE
Return None for unsupported formats in image_format_properties

### DIFF
--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -615,12 +615,13 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 
     fn image_format_properties(
         &self,
-        _format: hal::format::Format,
+        format: hal::format::Format,
         _dimensions: u8,
         _tiling: image::Tiling,
         _usage: image::Usage,
         _view_caps: image::ViewCapabilities,
     ) -> Option<image::FormatProperties> {
+        conv::describe_format(format)?;
         Some(image::FormatProperties {
             max_extent: image::Extent {
                 width: !0,


### PR DESCRIPTION
Fixes image_format_properties method for gfx-backend-gl to return None for unsupported/unmapped image formats.
Up until now clients where tricked into believing that all formats where available and subsequent calls to image_create failed.