### PR TITLE
Wayland Support for the OpenGL Backend

### DIFF
--- a/src/backend/gl/src/window/egl.rs
+++ b/src/backend/gl/src/window/egl.rs
@@ -3,7 +3,8 @@
 use crate::{conv, native, GlContainer, PhysicalDevice, Starc};
 use glow::HasContext;
 use hal::{image, window as w};
-use std::{os::raw, ptr, sync::Mutex};
+use parking_lot::Mutex;
+use std::{os::raw, ptr};
 
 #[derive(Debug)]
 pub struct Swapchain {
@@ -279,7 +280,7 @@ impl hal::Instance<crate::Backend> for Instance {
     }
 
     fn enumerate_adapters(&self) -> Vec<hal::adapter::Adapter<crate::Backend>> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock();
         inner
             .egl
             .make_current(inner.display, None, None, Some(inner.context))
@@ -299,7 +300,7 @@ impl hal::Instance<crate::Backend> for Instance {
     ) -> Result<Surface, w::InitError> {
         use raw_window_handle::RawWindowHandle as Rwh;
 
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         let mut native_window = match has_handle.raw_window_handle() {
             #[cfg(not(target_os = "android"))]
             Rwh::Xlib(handle) => handle.window,
@@ -394,7 +395,7 @@ impl hal::Instance<crate::Backend> for Instance {
     }
 
     unsafe fn destroy_surface(&self, surface: Surface) {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.inner.lock();
         inner
             .egl
             .destroy_surface(inner.display, surface.raw)


### PR DESCRIPTION
*~~This PR isn't meant to be merged in the current state, but to illustrate what changes were need to get it working.~~*

I've been trying to get the OpenGL backend working with wayland. The current device I'm targeting doesn't currently support Vulkan so I'm trying to get the wayland renderer working. During my tests I'm hitting some blockers with the `hal::Instance` API and I'm wondering if I'm doing something wrong, or if the API just wasn't developed with this in mind.

I'm hitting the following roadblocks:

1. I need a pointer to this display to pass to `get_platform_display`. Both creating a new connection and using `egl::DEFAULT_DISPLAY` results in the window not working or rendering in the `quad` example. To get around this I'm passing a pointer to the create function via the `version` parameter.
2. ~~To create `wl_egl_window_create` I need to pass in a window size. I don't think this is a show stopper as long as there was some way get resize events so I could call `wl_egl_window_resize`.~~ I *think* this can be done by calling `wl_egl_window_resize` in `PresentationSurface::configure_swapchain`

Another thing I had to remove the `GL_COLORSPACE`. This attribute is only supported in EGL 1.5, but currently are only testing 1.4. Seeing how the default value is `GL_COLORSPACE_SRGB`, then I just removed this attribute entirely.

Is there a proper way to overcome these hurdles without drastically modifying gfx's api?