### PR TITLE
Implement get_image_subresource_footprint in opengl backend

### DIFF
--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1537,6 +1537,8 @@ impl d::Device<B> for Device {
 
         Ok(n::Image {
             object_type: image,
+            kind,
+            format_desc: surface_desc,
             channel,
             requirements: memory::Requirements {
                 size,

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1556,10 +1556,22 @@ impl d::Device<B> for Device {
 
     unsafe fn get_image_subresource_footprint(
         &self,
-        _image: &n::Image,
-        _sub: i::Subresource,
+        image: &n::Image,
+        sub: i::Subresource,
     ) -> i::SubresourceFootprint {
-        unimplemented!()
+        let num_layers = image.kind.num_layers() as buffer::Offset;
+        let level_offset = (0..sub.level).fold(0, |offset, level| {
+            let pitches = image.pitches(level);
+            offset + num_layers * pitches[3]
+        });
+        let pitches = image.pitches(sub.level);
+        let layer_offset = level_offset + sub.layer as buffer::Offset * pitches[3];
+        i::SubresourceFootprint {
+            slice: layer_offset..layer_offset + pitches[3],
+            row_pitch: pitches[1] as _,
+            depth_pitch: pitches[2] as _,
+            array_pitch: pitches[3] as _,
+        }
     }
 
     unsafe fn bind_image_memory(

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -180,6 +180,22 @@ pub struct Image {
     pub(crate) num_layers: i::Layer,
 }
 
+impl Image {
+    pub(crate) fn pitches(&self, level: i::Level) -> [buffer::Offset; 4] {
+        let extent = self.kind.extent().at_level(level);
+        let bytes_per_texel = self.format_desc.bits as i::Size >> 3;
+        let row_pitch = extent.width * bytes_per_texel;
+        let depth_pitch = extent.height * row_pitch;
+        let array_pitch = extent.depth * depth_pitch;
+        [
+            bytes_per_texel as _,
+            row_pitch as _,
+            depth_pitch as _,
+            array_pitch as _,
+        ]
+    }
+}
+
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum ImageType {
     Renderbuffer {

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -4,7 +4,7 @@ use auxil::FastHashMap;
 use hal::{
     buffer, format, image as i,
     memory::{Properties, Requirements},
-    pass, pso,
+    pass, pso, window as w,
 };
 
 use parking_lot::{Mutex, RwLock};
@@ -171,6 +171,8 @@ pub struct ComputePipeline {
 #[derive(Copy, Clone, Debug)]
 pub struct Image {
     pub(crate) object_type: ImageType,
+    pub(crate) kind: i::Kind,
+    pub(crate) format_desc: format::FormatDesc,
     // Required for clearing operations
     pub(crate) channel: format::ChannelType,
     pub(crate) requirements: Requirements,
@@ -236,6 +238,7 @@ impl SwapchainImage {
     pub(crate) fn new(
         renderbuffer: Renderbuffer,
         format: TextureFormat,
+        extent: w::Extent2D,
         channel: format::ChannelType,
     ) -> Self {
         SwapchainImage {
@@ -245,6 +248,13 @@ impl SwapchainImage {
                     format,
                 },
                 channel,
+                kind: i::Kind::D2(extent.width as u32, extent.height as u32, 1, 1),
+                format_desc: format::FormatDesc {
+                    bits: 0,
+                    dim: (0, 0),
+                    packed: false,
+                    aspects: format::Aspects::empty(),
+                },
                 requirements: Requirements {
                     size: 0,
                     alignment: 1,

--- a/src/backend/gl/src/window/egl.rs
+++ b/src/backend/gl/src/window/egl.rs
@@ -274,7 +274,8 @@ impl w::PresentationSurface<crate::Backend> for Surface {
         _timeout_ns: u64,
     ) -> Result<(Self::SwapchainImage, Option<w::Suboptimal>), w::AcquireError> {
         let sc = self.swapchain.as_ref().unwrap();
-        let sc_image = native::SwapchainImage::new(sc.renderbuffer, sc.format, sc.channel);
+        let sc_image =
+            native::SwapchainImage::new(sc.renderbuffer, sc.format, sc.extent, sc.channel);
         Ok((sc_image, None))
     }
 }


### PR DESCRIPTION
Implementation similar to metal backend