### PR TITLE
[gl] fix the WASM target and enable on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       TARGET: aarch64-linux-android
+      #TODO: remove this once khronos-egl is updated
       PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - uses: actions/checkout@v2
@@ -35,6 +36,16 @@ jobs:
           sudo apt-get install -y -qq libegl1-mesa-dev
           echo "$ANDROID_HOME/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
       - run: cargo check --manifest-path src/backend/gl/Cargo.toml --target ${{ env.TARGET }}
+
+  webgl_build:
+    name: Web Assembly
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup target add wasm32-unknown-unknown
+      # version has to match the `Cargo.toml` dependency in GL backend
+      - run: cargo install wasm-bindgen-cli --version 0.2.60
+      - run: make quad-wasm
 
   check-advisories:
     name: Advisory Check
@@ -66,7 +77,6 @@ jobs:
             MacOS Nightly,
             Ubuntu Stable,
             Ubuntu Nightly,
-            Web Assembly,
             Windows Stable,
             Windows Nightly,
           ]
@@ -83,10 +93,6 @@ jobs:
           - os: ubuntu-18.04
             name: Ubuntu Nightly
             channel: nightly
-          - os: ubuntu-18.04
-            name: Web Assembly
-            channel: nightly
-            target: wasm32-unknown-unknown
           - os: windows-2019
             name: Windows Stable
             channel: stable

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ quad:
 	cd examples && cargo run --bin quad --features ${FEATURES_HAL}
 
 quad-wasm:
-	cd examples && cargo +nightly build --features gl --target wasm32-unknown-unknown --bin quad && wasm-bindgen ../target/wasm32-unknown-unknown/debug/quad.wasm --out-dir ../examples/generated-wasm --web
+	cd examples && cargo build --features gl --target wasm32-unknown-unknown --bin quad && wasm-bindgen ../target/wasm32-unknown-unknown/debug/quad.wasm --out-dir ../examples/generated-wasm --web
 
 shader-binaries: $(METAL_SHADERS)/*.metal
 ifeq ($(UNAME_S),Darwin)

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,7 @@
 status = [
   "Dependency Check",
   "iOS Stable",
+  "Web Assembly",
   "MacOS Stable",
   "MacOS Nightly",
   "Android Stable",

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -24,16 +24,15 @@ bitflags = "1"
 log = "0.4"
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
 auxil = { path = "../../auxil/auxil", version = "0.5", package = "gfx-auxil", features = ["spirv_cross"] }
-libloading = "0.6"
 smallvec = "1.0"
 glow = "0.6.1"
 parking_lot = "0.11"
 spirv_cross = { version = "0.22", features = ["glsl"]}
-lazy_static = "1"
 raw-window-handle = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 egl = { package = "khronos-egl", version = "2.2" }
+libloading = "0.6"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
@@ -44,7 +43,7 @@ optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"
-wasm-bindgen = "0.2.51"
+wasm-bindgen = "=0.2.60"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.6"

--- a/src/backend/gl/src/window/egl.rs
+++ b/src/backend/gl/src/window/egl.rs
@@ -174,12 +174,13 @@ impl hal::Instance<crate::Backend> for Instance {
 
     fn enumerate_adapters(&self) -> Vec<hal::adapter::Adapter<crate::Backend>> {
         egl::make_current(self.display, None, None, Some(self.context)).unwrap();
-        let gl = unsafe {
-            GlContainer::from_fn_proc(|name| egl::get_proc_address(name).unwrap() as *const _)
+        let context = unsafe {
+            glow::Context::from_loader_function(|name| {
+                egl::get_proc_address(name).unwrap() as *const _
+            })
         };
-
         // Create physical device
-        vec![PhysicalDevice::new_adapter(gl)]
+        vec![PhysicalDevice::new_adapter(context)]
     }
 
     unsafe fn create_surface(

--- a/src/backend/webgpu/Cargo.toml
+++ b/src/backend/webgpu/Cargo.toml
@@ -22,7 +22,7 @@ name = "gfx_backend_webgpu"
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
 js-sys = "0.3.37"
 raw-window-handle = "0.3"
-wasm-bindgen = "0.2.60"
+wasm-bindgen = "=0.2.60"
 wasm-bindgen-futures = "0.4.10"
 web-sys = { version = "0.3.37", features = [
     "Document",


### PR DESCRIPTION
I believe the target was broken for a while, possibly since we moved to Github actions.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
