### PR TITLE
[gl] unlock wasm-bindgen version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,9 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: rustup target add wasm32-unknown-unknown
-      # version has to match the `Cargo.toml` dependency in GL backend
-      - run: cargo install wasm-bindgen-cli --version 0.2.60
-      - run: make quad-wasm
+      - run: cargo build --manifest-path examples/Cargo.toml --features gl --target wasm32-unknown-unknown --bin quad
 
   check-advisories:
     name: Advisory Check

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -43,7 +43,7 @@ optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.6"
-wasm-bindgen = "=0.2.60"
+wasm-bindgen = "0.2.60"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.6"


### PR DESCRIPTION
Fixes the fact that our wasm-bindgen was locked to 0.2.60 by #3537