### PR TITLE
[dx11] Fixes regressions from 0.6 to Master

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -3538,14 +3538,6 @@ impl Image {
     }
 }
 
-impl Drop for Image {
-    fn drop(&mut self) {
-        unsafe {
-            (*self.internal.raw).Release();
-        }
-    }
-}
-
 pub struct ImageView {
     subresource: UINT,
     format: format::Format,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -964,7 +964,16 @@ impl window::PresentationSurface<Backend> for Surface {
                     return Ok(());
                 }
                 let non_srgb_format = conv::map_format_nosrgb(config.format).unwrap();
+
+                // Delete the existing view into the swapchain buffers.
                 drop(present.view);
+
+                // We must also delete the image data.
+                //
+                // This should not panic as all images must be deleted before
+                let mut present_image = Arc::try_unwrap(present.image).expect("Not all acquired images were deleted before the swapchain was reconfigured.");
+                present_image.internal.release_resources();
+
                 let result = present.swapchain.ResizeBuffers(
                     config.image_count,
                     config.extent.width,


### PR DESCRIPTION
This PR plus the gpu-alloc fixes all the DX11 specific issues in https://github.com/gfx-rs/wgpu/issues/1059.

These are all refcount issues, one was a double free of images, the other was some resources not being freed on the swapchain.