### PR TITLE
Add WebGPU backend build to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,17 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
       - run: cargo build --manifest-path examples/Cargo.toml --features gl --target wasm32-unknown-unknown --bin quad
 
+  webgpu_backend_build:
+    name: WebGPU
+    runs-on: ubuntu-18.04
+    continue-on-error: true
+    env:
+      RUSTFLAGS: --cfg=web_sys_unstable_apis
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup target add wasm32-unknown-unknown
+      - run: cargo build --manifest-path src/backend/webgpu/Cargo.toml --target wasm32-unknown-unknown
+
   check-advisories:
     name: Advisory Check
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Add an optional CI task to build the WebGPU backend on the `wasm32-unknown-unknown` target.

Note: This is just a test to see if we can at least see the status of the WebGPU build in the Ci pipeline. It may not be worth merging until the WebGPU backend is more mature, since it may just add noise for now.