### PR TITLE
Better GL context initialization

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -59,7 +59,6 @@ optional = true
 [target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos"), not(target_os = "android")))'.dependencies.gfx-backend-gl]
 path = "../src/backend/gl"
 version = "0.6"
-features = ["x11"]
 optional = true
 
 [target.'cfg(all(target_arch = "wasm32"))'.dependencies.gfx-backend-gl]

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 name = "gfx_backend_gl"
 
 [features]
-default = ["x11"]
+default = []
 
 [dependencies]
 arrayvec = "0.5"
@@ -24,6 +24,7 @@ bitflags = "1"
 log = "0.4"
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
 auxil = { path = "../../auxil/auxil", version = "0.5", package = "gfx-auxil", features = ["spirv_cross"] }
+libloading = "0.6"
 smallvec = "1.0"
 glow = "0.6.1"
 parking_lot = "0.11"
@@ -33,7 +34,6 @@ raw-window-handle = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 egl = { package = "khronos-egl", version = "2.2" }
-x11 = { version = "2", features = ["xlib"], optional = true }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -219,7 +219,7 @@ pub struct Info {
     pub extensions: HashSet<String>,
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// Flags for features that are required for Vulkan but may not
     /// be supported by legacy backends (GL/DX11).
     pub struct LegacyFeatures: u32 {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -4,8 +4,6 @@
 #![allow(missing_docs, missing_copy_implementations)]
 
 #[macro_use]
-extern crate bitflags;
-#[macro_use]
 extern crate log;
 
 use std::{

--- a/src/backend/gl/src/window/egl.rs
+++ b/src/backend/gl/src/window/egl.rs
@@ -3,6 +3,7 @@
 use crate::{conv, native, GlContainer, PhysicalDevice};
 use glow::HasContext;
 use hal::{image, window as w};
+use std::{os::raw, ptr};
 
 #[derive(Debug)]
 pub struct Swapchain {
@@ -26,34 +27,45 @@ pub struct Instance {
 unsafe impl Send for Instance {}
 unsafe impl Sync for Instance {}
 
+fn get_x11_open_display() -> Option<ptr::NonNull<raw::c_void>> {
+    type XOpenDisplayFun =
+        unsafe extern "system" fn(display_name: *const raw::c_char) -> *mut raw::c_void;
+    log::info!("Loading X11 library to get the current display");
+    let library = libloading::Library::new("libX11.so").ok()?;
+    let func: libloading::Symbol<XOpenDisplayFun> =
+        unsafe { library.get(b"XOpenDisplay").unwrap() };
+    ptr::NonNull::new(unsafe { func(ptr::null()) })
+}
+
 impl hal::Instance<crate::Backend> for Instance {
     fn create(_: &str, _: u32) -> Result<Self, hal::UnsupportedBackend> {
         let client_extensions = egl::query_string(None, egl::EXTENSIONS)
             .map_err(|_| hal::UnsupportedBackend)?
             .to_string_lossy();
         log::info!("Client extensions: {:?}", client_extensions);
-        let client_list = client_extensions.split_whitespace().collect::<Vec<_>>();
+        let client_ext_list = client_extensions.split_whitespace().collect::<Vec<_>>();
 
-        #[cfg(feature = "x11")]
-        let display = {
-            if client_list.contains(&"EGL_EXT_platform_x11") {
-                const EGL_PLATFORM_X11_KHR: u32 = 0x31D5;
-                let x11_display = unsafe { x11::xlib::XOpenDisplay(std::ptr::null()) };
-                assert!(!x11_display.is_null());
-                let display_attributes = [egl::ATTRIB_NONE];
-                egl::get_platform_display(
-                    EGL_PLATFORM_X11_KHR,
-                    x11_display as *mut _,
-                    &display_attributes,
-                )
-                .unwrap()
-            } else {
-                log::warn!("X11 is not supported");
-                egl::get_display(egl::DEFAULT_DISPLAY).unwrap()
-            }
+        let mut is_default_display = false;
+        let x11_display = if client_ext_list.contains(&"EGL_EXT_platform_x11") {
+            get_x11_open_display()
+        } else {
+            None
         };
-        #[cfg(not(feature = "x11"))]
-        let display = egl::get_display(egl::DEFAULT_DISPLAY).unwrap();
+        let display = if let Some(x11_display) = x11_display {
+            log::info!("Using X11 platform");
+            const EGL_PLATFORM_X11_KHR: u32 = 0x31D5;
+            let display_attributes = [egl::ATTRIB_NONE];
+            egl::get_platform_display(
+                EGL_PLATFORM_X11_KHR,
+                x11_display.as_ptr(),
+                &display_attributes,
+            )
+            .unwrap()
+        } else {
+            log::info!("Using default platform");
+            is_default_display = true;
+            egl::get_display(egl::DEFAULT_DISPLAY).unwrap()
+        };
 
         let version = egl::initialize(display).map_err(|_| hal::UnsupportedBackend)?;
         let vendor = egl::query_string(Some(display), egl::VENDOR).unwrap();
@@ -70,23 +82,21 @@ impl hal::Instance<crate::Backend> for Instance {
             log::error!("EGL supported version is only {:?}", version);
             return Err(hal::UnsupportedBackend);
         }
-        {
-            let required_list = ["EGL_KHR_create_context", "EGL_KHR_surfaceless_context"];
-            let list = display_extensions.split_whitespace().collect::<Vec<_>>();
-            for required_ext in required_list.iter() {
-                if !list.contains(required_ext) {
-                    log::warn!("{} is not present", required_ext);
-                }
+        let display_ext_list = display_extensions.split_whitespace().collect::<Vec<_>>();
+        let required_display_extensions = ["EGL_KHR_create_context", "EGL_KHR_surfaceless_context"];
+        for required_ext in required_display_extensions.iter() {
+            if !display_ext_list.contains(required_ext) {
+                log::warn!("{} is not present", required_ext);
             }
         }
 
-        {
-            debug!("Configurations:");
+        if log::max_level() >= log::LevelFilter::Trace {
+            log::trace!("Configurations:");
             let config_count = egl::get_config_count(display).unwrap();
             let mut configurations = Vec::with_capacity(config_count);
             egl::get_configs(display, &mut configurations).unwrap();
             for &config in configurations.iter() {
-                debug!("\tCONFORMANT=0x{:X}, RENDERABLE=0x{:X}, NATIVE_RENDERABLE=0x{:X}, SURFACE_TYPE=0x{:X}",
+                log::trace!("\tCONFORMANT=0x{:X}, RENDERABLE=0x{:X}, NATIVE_RENDERABLE=0x{:X}, SURFACE_TYPE=0x{:X}",
                     egl::get_config_attrib(display, config, egl::CONFORMANT).unwrap(),
                     egl::get_config_attrib(display, config, egl::RENDERABLE_TYPE).unwrap(),
                     egl::get_config_attrib(display, config, egl::NATIVE_RENDERABLE).unwrap(),
@@ -109,7 +119,12 @@ impl hal::Instance<crate::Backend> for Instance {
             egl::WINDOW_BIT,
             egl::NONE,
         ];
-        let config = match egl::choose_first_config(display, &config_attributes) {
+        let pre_config = if is_default_display {
+            Ok(None)
+        } else {
+            egl::choose_first_config(display, &config_attributes)
+        };
+        let config = match pre_config {
             Ok(Some(config)) => config,
             Ok(None) => {
                 log::warn!("no compatible EGL config found, trying off-screen");
@@ -134,7 +149,8 @@ impl hal::Instance<crate::Backend> for Instance {
             egl::CONTEXT_CLIENT_VERSION,
             3, // Request GLES 3.0 or higher
         ];
-        if cfg!(debug_assertions) {
+        if cfg!(debug_assertions) && !is_default_display {
+            //TODO: figure out why this is needed
             context_attributes.push(egl::CONTEXT_OPENGL_DEBUG);
             context_attributes.push(egl::TRUE as _);
         }

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -61,7 +61,6 @@ optional = true
 path = "../../src/backend/gl"
 version = "0.6"
 optional = true
-features = ["x11"]
 
 [[example]]
 name = "basic"


### PR DESCRIPTION
Fixes #3519 for real this time
Fixes #3534
Drops X11 dependency :tada: 

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: GL
