### PR TITLE
[gl] Fix the number of texture units

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use crate::{GlContext, MAX_SAMPLERS};
+use crate::{GlContext, MAX_SAMPLERS, MAX_TEXTURE_SLOTS};
 
 use hal::{
     self, buffer, command,
@@ -217,7 +217,7 @@ struct Cache {
     /// Currently bound samplers.
     samplers: Vec<Option<n::FatSampler>>,
     /// Current sampler redirection map.
-    texture_slots: [TextureSlotInfo; glow::MAX_TEXTURE_IMAGE_UNITS as usize],
+    texture_slots: [TextureSlotInfo; MAX_TEXTURE_SLOTS],
 }
 
 impl Cache {
@@ -239,7 +239,7 @@ impl Cache {
             depth_mask: None,
             stencil_mask: None,
             samplers: (0..MAX_SAMPLERS).map(|_| None).collect(),
-            texture_slots: [TextureSlotInfo::default(); glow::MAX_TEXTURE_IMAGE_UNITS as usize],
+            texture_slots: [TextureSlotInfo::default(); MAX_TEXTURE_SLOTS],
         }
     }
 }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -62,7 +62,9 @@ type ColorSlot = u8;
 
 // we can support more samplers if not every one of them is used at a time,
 // but it probably doesn't worth it.
-const MAX_SAMPLERS: usize = glow::MAX_TEXTURE_IMAGE_UNITS as usize;
+const MAX_SAMPLERS: usize = 16;
+//TODO: has to be within glow::MAX_COMBINED_TEXTURE_IMAGE_UNITS
+const MAX_TEXTURE_SLOTS: usize = 16;
 
 struct GlContainer {
     context: GlContext,

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -1,4 +1,4 @@
-use crate::{Backend, GlContext};
+use crate::{Backend, GlContext, MAX_TEXTURE_SLOTS};
 
 use hal::{
     buffer, format, image as i,
@@ -79,7 +79,7 @@ pub enum BindingRegister {
 
 /// For each texture in the pipeline layout, store the index of the only
 /// sampler (in this layout) that the texture is used with.    
-pub(crate) type SamplerBindMap = [Option<u8>; glow::MAX_TEXTURE_IMAGE_UNITS as usize];
+pub(crate) type SamplerBindMap = [Option<u8>; MAX_TEXTURE_SLOTS];
 
 #[derive(Clone, Debug)]
 pub struct GraphicsPipeline {

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -3,8 +3,7 @@
 //! Screen presentation (fullscreen or window) of images requires two objects:
 //!
 //! * [Surface][Surface] is an abstraction of a native screen or window, for graphics use.
-//! * [Swapchain][Swapchain] is a chain of multiple images, which can be presented on
-//!   a surface.
+//!     It hosts a chain of multiple images, which can be presented on a surface ("swapchain").
 //!
 //! ## Window
 //!


### PR DESCRIPTION
Fixes the stack overflow in tests
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
