### PR TITLE
Add typedef for buffer stride

### DIFF
--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -42,7 +42,7 @@ fn main() {
         .skip(1)
         .map(|s| u32::from_str(&s).expect("You must pass a list of positive integers!"))
         .collect();
-    let stride = std::mem::size_of::<u32>() as u64;
+    let stride = std::mem::size_of::<u32>() as buffer::Stride;
 
     let instance =
         back::Instance::create("gfx-rs compute", 1).expect("Failed to create an instance!");
@@ -193,7 +193,7 @@ fn main() {
             &[command::BufferCopy {
                 src: 0,
                 dst: 0,
-                size: stride * numbers.len() as u64,
+                size: stride as u64 * numbers.len() as u64,
             }],
         );
         command_buffer.pipeline_barrier(
@@ -227,7 +227,7 @@ fn main() {
             &[command::BufferCopy {
                 src: 0,
                 dst: 0,
-                size: stride * numbers.len() as u64,
+                size: stride as u64 * numbers.len() as u64,
             }],
         );
         command_buffer.finish();
@@ -269,10 +269,10 @@ unsafe fn create_buffer<B: hal::Backend>(
     memory_types: &[MemoryType],
     properties: memory::Properties,
     usage: buffer::Usage,
-    stride: u64,
+    stride: buffer::Stride,
     len: u64,
 ) -> (B::Memory, B::Buffer, u64) {
-    let mut buffer = device.create_buffer(stride * len, usage).unwrap();
+    let mut buffer = device.create_buffer(stride as u64 * len, usage).unwrap();
     let requirements = device.get_buffer_requirements(&buffer);
 
     let ty = memory_types

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -2313,7 +2313,7 @@ impl device::Device<Backend> for Device {
         _pool: &QueryPool,
         _queries: Range<query::Id>,
         _data: &mut [u8],
-        _stride: buffer::Offset,
+        _stride: buffer::Stride,
         _flags: query::ResultFlags,
     ) -> Result<bool, device::WaitError> {
         unimplemented!()

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -2858,7 +2858,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         buffer: &Buffer,
         offset: buffer::Offset,
         draw_count: DrawCount,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         assert_eq!(draw_count, 1, "DX11 doesn't support MULTI_DRAW_INDIRECT");
         self.context
@@ -2870,7 +2870,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         buffer: &Buffer,
         offset: buffer::Offset,
         draw_count: DrawCount,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         assert_eq!(draw_count, 1, "DX11 doesn't support MULTI_DRAW_INDIRECT");
         self.context
@@ -2884,7 +2884,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _count_buffer: &Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: u32,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         panic!("DX11 doesn't support DRAW_INDIRECT_COUNT")
     }
@@ -2896,7 +2896,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _count_buffer: &Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: u32,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         panic!("DX11 doesn't support DRAW_INDIRECT_COUNT")
     }
@@ -2910,7 +2910,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Buffer,
         _: buffer::Offset,
         _: hal::DrawCount,
-        _: u32,
+        _: buffer::Stride,
     ) {
         panic!("DX11 doesn't support MESH_SHADERS")
     }
@@ -2922,7 +2922,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Buffer,
         _: buffer::Offset,
         _: hal::DrawCount,
-        _: u32,
+        _: buffer::Stride,
     ) {
         panic!("DX11 doesn't support MESH_SHADERS")
     }
@@ -2963,7 +2963,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _queries: Range<query::Id>,
         _buffer: &Buffer,
         _offset: buffer::Offset,
-        _stride: buffer::Offset,
+        _stride: buffer::Stride,
         _flags: query::ResultFlags,
     ) {
         unimplemented!()

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -2669,7 +2669,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         _: &r::Buffer,
         _: buffer::Offset,
         _: hal::DrawCount,
-        _: u32,
+        _: buffer::Stride,
     ) {
         unimplemented!()
     }
@@ -2681,7 +2681,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         _: &r::Buffer,
         _: buffer::Offset,
         _: DrawCount,
-        _: u32,
+        _: buffer::Stride,
     ) {
         unimplemented!()
     }

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -2625,7 +2625,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         buffer: &r::Buffer,
         offset: buffer::Offset,
         draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         assert_eq!(stride, 16);
         let buffer = buffer.expect_bound();
@@ -2645,7 +2645,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         buffer: &r::Buffer,
         offset: buffer::Offset,
         draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         assert_eq!(stride, 20);
         let buffer = buffer.expect_bound();
@@ -2693,7 +2693,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         count_buffer: &r::Buffer,
         count_buffer_offset: buffer::Offset,
         max_draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         assert_eq!(stride, 16);
         let buffer = buffer.expect_bound();
@@ -2716,7 +2716,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         count_buffer: &r::Buffer,
         count_buffer_offset: buffer::Offset,
         max_draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         assert_eq!(stride, 20);
         let buffer = buffer.expect_bound();
@@ -2815,7 +2815,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         _queries: Range<query::Id>,
         _buffer: &r::Buffer,
         _offset: buffer::Offset,
-        _stride: buffer::Offset,
+        _stride: buffer::Stride,
         _flags: query::ResultFlags,
     ) {
         unimplemented!()

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3476,7 +3476,7 @@ impl d::Device<B> for Device {
         _pool: &r::QueryPool,
         _queries: Range<query::Id>,
         _data: &mut [u8],
-        _stride: buffer::Offset,
+        _stride: buffer::Stride,
         _flags: query::ResultFlags,
     ) -> Result<bool, d::WaitError> {
         unimplemented!()

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -883,7 +883,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Buffer,
         _: hal::buffer::Offset,
         _: hal::DrawCount,
-        _: u32,
+        _: hal::buffer::Stride,
     ) {
     }
 
@@ -918,7 +918,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
     ) {
     }
 
-    unsafe fn draw_mesh_tasks(&mut self, _: u32, _: u32) {
+    unsafe fn draw_mesh_tasks(&mut self, _: hal::TaskCount, _: hal::TaskCount) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -467,7 +467,7 @@ impl device::Device<Backend> for Device {
         _: &(),
         _: Range<query::Id>,
         _: &mut [u8],
-        _: hal::buffer::Offset,
+        _: hal::buffer::Stride,
         _: query::ResultFlags,
     ) -> Result<bool, device::WaitError> {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
@@ -892,7 +892,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Buffer,
         _: hal::buffer::Offset,
         _: hal::DrawCount,
-        _: u32,
+        _: hal::buffer::Stride,
     ) {
     }
 
@@ -903,7 +903,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Buffer,
         _: hal::buffer::Offset,
         _: u32,
-        _: u32,
+        _: hal::buffer::Stride,
     ) {
     }
 
@@ -914,7 +914,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Buffer,
         _: hal::buffer::Offset,
         _: u32,
-        _: u32,
+        _: hal::buffer::Stride,
     ) {
     }
 
@@ -927,7 +927,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Buffer,
         _: hal::buffer::Offset,
         _: hal::DrawCount,
-        _: u32,
+        _: hal::buffer::Stride,
     ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
@@ -939,7 +939,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Buffer,
         _: hal::buffer::Offset,
         _: u32,
-        _: u32,
+        _: hal::buffer::Stride,
     ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
@@ -980,7 +980,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: Range<query::Id>,
         _: &Buffer,
         _: hal::buffer::Offset,
-        _: hal::buffer::Offset,
+        _: hal::buffer::Stride,
         _: query::ResultFlags,
     ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1523,7 +1523,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _buffer: &n::Buffer,
         _offset: buffer::Offset,
         _draw_count: hal::DrawCount,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         unimplemented!()
     }
@@ -1533,7 +1533,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _buffer: &n::Buffer,
         _offset: buffer::Offset,
         _draw_count: hal::DrawCount,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         unimplemented!()
     }
@@ -1545,7 +1545,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _count_buffer: &n::Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: u32,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         unimplemented!()
     }
@@ -1557,7 +1557,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _count_buffer: &n::Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: u32,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         unimplemented!()
     }
@@ -1571,7 +1571,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &n::Buffer,
         _: buffer::Offset,
         _: hal::DrawCount,
-        _: u32,
+        _: buffer::Stride,
     ) {
         unimplemented!()
     }
@@ -1583,7 +1583,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &n::Buffer,
         _: buffer::Offset,
         _: u32,
-        _: u32,
+        _: buffer::Stride,
     ) {
         unimplemented!()
     }
@@ -1615,7 +1615,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _queries: Range<query::Id>,
         _buffer: &n::Buffer,
         _offset: buffer::Offset,
-        _stride: buffer::Offset,
+        _stride: buffer::Stride,
         _flags: query::ResultFlags,
     ) {
         unimplemented!()

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1956,7 +1956,7 @@ impl d::Device<B> for Device {
         _pool: &(),
         _queries: Range<query::Id>,
         _data: &mut [u8],
-        _stride: buffer::Offset,
+        _stride: buffer::Stride,
         _flags: query::ResultFlags,
     ) -> Result<bool, d::WaitError> {
         unimplemented!()

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -4789,8 +4789,13 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                 }
             }
             native::QueryPool::Timestamp => {
-                let start = range.start + offset + queries.start as buffer::Offset * stride;
-                let end = range.start + offset + (queries.end - 1) as buffer::Offset * stride + 4;
+                let start = range.start
+                    + offset
+                    + queries.start as buffer::Offset * stride as buffer::Offset;
+                let end = range.start
+                    + offset
+                    + (queries.end - 1) as buffer::Offset * stride as buffer::Offset
+                    + 4;
                 let command = soft::BlitCommand::FillBuffer {
                     dst: AsNative::from(raw),
                     range: start..end,

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -1550,7 +1550,7 @@ impl CommandSink {
 pub struct IndexBuffer<B> {
     buffer: B,
     offset: u32,
-    stride: u32,
+    stride: buffer::Stride,
 }
 
 /// This is an inner mutable part of the command buffer that is
@@ -4469,7 +4469,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         buffer: &native::Buffer,
         offset: buffer::Offset,
         count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         assert_eq!(offset % WORD_ALIGNMENT, 0);
         assert_eq!(stride % WORD_ALIGNMENT as u32, 0);
@@ -4494,7 +4494,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         buffer: &native::Buffer,
         offset: buffer::Offset,
         count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         assert_eq!(offset % WORD_ALIGNMENT, 0);
         assert_eq!(stride % WORD_ALIGNMENT as u32, 0);
@@ -4526,7 +4526,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         _count_buffer: &native::Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: u32,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         unimplemented!()
     }
@@ -4538,7 +4538,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         _count_buffer: &native::Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: u32,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         unimplemented!()
     }
@@ -4695,7 +4695,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         queries: Range<query::Id>,
         buffer: &native::Buffer,
         offset: buffer::Offset,
-        stride: buffer::Offset,
+        stride: buffer::Stride,
         flags: query::ResultFlags,
     ) {
         let (raw, range) = buffer.as_bound();
@@ -4705,7 +4705,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                 let size_data = mem::size_of::<u64>() as buffer::Offset;
                 let size_meta = mem::size_of::<u32>() as buffer::Offset;
 
-                if stride == size_data
+                if stride as u64 == size_data
                     && flags.contains(query::ResultFlags::BITS_64)
                     && !flags.contains(query::ResultFlags::WITH_AVAILABILITY)
                 {
@@ -4733,7 +4733,8 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                     let commands = (0..queries.end - queries.start).flat_map(|i| {
                         let absolute_index =
                             (pool_range.start + queries.start + i) as buffer::Offset;
-                        let dst_offset = range.start + offset + i as buffer::Offset * stride;
+                        let dst_offset =
+                            range.start + offset + i as buffer::Offset * stride as buffer::Offset;
                         let com_data = soft::BlitCommand::CopyBuffer {
                             src: AsNative::from(visibility.buffer.as_ref()),
                             dst: AsNative::from(raw),

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -3086,7 +3086,7 @@ impl hal::device::Device<Backend> for Device {
         pool: &n::QueryPool,
         queries: Range<query::Id>,
         data: &mut [u8],
-        stride: buffer::Offset,
+        stride: buffer::Stride,
         flags: query::ResultFlags,
     ) -> Result<bool, d::WaitError> {
         let is_ready = match *pool {
@@ -3103,7 +3103,7 @@ impl hal::device::Device<Backend> for Device {
                 };
 
                 let size_data = mem::size_of::<u64>() as buffer::Offset;
-                if stride == size_data
+                if stride as u64 == size_data
                     && flags.contains(query::ResultFlags::BITS_64)
                     && !flags.contains(query::ResultFlags::WITH_AVAILABILITY)
                 {

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -843,7 +843,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         buffer: &n::Buffer,
         offset: buffer::Offset,
         draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         self.device
             .raw
@@ -855,7 +855,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         buffer: &n::Buffer,
         offset: buffer::Offset,
         draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         self.device
             .raw
@@ -876,7 +876,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         buffer: &n::Buffer,
         offset: buffer::Offset,
         draw_count: hal::DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         self.device
             .extension_fns
@@ -893,7 +893,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         count_buffer: &n::Buffer,
         count_buffer_offset: buffer::Offset,
         max_draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         self.device
             .extension_fns
@@ -918,7 +918,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         count_buffer: &n::Buffer,
         count_buffer_offset: buffer::Offset,
         max_draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         self.device
             .extension_fns
@@ -943,7 +943,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         count_buffer: &n::Buffer,
         count_buffer_offset: buffer::Offset,
         max_draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     ) {
         self.device
             .extension_fns
@@ -1044,7 +1044,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         queries: Range<query::Id>,
         buffer: &n::Buffer,
         offset: buffer::Offset,
-        stride: buffer::Offset,
+        stride: buffer::Stride,
         flags: query::ResultFlags,
     ) {
         //TODO: use safer wrapper
@@ -1055,7 +1055,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             queries.end - queries.start,
             buffer.raw,
             offset,
-            stride,
+            stride as vk::DeviceSize,
             conv::map_query_result_flags(flags),
         );
     }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -2014,7 +2014,7 @@ impl d::Device<B> for Device {
         pool: &n::QueryPool,
         queries: Range<query::Id>,
         data: &mut [u8],
-        stride: buffer::Offset,
+        stride: buffer::Stride,
         flags: query::ResultFlags,
     ) -> Result<bool, d::WaitError> {
         let result = self.shared.raw.fp_v1_0().get_query_pool_results(
@@ -2024,7 +2024,7 @@ impl d::Device<B> for Device {
             queries.end - queries.start,
             data.len(),
             data.as_mut_ptr() as *mut _,
-            stride,
+            stride as vk::DeviceSize,
             conv::map_query_result_flags(flags),
         );
 

--- a/src/backend/webgpu/src/command.rs
+++ b/src/backend/webgpu/src/command.rs
@@ -402,7 +402,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _buffer: &<Backend as hal::Backend>::Buffer,
         _offset: buffer::Offset,
         _draw_count: DrawCount,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         todo!()
     }
@@ -412,7 +412,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _buffer: &<Backend as hal::Backend>::Buffer,
         _offset: buffer::Offset,
         _draw_count: DrawCount,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         todo!()
     }
@@ -424,7 +424,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _count_buffer: &<Backend as hal::Backend>::Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: u32,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         todo!()
     }
@@ -436,7 +436,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _count_buffer: &<Backend as hal::Backend>::Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: u32,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         todo!()
     }
@@ -450,7 +450,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _buffer: &<Backend as hal::Backend>::Buffer,
         _offset: buffer::Offset,
         _draw_count: DrawCount,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         todo!()
     }
@@ -462,7 +462,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _count_buffer: &<Backend as hal::Backend>::Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: DrawCount,
-        _stride: u32,
+        _stride: buffer::Stride,
     ) {
         todo!()
     }

--- a/src/hal/src/buffer.rs
+++ b/src/hal/src/buffer.rs
@@ -10,6 +10,9 @@ use crate::{device::OutOfMemory, format::Format};
 /// An offset inside a buffer, in bytes.
 pub type Offset = u64;
 
+/// An stride between elements inside a buffer, in bytes.
+pub type Stride = u32;
+
 /// A subrange of the buffer.
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -474,7 +474,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         buffer: &B::Buffer,
         offset: buffer::Offset,
         draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     );
 
     /// Like `draw_indirect()`, this does indexed drawing a la `draw_indexed()` but
@@ -489,7 +489,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         buffer: &B::Buffer,
         offset: buffer::Offset,
         draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     );
 
     /// Functions identically to `draw_indirect()`, except the amount of draw
@@ -507,7 +507,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         _count_buffer: &B::Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: u32,
-        _stride: u32,
+        _stride: buffer::Stride,
     );
 
     /// Functions identically to `draw_indexed_indirect()`, except the amount of draw
@@ -525,7 +525,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         _count_buffer: &B::Buffer,
         _count_buffer_offset: buffer::Offset,
         _max_draw_count: u32,
-        _stride: u32,
+        _stride: buffer::Stride,
     );
 
     /// Dispatches `task_count` of threads. Similar to compute dispatch.
@@ -537,7 +537,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         buffer: &B::Buffer,
         offset: buffer::Offset,
         draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     );
 
     /// Like `draw_mesh_tasks_indirect` except that the draw count is read by
@@ -551,7 +551,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         count_buffer: &B::Buffer,
         count_buffer_offset: buffer::Offset,
         max_draw_count: DrawCount,
-        stride: u32,
+        stride: buffer::Stride,
     );
 
     /// Signals an event once all specified stages of the shader pipeline have completed.
@@ -597,7 +597,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         queries: Range<query::Id>,
         buffer: &B::Buffer,
         offset: buffer::Offset,
-        stride: buffer::Offset,
+        stride: buffer::Stride,
         flags: query::ResultFlags,
     );
 

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -730,7 +730,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         pool: &B::QueryPool,
         queries: Range<query::Id>,
         data: &mut [u8],
-        stride: buffer::Offset,
+        stride: buffer::Stride,
         flags: query::ResultFlags,
     ) -> Result<bool, WaitError>;
 


### PR DESCRIPTION
Adds the following:

```rust
/// An stride between elements inside a buffer, in bytes.
pub type Stride = u32;
```

Note that `CommandBuffer::copy_query_pool_results`'s and `Device::get_query_pool_results`'s `stride` parameters have changed from `u64` to `u32`. I'm unsure of the implications of this, but I don't imagine nobody has a buffer with a stride > `u32::max_value()` (can backends even support buffers that large?). Please let me know if I should change this back!

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan, DX11, DX12