### PR TITLE
Remove optional dependency on mint

### DIFF
--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -20,7 +20,6 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.0"
-mint = { version = "0.5", optional = true }
 naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-4" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }


### PR DESCRIPTION
It seems that `mint` is no longer used anywhere in `gfx`. This change removes the listing from the manifest file.