### PR TITLE
WIP acceleration structure API proposal

### DIFF
--- a/src/hal/src/acceleration_structure.rs
+++ b/src/hal/src/acceleration_structure.rs
@@ -1,0 +1,232 @@
+//! TODO docs
+
+// TODO remove and add docs
+#![allow(missing_docs)]
+
+use std::ops::Range;
+
+use crate::{buffer::Offset, format::Format, Backend, IndexType};
+
+/// Denotes the type of acceleration structure.
+#[derive(Debug)]
+pub enum AccelerationStructureType {
+    ///
+    TopLevel,
+    ///
+    BottomLevel,
+    // TODO vulkan supports "generic level" (where the concrete build type is specified), but discourages its use for applications "written directly for Vulkan" since it "could affect capabilities or performance in the future" (https://www.khronos.org/blog/vulkan-ray-tracing-final-specification-release). Perhaps this is to better support `vkd3d-proton`, but we probably don't want it exposed in gfx?
+}
+
+/// A description of the data needed to build an acceleration structure.
+#[derive(Debug)]
+pub struct AccelerationStructureDesc<'a, B: Backend> {
+    /// TODO: document lifetime required for this buffer
+    pub buffer: &'a B::Buffer,
+    /// TODO: the final gpu address on DX12 needs to be D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BYTE_ALIGNMENT (256), but vulkan only requires this offset to be 256 (as defined by https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureCreateInfoKHR.html)
+    pub buffer_offset: Offset,
+
+    /// The type of acceleration structure to build.
+    pub ty: AccelerationStructureType,
+    // /// currently only has `accelerationStructureCaptureReplay`
+    // create_flags: VkAccelerationStructureCreateFlagsKHR,
+    // /// used for `accelerationStructureCaptureReplay`
+    // device_address: VkDeviceAddress,
+}
+
+bitflags! {
+    /// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBuildAccelerationStructureFlagBitsKHR.html
+    pub struct AccelerationStructureFlags: u32 {
+        /// indicates that the specified acceleration structure can be updated with update of VK_TRUE in vkCmdBuildAccelerationStructuresKHR or vkCmdBuildAccelerationStructureNV .
+        const ALLOW_UPDATE = 0x1;
+        ///  indicates that the specified acceleration structure can act as the source for a copy acceleration structure command with mode of VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR to produce a compacted acceleration structure.
+        const ALLOW_COMPACTION = 0x2;
+        /// indicates that the given acceleration structure build should prioritize trace performance over build time.
+        const PREFER_FAST_TRACE = 0x4;
+        ///  indicates that the given acceleration structure build should prioritize build time over trace performance.
+        const PREFER_FAST_BUILD = 0x8;
+        /// indicates that this acceleration structure should minimize the size of the scratch memory and the final result build, potentially at the expense of build time or trace performance.
+        const LOW_MEMORY = 0x10;
+    }
+}
+
+/// TODO docs
+#[derive(Debug)]
+pub enum AccelerationStructureCreateMode {
+    /// specifies that the destination acceleration structure will be built using the specified geometries.
+    Build,
+    /// specifies that the destination acceleration structure will be built using data in a source acceleration structure, updated by the specified geometries.
+    /// Note there's constraints on update: https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#acceleration-structure-update-constraints
+    Update,
+}
+
+/// A description of the geometry data needed to populate an acceleration structure.
+///
+/// TODO: there's something here that smells w/ what fields are needed to get the required build size vs what fields are needed to actually build. Also, the top/bottom levels having different requirements on which fields are valid.
+#[derive(Debug)]
+pub struct AccelerationStructureGeometryDesc<'a, B: Backend> {
+    pub flags: AccelerationStructureFlags,
+    /// The type of acceleration structure to build.
+    pub ty: AccelerationStructureType,
+    pub mode: AccelerationStructureCreateMode,
+
+    pub src: Option<B::AccelerationStructure>,
+    pub dst: Option<B::AccelerationStructure>,
+
+    // TODO: We could enforce the following the type system?
+    // - in both vulkan (via `VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03792`) and DX12 (via type system), all of the structs here must be the same variant.
+    // - blas must be triangles or aabbs, tlas must be instances
+    pub geometries: &'a [AccelerationStructureGeometry<'a, B>],
+    // Both APIs support "array" and "array of pointers", presumably to allow for cheap reuse of the geometry descriptors.
+    // pgeometries: &'a [&'a GeometryDesc<'a, B>],
+    pub scratch: Option<(&'a B::Buffer, Offset)>,
+}
+
+bitflags! {
+    /// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryFlagBitsKHR.html
+    pub struct AccelerationStructureGeometryFlags: u32 {
+        /// indicates that this geometry does not invoke the any-hit shaders even if present in a hit group.
+        const OPAQUE = 0x1;
+        /// indicates that the implementation must only call the any-hit shader a single time for each primitive in this geometry. If this bit is absent an implementation may invoke the any-hit shader more than once for this geometry.
+        const NO_DUPLICATE_ANY_HIT_INVOCATION = 0x2;
+    }
+}
+
+/// TODO docs
+#[derive(Debug)]
+pub struct AccelerationStructureGeometry<'a, B: Backend> {
+    pub flags: AccelerationStructureGeometryFlags,
+    pub geometry: Geometry<'a, B>,
+}
+
+/// TODO docs
+#[derive(Debug)]
+pub enum Geometry<'a, B: Backend> {
+    /// TODO docs
+    Triangles(GeometryTriangles<'a, B>),
+
+    /// TODO docs
+    /// TODO bikeshed capitalization of AABBs.
+    Aabbs(GeometryAabbs<'a, B>),
+
+    // TODO
+    /// TODO docs
+    Instances(GeometryInstances<'a, B>),
+}
+
+// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureGeometryTrianglesDataKHR.html
+// for docs: Memory Safety (https://nvpro-samples.github.io/vk_raytracing_tutorial_KHR/#accelerationstructure)
+// TODO: I don't like that this is reused for the "get build sizes" and "do actual build" with complex rules on what fields are ignored when. Perhaps we could use DX12's model for `D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC` and `D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS`?
+#[derive(Debug)]
+pub struct GeometryTriangles<'a, B: Backend> {
+    /// Both APIs require support for at least the following:
+    /// - `(R32_G32, Float)`
+    /// - `(R32_G32_B32, Float)`
+    /// - `(R16_G16, Float)`
+    /// - `(R16_G16_B16_A16, Float)`
+    /// - `(R16_G16, Inorm)`
+    /// - `(R16_G16_B16_A16, Inorm)`
+    /// VK could support more by querying `VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR`, DX12 is not queryable? Note [the DX12 ray tracing spec](https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#d3d12_raytracing_geometry_triangles_desc) says it supports more than [the Win32 docs](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_raytracing_geometry_triangles_desc).
+    pub vertex_format: Format,
+    pub vertex_buffer: &'a B::Buffer,
+    pub vertex_buffer_offset: Offset,
+    pub vertex_buffer_stride: Offset,
+
+    /// aka "vertex count"?
+    pub max_vertex: Offset,
+
+    // index format must be DXGI_FORMAT_R32_UINT, DXGI_FORMAT_R16_UINT
+    // can also be VK_INDEX_TYPE_NONE_KHR/DXGI_FORMAT_UNKNOWN
+    pub index_buffer: Option<(&'a B::Buffer, Offset, IndexType)>,
+
+    /// 3x4 matrix
+    /// TODO enum for cpu repr?
+    /// Must point to an address containing `TransformMatrix`
+    pub transform: Option<(&'a B::Buffer, Offset)>,
+}
+
+// VkTransformMatrixKHR
+#[derive(Debug)]
+pub struct TransformMatrix {
+    /// 3x4 row-major affine transformation matrix. Use `mint::RowMatrix3x4` if available.
+    pub matrix: [[f32; 4]; 3],
+}
+
+#[derive(Debug)]
+pub struct GeometryAabbs<'a, B: Backend> {
+    /// Must point to a buffer with buffer with an array of `AabbPositions`s
+    /// TODO: document lifetime required for this buffer
+    pub buffer: &'a B::Buffer,
+    pub buffer_offset: Offset,
+    pub buffer_stride: Offset,
+}
+
+// TODO doc
+#[derive(Debug)]
+pub struct AabbPositions {
+    /// Use `mint::Vector3` if available.
+    pub min: [f32; 3],
+    pub max: [f32; 3],
+}
+
+/// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureGeometryInstancesDataKHR.html
+#[derive(Debug)]
+pub struct GeometryInstances<'a, B: Backend> {
+    /// Must point to a buffer with buffer with an array of `Instance`s
+    /// TODO: document lifetime required for this buffer
+    /// TODO this struct also allows passing an array of pointers, idk if that makes sense outside the host operations case
+    pub buffer: &'a B::Buffer,
+    pub buffer_offset: Offset,
+}
+
+bitflags! {
+    /// https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryInstanceFlagBitsKHR.html
+    pub struct InstanceFlags: u32 {
+        const TRIANGLE_FACING_CULL_DISABLE_BIT = 0x1;
+        const TRIANGLE_FRONT_COUNTERCLOCKWISE_BIT = 0x2;
+        const FORCE_OPAQUE_BIT = 0x4;
+        const FORCE_NO_OPAQUE_BIT = 0x8;
+    }
+}
+
+// TODO AFAIK rust doesn't have custom sized fields, so we'll need some binary writer wrapper to actually support this at an API level.
+#[derive(Debug)]
+pub struct Instance {
+    transform: TransformMatrix,
+    /// 24 bits
+    instance_custom_index: u32,
+    /// 8 bits visibility mask for the geometry. The instance may only be hit if rayMask & instance.mask != 0
+    mask: u32,
+    /// 24 bit
+    instance_shader_binding_table_record_offset: u32,
+    /// 8 bits
+    flags: InstanceFlags,
+
+    /// either B::AccelerationStructure (host operations) or GPU address (buffer + offset?)
+    acceleration_structure_reference: u64,
+}
+
+#[derive(Debug)]
+pub struct AccelerationStructureSizeRequirements {
+    pub acceleration_structure_size: u64,
+    pub update_scratch_size: u64,
+    pub build_scratch_size: u64,
+}
+
+#[derive(Debug)]
+pub enum AccelerationStructureCopyMode {
+    Clone,
+    Compact,
+
+    // these are subject to the device supporting serialization--also (at least on DX12) mainly used for debug tooling and not load perf--I'm unsure what an end-user use case looks like.
+    Serialize,
+    Deserialize,
+}
+
+#[derive(Debug)]
+pub struct AccelerationStructureBuildRangeDesc {
+    pub primitive: Range<u32>,
+    pub first_vertex: u32,
+    /// "defines an offset in bytes into the memory where a transform matrix is defined.""
+    /// TODO: this is documented as only used for `Geometry::Triangles`, but I have no idea why. GeometryTriangles::transform is implied to point to exactly one transform matrix, but I guess this pattern would allow for passing a list of transforms to reuse the same geometry (but not go through the TLAS' Instance::transform...). DX12 doesn't require any additional info at build time and thus doesn't have this concept--passing 0 here in the vulkan case would probably meet parity with DX12
+    pub transform_offset: u32,
+}

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -82,6 +82,10 @@ bitflags!(
         const VERTEX = 0x80;
         ///
         const INDIRECT = 0x100;
+        ///
+        const ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY = 0x200;
+        ///
+        const ACCELERATION_STRUCTURE_STORAGE = 0x400;
     }
 );
 
@@ -126,5 +130,9 @@ bitflags!(
         const MEMORY_READ = 0x8000;
         ///
         const MEMORY_WRITE = 0x10000;
+        ///
+        const ACCELERATION_STRUCTURE_READ = 0x20000;
+        ///
+        const ACCELERATION_STRUCTURE_WRITE = 0x40000;
     }
 );

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -17,7 +17,7 @@ mod clear;
 mod structs;
 
 use crate::{
-    buffer,
+    acceleration_structure, buffer,
     image::{Filter, Layout, SubresourceRange},
     memory::{Barrier, Dependencies},
     pass, pso, query, Backend, DrawCount, IndexCount, IndexType, InstanceCount, TaskCount,
@@ -603,6 +603,46 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
 
     /// Requests a timestamp to be written.
     unsafe fn write_timestamp(&mut self, stage: pso::PipelineStage, query: query::Query<B>);
+
+    /// TODO docs
+    /// `build_range_infos` must be the same length as `infos` and each element must have a length equal to the parallel `info` entry's `geometries.len()`. there's probably a way to make this safer without mangling the api shape too much...
+    unsafe fn build_acceleration_structures(
+        &self,
+        infos: &[acceleration_structure::AccelerationStructureGeometryDesc<B>],
+        build_range_infos: &[&[acceleration_structure::AccelerationStructureBuildRangeDesc]],
+    );
+
+    /// TODO docs
+    /// `indirect_device_addresses` is an array of infoCount buffer device addresses which point to infos[i]->geometryCount VkAccelerationStructureBuildRangeInfoKHR structures defining dynamic offsets to the addresses where geometry data is stored, as defined by infos[i].
+    unsafe fn build_acceleration_structures_indirect(
+        &self,
+        infos: &[acceleration_structure::AccelerationStructureGeometryDesc<B>],
+
+        indirect_device_addresses: &[(B::Buffer, buffer::Offset)],
+        indirect_strides: &[u32],
+        max_primitive_counts: &[&u32],
+    );
+
+    /// TODO docs
+    unsafe fn copy_acceleration_structure(
+        &self,
+        src: B::AccelerationStructure,
+        dst: B::AccelerationStructure,
+        mode: acceleration_structure::AccelerationStructureCopyMode,
+    );
+
+    // for host ops?
+    // - copy_acceleration_structure_to_memory
+    // - copy_memory_to_acceleration_structure
+
+    /// TODO docs
+    unsafe fn write_acceleration_structures_properties(
+        &self,
+        structures: &[B::AccelerationStructure],
+        query_type: query::Type,
+        pool: &B::QueryPool,
+        first_query: u32,
+    );
 
     /// Modify constant data in a graphics pipeline. Push constants are intended to modify data in a
     /// pipeline more quickly than a updating the values inside a descriptor set.

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -48,6 +48,7 @@ extern crate serde;
 
 use std::{any::Any, fmt, hash::Hash};
 
+pub mod acceleration_structure;
 pub mod adapter;
 pub mod buffer;
 pub mod command;
@@ -261,6 +262,19 @@ bitflags! {
         const TASK_SHADER = 0x0001 << 96;
         /// Supports mesh shader stage.
         const MESH_SHADER = 0x0002 << 96;
+
+        /// Supports acceleration structures.
+        const ACCELERATION_STRUCTURE = 0x0001 << 112;
+        // TODO Is this the right place to put these features?
+
+        // TODO "capture replay" is a vulkan term, which seems to be covered by PIX and AS (de)serialization on the DX side... should this just be an impl detail of gfx and not be exposed to end-users?
+        // const ACCELERATION_STRUCTURE_CAPTURE_REPLAY = 0x0001 << 112;
+        // TODO this is probably a good idea and supported on both APIs
+        // const ACCELERATION_STRUCTURE_CAPTURE_INDIRECT_BUILD = 0x0001 << 112;
+        // TODO this could be a way to gate this feature
+        // const ACCELERATION_STRUCTURE_CAPTURE_HOST_OPERATIONS = 0x0001 << 112;
+        // TODO this is not supported for other resource types yet
+        // const ACCELERATION_STRUCTURE_UPDATE_AFTER_BIND = 0x0001 << 112;
     }
 }
 
@@ -462,6 +476,22 @@ pub struct Limits {
     /// The granularity with which mesh outputs qualified as per-primitive are allocated. The value can be used to
     /// compute the memory size used by the mesh shader, which must be less than or equal to
     pub mesh_output_per_primitive_granularity: u32,
+
+    /// The maximum number of geometries in a bottom level acceleration structure.
+    pub max_acceleration_structure_bottom_level_geometry_count: u64,
+    /// The maximum number of instances in a top level acceleration structure.
+    pub max_acceleration_structure_top_level_instance_count: u64,
+    /// The maximum total number of triangles or AABBs in all geometries in a bottom level acceleration structure.
+    pub max_acceleration_structure_bottom_level_total_primitive_count: u64,
+    /// The maximum number of acceleration structure bindings that can be accessible to a single shader stage in a pipeline layout.
+    pub max_per_stage_descriptor_acceleration_structures: u32,
+    ///    
+    pub max_descriptor_set_acceleration_structures: u32,
+    /// The minimum alignment in bytes for scratch data passed in to an acceleration structure build command.
+    pub min_acceleration_structure_scratch_offset_alignment: u32,
+    // TODO since we don't use `vk::DescriptorSetLayoutCreateFlags`, I'm leaving this out
+    // pub max_per_stage_descriptor_update_after_bind_acceleration_structures: u32,
+    // pub max_descriptor_set_update_after_bind_acceleration_structures: u32,
 }
 
 /// An enum describing the type of an index value in a slice's index buffer
@@ -631,4 +661,8 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send
     type Event: fmt::Debug + Any + Send + Sync;
     /// The corresponding query pool type for this backend.
     type QueryPool: fmt::Debug + Any + Send + Sync;
+
+    /// The corresponding acceleration structure type for this backend.
+    // TODO: This probably corresponds to `()` on DX12, since there's no handle for acceleration structures on DX12
+    type AccelerationStructure: fmt::Debug + Any + Send + Sync;
 }

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -94,6 +94,8 @@ pub enum DescriptorType {
     },
     /// A descriptor associated with an input attachment.
     InputAttachment,
+    /// TODO docs
+    AccelerationStructure,
 }
 
 /// Information about the contents of and in which stages descriptors may be bound to a descriptor
@@ -251,6 +253,7 @@ pub enum Descriptor<'a, B: Backend> {
     CombinedImageSampler(&'a B::ImageView, Layout, &'a B::Sampler),
     Buffer(&'a B::Buffer, SubRange),
     TexelBuffer(&'a B::BufferView),
+    AccelerationStructure(&'a B::AccelerationStructure),
 }
 
 /// Copies a range of descriptors to be bound from one descriptor set to another.

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -45,6 +45,8 @@ bitflags!(
     /// Some stages are queue type dependent.
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct PipelineStage: u32 {
+        // NOTE: these values follow [VkPipelineStageFlagBits](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineStageFlagBits.html).
+
         /// Beginning of the command queue.
         const TOP_OF_PIPE = 0x1;
         /// Indirect data consumption.
@@ -76,6 +78,8 @@ bitflags!(
         /// Read/Write access from host.
         /// (Not a real pipeline stage)
         const HOST = 0x4000;
+        /// Acceleration structure building stage.
+        const ACCELERATION_STRUCTURE_BUILD = 0x02000000;
         /// Task shader stage.
         const TASK_SHADER = 0x80000;
         /// Mesh shader stage.

--- a/src/hal/src/query.rs
+++ b/src/hal/src/query.rs
@@ -70,6 +70,10 @@ pub enum Type {
     /// Timestamp query. Timestamps can be recorded to the
     /// query pool by calling `write_timestamp()`.
     Timestamp,
+    /// TODO docs
+    AccelerationStructureCompactedSize,
+    /// TODO docs
+    AccelerationStructureSerializationSize,
 }
 
 bitflags!(


### PR DESCRIPTION
Initial API proposal for just the acceleration structure part of adding ray tracing support. Once the API design is set, we can implement (and smoke test) and then move on to adding ray tracing pipelines and ray query feature detection.

There's a lot of open questions I have in the comments and I intend for this draft to be a place to track discussion. @kvark: I intend to drive discussion on individual pieces at `#gfx:matrix.org`, referring to this PR as a reference, so don't worry about reviewing all at once (I'll make sure we get through all of it)!

**The main theme of nearly all my questions is about how far can we deviate from `VK_KHR_acceleration_structure` to better fit `gfx` (and potentially gain some API safety).**

Here's some notes on implementation differences I expect between DX12 and Vulkan, which may be interesting to discuss how we'll solve:
- `B::AccelerationStructure`
	- VK: `vk::AccelerationStructureKHR`
	- DX: Proabaly `()`, since there's no handle associated with an acceleration structure--they're just packed into buffers.
- Serialize/Deserialize
	- VK:
		- Get serialized size: `ash::extensions::khr::AccelerationStructure::write_acceleration_structures_properties` with `ash::vk::QueryType::ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR`
	- DX:
		- Get serialized size: `ID3D12GraphicsCommandList4::EmitRaytracingAccelerationStructurePostbuildInfo` (or `BuildRaytracingAccelerationStructure`), but it writes to a buffer and not to CPU mem?
- Host operations
	- VK: `vk::PhysicalDeviceAccelerationStructureFeaturesKHR::acceleration_structure_host_commands` + methods on `Device`
	- DX: unsupported natively, could be emulated in gfx
- Specifically laid out structs for GPU buffers:
	- Transform matrix: 3x4 row matrix that corresponds to `mint::RowMatrix3x4`. Metal uses a 4x4 matrix (`matrix_float4x4`), which I believe maps to `mint::RowMatrix4`, given [this "Working with Matrices" doc](https://developer.apple.com/documentation/accelerate/working_with_matrices).
	- AABB positions: Both APIs use a `float3` min, then max to specify the AABB. Metal puts a bounding box on every acceleration structure and doesn't have an AABB-specific variant.
	- TLAS instance struct:
		- VK: [`VkAccelerationStructureInstanceKHR`](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureInstanceKHR.html)
		- DX: [`D3D12_RAYTRACING_INSTANCE_DESC`](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_raytracing_instance_desc)
		- These two structs have the same layout ([not it Metal, though](https://developer.apple.com/documentation/metalperformanceshaders/mpsinstanceaccelerationstructure)) and are probably intended to be written from compute shaders, which probably users probably need to know about it (either by docs or querying for it).
- Building acceleration structures
	- Primitive counts
		- VK: Separates the primitive counts and the geometry data in `VkAccelerationStructureGeometryKHR`  and `VkAccelerationStructureBuildRangeInfoKHR` at descriptor and build time, respectively
		- DX: Requires the primitive count at descriptor time when creating `D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC` or `D3D12_RAYTRACING_GEOMETRY_AABBS_DESC`, and doesn't require any additional data at build time

Related: #2418