### PR TITLE
Fix WebGPU build to use buffer::Stride

### DIFF
--- a/src/backend/webgpu/src/command.rs
+++ b/src/backend/webgpu/src/command.rs
@@ -519,7 +519,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _queries: Range<query::Id>,
         _buffer: &<Backend as hal::Backend>::Buffer,
         _offset: buffer::Offset,
-        _stride: buffer::Offset,
+        _stride: buffer::Stride,
         _flags: query::ResultFlags,
     ) {
         todo!()

--- a/src/backend/webgpu/src/device.rs
+++ b/src/backend/webgpu/src/device.rs
@@ -492,7 +492,7 @@ impl hal::device::Device<Backend> for Device {
         _pool: &<Backend as hal::Backend>::QueryPool,
         _queries: Range<query::Id>,
         _data: &mut [u8],
-        _stride: buffer::Offset,
+        _stride: buffer::Stride,
         _flags: query::ResultFlags,
     ) -> Result<bool, WaitError> {
         todo!()


### PR DESCRIPTION
Fixing the parts of the WebGPU build I broke in #3546, since it's not included in the `make` build.