### PR TITLE
Rewrite the GL binding model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ members = [
     "src/warden",
     "examples",
 ]
+
+[patch."https://github.com/gfx-rs/naga"]
+#naga = { path = "../naga" }

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -36,7 +36,7 @@ libloading = "0.6"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-4"
+tag = "gfx-5"
 #TODO: remove `spv-out` once spirv-cross is deprecated
 features = ["spv-out", "glsl-out"]
 optional = true

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -753,11 +753,9 @@ impl CommandQueue {
                 let gl = &self.share.context;
                 gl.bind_sampler(index, Some(sampler));
             },
-            com::Command::SetTextureSamplerSettings(index, texture, textype, ref sinfo) => unsafe {
+            com::Command::SetTextureSamplerSettings(index, textype, ref sinfo) => unsafe {
                 let gl = &self.share.context;
                 gl.active_texture(glow::TEXTURE0 + index);
-                gl.bind_texture(textype, Some(texture));
-
                 // TODO: Optimization: only change texture properties that have changed.
                 device::set_sampler_info(
                     &sinfo,

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -43,7 +43,7 @@ raw-window-handle = "0.3"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-4"
+tag = "gfx-5"
 #TODO: remove `spv-out` once spirv-cross is deprecated
 features = ["spv-out", "msl-out"]
 optional = true

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -33,7 +33,7 @@ inplace_it = "0.3.2"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-4"
+tag = "gfx-5"
 features = ["spv-out"]
 optional = true
 

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.0"
-naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-4" }
+naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-5" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"


### PR DESCRIPTION
Closes #2858
Closes #2784
Depends on https://github.com/gfx-rs/naga/pull/333

I was having a hard time trying to map our Naga semantics to the old binding model of gfx-backend-gl. I also couldn't stand the fact that the pipeline layouts were internally mutable, and mapping could grow as more pipelines are created. That seemed very out of line with regards to how other backends are written, and I didn't fully understand that code...

So the binding model is totally rewritten here. It becomes somewhat similar to Metal or D3D11, but with special logic to update the texture binding state instead of having true sampler objects.
The new code likely hosts bugs, I wasn't able to test it a lot, especially given the overall state of the backend. I think this rewrite is still a good investment into the future of the backend, and we should cope with the bugs coming our way.

The thing I'm most interesting in getting reviewed here is the general approach, the architecture of the binding model, which is described a bit in the crate `lib.rs` comment.