### PR TITLE
Update API object mutability according to external synchronization requirements in Vulkan

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -691,7 +691,7 @@ impl<B: Backend> BufferState<B> {
     where
         T: Copy,
     {
-        let memory: B::Memory;
+        let mut memory: B::Memory;
         let mut buffer: B::Buffer;
         let size: u64;
 
@@ -726,9 +726,9 @@ impl<B: Backend> BufferState<B> {
             size = mem_req.size;
 
             // TODO: check transitions: read/write mapping and vertex buffer read
-            let mapping = device.map_memory(&memory, m::Segment::ALL).unwrap();
+            let mapping = device.map_memory(&mut memory, m::Segment::ALL).unwrap();
             ptr::copy_nonoverlapping(data_source.as_ptr() as *const u8, mapping, upload_size);
-            device.unmap_memory(&memory);
+            device.unmap_memory(&mut memory);
         }
 
         BufferState {
@@ -749,7 +749,7 @@ impl<B: Backend> BufferState<B> {
         let upload_size = data_source.len() * stride;
 
         assert!(offset + upload_size as u64 <= self.size);
-        let memory = self.memory.as_ref().unwrap();
+        let memory = self.memory.as_mut().unwrap();
 
         unsafe {
             let mapping = device
@@ -775,7 +775,7 @@ impl<B: Backend> BufferState<B> {
         let row_pitch = (width * stride as u32 + row_alignment_mask) & !row_alignment_mask;
         let upload_size = (height * row_pitch) as u64;
 
-        let memory: B::Memory;
+        let mut memory: B::Memory;
         let mut buffer: B::Buffer;
         let size: u64;
 
@@ -801,7 +801,7 @@ impl<B: Backend> BufferState<B> {
             size = mem_reqs.size;
 
             // copy image data into staging buffer
-            let mapping = device.map_memory(&memory, m::Segment::ALL).unwrap();
+            let mapping = device.map_memory(&mut memory, m::Segment::ALL).unwrap();
             for y in 0..height as usize {
                 let data_source_slice =
                     &(**img)[y * (width as usize) * stride..(y + 1) * (width as usize) * stride];
@@ -811,7 +811,7 @@ impl<B: Backend> BufferState<B> {
                     data_source_slice.len(),
                 );
             }
-            device.unmap_memory(&memory);
+            device.unmap_memory(&mut memory);
         }
 
         (

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -131,7 +131,7 @@ fn main() {
         (pipeline_layout, pipeline, set_layout, desc_pool)
     };
 
-    let (staging_memory, staging_buffer, _staging_size) = unsafe {
+    let (mut staging_memory, staging_buffer, _staging_size) = unsafe {
         create_buffer::<back::Backend>(
             &device,
             &memory_properties.memory_types,
@@ -144,14 +144,14 @@ fn main() {
 
     unsafe {
         let mapping = device
-            .map_memory(&staging_memory, memory::Segment::ALL)
+            .map_memory(&mut staging_memory, memory::Segment::ALL)
             .unwrap();
         ptr::copy_nonoverlapping(
             numbers.as_ptr() as *const u8,
             mapping,
             numbers.len() * stride as usize,
         );
-        device.unmap_memory(&staging_memory);
+        device.unmap_memory(&mut staging_memory);
     }
 
     let (device_memory, device_buffer, _device_buffer_size) = unsafe {
@@ -239,13 +239,13 @@ fn main() {
 
     unsafe {
         let mapping = device
-            .map_memory(&staging_memory, memory::Segment::ALL)
+            .map_memory(&mut staging_memory, memory::Segment::ALL)
             .unwrap();
         println!(
             "Times: {:?}",
             slice::from_raw_parts::<u32>(mapping as *const u8 as *const u32, numbers.len()),
         );
-        device.unmap_memory(&staging_memory);
+        device.unmap_memory(&mut staging_memory);
     }
 
     unsafe {

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -165,19 +165,18 @@ fn main() {
         )
     };
 
-    let desc_set;
-
-    unsafe {
-        desc_set = desc_pool.allocate_set(&set_layout).unwrap();
-        device.write_descriptor_sets(Some(pso::DescriptorSetWrite {
-            set: &desc_set,
+    let desc_set = unsafe {
+        let mut desc_set = desc_pool.allocate_set(&set_layout).unwrap();
+        device.write_descriptor_set(pso::DescriptorSetWrite {
+            set: &mut desc_set,
             binding: 0,
             array_offset: 0,
             descriptors: Some(pso::Descriptor::Buffer(
                 &device_buffer,
                 buffer::SubRange::WHOLE,
             )),
-        }));
+        });
+        desc_set
     };
 
     let mut command_pool =

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -182,7 +182,7 @@ fn main() {
     let mut command_pool =
         unsafe { device.create_command_pool(family.id(), pool::CommandPoolCreateFlags::empty()) }
             .expect("Can't create command pool");
-    let fence = device.create_fence(false).unwrap();
+    let mut fence = device.create_fence(false).unwrap();
     unsafe {
         let mut command_buffer = command_pool.allocate_one(command::Level::Primary);
         command_buffer.begin_primary(command::CommandBufferFlags::ONE_TIME_SUBMIT);
@@ -231,7 +231,7 @@ fn main() {
         );
         command_buffer.finish();
 
-        queue_group.queues[0].submit_without_semaphores(Some(&command_buffer), Some(&fence));
+        queue_group.queues[0].submit_without_semaphores(Some(&command_buffer), Some(&mut fence));
 
         device.wait_for_fence(&fence, !0).unwrap();
         command_pool.free(Some(command_buffer));

--- a/examples/mesh-shading/main.rs
+++ b/examples/mesh-shading/main.rs
@@ -307,13 +307,13 @@ where
 
         // TODO: check transitions: read/write mapping and vertex buffer read
         let buffer_memory = unsafe {
-            let memory = device
+            let mut memory = device
                 .allocate_memory(upload_type, buffer_req.size)
                 .unwrap();
             device
                 .bind_buffer_memory(&memory, 0, &mut positions_buffer)
                 .unwrap();
-            let mapping = device.map_memory(&memory, m::Segment::ALL).unwrap();
+            let mapping = device.map_memory(&mut memory, m::Segment::ALL).unwrap();
             ptr::copy_nonoverlapping(
                 positions.as_ptr() as *const u8,
                 mapping,
@@ -322,7 +322,7 @@ where
             device
                 .flush_mapped_memory_ranges(iter::once((&memory, m::Segment::ALL)))
                 .unwrap();
-            device.unmap_memory(&memory);
+            device.unmap_memory(&mut memory);
             ManuallyDrop::new(memory)
         };
 

--- a/examples/mesh-shading/main.rs
+++ b/examples/mesh-shading/main.rs
@@ -267,7 +267,7 @@ where
             }
             .expect("Can't create descriptor pool"),
         );
-        let desc_set = unsafe { desc_pool.allocate_set(&set_layout) }.unwrap();
+        let mut desc_set = unsafe { desc_pool.allocate_set(&set_layout) }.unwrap();
 
         // Buffer allocations
         println!("Memory types: {:?}", memory_types);
@@ -327,15 +327,15 @@ where
         };
 
         unsafe {
-            device.write_descriptor_sets(vec![pso::DescriptorSetWrite {
-                set: &desc_set,
+            device.write_descriptor_set(pso::DescriptorSetWrite {
+                set: &mut desc_set,
                 binding: 0,
                 array_offset: 0,
                 descriptors: Some(pso::Descriptor::Buffer(
                     &*positions_buffer,
                     buffer::SubRange::WHOLE,
                 )),
-            }]);
+            });
         }
 
         let caps = surface.capabilities(&adapter.physical_device);

--- a/examples/mesh-shading/main.rs
+++ b/examples/mesh-shading/main.rs
@@ -583,7 +583,7 @@ where
         // updated with a CPU->GPU data copy are not in use by the GPU, so we can perform those updates.
         // In this case there are none to be done, however.
         unsafe {
-            let fence = &self.submission_complete_fences[frame_idx];
+            let fence = &mut self.submission_complete_fences[frame_idx];
             self.device
                 .wait_for_fence(fence, !0)
                 .expect("Failed to wait for fence");
@@ -637,7 +637,7 @@ where
             let result = self.queue_group.queues[0].present(
                 &mut self.surface,
                 surface_image,
-                Some(&self.submission_complete_semaphores[frame_idx]),
+                Some(&mut self.submission_complete_semaphores[frame_idx]),
             );
 
             self.device.destroy_framebuffer(framebuffer);

--- a/examples/mesh-shading/main.rs
+++ b/examples/mesh-shading/main.rs
@@ -630,7 +630,7 @@ where
             };
             self.queue_group.queues[0].submit(
                 submission,
-                Some(&self.submission_complete_fences[frame_idx]),
+                Some(&mut self.submission_complete_fences[frame_idx]),
             );
 
             // present frame

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -859,7 +859,7 @@ where
             };
             self.queue_group.queues[0].submit(
                 submission,
-                Some(&self.submission_complete_fences[frame_idx]),
+                Some(&mut self.submission_complete_fences[frame_idx]),
             );
 
             // present frame

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -323,18 +323,18 @@ where
 
         // TODO: check transitions: read/write mapping and vertex buffer read
         let buffer_memory = unsafe {
-            let memory = device
+            let mut memory = device
                 .allocate_memory(upload_type, buffer_req.size)
                 .unwrap();
             device
                 .bind_buffer_memory(&memory, 0, &mut vertex_buffer)
                 .unwrap();
-            let mapping = device.map_memory(&memory, m::Segment::ALL).unwrap();
+            let mapping = device.map_memory(&mut memory, m::Segment::ALL).unwrap();
             ptr::copy_nonoverlapping(QUAD.as_ptr() as *const u8, mapping, buffer_len as usize);
             device
                 .flush_mapped_memory_ranges(iter::once((&memory, m::Segment::ALL)))
                 .unwrap();
-            device.unmap_memory(&memory);
+            device.unmap_memory(&mut memory);
             ManuallyDrop::new(memory)
         };
 
@@ -362,13 +362,13 @@ where
 
         // copy image data into staging buffer
         let image_upload_memory = unsafe {
-            let memory = device
+            let mut memory = device
                 .allocate_memory(upload_type, image_mem_reqs.size)
                 .unwrap();
             device
                 .bind_buffer_memory(&memory, 0, &mut image_upload_buffer)
                 .unwrap();
-            let mapping = device.map_memory(&memory, m::Segment::ALL).unwrap();
+            let mapping = device.map_memory(&mut memory, m::Segment::ALL).unwrap();
             for y in 0..height as usize {
                 let row = &(*img)[y * (width as usize) * image_stride
                     ..(y + 1) * (width as usize) * image_stride];
@@ -381,7 +381,7 @@ where
             device
                 .flush_mapped_memory_ranges(iter::once((&memory, m::Segment::ALL)))
                 .unwrap();
-            device.unmap_memory(&memory);
+            device.unmap_memory(&mut memory);
             ManuallyDrop::new(memory)
         };
 

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -808,7 +808,7 @@ where
         // updated with a CPU->GPU data copy are not in use by the GPU, so we can perform those updates.
         // In this case there are none to be done, however.
         unsafe {
-            let fence = &self.submission_complete_fences[frame_idx];
+            let fence = &mut self.submission_complete_fences[frame_idx];
             self.device
                 .wait_for_fence(fence, !0)
                 .expect("Failed to wait for fence");
@@ -866,7 +866,7 @@ where
             let result = self.queue_group.queues[0].present(
                 &mut self.surface,
                 surface_image,
-                Some(&self.submission_complete_semaphores[frame_idx]),
+                Some(&mut self.submission_complete_semaphores[frame_idx]),
             );
 
             self.device.destroy_framebuffer(framebuffer);

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -289,7 +289,7 @@ where
             }
             .expect("Can't create descriptor pool"),
         );
-        let desc_set = unsafe { desc_pool.allocate_set(&set_layout) }.unwrap();
+        let mut desc_set = unsafe { desc_pool.allocate_set(&set_layout) }.unwrap();
 
         // Buffer allocations
         println!("Memory types: {:?}", memory_types);
@@ -438,15 +438,15 @@ where
         );
 
         unsafe {
-            device.write_descriptor_sets(iter::once(pso::DescriptorSetWrite {
-                set: &desc_set,
+            device.write_descriptor_set(pso::DescriptorSetWrite {
+                set: &mut desc_set,
                 binding: 0,
                 array_offset: 0,
                 descriptors: vec![
                     pso::Descriptor::Image(&*image_srv, i::Layout::ShaderReadOnlyOptimal),
                     pso::Descriptor::Sampler(&*sampler),
                 ],
-            }));
+            });
         }
 
         // copy buffer to texture

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -2139,13 +2139,13 @@ impl device::Device<Backend> for Device {
 
     unsafe fn map_memory(
         &self,
-        memory: &Memory,
+        memory: &mut Memory,
         segment: memory::Segment,
     ) -> Result<*mut u8, device::MapError> {
         Ok(memory.host_ptr.offset(segment.offset as isize))
     }
 
-    unsafe fn unmap_memory(&self, _memory: &Memory) {
+    unsafe fn unmap_memory(&self, _memory: &mut Memory) {
         // persistent mapping FTW
     }
 

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1976,180 +1976,165 @@ impl device::Device<Backend> for Device {
         })
     }
 
-    unsafe fn write_descriptor_sets<'a, I, J>(&self, write_iter: I)
+    unsafe fn write_descriptor_set<'a, I>(&self, op: pso::DescriptorSetWrite<'a, Backend, I>)
     where
-        I: IntoIterator<Item = pso::DescriptorSetWrite<'a, Backend, J>>,
-        J: IntoIterator,
-        J::Item: Borrow<pso::Descriptor<'a, Backend>>,
+        I: IntoIterator,
+        I::Item: Borrow<pso::Descriptor<'a, Backend>>,
     {
-        for write in write_iter {
-            // Get baseline mapping
-            let mut mapping = write
-                .set
-                .layout
-                .pool_mapping
-                .map_register(|mapping| mapping.offset);
+        // Get baseline mapping
+        let mut mapping = op
+            .set
+            .layout
+            .pool_mapping
+            .map_register(|mapping| mapping.offset);
 
-            // Iterate over layout bindings until the first binding is found.
-            let binding_start = write
-                .set
-                .layout
-                .bindings
-                .iter()
-                .position(|binding| binding.binding == write.binding)
-                .unwrap();
+        // Iterate over layout bindings until the first binding is found.
+        let binding_start = op
+            .set
+            .layout
+            .bindings
+            .iter()
+            .position(|binding| binding.binding == op.binding)
+            .unwrap();
 
-            // If we've skipped layout bindings, we need to add them to get the correct binding offset
-            for binding in &write.set.layout.bindings[..binding_start] {
-                let content = DescriptorContent::from(binding.ty);
-                mapping.add_content_many(content, binding.stage_flags, binding.count as _);
-            }
+        // If we've skipped layout bindings, we need to add them to get the correct binding offset
+        for binding in &op.set.layout.bindings[..binding_start] {
+            let content = DescriptorContent::from(binding.ty);
+            mapping.add_content_many(content, binding.stage_flags, binding.count as _);
+        }
 
-            // We start at the given binding index and array index
-            let mut binding_index = binding_start;
-            let mut array_index = write.array_offset;
+        // We start at the given binding index and array index
+        let mut binding_index = binding_start;
+        let mut array_index = op.array_offset;
 
-            // If we're skipping array indices in the current binding, we need to add them to get the correct binding offset
-            if array_index > 0 {
-                let binding: &pso::DescriptorSetLayoutBinding =
-                    &write.set.layout.bindings[binding_index];
-                let content = DescriptorContent::from(binding.ty);
-                mapping.add_content_many(content, binding.stage_flags, array_index as _);
-            }
+        // If we're skipping array indices in the current binding, we need to add them to get the correct binding offset
+        if array_index > 0 {
+            let binding: &pso::DescriptorSetLayoutBinding = &op.set.layout.bindings[binding_index];
+            let content = DescriptorContent::from(binding.ty);
+            mapping.add_content_many(content, binding.stage_flags, array_index as _);
+        }
 
-            // Iterate over the descriptors, figuring out the corresponding binding, and adding
-            // it to the set of bindings.
-            //
-            // When we hit the end of an array of descriptors and there are still descriptors left
-            // over, we will spill into writing the next binding.
-            for descriptor in write.descriptors {
-                let binding: &pso::DescriptorSetLayoutBinding =
-                    &write.set.layout.bindings[binding_index];
+        // Iterate over the descriptors, figuring out the corresponding binding, and adding
+        // it to the set of bindings.
+        //
+        // When we hit the end of an array of descriptors and there are still descriptors left
+        // over, we will spill into writing the next binding.
+        for descriptor in op.descriptors {
+            let binding: &pso::DescriptorSetLayoutBinding = &op.set.layout.bindings[binding_index];
 
-                let handles = match *descriptor.borrow() {
-                    pso::Descriptor::Buffer(buffer, ref _sub) => RegisterData {
-                        c: match buffer.internal.disjoint_cb {
-                            Some(dj_buf) => dj_buf as *mut _,
-                            None => buffer.internal.raw as *mut _,
-                        },
-                        t: buffer.internal.srv.map_or(ptr::null_mut(), |p| p as *mut _),
-                        u: buffer.internal.uav.map_or(ptr::null_mut(), |p| p as *mut _),
-                        s: ptr::null_mut(),
+            let handles = match *descriptor.borrow() {
+                pso::Descriptor::Buffer(buffer, ref _sub) => RegisterData {
+                    c: match buffer.internal.disjoint_cb {
+                        Some(dj_buf) => dj_buf as *mut _,
+                        None => buffer.internal.raw as *mut _,
                     },
-                    pso::Descriptor::Image(image, _layout) => RegisterData {
-                        c: ptr::null_mut(),
-                        t: image.srv_handle.map_or(ptr::null_mut(), |h| h as *mut _),
-                        u: image.uav_handle.map_or(ptr::null_mut(), |h| h as *mut _),
-                        s: ptr::null_mut(),
-                    },
-                    pso::Descriptor::Sampler(sampler) => RegisterData {
-                        c: ptr::null_mut(),
-                        t: ptr::null_mut(),
-                        u: ptr::null_mut(),
-                        s: sampler.sampler_handle.as_raw() as *mut _,
-                    },
-                    pso::Descriptor::CombinedImageSampler(image, _layout, sampler) => {
-                        RegisterData {
-                            c: ptr::null_mut(),
-                            t: image.srv_handle.map_or(ptr::null_mut(), |h| h as *mut _),
-                            u: image.uav_handle.map_or(ptr::null_mut(), |h| h as *mut _),
-                            s: sampler.sampler_handle.as_raw() as *mut _,
-                        }
-                    }
-                    pso::Descriptor::TexelBuffer(_buffer_view) => unimplemented!(),
+                    t: buffer.internal.srv.map_or(ptr::null_mut(), |p| p as *mut _),
+                    u: buffer.internal.uav.map_or(ptr::null_mut(), |p| p as *mut _),
+                    s: ptr::null_mut(),
+                },
+                pso::Descriptor::Image(image, _layout) => RegisterData {
+                    c: ptr::null_mut(),
+                    t: image.srv_handle.map_or(ptr::null_mut(), |h| h as *mut _),
+                    u: image.uav_handle.map_or(ptr::null_mut(), |h| h as *mut _),
+                    s: ptr::null_mut(),
+                },
+                pso::Descriptor::Sampler(sampler) => RegisterData {
+                    c: ptr::null_mut(),
+                    t: ptr::null_mut(),
+                    u: ptr::null_mut(),
+                    s: sampler.sampler_handle.as_raw() as *mut _,
+                },
+                pso::Descriptor::CombinedImageSampler(image, _layout, sampler) => RegisterData {
+                    c: ptr::null_mut(),
+                    t: image.srv_handle.map_or(ptr::null_mut(), |h| h as *mut _),
+                    u: image.uav_handle.map_or(ptr::null_mut(), |h| h as *mut _),
+                    s: sampler.sampler_handle.as_raw() as *mut _,
+                },
+                pso::Descriptor::TexelBuffer(_buffer_view) => unimplemented!(),
+            };
+
+            let content = DescriptorContent::from(binding.ty);
+            if content.contains(DescriptorContent::CBV) {
+                let offsets = mapping.map_other(|map| map.c);
+                op.set
+                    .assign_stages(&offsets, binding.stage_flags, handles.c);
+            };
+            if content.contains(DescriptorContent::SRV) {
+                let offsets = mapping.map_other(|map| map.t);
+                op.set
+                    .assign_stages(&offsets, binding.stage_flags, handles.t);
+            };
+            if content.contains(DescriptorContent::UAV) {
+                // If this binding is used by the graphics pipeline and is a UAV, it belongs to the "Output Merger"
+                // stage, so we only put them in the fragment stage to save redundant descriptor allocations.
+                let stage_flags = if binding
+                    .stage_flags
+                    .intersects(pso::ShaderStageFlags::ALL - pso::ShaderStageFlags::COMPUTE)
+                {
+                    let mut stage_flags = pso::ShaderStageFlags::FRAGMENT;
+                    stage_flags.set(
+                        pso::ShaderStageFlags::COMPUTE,
+                        binding.stage_flags.contains(pso::ShaderStageFlags::COMPUTE),
+                    );
+                    stage_flags
+                } else {
+                    binding.stage_flags
                 };
 
-                let content = DescriptorContent::from(binding.ty);
-                if content.contains(DescriptorContent::CBV) {
-                    let offsets = mapping.map_other(|map| map.c);
-                    write
-                        .set
-                        .assign_stages(&offsets, binding.stage_flags, handles.c);
-                };
-                if content.contains(DescriptorContent::SRV) {
-                    let offsets = mapping.map_other(|map| map.t);
-                    write
-                        .set
-                        .assign_stages(&offsets, binding.stage_flags, handles.t);
-                };
-                if content.contains(DescriptorContent::UAV) {
-                    // If this binding is used by the graphics pipeline and is a UAV, it belongs to the "Output Merger"
-                    // stage, so we only put them in the fragment stage to save redundant descriptor allocations.
-                    let stage_flags = if binding
-                        .stage_flags
-                        .intersects(pso::ShaderStageFlags::ALL - pso::ShaderStageFlags::COMPUTE)
-                    {
-                        let mut stage_flags = pso::ShaderStageFlags::FRAGMENT;
-                        stage_flags.set(
-                            pso::ShaderStageFlags::COMPUTE,
-                            binding.stage_flags.contains(pso::ShaderStageFlags::COMPUTE),
-                        );
-                        stage_flags
-                    } else {
-                        binding.stage_flags
-                    };
+                let offsets = mapping.map_other(|map| map.u);
+                op.set.assign_stages(&offsets, stage_flags, handles.u);
+            };
+            if content.contains(DescriptorContent::SAMPLER) {
+                let offsets = mapping.map_other(|map| map.s);
+                op.set
+                    .assign_stages(&offsets, binding.stage_flags, handles.s);
+            };
 
-                    let offsets = mapping.map_other(|map| map.u);
-                    write.set.assign_stages(&offsets, stage_flags, handles.u);
-                };
-                if content.contains(DescriptorContent::SAMPLER) {
-                    let offsets = mapping.map_other(|map| map.s);
-                    write
-                        .set
-                        .assign_stages(&offsets, binding.stage_flags, handles.s);
-                };
+            mapping.add_content_many(content, binding.stage_flags, 1);
 
-                mapping.add_content_many(content, binding.stage_flags, 1);
-
-                array_index += 1;
-                if array_index >= binding.count {
-                    // We've run out of array to write to, we should overflow to the next binding.
-                    array_index = 0;
-                    binding_index += 1;
-                }
+            array_index += 1;
+            if array_index >= binding.count {
+                // We've run out of array to write to, we should overflow to the next binding.
+                array_index = 0;
+                binding_index += 1;
             }
         }
     }
 
-    unsafe fn copy_descriptor_sets<'a, I>(&self, copy_iter: I)
-    where
-        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, Backend>>,
-    {
-        for _copy in copy_iter {
-            //TODO
-            /*
-            for offset in 0 .. copy.count {
-                let (dst_ty, dst_handle_offset, dst_second_handle_offset) = copy
-                    .dst_set
-                    .get_handle_offset(copy.dst_binding + offset as u32);
-                let (src_ty, src_handle_offset, src_second_handle_offset) = copy
-                    .src_set
-                    .get_handle_offset(copy.src_binding + offset as u32);
-                assert_eq!(dst_ty, src_ty);
+    unsafe fn copy_descriptor_set<'a>(&self, _op: pso::DescriptorSetCopy<'a, Backend>) {
+        unimplemented!()
+        /*
+        for offset in 0 .. copy.count {
+            let (dst_ty, dst_handle_offset, dst_second_handle_offset) = copy
+                .dst_set
+                .get_handle_offset(copy.dst_binding + offset as u32);
+            let (src_ty, src_handle_offset, src_second_handle_offset) = copy
+                .src_set
+                .get_handle_offset(copy.src_binding + offset as u32);
+            assert_eq!(dst_ty, src_ty);
 
-                let dst_handle = copy.dst_set.handles.offset(dst_handle_offset as isize);
-                let src_handle = copy.dst_set.handles.offset(src_handle_offset as isize);
+            let dst_handle = copy.dst_set.handles.offset(dst_handle_offset as isize);
+            let src_handle = copy.dst_set.handles.offset(src_handle_offset as isize);
 
-                match dst_ty {
-                    pso::DescriptorType::Image {
-                        ty: pso::ImageDescriptorType::Sampled { with_sampler: true }
-                    } => {
-                        let dst_second_handle = copy
-                            .dst_set
-                            .handles
-                            .offset(dst_second_handle_offset as isize);
-                        let src_second_handle = copy
-                            .dst_set
-                            .handles
-                            .offset(src_second_handle_offset as isize);
+            match dst_ty {
+                pso::DescriptorType::Image {
+                    ty: pso::ImageDescriptorType::Sampled { with_sampler: true }
+                } => {
+                    let dst_second_handle = copy
+                        .dst_set
+                        .handles
+                        .offset(dst_second_handle_offset as isize);
+                    let src_second_handle = copy
+                        .dst_set
+                        .handles
+                        .offset(src_second_handle_offset as isize);
 
-                        *dst_handle = *src_handle;
-                        *dst_second_handle = *src_second_handle;
-                    }
-                    _ => *dst_handle = *src_handle,
+                    *dst_handle = *src_handle;
+                    *dst_second_handle = *src_second_handle;
                 }
-            }*/
-        }
+                _ => *dst_handle = *src_handle,
+            }
+        }*/
     }
 
     unsafe fn map_memory(

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -2259,11 +2259,11 @@ impl device::Device<Backend> for Device {
         unimplemented!()
     }
 
-    unsafe fn set_event(&self, _event: &()) -> Result<(), device::OutOfMemory> {
+    unsafe fn set_event(&self, _event: &mut ()) -> Result<(), device::OutOfMemory> {
         unimplemented!()
     }
 
-    unsafe fn reset_event(&self, _event: &()) -> Result<(), device::OutOfMemory> {
+    unsafe fn reset_event(&self, _event: &mut ()) -> Result<(), device::OutOfMemory> {
         unimplemented!()
     }
 

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -2113,11 +2113,9 @@ impl device::Device<Backend> for Device {
 
     unsafe fn copy_descriptor_sets<'a, I>(&self, copy_iter: I)
     where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetCopy<'a, Backend>>,
+        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, Backend>>,
     {
-        for copy in copy_iter {
-            let _copy = copy.borrow();
+        for _copy in copy_iter {
             //TODO
             /*
             for offset in 0 .. copy.count {
@@ -2224,7 +2222,7 @@ impl device::Device<Backend> for Device {
         }))
     }
 
-    unsafe fn reset_fence(&self, fence: &Fence) -> Result<(), device::OutOfMemory> {
+    unsafe fn reset_fence(&self, fence: &mut Fence) -> Result<(), device::OutOfMemory> {
         *fence.mutex.lock() = false;
         Ok(())
     }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -4161,6 +4161,8 @@ impl DescriptorSet {
 
 #[derive(Debug)]
 pub struct DescriptorPool {
+    //TODO: do we need this in the pool?
+    // if the sets owned their data, we could make this just `Vec<Descriptor>`
     handles: Vec<Descriptor>,
     allocator: RangeAllocator<DescriptorIndex>,
 }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1124,7 +1124,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
     unsafe fn submit<'a, T, Ic, S, Iw, Is>(
         &mut self,
         submission: queue::Submission<Ic, Iw, Is>,
-        fence: Option<&Fence>,
+        fence: Option<&mut Fence>,
     ) where
         T: 'a + Borrow<CommandBuffer>,
         Ic: IntoIterator<Item = &'a T>,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1184,7 +1184,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
         Ok(None)
     }
 
-    fn wait_idle(&self) -> Result<(), hal::device::OutOfMemory> {
+    fn wait_idle(&mut self) -> Result<(), hal::device::OutOfMemory> {
         // unimplemented!()
         Ok(())
     }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -971,7 +971,9 @@ impl window::PresentationSurface<Backend> for Surface {
                 // We must also delete the image data.
                 //
                 // This should not panic as all images must be deleted before
-                let mut present_image = Arc::try_unwrap(present.image).expect("Not all acquired images were deleted before the swapchain was reconfigured.");
+                let mut present_image = Arc::try_unwrap(present.image).expect(
+                    "Not all acquired images were deleted before the swapchain was reconfigured.",
+                );
                 present_image.internal.release_resources();
 
                 let result = present.swapchain.ResizeBuffers(
@@ -1167,7 +1169,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
         &mut self,
         surface: &mut Surface,
         _image: SwapchainImage,
-        _wait_semaphore: Option<&Semaphore>,
+        _wait_semaphore: Option<&mut Semaphore>,
     ) -> Result<Option<window::Suboptimal>, window::PresentError> {
         let mut presentation = surface.presentation.as_mut().unwrap();
         let (interval, flags) = match presentation.mode {

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -243,7 +243,7 @@ impl PipelineCache {
             }
 
             // Bind Sampler descriptor tables.
-            if let Some(gpu) = set.first_gpu_sampler.get() {
+            if let Some(gpu) = set.first_gpu_sampler {
                 assert!(element.table.ty.contains(r::SAMPLERS));
 
                 // Cast is safe as offset **must** be in u32 range. Unable to
@@ -259,8 +259,7 @@ impl PipelineCache {
             //       Requires changes then in the descriptor update process.
             for binding in &set.binding_infos {
                 // It's not valid to modify the descriptor sets during recording -> access if safe.
-                let dynamic_descriptors = unsafe { &*binding.dynamic_descriptors.get() };
-                for descriptor in dynamic_descriptors {
+                for descriptor in binding.dynamic_descriptors.iter() {
                     let gpu_offset = descriptor.gpu_buffer_location + offsets.next().unwrap();
                     self.user_data.set_descriptor_cbv(root_offset, gpu_offset);
                     root_offset += 2;

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2997,258 +2997,234 @@ impl d::Device<B> for Device {
         })
     }
 
-    unsafe fn write_descriptor_sets<'a, I, J>(&self, write_iter: I)
+    unsafe fn write_descriptor_set<'a, I>(&self, op: pso::DescriptorSetWrite<'a, B, I>)
     where
-        I: IntoIterator<Item = pso::DescriptorSetWrite<'a, B, J>>,
-        J: IntoIterator,
-        J::Item: Borrow<pso::Descriptor<'a, B>>,
+        I: IntoIterator,
+        I::Item: Borrow<pso::Descriptor<'a, B>>,
     {
         let mut descriptor_updater = self.descriptor_updater.lock();
         descriptor_updater.reset();
 
         let mut accum = descriptors_cpu::MultiCopyAccumulator::default();
-        debug!("write_descriptor_sets");
+        debug!("write_descriptor_set");
 
-        for write in write_iter {
-            let mut offset = write.array_offset as u64;
-            let mut target_binding = write.binding as usize;
-            let mut bind_info = &write.set.binding_infos[target_binding];
-            debug!(
-                "\t{:?} binding {} array offset {}",
-                bind_info, target_binding, offset
-            );
-            let base_sampler_offset = write.set.sampler_offset(write.binding, write.array_offset);
-            trace!("\tsampler offset {}", base_sampler_offset);
-            let mut sampler_offset = base_sampler_offset;
-            let mut desc_samplers = write.set.sampler_origins.borrow_mut();
+        let mut offset = op.array_offset as u64;
+        let mut target_binding = op.binding as usize;
+        let base_sampler_offset = op.set.sampler_offset(op.binding, op.array_offset);
+        trace!("\tsampler offset {}", base_sampler_offset);
+        let mut sampler_offset = base_sampler_offset;
+        debug!("\tbinding {} array offset {}", target_binding, offset);
 
-            for descriptor in write.descriptors {
-                // spill over the writes onto the next binding
-                while offset >= bind_info.count {
-                    assert_eq!(offset, bind_info.count);
-                    target_binding += 1;
-                    bind_info = &write.set.binding_infos[target_binding];
-                    offset = 0;
-                }
-                let mut src_cbv = None;
-                let mut src_srv = None;
-                let mut src_uav = None;
+        for descriptor in op.descriptors {
+            // spill over the writes onto the next binding
+            while offset >= op.set.binding_infos[target_binding].count {
+                target_binding += 1;
+                offset = 0;
+            }
+            let mut bind_info = &mut op.set.binding_infos[target_binding];
+            let mut src_cbv = None;
+            let mut src_srv = None;
+            let mut src_uav = None;
 
-                match *descriptor.borrow() {
-                    pso::Descriptor::Buffer(buffer, ref sub) => {
-                        let buffer = buffer.expect_bound();
+            match *descriptor.borrow() {
+                pso::Descriptor::Buffer(buffer, ref sub) => {
+                    let buffer = buffer.expect_bound();
 
-                        if bind_info.content.is_dynamic() {
-                            // Root Descriptor
-                            let buffer_address = (*buffer.resource).GetGPUVirtualAddress();
-                            // Descriptor sets need to be externally synchronized according to specification
-                            let dynamic_descriptors = &mut *bind_info.dynamic_descriptors.get();
-                            dynamic_descriptors[offset as usize].gpu_buffer_location =
-                                buffer_address + sub.offset;
-                        } else {
-                            // Descriptor table
-                            let size = sub.size_to(buffer.requirements.size);
-
-                            if bind_info.content.contains(r::DescriptorContent::CBV) {
-                                // Making the size field of buffer requirements for uniform
-                                // buffers a multiple of 256 and setting the required offset
-                                // alignment to 256 allows us to patch the size here.
-                                // We can always enforce the size to be aligned to 256 for
-                                // CBVs without going out-of-bounds.
-                                let mask =
-                                    d3d12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1;
-                                let desc = d3d12::D3D12_CONSTANT_BUFFER_VIEW_DESC {
-                                    BufferLocation: (*buffer.resource).GetGPUVirtualAddress()
-                                        + sub.offset,
-                                    SizeInBytes: (size as u32 + mask) as u32 & !mask,
-                                };
-                                let handle = descriptor_updater.alloc_handle(self.raw);
-                                self.raw.CreateConstantBufferView(&desc, handle);
-                                src_cbv = Some(handle);
-                            }
-                            if bind_info.content.contains(r::DescriptorContent::SRV) {
-                                assert_eq!(size % 4, 0);
-                                let mut desc = d3d12::D3D12_SHADER_RESOURCE_VIEW_DESC {
-                                    Format: dxgiformat::DXGI_FORMAT_R32_TYPELESS,
-                                    Shader4ComponentMapping: IDENTITY_MAPPING,
-                                    ViewDimension: d3d12::D3D12_SRV_DIMENSION_BUFFER,
-                                    u: mem::zeroed(),
-                                };
-                                *desc.u.Buffer_mut() = d3d12::D3D12_BUFFER_SRV {
-                                    FirstElement: sub.offset as _,
-                                    NumElements: (size / 4) as _,
-                                    StructureByteStride: 0,
-                                    Flags: d3d12::D3D12_BUFFER_SRV_FLAG_RAW,
-                                };
-                                let handle = descriptor_updater.alloc_handle(self.raw);
-                                self.raw.CreateShaderResourceView(
-                                    buffer.resource.as_mut_ptr(),
-                                    &desc,
-                                    handle,
-                                );
-                                src_srv = Some(handle);
-                            }
-                            if bind_info.content.contains(r::DescriptorContent::UAV) {
-                                assert_eq!(size % 4, 0);
-                                let mut desc = d3d12::D3D12_UNORDERED_ACCESS_VIEW_DESC {
-                                    Format: dxgiformat::DXGI_FORMAT_R32_TYPELESS,
-                                    ViewDimension: d3d12::D3D12_UAV_DIMENSION_BUFFER,
-                                    u: mem::zeroed(),
-                                };
-                                *desc.u.Buffer_mut() = d3d12::D3D12_BUFFER_UAV {
-                                    FirstElement: sub.offset as _,
-                                    NumElements: (size / 4) as _,
-                                    StructureByteStride: 0,
-                                    CounterOffsetInBytes: 0,
-                                    Flags: d3d12::D3D12_BUFFER_UAV_FLAG_RAW,
-                                };
-                                let handle = descriptor_updater.alloc_handle(self.raw);
-                                self.raw.CreateUnorderedAccessView(
-                                    buffer.resource.as_mut_ptr(),
-                                    ptr::null_mut(),
-                                    &desc,
-                                    handle,
-                                );
-                                src_uav = Some(handle);
-                            }
-                        }
-                    }
-                    pso::Descriptor::Image(image, _layout) => {
-                        if bind_info.content.contains(r::DescriptorContent::SRV) {
-                            src_srv = image.handle_srv.map(|h| h.raw);
-                        }
-                        if bind_info.content.contains(r::DescriptorContent::UAV) {
-                            src_uav = image.handle_uav.map(|h| h.raw);
-                        }
-                    }
-                    pso::Descriptor::CombinedImageSampler(image, _layout, sampler) => {
-                        src_srv = image.handle_srv.map(|h| h.raw);
-                        desc_samplers[sampler_offset] = sampler.handle.raw;
-                        sampler_offset += 1;
-                    }
-                    pso::Descriptor::Sampler(sampler) => {
-                        desc_samplers[sampler_offset] = sampler.handle.raw;
-                        sampler_offset += 1;
-                    }
-                    pso::Descriptor::TexelBuffer(buffer_view) => {
-                        if bind_info.content.contains(r::DescriptorContent::SRV) {
-                            let handle = buffer_view.handle_srv
-                                .expect("SRV handle of the storage texel buffer is zero (not supported by specified format)");
-                            src_srv = Some(handle.raw);
-                        }
-                        if bind_info.content.contains(r::DescriptorContent::UAV) {
-                            let handle = buffer_view.handle_uav
-                                .expect("UAV handle of the storage texel buffer is zero (not supported by specified format)");
-                            src_uav = Some(handle.raw);
-                        }
-                    }
-                }
-
-                if let Some(handle) = src_cbv {
-                    trace!("\tcbv offset {}", offset);
-                    accum.src_views.add(handle, 1);
-                    accum
-                        .dst_views
-                        .add(bind_info.view_range.as_ref().unwrap().at(offset), 1);
-                }
-                if let Some(handle) = src_srv {
-                    trace!("\tsrv offset {}", offset);
-                    accum.src_views.add(handle, 1);
-                    accum
-                        .dst_views
-                        .add(bind_info.view_range.as_ref().unwrap().at(offset), 1);
-                }
-                if let Some(handle) = src_uav {
-                    let uav_offset = if bind_info.content.contains(r::DescriptorContent::SRV) {
-                        bind_info.count + offset
+                    if bind_info.content.is_dynamic() {
+                        // Root Descriptor
+                        let buffer_address = (*buffer.resource).GetGPUVirtualAddress();
+                        // Descriptor sets need to be externally synchronized according to specification
+                        bind_info.dynamic_descriptors[offset as usize].gpu_buffer_location =
+                            buffer_address + sub.offset;
                     } else {
-                        offset
-                    };
-                    trace!("\tuav offset {}", uav_offset);
-                    accum.src_views.add(handle, 1);
-                    accum
-                        .dst_views
-                        .add(bind_info.view_range.as_ref().unwrap().at(uav_offset), 1);
+                        // Descriptor table
+                        let size = sub.size_to(buffer.requirements.size);
+
+                        if bind_info.content.contains(r::DescriptorContent::CBV) {
+                            // Making the size field of buffer requirements for uniform
+                            // buffers a multiple of 256 and setting the required offset
+                            // alignment to 256 allows us to patch the size here.
+                            // We can always enforce the size to be aligned to 256 for
+                            // CBVs without going out-of-bounds.
+                            let mask = d3d12::D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT - 1;
+                            let desc = d3d12::D3D12_CONSTANT_BUFFER_VIEW_DESC {
+                                BufferLocation: (*buffer.resource).GetGPUVirtualAddress()
+                                    + sub.offset,
+                                SizeInBytes: (size as u32 + mask) as u32 & !mask,
+                            };
+                            let handle = descriptor_updater.alloc_handle(self.raw);
+                            self.raw.CreateConstantBufferView(&desc, handle);
+                            src_cbv = Some(handle);
+                        }
+                        if bind_info.content.contains(r::DescriptorContent::SRV) {
+                            assert_eq!(size % 4, 0);
+                            let mut desc = d3d12::D3D12_SHADER_RESOURCE_VIEW_DESC {
+                                Format: dxgiformat::DXGI_FORMAT_R32_TYPELESS,
+                                Shader4ComponentMapping: IDENTITY_MAPPING,
+                                ViewDimension: d3d12::D3D12_SRV_DIMENSION_BUFFER,
+                                u: mem::zeroed(),
+                            };
+                            *desc.u.Buffer_mut() = d3d12::D3D12_BUFFER_SRV {
+                                FirstElement: sub.offset as _,
+                                NumElements: (size / 4) as _,
+                                StructureByteStride: 0,
+                                Flags: d3d12::D3D12_BUFFER_SRV_FLAG_RAW,
+                            };
+                            let handle = descriptor_updater.alloc_handle(self.raw);
+                            self.raw.CreateShaderResourceView(
+                                buffer.resource.as_mut_ptr(),
+                                &desc,
+                                handle,
+                            );
+                            src_srv = Some(handle);
+                        }
+                        if bind_info.content.contains(r::DescriptorContent::UAV) {
+                            assert_eq!(size % 4, 0);
+                            let mut desc = d3d12::D3D12_UNORDERED_ACCESS_VIEW_DESC {
+                                Format: dxgiformat::DXGI_FORMAT_R32_TYPELESS,
+                                ViewDimension: d3d12::D3D12_UAV_DIMENSION_BUFFER,
+                                u: mem::zeroed(),
+                            };
+                            *desc.u.Buffer_mut() = d3d12::D3D12_BUFFER_UAV {
+                                FirstElement: sub.offset as _,
+                                NumElements: (size / 4) as _,
+                                StructureByteStride: 0,
+                                CounterOffsetInBytes: 0,
+                                Flags: d3d12::D3D12_BUFFER_UAV_FLAG_RAW,
+                            };
+                            let handle = descriptor_updater.alloc_handle(self.raw);
+                            self.raw.CreateUnorderedAccessView(
+                                buffer.resource.as_mut_ptr(),
+                                ptr::null_mut(),
+                                &desc,
+                                handle,
+                            );
+                            src_uav = Some(handle);
+                        }
+                    }
                 }
-
-                offset += 1;
+                pso::Descriptor::Image(image, _layout) => {
+                    if bind_info.content.contains(r::DescriptorContent::SRV) {
+                        src_srv = image.handle_srv.map(|h| h.raw);
+                    }
+                    if bind_info.content.contains(r::DescriptorContent::UAV) {
+                        src_uav = image.handle_uav.map(|h| h.raw);
+                    }
+                }
+                pso::Descriptor::CombinedImageSampler(image, _layout, sampler) => {
+                    src_srv = image.handle_srv.map(|h| h.raw);
+                    op.set.sampler_origins[sampler_offset] = sampler.handle.raw;
+                    sampler_offset += 1;
+                }
+                pso::Descriptor::Sampler(sampler) => {
+                    op.set.sampler_origins[sampler_offset] = sampler.handle.raw;
+                    sampler_offset += 1;
+                }
+                pso::Descriptor::TexelBuffer(buffer_view) => {
+                    if bind_info.content.contains(r::DescriptorContent::SRV) {
+                        let handle = buffer_view.handle_srv
+                            .expect("SRV handle of the storage texel buffer is zero (not supported by specified format)");
+                        src_srv = Some(handle.raw);
+                    }
+                    if bind_info.content.contains(r::DescriptorContent::UAV) {
+                        let handle = buffer_view.handle_uav
+                            .expect("UAV handle of the storage texel buffer is zero (not supported by specified format)");
+                        src_uav = Some(handle.raw);
+                    }
+                }
             }
 
-            if sampler_offset != base_sampler_offset {
-                drop(desc_samplers);
-                write
-                    .set
-                    .update_samplers(&self.samplers.heap, &self.samplers.origins, &mut accum);
+            if let Some(handle) = src_cbv {
+                trace!("\tcbv offset {}", offset);
+                accum.src_views.add(handle, 1);
+                accum
+                    .dst_views
+                    .add(bind_info.view_range.as_ref().unwrap().at(offset), 1);
             }
+            if let Some(handle) = src_srv {
+                trace!("\tsrv offset {}", offset);
+                accum.src_views.add(handle, 1);
+                accum
+                    .dst_views
+                    .add(bind_info.view_range.as_ref().unwrap().at(offset), 1);
+            }
+            if let Some(handle) = src_uav {
+                let uav_offset = if bind_info.content.contains(r::DescriptorContent::SRV) {
+                    bind_info.count + offset
+                } else {
+                    offset
+                };
+                trace!("\tuav offset {}", uav_offset);
+                accum.src_views.add(handle, 1);
+                accum
+                    .dst_views
+                    .add(bind_info.view_range.as_ref().unwrap().at(uav_offset), 1);
+            }
+
+            offset += 1;
+        }
+
+        if sampler_offset != base_sampler_offset {
+            op.set
+                .update_samplers(&self.samplers.heap, &self.samplers.origins, &mut accum);
         }
 
         accum.flush(self.raw);
     }
 
-    unsafe fn copy_descriptor_sets<'a, I>(&self, copy_iter: I)
-    where
-        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, B>>,
-    {
+    unsafe fn copy_descriptor_set<'a>(&self, op: pso::DescriptorSetCopy<'a, B>) {
         let mut accum = descriptors_cpu::MultiCopyAccumulator::default();
 
-        for copy in copy_iter {
-            let src_info = &copy.src_set.binding_infos[copy.src_binding as usize];
-            let dst_info = &copy.dst_set.binding_infos[copy.dst_binding as usize];
+        let src_info = &op.src_set.binding_infos[op.src_binding as usize];
+        let dst_info = &op.dst_set.binding_infos[op.dst_binding as usize];
 
-            if let (Some(src_range), Some(dst_range)) =
-                (src_info.view_range.as_ref(), dst_info.view_range.as_ref())
+        if let (Some(src_range), Some(dst_range)) =
+            (src_info.view_range.as_ref(), dst_info.view_range.as_ref())
+        {
+            assert!(op.src_array_offset + op.count <= src_range.handle.size as usize);
+            assert!(op.dst_array_offset + op.count <= dst_range.handle.size as usize);
+            let count = op.count as u32;
+            accum
+                .src_views
+                .add(src_range.at(op.src_array_offset as _), count);
+            accum
+                .dst_views
+                .add(dst_range.at(op.dst_array_offset as _), count);
+
+            if (src_info.content & dst_info.content)
+                .contains(r::DescriptorContent::SRV | r::DescriptorContent::UAV)
             {
-                assert!(copy.src_array_offset + copy.count <= src_range.handle.size as usize);
-                assert!(copy.dst_array_offset + copy.count <= dst_range.handle.size as usize);
-                let count = copy.count as u32;
-                accum
-                    .src_views
-                    .add(src_range.at(copy.src_array_offset as _), count);
-                accum
-                    .dst_views
-                    .add(dst_range.at(copy.dst_array_offset as _), count);
-
-                if (src_info.content & dst_info.content)
-                    .contains(r::DescriptorContent::SRV | r::DescriptorContent::UAV)
-                {
-                    assert!(
-                        src_info.count as usize + copy.src_array_offset + copy.count
-                            <= src_range.handle.size as usize
-                    );
-                    assert!(
-                        dst_info.count as usize + copy.dst_array_offset + copy.count
-                            <= dst_range.handle.size as usize
-                    );
-                    accum.src_views.add(
-                        src_range.at(src_info.count + copy.src_array_offset as u64),
-                        count,
-                    );
-                    accum.dst_views.add(
-                        dst_range.at(dst_info.count + copy.dst_array_offset as u64),
-                        count,
-                    );
-                }
-            }
-
-            if dst_info.content.contains(r::DescriptorContent::SAMPLER) {
-                let src_offset = copy
-                    .src_set
-                    .sampler_offset(copy.src_binding, copy.src_array_offset);
-                let dst_offset = copy
-                    .dst_set
-                    .sampler_offset(copy.dst_binding, copy.dst_array_offset);
-                let src_samplers = copy.src_set.sampler_origins.borrow();
-                let mut dst_samplers = copy.dst_set.sampler_origins.borrow_mut();
-                dst_samplers[dst_offset..dst_offset + copy.count]
-                    .copy_from_slice(&src_samplers[src_offset..src_offset + copy.count]);
-                drop(dst_samplers);
-
-                copy.dst_set.update_samplers(
-                    &self.samplers.heap,
-                    &self.samplers.origins,
-                    &mut accum,
+                assert!(
+                    src_info.count as usize + op.src_array_offset + op.count
+                        <= src_range.handle.size as usize
+                );
+                assert!(
+                    dst_info.count as usize + op.dst_array_offset + op.count
+                        <= dst_range.handle.size as usize
+                );
+                accum.src_views.add(
+                    src_range.at(src_info.count + op.src_array_offset as u64),
+                    count,
+                );
+                accum.dst_views.add(
+                    dst_range.at(dst_info.count + op.dst_array_offset as u64),
+                    count,
                 );
             }
+        }
+
+        if dst_info.content.contains(r::DescriptorContent::SAMPLER) {
+            let src_offset = op
+                .src_set
+                .sampler_offset(op.src_binding, op.src_array_offset);
+            let dst_offset = op
+                .dst_set
+                .sampler_offset(op.dst_binding, op.dst_array_offset);
+            op.dst_set.sampler_origins[dst_offset..dst_offset + op.count]
+                .copy_from_slice(&op.src_set.sampler_origins[src_offset..src_offset + op.count]);
+
+            op.dst_set
+                .update_samplers(&self.samplers.heap, &self.samplers.origins, &mut accum);
         }
 
         accum.flush(self.raw.clone());

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -18,16 +18,8 @@ use winapi::{
 
 use auxil::{spirv_cross_specialize_ast, ShaderStage};
 use hal::{
-    buffer, device as d, format,
-    format::Aspects,
-    image, memory,
-    memory::Requirements,
-    pass,
-    pool::CommandPoolCreateFlags,
-    pso,
-    pso::VertexInputRate,
-    query,
-    queue::{CommandQueue as _, QueueFamilyId},
+    buffer, device as d, format, format::Aspects, image, memory, memory::Requirements, pass,
+    pool::CommandPoolCreateFlags, pso, pso::VertexInputRate, query, queue::QueueFamilyId,
     window as w,
 };
 
@@ -3021,7 +3013,7 @@ impl d::Device<B> for Device {
                 target_binding += 1;
                 offset = 0;
             }
-            let mut bind_info = &mut op.set.binding_infos[target_binding];
+            let bind_info = &mut op.set.binding_infos[target_binding];
             let mut src_cbv = None;
             let mut src_srv = None;
             let mut src_uav = None;
@@ -3406,11 +3398,11 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    unsafe fn set_event(&self, _event: &()) -> Result<(), d::OutOfMemory> {
+    unsafe fn set_event(&self, _event: &mut ()) -> Result<(), d::OutOfMemory> {
         unimplemented!()
     }
 
-    unsafe fn reset_event(&self, _event: &()) -> Result<(), d::OutOfMemory> {
+    unsafe fn reset_event(&self, _event: &mut ()) -> Result<(), d::OutOfMemory> {
         unimplemented!()
     }
 
@@ -3572,7 +3564,7 @@ impl d::Device<B> for Device {
 
     fn wait_idle(&self) -> Result<(), d::OutOfMemory> {
         for queue in &self.queues {
-            queue.wait_idle()?;
+            queue.wait_idle_impl()?;
         }
         Ok(())
     }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3187,13 +3187,11 @@ impl d::Device<B> for Device {
 
     unsafe fn copy_descriptor_sets<'a, I>(&self, copy_iter: I)
     where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetCopy<'a, B>>,
+        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, B>>,
     {
         let mut accum = descriptors_cpu::MultiCopyAccumulator::default();
 
-        for copy_wrap in copy_iter {
-            let copy = copy_wrap.borrow();
+        for copy in copy_iter {
             let src_info = &copy.src_set.binding_infos[copy.src_binding as usize];
             let dst_info = &copy.dst_set.binding_infos[copy.dst_binding as usize];
 
@@ -3353,7 +3351,7 @@ impl d::Device<B> for Device {
         })
     }
 
-    unsafe fn reset_fence(&self, fence: &r::Fence) -> Result<(), d::OutOfMemory> {
+    unsafe fn reset_fence(&self, fence: &mut r::Fence) -> Result<(), d::OutOfMemory> {
         assert_eq!(winerror::S_OK, fence.raw.signal(0));
         Ok(())
     }

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3224,7 +3224,7 @@ impl d::Device<B> for Device {
 
     unsafe fn map_memory(
         &self,
-        memory: &r::Memory,
+        memory: &mut r::Memory,
         segment: memory::Segment,
     ) -> Result<*mut u8, d::MapError> {
         let mem = memory
@@ -3239,7 +3239,7 @@ impl d::Device<B> for Device {
         Ok(ptr as *mut _)
     }
 
-    unsafe fn unmap_memory(&self, memory: &r::Memory) {
+    unsafe fn unmap_memory(&self, memory: &mut r::Memory) {
         if let Some(mem) = memory.resource {
             (*mem).Unmap(0, &d3d12::D3D12_RANGE { Begin: 0, End: 0 });
         }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -511,7 +511,7 @@ impl q::CommandQueue<Backend> for CommandQueue {
         &mut self,
         surface: &mut window::Surface,
         image: window::SwapchainImage,
-        _wait_semaphore: Option<&resource::Semaphore>,
+        _wait_semaphore: Option<&mut resource::Semaphore>,
     ) -> Result<Option<hal::window::Suboptimal>, hal::window::PresentError> {
         surface.present(image).map(|()| None)
     }

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -494,7 +494,7 @@ impl q::CommandQueue<Backend> for CommandQueue {
     unsafe fn submit<'a, T, Ic, S, Iw, Is>(
         &mut self,
         submission: q::Submission<Ic, Iw, Is>,
-        fence: Option<&resource::Fence>,
+        fence: Option<&mut resource::Fence>,
     ) where
         T: 'a + Borrow<command::CommandBuffer>,
         Ic: IntoIterator<Item = &'a T>,

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -179,7 +179,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
         &mut self,
         _surface: &mut Surface,
         _image: SwapchainImage,
-        _wait_semaphore: Option<&()>,
+        _wait_semaphore: Option<&mut ()>,
     ) -> Result<Option<window::Suboptimal>, window::PresentError> {
         Ok(None)
     }
@@ -420,8 +420,7 @@ impl device::Device<Backend> for Device {
 
     unsafe fn copy_descriptor_sets<'a, I>(&self, _: I)
     where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetCopy<'a, Backend>>,
+        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, Backend>>,
     {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
@@ -584,7 +583,7 @@ impl device::Device<Backend> for Device {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn reset_fence(&self, _: &()) -> Result<(), device::OutOfMemory> {
+    unsafe fn reset_fence(&self, _: &mut ()) -> Result<(), device::OutOfMemory> {
         Ok(())
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -410,18 +410,14 @@ impl device::Device<Backend> for Device {
         Ok(layout)
     }
 
-    unsafe fn write_descriptor_sets<'a, I, J>(&self, _: I)
+    unsafe fn write_descriptor_set<'a, I>(&self, _: pso::DescriptorSetWrite<'a, Backend, I>)
     where
-        I: IntoIterator<Item = pso::DescriptorSetWrite<'a, Backend, J>>,
-        J: IntoIterator,
-        J::Item: Borrow<pso::Descriptor<'a, Backend>>,
+        I: IntoIterator,
+        I::Item: Borrow<pso::Descriptor<'a, Backend>>,
     {
     }
 
-    unsafe fn copy_descriptor_sets<'a, I>(&self, _: I)
-    where
-        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, Backend>>,
-    {
+    unsafe fn copy_descriptor_set<'a>(&self, _: pso::DescriptorSetCopy<'a, Backend>) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -184,7 +184,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
         Ok(None)
     }
 
-    fn wait_idle(&self) -> Result<(), device::OutOfMemory> {
+    fn wait_idle(&mut self) -> Result<(), device::OutOfMemory> {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 }
@@ -441,11 +441,11 @@ impl device::Device<Backend> for Device {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn set_event(&self, _: &()) -> Result<(), device::OutOfMemory> {
+    unsafe fn set_event(&self, _: &mut ()) -> Result<(), device::OutOfMemory> {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn reset_event(&self, _: &()) -> Result<(), device::OutOfMemory> {
+    unsafe fn reset_event(&self, _: &mut ()) -> Result<(), device::OutOfMemory> {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -470,13 +470,13 @@ impl device::Device<Backend> for Device {
 
     unsafe fn map_memory(
         &self,
-        memory: &Memory,
+        memory: &mut Memory,
         segment: hal::memory::Segment,
     ) -> Result<*mut u8, device::MapError> {
         memory.map(segment)
     }
 
-    unsafe fn unmap_memory(&self, _memory: &Memory) {}
+    unsafe fn unmap_memory(&self, _memory: &mut Memory) {}
 
     unsafe fn flush_mapped_memory_ranges<'a, I>(&self, _: I) -> Result<(), device::OutOfMemory>
     where

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -165,7 +165,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
     unsafe fn submit<'a, T, Ic, S, Iw, Is>(
         &mut self,
         _: queue::Submission<Ic, Iw, Is>,
-        _: Option<&()>,
+        _: Option<&mut ()>,
     ) where
         T: 'a + Borrow<CommandBuffer>,
         Ic: IntoIterator<Item = &'a T>,

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -706,8 +706,9 @@ impl CommandBuffer {
         let mut set = first_set as usize;
         for desc_set in sets {
             let desc_set = desc_set.borrow();
-            let bindings = desc_set.bindings.lock();
-            for (binding_layout, new_binding) in desc_set.layout.iter().zip(bindings.iter()) {
+            for (binding_layout, new_binding) in
+                desc_set.layout.iter().zip(desc_set.bindings.iter())
+            {
                 let binding = layout.sets[set].bindings[binding_layout.binding as usize] as u32;
                 match *new_binding {
                     n::DescSetBindings::Buffer {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1767,12 +1767,9 @@ impl d::Device<B> for Device {
 
     unsafe fn copy_descriptor_sets<'a, I>(&self, copies: I)
     where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetCopy<'a, B>>,
+        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, B>>,
     {
         for copy in copies {
-            let copy = copy.borrow();
-
             let src_set = &copy.src_set;
             let dst_set = &copy.dst_set;
             if std::ptr::eq(src_set, dst_set) {
@@ -1808,7 +1805,7 @@ impl d::Device<B> for Device {
         Ok(n::Fence(cell))
     }
 
-    unsafe fn reset_fence(&self, fence: &n::Fence) -> Result<(), d::OutOfMemory> {
+    unsafe fn reset_fence(&self, fence: &mut n::Fence) -> Result<(), d::OutOfMemory> {
         fence.0.replace(n::FenceInner::Idle { signaled: false });
         Ok(())
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1904,11 +1904,11 @@ impl d::Device<B> for Device {
         unimplemented!()
     }
 
-    unsafe fn set_event(&self, _event: &()) -> Result<(), d::OutOfMemory> {
+    unsafe fn set_event(&self, _event: &mut ()) -> Result<(), d::OutOfMemory> {
         unimplemented!()
     }
 
-    unsafe fn reset_event(&self, _event: &()) -> Result<(), d::OutOfMemory> {
+    unsafe fn reset_event(&self, _event: &mut ()) -> Result<(), d::OutOfMemory> {
         unimplemented!()
     }
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -65,6 +65,7 @@ pub(crate) enum FenceInner {
     Pending(Option<<GlContext as glow::HasContext>::Fence>),
 }
 
+//TODO: reconsider the use of `Cell`
 #[derive(Debug)]
 pub struct Fence(pub(crate) Cell<FenceInner>);
 unsafe impl Send for Fence {}

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -6,7 +6,7 @@ use hal::{
     pass, pso, window as w,
 };
 
-use std::{borrow::Borrow, cell::Cell, ops::Range, sync::Arc};
+use std::{borrow::Borrow, ops::Range, sync::Arc};
 
 pub type TextureTarget = u32;
 pub type TextureFormat = u32;
@@ -285,7 +285,7 @@ pub struct Memory {
     /// Allocation size
     pub(crate) size: u64,
     pub(crate) map_flags: u32,
-    pub(crate) emulate_map_allocation: Cell<Option<*mut u8>>,
+    pub(crate) emulate_map_allocation: Option<*mut u8>,
 }
 
 unsafe impl Send for Memory {}

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -6,8 +6,6 @@ use hal::{
     pass, pso, window as w,
 };
 
-use parking_lot::Mutex;
-
 use std::{borrow::Borrow, cell::Cell, ops::Range, sync::Arc};
 
 pub type TextureTarget = u32;
@@ -242,7 +240,7 @@ pub(crate) enum DescSetBindings {
 pub struct DescriptorSet {
     pub(crate) layout: DescriptorSetLayout,
     //TODO: use `UnsafeCell` instead
-    pub(crate) bindings: Arc<Mutex<Vec<DescSetBindings>>>,
+    pub(crate) bindings: Vec<DescSetBindings>,
 }
 
 #[derive(Debug)]
@@ -255,7 +253,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
     ) -> Result<DescriptorSet, pso::AllocationError> {
         Ok(DescriptorSet {
             layout: Arc::clone(layout),
-            bindings: Arc::new(Mutex::new(Vec::new())),
+            bindings: Vec::new(),
         })
     }
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -57,15 +57,12 @@ impl Buffer {
 #[derive(Debug)]
 pub struct BufferView;
 
-#[derive(Copy, Clone, Debug)]
-pub(crate) enum FenceInner {
+#[derive(Debug)]
+pub enum Fence {
     Idle { signaled: bool },
-    Pending(Option<<GlContext as glow::HasContext>::Fence>),
+    Pending(<GlContext as glow::HasContext>::Fence),
 }
 
-//TODO: reconsider the use of `Cell`
-#[derive(Debug)]
-pub struct Fence(pub(crate) Cell<FenceInner>);
 unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}
 

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1115,7 +1115,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
         &mut self,
         surface: &mut Surface,
         image: native::SwapchainImage,
-        _wait_semaphore: Option<&native::Semaphore>,
+        _wait_semaphore: Option<&mut native::Semaphore>,
     ) -> Result<Option<hal::window::Suboptimal>, hal::window::PresentError> {
         surface.present(image, &self.share.context)
     }

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1120,7 +1120,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
         surface.present(image, &self.share.context)
     }
 
-    fn wait_idle(&self) -> Result<(), hal::device::OutOfMemory> {
+    fn wait_idle(&mut self) -> Result<(), hal::device::OutOfMemory> {
         unsafe {
             self.share.context.finish();
         }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2199,7 +2199,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
             wait_semaphores,
             signal_semaphores,
         }: hal::queue::Submission<Ic, Iw, Is>,
-        fence: Option<&native::Fence>,
+        fence: Option<&mut native::Fence>,
     ) where
         T: 'a + Borrow<CommandBuffer>,
         Ic: IntoIterator<Item = &'a T>,
@@ -2376,11 +2376,8 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
                 blocker.submit_impl(cmd_buffer);
 
                 if let Some(fence) = fence {
-                    debug!(
-                        "\tmarking fence ptr {:?} as pending",
-                        fence.0.raw() as *const _
-                    );
-                    *fence.0.lock() = native::FenceInner::PendingSubmission(cmd_buffer.to_owned());
+                    debug!("\tmarking fence as pending");
+                    *fence = native::Fence::PendingSubmission(cmd_buffer.to_owned());
                 }
             } else if let Some(cmd_buffer) = deferred_cmd_buffer {
                 blocker.submit_impl(cmd_buffer);

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2411,9 +2411,13 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
         &mut self,
         _surface: &mut window::Surface,
         image: window::SwapchainImage,
-        wait_semaphore: Option<&native::Semaphore>,
+        wait_semaphore: Option<&mut native::Semaphore>,
     ) -> Result<Option<Suboptimal>, PresentError> {
-        self.wait(wait_semaphore);
+        if let Some(semaphore) = wait_semaphore {
+            if let Some(ref system) = semaphore.system {
+                system.wait(!0);
+            }
+        }
 
         let queue = self.shared.queue.lock();
         let drawable = image.into_drawable();

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2434,7 +2434,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
         Ok(None)
     }
 
-    fn wait_idle(&self) -> Result<(), OutOfMemory> {
+    fn wait_idle(&mut self) -> Result<(), OutOfMemory> {
         QueueInner::wait_idle(&self.shared.queue);
         Ok(())
     }

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1893,7 +1893,7 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn map_memory(
         &self,
-        memory: &n::Memory,
+        memory: &mut n::Memory,
         segment: memory::Segment,
     ) -> Result<*mut u8, d::MapError> {
         let range = memory.resolve(&segment);
@@ -1906,7 +1906,7 @@ impl hal::device::Device<Backend> for Device {
         Ok(base_ptr.offset(range.start as _))
     }
 
-    unsafe fn unmap_memory(&self, memory: &n::Memory) {
+    unsafe fn unmap_memory(&self, memory: &mut n::Memory) {
         debug!("unmap_memory of size {}", memory.size);
     }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2370,8 +2370,7 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn copy_descriptor_sets<'a, I>(&self, copies: I)
     where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetCopy<'a, Backend>>,
+        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, Backend>>,
     {
         for _copy in copies {
             unimplemented!()
@@ -2963,7 +2962,7 @@ impl hal::device::Device<Backend> for Device {
         Ok(n::Fence(mutex))
     }
 
-    unsafe fn reset_fence(&self, fence: &n::Fence) -> Result<(), d::OutOfMemory> {
+    unsafe fn reset_fence(&self, fence: &mut n::Fence) -> Result<(), d::OutOfMemory> {
         debug!("Resetting fence ptr {:?}", fence.0.raw() as *const _);
         *fence.0.lock() = n::FenceInner::Idle { signaled: false };
         Ok(())

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -3014,13 +3014,13 @@ impl hal::device::Device<Backend> for Device {
         Ok(event.0.load(Ordering::Acquire))
     }
 
-    unsafe fn set_event(&self, event: &n::Event) -> Result<(), d::OutOfMemory> {
+    unsafe fn set_event(&self, event: &mut n::Event) -> Result<(), d::OutOfMemory> {
         event.0.store(true, Ordering::Release);
         self.shared.queue_blocker.lock().triage();
         Ok(())
     }
 
-    unsafe fn reset_event(&self, event: &n::Event) -> Result<(), d::OutOfMemory> {
+    unsafe fn reset_event(&self, event: &mut n::Event) -> Result<(), d::OutOfMemory> {
         Ok(event.0.store(false, Ordering::Release))
     }
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -879,6 +879,8 @@ pub struct UsedResource {
 #[derive(Debug)]
 pub enum DescriptorSet {
     Emulated {
+        //TODO: consider storing the descriptors right here,
+        // to reduce the amount of locking, e.g. in descriptor binding.
         pool: Arc<RwLock<DescriptorEmulatedPoolInner>>,
         layouts: Arc<Vec<DescriptorLayout>>,
         resources: ResourceData<Range<PoolResourceIndex>>,

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -998,6 +998,8 @@ pub enum FenceInner {
     PendingSubmission(metal::CommandBuffer),
 }
 
+//TODO: reconsider the `Mutex`
+// it's only used in `submit()`
 #[derive(Debug)]
 pub struct Fence(pub(crate) Mutex<FenceInner>);
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1009,6 +1009,7 @@ unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}
 
 //TODO: review the atomic ordering
+//TODO: reconsider if Arc<Atomic> is needed
 #[derive(Debug)]
 pub struct Event(pub(crate) Arc<AtomicBool>);
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -17,7 +17,7 @@ use range_alloc::RangeAllocator;
 use arrayvec::ArrayVec;
 use cocoa_foundation::foundation::NSRange;
 use metal;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use spirv_cross::{msl, spirv};
 
 use std::{
@@ -995,15 +995,10 @@ pub enum QueryPool {
 }
 
 #[derive(Debug)]
-pub enum FenceInner {
+pub enum Fence {
     Idle { signaled: bool },
     PendingSubmission(metal::CommandBuffer),
 }
-
-//TODO: reconsider the `Mutex`
-// it's only used in `submit()`
-#[derive(Debug)]
-pub struct Fence(pub(crate) Mutex<FenceInner>);
 
 unsafe impl Send for Fence {}
 unsafe impl Sync for Fence {}

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1936,7 +1936,7 @@ impl d::Device<B> for Device {
         }
     }
 
-    unsafe fn set_event(&self, event: &n::Event) -> Result<(), d::OutOfMemory> {
+    unsafe fn set_event(&self, event: &mut n::Event) -> Result<(), d::OutOfMemory> {
         let result = self.shared.raw.set_event(event.0);
         match result {
             Ok(()) => Ok(()),
@@ -1946,7 +1946,7 @@ impl d::Device<B> for Device {
         }
     }
 
-    unsafe fn reset_event(&self, event: &n::Event) -> Result<(), d::OutOfMemory> {
+    unsafe fn reset_event(&self, event: &mut n::Event) -> Result<(), d::OutOfMemory> {
         let result = self.shared.raw.reset_event(event.0);
         match result {
             Ok(()) => Ok(()),

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1764,7 +1764,7 @@ impl d::Device<B> for Device {
 
     unsafe fn map_memory(
         &self,
-        memory: &n::Memory,
+        memory: &mut n::Memory,
         segment: Segment,
     ) -> Result<*mut u8, d::MapError> {
         let result = self.shared.raw.map_memory(
@@ -1783,7 +1783,7 @@ impl d::Device<B> for Device {
         }
     }
 
-    unsafe fn unmap_memory(&self, memory: &n::Memory) {
+    unsafe fn unmap_memory(&self, memory: &mut n::Memory) {
         self.shared.raw.unmap_memory(memory.raw)
     }
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -15,7 +15,7 @@ use hal::{
 };
 
 use std::{
-    borrow::Borrow,
+    borrow::{Borrow, BorrowMut},
     ffi::{CStr, CString},
     mem,
     ops::Range,
@@ -1751,12 +1751,10 @@ impl d::Device<B> for Device {
 
     unsafe fn copy_descriptor_sets<'a, I>(&self, copies: I)
     where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetCopy<'a, B>>,
+        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, B>>,
         I::IntoIter: ExactSizeIterator,
     {
-        let copies = copies.into_iter().map(|copy| {
-            let c = copy.borrow();
+        let copies = copies.into_iter().map(|c| {
             vk::CopyDescriptorSet::builder()
                 .src_set(c.src_set.raw)
                 .src_binding(c.src_binding as u32)
@@ -1865,7 +1863,7 @@ impl d::Device<B> for Device {
     unsafe fn reset_fences<I>(&self, fences: I) -> Result<(), d::OutOfMemory>
     where
         I: IntoIterator,
-        I::Item: Borrow<n::Fence>,
+        I::Item: BorrowMut<n::Fence>,
         I::IntoIter: ExactSizeIterator,
     {
         let fences = fences.into_iter().map(|fence| fence.borrow().0);

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1502,7 +1502,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
         }
     }
 
-    fn wait_idle(&self) -> Result<(), OutOfMemory> {
+    fn wait_idle(&mut self) -> Result<(), OutOfMemory> {
         match unsafe { self.device.raw.queue_wait_idle(*self.raw) } {
             Ok(()) => Ok(()),
             Err(vk::Result::ERROR_OUT_OF_HOST_MEMORY) => Err(OutOfMemory::Host),

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1421,7 +1421,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
     unsafe fn submit<'a, T, Ic, S, Iw, Is>(
         &mut self,
         submission: queue::Submission<Ic, Iw, Is>,
-        fence: Option<&native::Fence>,
+        fence: Option<&mut native::Fence>,
     ) where
         T: 'a + Borrow<command::CommandBuffer>,
         Ic: IntoIterator<Item = &'a T>,

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1467,7 +1467,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
         &mut self,
         surface: &mut window::Surface,
         image: window::SurfaceImage,
-        wait_semaphore: Option<&native::Semaphore>,
+        wait_semaphore: Option<&mut native::Semaphore>,
     ) -> Result<Option<Suboptimal>, PresentError> {
         let ssc = surface.swapchain.as_ref().unwrap();
         let wait_semaphore = if let Some(wait_semaphore) = wait_semaphore {

--- a/src/backend/webgpu/src/command.rs
+++ b/src/backend/webgpu/src/command.rs
@@ -26,24 +26,13 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
     unsafe fn submit<'a, T, Ic, S, Iw, Is>(
         &mut self,
         _submission: Submission<Ic, Iw, Is>,
-        _fence: Option<&<Backend as hal::Backend>::Fence>,
+        _fence: Option<&mut <Backend as hal::Backend>::Fence>,
     ) where
         T: 'a + Borrow<<Backend as hal::Backend>::CommandBuffer>,
         Ic: IntoIterator<Item = &'a T>,
         S: 'a + Borrow<<Backend as hal::Backend>::Semaphore>,
         Iw: IntoIterator<Item = (&'a S, pso::PipelineStage)>,
         Is: IntoIterator<Item = &'a S>,
-    {
-        todo!()
-    }
-
-    unsafe fn submit_without_semaphores<'a, T, Ic>(
-        &mut self,
-        _command_buffers: Ic,
-        _fence: Option<&<Backend as hal::Backend>::Fence>,
-    ) where
-        T: 'a + Borrow<<Backend as hal::Backend>::CommandBuffer>,
-        Ic: IntoIterator<Item = &'a T>,
     {
         todo!()
     }
@@ -57,7 +46,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
         todo!()
     }
 
-    fn wait_idle(&self) -> Result<(), OutOfMemory> {
+    fn wait_idle(&mut self) -> Result<(), OutOfMemory> {
         todo!()
     }
 }

--- a/src/backend/webgpu/src/command.rs
+++ b/src/backend/webgpu/src/command.rs
@@ -52,7 +52,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
         &mut self,
         _surface: &mut <Backend as hal::Backend>::Surface,
         _image: <<Backend as hal::Backend>::Surface as PresentationSurface<Backend>>::SwapchainImage,
-        _wait_semaphore: Option<&<Backend as hal::Backend>::Semaphore>,
+        _wait_semaphore: Option<&mut <Backend as hal::Backend>::Semaphore>,
     ) -> Result<Option<Suboptimal>, PresentError> {
         todo!()
     }

--- a/src/backend/webgpu/src/device.rs
+++ b/src/backend/webgpu/src/device.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Borrow, ops::Range};
+use std::{
+    borrow::{Borrow, BorrowMut},
+    ops::Range,
+};
 
 use hal::{
     buffer,
@@ -350,8 +353,7 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn copy_descriptor_sets<'a, I>(&self, _copy_iter: I)
     where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetCopy<'a, Backend>>,
+        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, Backend>>,
     {
         todo!()
     }
@@ -401,7 +403,7 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn reset_fence(
         &self,
-        _fence: &<Backend as hal::Backend>::Fence,
+        _fence: &mut <Backend as hal::Backend>::Fence,
     ) -> Result<(), OutOfMemory> {
         todo!()
     }
@@ -409,7 +411,7 @@ impl hal::device::Device<Backend> for Device {
     unsafe fn reset_fences<I>(&self, _fences: I) -> Result<(), OutOfMemory>
     where
         I: IntoIterator,
-        I::Item: Borrow<<Backend as hal::Backend>::Fence>,
+        I::Item: BorrowMut<<Backend as hal::Backend>::Fence>,
     {
         todo!()
     }

--- a/src/backend/webgpu/src/device.rs
+++ b/src/backend/webgpu/src/device.rs
@@ -465,14 +465,14 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn set_event(
         &self,
-        _event: &<Backend as hal::Backend>::Event,
+        _event: &mut <Backend as hal::Backend>::Event,
     ) -> Result<(), OutOfMemory> {
         todo!()
     }
 
     unsafe fn reset_event(
         &self,
-        _event: &<Backend as hal::Backend>::Event,
+        _event: &mut <Backend as hal::Backend>::Event,
     ) -> Result<(), OutOfMemory> {
         todo!()
     }
@@ -500,7 +500,7 @@ impl hal::device::Device<Backend> for Device {
         todo!()
     }
 
-    fn wait_idle(&self) -> Result<(), OutOfMemory> {
+    fn wait_idle(&mut self) -> Result<(), OutOfMemory> {
         todo!()
     }
 

--- a/src/backend/webgpu/src/device.rs
+++ b/src/backend/webgpu/src/device.rs
@@ -342,25 +342,21 @@ impl hal::device::Device<Backend> for Device {
         todo!()
     }
 
-    unsafe fn write_descriptor_sets<'a, I, J>(&self, _write_iter: I)
+    unsafe fn write_descriptor_set<'a, I>(&self, _op: pso::DescriptorSetWrite<'a, Backend, I>)
     where
-        I: IntoIterator<Item = pso::DescriptorSetWrite<'a, Backend, J>>,
-        J: IntoIterator,
-        J::Item: Borrow<pso::Descriptor<'a, Backend>>,
+        I: IntoIterator,
+        I::Item: Borrow<pso::Descriptor<'a, Backend>>,
     {
         todo!()
     }
 
-    unsafe fn copy_descriptor_sets<'a, I>(&self, _copy_iter: I)
-    where
-        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, Backend>>,
-    {
+    unsafe fn copy_descriptor_set<'a>(&self, _op: pso::DescriptorSetCopy<'a, Backend>) {
         todo!()
     }
 
     unsafe fn map_memory(
         &self,
-        _memory: &<Backend as hal::Backend>::Memory,
+        _memory: &mut <Backend as hal::Backend>::Memory,
         _segment: Segment,
     ) -> Result<*mut u8, MapError> {
         todo!()
@@ -382,7 +378,7 @@ impl hal::device::Device<Backend> for Device {
         todo!()
     }
 
-    unsafe fn unmap_memory(&self, _memory: &<Backend as hal::Backend>::Memory) {
+    unsafe fn unmap_memory(&self, _memory: &mut <Backend as hal::Backend>::Memory) {
         todo!()
     }
 
@@ -494,13 +490,13 @@ impl hal::device::Device<Backend> for Device {
         _pool: &<Backend as hal::Backend>::QueryPool,
         _queries: Range<query::Id>,
         _data: &mut [u8],
-        _stride: buffer::Offset,
+        _stride: buffer::Stride,
         _flags: query::ResultFlags,
     ) -> Result<bool, WaitError> {
         todo!()
     }
 
-    fn wait_idle(&mut self) -> Result<(), OutOfMemory> {
+    fn wait_idle(&self) -> Result<(), OutOfMemory> {
         todo!()
     }
 

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -567,7 +567,11 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Map a memory object into application address space
     ///
     /// Call `map_memory()` to retrieve a host virtual address pointer to a region of a mappable memory object
-    unsafe fn map_memory(&self, memory: &B::Memory, segment: Segment) -> Result<*mut u8, MapError>;
+    unsafe fn map_memory(
+        &self,
+        memory: &mut B::Memory,
+        segment: Segment,
+    ) -> Result<*mut u8, MapError>;
 
     /// Flush mapped memory ranges
     unsafe fn flush_mapped_memory_ranges<'a, I>(&self, ranges: I) -> Result<(), OutOfMemory>
@@ -582,7 +586,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         I::Item: Borrow<(&'a B::Memory, Segment)>;
 
     /// Unmap a memory object once host access to it is no longer needed by the application
-    unsafe fn unmap_memory(&self, memory: &B::Memory);
+    unsafe fn unmap_memory(&self, memory: &mut B::Memory);
 
     /// Create a new semaphore object.
     fn create_semaphore(&self) -> Result<B::Semaphore, OutOfMemory>;

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -706,10 +706,10 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     unsafe fn get_event_status(&self, event: &B::Event) -> Result<bool, WaitError>;
 
     /// Sets an event.
-    unsafe fn set_event(&self, event: &B::Event) -> Result<(), OutOfMemory>;
+    unsafe fn set_event(&self, event: &mut B::Event) -> Result<(), OutOfMemory>;
 
     /// Resets an event.
-    unsafe fn reset_event(&self, event: &B::Event) -> Result<(), OutOfMemory>;
+    unsafe fn reset_event(&self, event: &mut B::Event) -> Result<(), OutOfMemory>;
 
     /// Create a new query pool object
     ///

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -554,18 +554,15 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Destroy a descriptor set layout object
     unsafe fn destroy_descriptor_set_layout(&self, layout: B::DescriptorSetLayout);
 
-    /// Specifying the parameters of a descriptor set write operation
-    unsafe fn write_descriptor_sets<'a, I, J>(&self, write_iter: I)
+    /// Specifying the parameters of a descriptor set write operation.
+    unsafe fn write_descriptor_set<'a, I>(&self, op: pso::DescriptorSetWrite<'a, B, I>)
     where
-        I: IntoIterator<Item = pso::DescriptorSetWrite<'a, B, J>>,
-        J: IntoIterator,
-        J::Item: Borrow<pso::Descriptor<'a, B>>;
+        I: IntoIterator,
+        I::IntoIter: ExactSizeIterator,
+        I::Item: Borrow<pso::Descriptor<'a, B>>;
 
-    /// Structure specifying a copy descriptor set operation
-    unsafe fn copy_descriptor_sets<'a, I>(&self, copy_iter: I)
-    where
-        I: IntoIterator<Item = pso::DescriptorSetCopy<'a, B>>,
-        I::IntoIter: ExactSizeIterator;
+    /// Structure specifying a copy descriptor set operation.
+    unsafe fn copy_descriptor_set<'a>(&self, op: pso::DescriptorSetCopy<'a, B>);
 
     /// Map a memory object into application address space
     ///

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -225,7 +225,7 @@ where
     WI::Item: Borrow<Descriptor<'a, B>>,
 {
     /// The descriptor set to modify.
-    pub set: &'a B::DescriptorSet,
+    pub set: &'a mut B::DescriptorSet,
     /// Binding index to start writing at.
     ///
     /// *Note*: when there are more descriptors provided than
@@ -256,7 +256,7 @@ pub enum Descriptor<'a, B: Backend> {
 /// Copies a range of descriptors to be bound from one descriptor set to another.
 ///
 /// Should be provided to the `copy_descriptor_sets` method of a `Device`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub struct DescriptorSetCopy<'a, B: Backend> {
     /// Descriptor set to copy from.
     pub src_set: &'a B::DescriptorSet,
@@ -270,7 +270,7 @@ pub struct DescriptorSetCopy<'a, B: Backend> {
     /// Offset into the descriptor array to start copying from.
     pub src_array_offset: DescriptorArrayIndex,
     /// Descriptor set to copy to.
-    pub dst_set: &'a B::DescriptorSet,
+    pub dst_set: &'a mut B::DescriptorSet,
     /// Binding to copy to.
     ///
     /// *Note*: when there are more descriptors provided than

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -131,7 +131,7 @@ pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
         &mut self,
         surface: &mut B::Surface,
         image: <B::Surface as PresentationSurface<B>>::SwapchainImage,
-        wait_semaphore: Option<&B::Semaphore>,
+        wait_semaphore: Option<&mut B::Semaphore>,
     ) -> Result<Option<Suboptimal>, PresentError>;
 
     /// Wait for the queue to be idle.

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -96,7 +96,7 @@ pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
     unsafe fn submit<'a, T, Ic, S, Iw, Is>(
         &mut self,
         submission: Submission<Ic, Iw, Is>,
-        fence: Option<&B::Fence>,
+        fence: Option<&mut B::Fence>,
     ) where
         T: 'a + Borrow<B::CommandBuffer>,
         Ic: IntoIterator<Item = &'a T>,
@@ -108,7 +108,7 @@ pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
     unsafe fn submit_without_semaphores<'a, T, Ic>(
         &mut self,
         command_buffers: Ic,
-        fence: Option<&B::Fence>,
+        fence: Option<&mut B::Fence>,
     ) where
         T: 'a + Borrow<B::CommandBuffer>,
         Ic: IntoIterator<Item = &'a T>,

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -135,5 +135,5 @@ pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
     ) -> Result<Option<Suboptimal>, PresentError>;
 
     /// Wait for the queue to be idle.
-    fn wait_idle(&self) -> Result<(), OutOfMemory>;
+    fn wait_idle(&mut self) -> Result<(), OutOfMemory>;
 }

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -37,12 +37,12 @@
 //! # let device: empty::Device = return;
 //! # let mut present_queue: empty::CommandQueue = return;
 //! # unsafe {
-//! let render_semaphore = device.create_semaphore().unwrap();
+//! let mut render_semaphore = device.create_semaphore().unwrap();
 //!
 //! let (frame, suboptimal) = surface.acquire_image(!0).unwrap();
 //! // render the scene..
 //! // `render_semaphore` will be signalled once rendering has been finished
-//! present_queue.present(&mut surface, frame, Some(&render_semaphore));
+//! present_queue.present(&mut surface, frame, Some(&mut render_semaphore));
 //! # }}
 //! ```
 //!

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -1568,13 +1568,13 @@ impl<B: hal::Backend> Scene<B> {
             cmd_buffer.finish()
         }
 
-        let copy_fence = self
+        let mut copy_fence = self
             .device
             .create_fence(false)
             .expect("Can't create copy-fence");
         unsafe {
             self.queue_group.queues[0]
-                .submit_without_semaphores(iter::once(&cmd_buffer), Some(&copy_fence));
+                .submit_without_semaphores(iter::once(&cmd_buffer), Some(&mut copy_fence));
             self.device.wait_for_fence(&copy_fence, !0).unwrap();
             self.device.destroy_fence(copy_fence);
             self.device.destroy_command_pool(command_pool);
@@ -1707,13 +1707,13 @@ impl<B: hal::Backend> Scene<B> {
             cmd_buffer.finish();
         }
 
-        let copy_fence = self
+        let mut copy_fence = self
             .device
             .create_fence(false)
             .expect("Can't create copy-fence");
         unsafe {
             self.queue_group.queues[0]
-                .submit_without_semaphores(iter::once(&cmd_buffer), Some(&copy_fence));
+                .submit_without_semaphores(iter::once(&cmd_buffer), Some(&mut copy_fence));
             self.device.wait_for_fence(&copy_fence, !0).unwrap();
             self.device.destroy_fence(copy_fence);
             self.device.destroy_command_pool(command_pool);

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -774,7 +774,7 @@ impl<B: hal::Backend> Scene<B> {
                 } => {
                     // create a descriptor set
                     let (ref binding_indices, ref set_layout) = resources.desc_set_layouts[layout];
-                    let desc_set = unsafe {
+                    let mut desc_set = unsafe {
                         resources
                             .desc_pools
                             .get_mut(pool)
@@ -786,11 +786,10 @@ impl<B: hal::Backend> Scene<B> {
                         set_layout
                     ));
                     // fill it up
-                    let mut writes = Vec::new();
                     let mut views = Vec::new();
                     for (&binding, range) in binding_indices.iter().zip(data) {
-                        writes.push(hal::pso::DescriptorSetWrite {
-                            set: &desc_set,
+                        let write = hal::pso::DescriptorSetWrite {
+                            set: &mut desc_set,
                             binding,
                             array_offset: 0,
                             descriptors: match *range {
@@ -831,10 +830,10 @@ impl<B: hal::Backend> Scene<B> {
                                     })
                                     .collect::<Vec<_>>(),
                             },
-                        });
-                    }
-                    unsafe {
-                        device.write_descriptor_sets(writes);
+                        };
+                        unsafe {
+                            device.write_descriptor_set(write);
+                        }
                     }
                     resources.desc_sets.insert(
                         name.clone(),


### PR DESCRIPTION
~~The external sync in these objects *almost* allows us to simplify the implementations, but not really. So it's sort of a waste, but there is no reason to diverge from Vulkan here.~~
This allows our backends to do less locking! 🎉 

Fixes #3551 
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
