### PR TITLE
WIP remove framebuffer object

### DIFF
--- a/examples/mesh-shading/main.rs
+++ b/examples/mesh-shading/main.rs
@@ -558,20 +558,6 @@ where
             }
         };
 
-        let framebuffer = unsafe {
-            self.device
-                .create_framebuffer(
-                    &self.render_pass,
-                    iter::once(surface_image.borrow()),
-                    i::Extent {
-                        width: self.dimensions.width,
-                        height: self.dimensions.height,
-                        depth: 1,
-                    },
-                )
-                .unwrap()
-        };
-
         // Compute index into our resource ring buffers based on the frame number
         // and number of frames in flight. Pay close attention to where this index is needed
         // versus when the swapchain image index we got from acquire_image is needed.
@@ -610,13 +596,15 @@ where
 
             cmd_buffer.begin_render_pass(
                 &self.render_pass,
-                &framebuffer,
-                self.viewport.rect,
-                &[command::ClearValue {
-                    color: command::ClearColor {
-                        float32: [0.8, 0.8, 0.8, 1.0],
+                iter::once(command::RenderAttachmentInfo {
+                    image_view: surface_image.borrow(),
+                    clear_value: command::ClearValue {
+                        color: command::ClearColor {
+                            float32: [0.8, 0.8, 0.8, 1.0],
+                        },
                     },
-                }],
+                }),
+                self.viewport.rect,
                 command::SubpassContents::Inline,
             );
             cmd_buffer.draw_mesh_tasks(1, 0);
@@ -639,8 +627,6 @@ where
                 surface_image,
                 Some(&mut self.submission_complete_semaphores[frame_idx]),
             );
-
-            self.device.destroy_framebuffer(framebuffer);
 
             if result.is_err() {
                 self.recreate_swapchain();

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -40,7 +40,6 @@ impl hal::Backend for Backend {
 
     type ShaderModule = ();
     type RenderPass = ();
-    type Framebuffer = ();
 
     type Buffer = Buffer;
     type BufferView = ();
@@ -168,10 +167,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
         _: Option<&mut ()>,
     ) where
         T: 'a + Borrow<CommandBuffer>,
-        Ic: IntoIterator<Item = &'a T>,
         S: 'a + Borrow<()>,
-        Iw: IntoIterator<Item = (&'a S, pso::PipelineStage)>,
-        Is: IntoIterator<Item = &'a S>,
     {
     }
 
@@ -218,23 +214,17 @@ impl device::Device<Backend> for Device {
         _: ID,
     ) -> Result<(), device::OutOfMemory>
     where
-        IA: IntoIterator,
-        IA::Item: Borrow<pass::Attachment>,
         IS: IntoIterator,
         IS::Item: Borrow<pass::SubpassDesc<'a>>,
-        ID: IntoIterator,
-        ID::Item: Borrow<pass::SubpassDependency>,
     {
         Ok(())
     }
 
-    unsafe fn create_pipeline_layout<IS, IR>(&self, _: IS, _: IR) -> Result<(), device::OutOfMemory>
-    where
-        IS: IntoIterator,
-        IS::Item: Borrow<DescriptorSetLayout>,
-        IR: IntoIterator,
-        IR::Item: Borrow<(pso::ShaderStageFlags, Range<u32>)>,
-    {
+    unsafe fn create_pipeline_layout<IS, IR>(
+        &self,
+        _: IS,
+        _: IR,
+    ) -> Result<(), device::OutOfMemory> {
         Ok(())
     }
 
@@ -269,25 +259,8 @@ impl device::Device<Backend> for Device {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn merge_pipeline_caches<I>(&self, _: &(), _: I) -> Result<(), device::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<()>,
-    {
+    unsafe fn merge_pipeline_caches<I>(&self, _: &(), _: I) -> Result<(), device::OutOfMemory> {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
-    }
-
-    unsafe fn create_framebuffer<I>(
-        &self,
-        _: &(),
-        _: I,
-        _: hal::image::Extent,
-    ) -> Result<(), device::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<()>,
-    {
-        Ok(())
     }
 
     unsafe fn create_shader_module(&self, _: &[u32]) -> Result<(), device::ShaderError> {
@@ -385,11 +358,7 @@ impl device::Device<Backend> for Device {
         _: usize,
         _: I,
         _: pso::DescriptorPoolCreateFlags,
-    ) -> Result<DescriptorPool, device::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorRangeDesc>,
-    {
+    ) -> Result<DescriptorPool, device::OutOfMemory> {
         Ok(DescriptorPool)
     }
 
@@ -397,13 +366,7 @@ impl device::Device<Backend> for Device {
         &self,
         _bindings: I,
         _samplers: J,
-    ) -> Result<DescriptorSetLayout, device::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetLayoutBinding>,
-        J: IntoIterator,
-        J::Item: Borrow<()>,
-    {
+    ) -> Result<DescriptorSetLayout, device::OutOfMemory> {
         let layout = DescriptorSetLayout {
             name: String::new(),
         };
@@ -509,7 +472,6 @@ impl device::Device<Backend> for Device {
     unsafe fn destroy_compute_pipeline(&self, _: ()) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
-    unsafe fn destroy_framebuffer(&self, _: ()) {}
 
     unsafe fn destroy_buffer(&self, _: Buffer) {}
 
@@ -556,10 +518,6 @@ impl device::Device<Backend> for Device {
     }
 
     unsafe fn set_fence_name(&self, _: &mut (), _: &str) {
-        unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
-    }
-
-    unsafe fn set_framebuffer_name(&self, _: &mut (), _: &str) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -619,10 +577,7 @@ impl pool::CommandPool<Backend> for CommandPool {
 
     unsafe fn reset(&mut self, _: bool) {}
 
-    unsafe fn free<I>(&mut self, _: I)
-    where
-        I: IntoIterator<Item = CommandBuffer>,
-    {
+    unsafe fn free<I>(&mut self, _: I) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 }
@@ -631,10 +586,10 @@ impl pool::CommandPool<Backend> for CommandPool {
 #[derive(Debug)]
 pub struct CommandBuffer;
 impl command::CommandBuffer<Backend> for CommandBuffer {
-    unsafe fn begin(
+    unsafe fn begin<I>(
         &mut self,
         _: command::CommandBufferFlags,
-        _: command::CommandBufferInheritanceInfo<Backend>,
+        _: command::CommandBufferInheritanceInfo<Backend, I>,
     ) {
     }
 
@@ -669,20 +624,11 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: hal::image::Layout,
         _: command::ClearValue,
         _: T,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<hal::image::SubresourceRange>,
-    {
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn clear_attachments<T, U>(&mut self, _: T, _: U)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<command::AttachmentClear>,
-        U: IntoIterator,
-        U::Item: Borrow<pso::ClearRect>,
-    {
+    unsafe fn clear_attachments<T, U>(&mut self, _: T, _: U) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -693,10 +639,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Image,
         _: hal::image::Layout,
         _: T,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ImageResolve>,
-    {
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -708,10 +651,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: hal::image::Layout,
         _: hal::image::Filter,
         _: T,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ImageBlit>,
-    {
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -724,26 +664,11 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn bind_vertex_buffers<I, T>(&mut self, _: u32, _: I)
-    where
-        I: IntoIterator<Item = (T, hal::buffer::SubRange)>,
-        T: Borrow<Buffer>,
-    {
-    }
+    unsafe fn bind_vertex_buffers<I, T>(&mut self, _: u32, _: I) {}
 
-    unsafe fn set_viewports<T>(&mut self, _: u32, _: T)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<pso::Viewport>,
-    {
-    }
+    unsafe fn set_viewports<T>(&mut self, _: u32, _: T) {}
 
-    unsafe fn set_scissors<T>(&mut self, _: u32, _: T)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<pso::Rect>,
-    {
-    }
+    unsafe fn set_scissors<T>(&mut self, _: u32, _: T) {}
 
     unsafe fn set_stencil_reference(&mut self, _: pso::Face, _: pso::StencilValue) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
@@ -773,16 +698,14 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn begin_render_pass<T>(
+    unsafe fn begin_render_pass<'a, T>(
         &mut self,
         _: &(),
-        _: &(),
-        _: pso::Rect,
         _: T,
+        _: pso::Rect,
         _: command::SubpassContents,
     ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ClearValue>,
+        T: IntoIterator<Item = command::RenderAttachmentInfo<'a, Backend>>,
     {
     }
 
@@ -794,13 +717,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn bind_graphics_pipeline(&mut self, _: &()) {}
 
-    unsafe fn bind_graphics_descriptor_sets<I, J>(&mut self, _: &(), _: usize, _: I, _: J)
-    where
-        I: IntoIterator,
-        I::Item: Borrow<DescriptorSet>,
-        J: IntoIterator,
-        J::Item: Borrow<command::DescriptorSetOffset>,
-    {
+    unsafe fn bind_graphics_descriptor_sets<I, J>(&mut self, _: &(), _: usize, _: I, _: J) {
         // Do nothing
     }
 
@@ -808,13 +725,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn bind_compute_descriptor_sets<I, J>(&mut self, _: &(), _: usize, _: I, _: J)
-    where
-        I: IntoIterator,
-        I::Item: Borrow<DescriptorSet>,
-        J: IntoIterator,
-        J::Item: Borrow<command::DescriptorSetOffset>,
-    {
+    unsafe fn bind_compute_descriptor_sets<I, J>(&mut self, _: &(), _: usize, _: I, _: J) {
         // Do nothing
     }
 
@@ -826,11 +737,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn copy_buffer<T>(&mut self, _: &Buffer, _: &Buffer, _: T)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<command::BufferCopy>,
-    {
+    unsafe fn copy_buffer<T>(&mut self, _: &Buffer, _: &Buffer, _: T) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -841,25 +748,26 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Image,
         _: hal::image::Layout,
         _: T,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ImageCopy>,
-    {
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn copy_buffer_to_image<T>(&mut self, _: &Buffer, _: &Image, _: hal::image::Layout, _: T)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<command::BufferImageCopy>,
-    {
+    unsafe fn copy_buffer_to_image<T>(
+        &mut self,
+        _: &Buffer,
+        _: &Image,
+        _: hal::image::Layout,
+        _: T,
+    ) {
     }
 
-    unsafe fn copy_image_to_buffer<T>(&mut self, _: &Image, _: hal::image::Layout, _: &Buffer, _: T)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<command::BufferImageCopy>,
-    {
+    unsafe fn copy_image_to_buffer<T>(
+        &mut self,
+        _: &Image,
+        _: hal::image::Layout,
+        _: &Buffer,
+        _: T,
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -949,8 +857,6 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn wait_events<'a, I, J>(&mut self, _: I, _: Range<pso::PipelineStage>, _: J)
     where
-        I: IntoIterator,
-        I::Item: Borrow<()>,
         J: IntoIterator,
         J::Item: Borrow<hal::memory::Barrier<'a, Backend>>,
     {

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use crate::{GlContext, MAX_SAMPLERS, MAX_TEXTURE_SLOTS, MAX_COLOR_ATTACHMENTS};
+use crate::{GlContext, MAX_COLOR_ATTACHMENTS, MAX_SAMPLERS, MAX_TEXTURE_SLOTS};
 
 use hal::{
     self, buffer, command,
@@ -536,7 +536,7 @@ impl CommandBuffer {
             // TODO: handle case where we don't do double-buffering?
             vec![glow::BACK_LEFT]
         } else {
-            (glow::COLOR_ATTACHMENT0 ..)
+            (glow::COLOR_ATTACHMENT0..)
                 .take(subpass.color_attachments.len())
                 .collect()
         };

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -534,12 +534,9 @@ impl CommandBuffer {
             // TODO: handle case where we don't do double-buffering?
             vec![glow::BACK_LEFT]
         } else {
-            subpass
-                .color_attachments
-                .iter()
-                .enumerate()
-                .map(|(index, _)| glow::COLOR_ATTACHMENT0 + index as u32)
-                .collect::<Vec<_>>()
+            (glow::COLOR_ATTACHMENT0 ..)
+                .take(subpass.color_attachments.len())
+                .collect()
         };
 
         // Record commands
@@ -757,10 +754,10 @@ impl CommandBuffer {
 }
 
 impl command::CommandBuffer<Backend> for CommandBuffer {
-    unsafe fn begin(
+    unsafe fn begin<'a, I>(
         &mut self,
         _flags: command::CommandBufferFlags,
-        _inheritance_info: command::CommandBufferInheritanceInfo<Backend>,
+        _inheritance_info: command::CommandBufferInheritanceInfo<Backend, I>,
     ) {
         // TODO: Implement flags!
         if self.individual_reset {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -190,7 +190,7 @@ impl Device {
         Ok((program, sampler_map))
     }
 
-    fn bind_target_compat(gl: &GlContainer, point: u32, attachment: u32, view: &n::ImageView) {
+    pub(crate) fn bind_target_compat(gl: &GlContainer, point: u32, attachment: u32, view: &n::ImageView) {
         match *view {
             n::ImageView::Renderbuffer { raw: rb, .. } => unsafe {
                 gl.framebuffer_renderbuffer(point, attachment, glow::RENDERBUFFER, Some(rb));

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1078,14 +1078,11 @@ impl d::Device<B> for Device {
             let name = gl.create_framebuffer().unwrap();
             gl.bind_framebuffer(target, Some(name));
 
-            for (index, &color) in subpass.color_attachments.iter().enumerate() {
-                let color_attachment = glow::COLOR_ATTACHMENT0 + index as u32;
-                assert!(color_attachment <= glow::COLOR_ATTACHMENT31);
-
+            for (bind_point, &color) in (glow::COLOR_ATTACHMENT0 .. ).zip(subpass.color_attachments.iter()) {
                 if self.share.private_caps.framebuffer_texture {
-                    Self::bind_target(gl, target, color_attachment, &attachments[color]);
+                    Self::bind_target(gl, target, bind_point, &attachments[color]);
                 } else {
-                    Self::bind_target_compat(gl, target, color_attachment, &attachments[color]);
+                    Self::bind_target_compat(gl, target, bind_point, &attachments[color]);
                 }
             }
 
@@ -2038,10 +2035,6 @@ impl d::Device<B> for Device {
     }
 
     unsafe fn set_fence_name(&self, _fence: &mut n::Fence, _name: &str) {
-        // TODO
-    }
-
-    unsafe fn set_framebuffer_name(&self, _framebuffer: &mut n::FrameBuffer, _name: &str) {
         // TODO
     }
 

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -190,7 +190,12 @@ impl Device {
         Ok((program, sampler_map))
     }
 
-    pub(crate) fn bind_target_compat(gl: &GlContainer, point: u32, attachment: u32, view: &n::ImageView) {
+    pub(crate) fn bind_target_compat(
+        gl: &GlContainer,
+        point: u32,
+        attachment: u32,
+        view: &n::ImageView,
+    ) {
         match *view {
             n::ImageView::Renderbuffer { raw: rb, .. } => unsafe {
                 gl.framebuffer_renderbuffer(point, attachment, glow::RENDERBUFFER, Some(rb));

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -376,7 +376,9 @@ pub(crate) fn query_all(
         min_storage_buffer_offset_alignment,
         framebuffer_color_sample_counts: max_samples_mask,
         non_coherent_atom_size: 1,
-        max_color_attachments: get_usize(gl, glow::MAX_COLOR_ATTACHMENTS).unwrap_or(1).min(MAX_COLOR_ATTACHMENTS),
+        max_color_attachments: get_usize(gl, glow::MAX_COLOR_ATTACHMENTS)
+            .unwrap_or(1)
+            .min(MAX_COLOR_ATTACHMENTS),
         ..Limits::default()
     };
 

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -1,4 +1,4 @@
-use crate::{Error, GlContainer};
+use crate::{Error, GlContainer, MAX_COLOR_ATTACHMENTS};
 use glow::HasContext;
 use hal::{Features, Hints, Limits};
 use std::{collections::HashSet, fmt, str};
@@ -376,7 +376,7 @@ pub(crate) fn query_all(
         min_storage_buffer_offset_alignment,
         framebuffer_color_sample_counts: max_samples_mask,
         non_coherent_atom_size: 1,
-        max_color_attachments: get_usize(gl, glow::MAX_COLOR_ATTACHMENTS).unwrap_or(1),
+        max_color_attachments: get_usize(gl, glow::MAX_COLOR_ATTACHMENTS).unwrap_or(1).min(MAX_COLOR_ATTACHMENTS),
         ..Limits::default()
     };
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -65,6 +65,7 @@ type ColorSlot = u8;
 const MAX_SAMPLERS: usize = 16;
 //TODO: has to be within glow::MAX_COMBINED_TEXTURE_IMAGE_UNITS
 const MAX_TEXTURE_SLOTS: usize = 16;
+const MAX_COLOR_ATTACHMENTS: usize = 8;
 
 struct GlContainer {
     context: GlContext,

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -18,6 +18,7 @@ pub type RawBuffer = <GlContext as glow::HasContext>::Buffer;
 pub type Shader = <GlContext as glow::HasContext>::Shader;
 pub type Program = <GlContext as glow::HasContext>::Program;
 pub type Renderbuffer = <GlContext as glow::HasContext>::Renderbuffer;
+pub type Framebuffer = <GlContext as glow::HasContext>::Framebuffer;
 pub type Texture = <GlContext as glow::HasContext>::Texture;
 pub type Sampler = <GlContext as glow::HasContext>::Sampler;
 // TODO: UniformLocation was copy in glow 0.3, but in 0.4 it isn't. Wrap it in a Starc for now
@@ -25,11 +26,10 @@ pub type Sampler = <GlContext as glow::HasContext>::Sampler;
 pub type UniformLocation = crate::Starc<<GlContext as glow::HasContext>::UniformLocation>;
 pub type DescriptorSetLayout = Arc<Vec<pso::DescriptorSetLayoutBinding>>;
 
-pub type RawFrameBuffer = <GlContext as glow::HasContext>::Framebuffer;
-
-#[derive(Clone, Debug)]
-pub struct FrameBuffer {
-    pub(crate) fbos: Vec<Option<RawFrameBuffer>>,
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub(crate) struct FramebufferKey {
+    pub colors: ArrayVec<[native::ImageView; MAX_COLOR_ATTACHMENTS]>,
+    pub depth_stencil: Option<native::ImageView>,
 }
 
 #[derive(Debug)]

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -56,7 +56,7 @@ pub enum BufferMemory {
 
 #[derive(Debug)]
 pub struct CommandPool {
-    pub(crate) fbo: Option<n::RawFrameBuffer>,
+    pub(crate) fbo: Option<n::Framebuffer>,
     pub(crate) limits: command::Limits,
     pub(crate) memory: Arc<Mutex<BufferMemory>>,
     pub(crate) legacy_features: info::LegacyFeatures,

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -182,7 +182,10 @@ impl CommandQueue {
         &data[ptr.offset as usize..(ptr.offset + ptr.size) as usize]
     }
 
-    fn make_framebuffer(&mut self, key: native::FramebufferKey) -> Result<native::Framebuffer, hal::device::OutOfMemory> {
+    fn make_framebuffer(
+        &mut self,
+        key: native::FramebufferKey,
+    ) -> Result<native::Framebuffer, hal::device::OutOfMemory> {
         if !self.share.private_caps.framebuffer {
             return Err(hal::device::OutOfMemory::Host);
         }
@@ -193,7 +196,7 @@ impl CommandQueue {
         let framebuffer = gl.create_framebuffer().unwrap();
         gl.bind_framebuffer(target, Some(framebuffer));
 
-        for (bind_point, view) in (glow::COLOR_ATTACHMENT0 .. ).zip(key.colors.iter()) {
+        for (bind_point, view) in (glow::COLOR_ATTACHMENT0..).zip(key.colors.iter()) {
             if self.share.private_caps.framebuffer_texture {
                 Device::bind_target(gl, target, bind_point, view);
             } else {

--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -13,7 +13,7 @@ pub struct Swapchain {
     pub(crate) extent: window::Extent2D,
     pub(crate) channel: f::ChannelType,
     pub(crate) raw_format: native::TextureFormat,
-    pub(crate) frame_buffers: ArrayVec<[native::RawFrameBuffer; 3]>,
+    pub(crate) frame_buffers: ArrayVec<[native::Framebuffer; 3]>,
 }
 
 #[derive(Debug)]

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1797,25 +1797,6 @@ impl hal::device::Device<Backend> for Device {
             })
     }
 
-    unsafe fn create_framebuffer<I>(
-        &self,
-        _render_pass: &n::RenderPass,
-        attachments: I,
-        extent: image::Extent,
-    ) -> Result<n::Framebuffer, d::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<n::ImageView>,
-    {
-        Ok(n::Framebuffer {
-            extent,
-            attachments: attachments
-                .into_iter()
-                .map(|at| at.borrow().texture.clone())
-                .collect(),
-        })
-    }
-
     unsafe fn create_shader_module(
         &self,
         raw_data: &[u32],
@@ -2377,8 +2358,6 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn destroy_compute_pipeline(&self, _pipeline: n::ComputePipeline) {}
 
-    unsafe fn destroy_framebuffer(&self, _buffer: n::Framebuffer) {}
-
     unsafe fn destroy_semaphore(&self, _semaphore: n::Semaphore) {}
 
     unsafe fn allocate_memory(
@@ -2933,6 +2912,7 @@ impl hal::device::Device<Backend> for Device {
         Ok(n::ImageView {
             texture,
             mtl_format,
+            extent: image.kind.level_extent(range.level_start),
         })
     }
 
@@ -3192,8 +3172,6 @@ impl hal::device::Device<Backend> for Device {
     unsafe fn set_semaphore_name(&self, _semaphore: &mut n::Semaphore, _name: &str) {}
 
     unsafe fn set_fence_name(&self, _fence: &mut n::Fence, _name: &str) {}
-
-    unsafe fn set_framebuffer_name(&self, _framebuffer: &mut n::Framebuffer, _name: &str) {}
 
     unsafe fn set_render_pass_name(&self, render_pass: &mut n::RenderPass, name: &str) {
         render_pass.name = name.to_string();

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -468,7 +468,6 @@ impl hal::Backend for Backend {
 
     type ShaderModule = native::ShaderModule;
     type RenderPass = native::RenderPass;
-    type Framebuffer = native::Framebuffer;
 
     type Buffer = native::Buffer;
     type BufferView = native::BufferView;

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -99,15 +99,6 @@ pub struct RenderPass {
     pub(crate) name: String,
 }
 
-#[derive(Debug)]
-pub struct Framebuffer {
-    pub(crate) extent: image::Extent,
-    pub(crate) attachments: Vec<metal::Texture>,
-}
-
-unsafe impl Send for Framebuffer {}
-unsafe impl Sync for Framebuffer {}
-
 #[derive(Clone, Debug)]
 pub struct ResourceData<T> {
     pub buffers: T,
@@ -381,6 +372,8 @@ unsafe impl Sync for BufferView {}
 pub struct ImageView {
     pub(crate) texture: metal::Texture,
     pub(crate) mtl_format: metal::MTLPixelFormat,
+    // This extent is always considered 2D.
+    pub(crate) extent: image::Extent,
 }
 
 unsafe impl Send for ImageView {}

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -286,6 +286,11 @@ impl w::PresentationSurface<Backend> for Surface {
             view: native::ImageView {
                 texture,
                 mtl_format: self.swapchain_format,
+                extent: image::Extent {
+                    width: size.width as u32,
+                    height: size.height as u32,
+                    depth: 1,
+                },
             },
             drawable,
         };

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -22,12 +22,14 @@ name = "gfx_backend_vulkan"
 [dependencies]
 arrayvec = "0.5"
 byteorder = "1"
+fxhash = "0.2.1"
 log = { version = "0.4" }
 lazy_static = "1"
 shared_library = { version = "0.1.9", optional = true }
 ash = "0.31"
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
 smallvec = "1.0"
+parking_lot = "0.11"
 raw-window-handle = "0.3"
 inplace_it = "0.3.2"
 

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -264,7 +264,6 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         first_subpass: com::SubpassContents,
     ) where
         T: IntoIterator<Item = com::RenderAttachmentInfo<'a, Backend>>,
-        T::IntoIter: ExactSizeIterator,
     {
         let render_area = conv::map_rect(&render_area);
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1454,7 +1454,10 @@ impl d::Device<B> for Device {
                     height: (image.extent.height >> range.level_start).max(1),
                     depth: match kind {
                         image::ViewKind::D3 => (image.extent.depth >> range.level_start).max(1),
-                        _ => range.layer_count.unwrap_or(image.array_layers - range.layer_start) as u32,
+                        _ => range
+                            .layer_count
+                            .unwrap_or(image.array_layers - range.layer_start)
+                            as u32,
                     },
                 },
                 range,

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -1,6 +1,6 @@
-use crate::{window::FramebufferCachePtr, Backend, RawDevice};
+use crate::{Backend, RawDevice};
 use ash::{version::DeviceV1_0, vk};
-use hal::{device::OutOfMemory, image::SubresourceRange, pso};
+use hal::{device::OutOfMemory, image::{Layer, SubresourceRange}, pso};
 use std::{borrow::Borrow, sync::Arc};
 
 #[derive(Debug, Hash)]
@@ -42,20 +42,15 @@ pub struct Image {
     pub(crate) ty: vk::ImageType,
     pub(crate) flags: vk::ImageCreateFlags,
     pub(crate) extent: vk::Extent3D,
-}
-
-#[derive(Debug, Hash, PartialEq, Eq)]
-pub enum ImageViewOwner {
-    User,
-    Surface(FramebufferCachePtr),
+    pub(crate) array_layers: Layer,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ImageView {
+    pub(crate) raw: vk::ImageView,
     pub(crate) image: vk::Image,
-    pub(crate) view: vk::ImageView,
     pub(crate) range: SubresourceRange,
-    pub(crate) owner: ImageViewOwner,
+    pub(crate) extent: vk::Extent3D,
 }
 
 #[derive(Debug, Hash)]
@@ -70,7 +65,6 @@ pub struct RenderPass {
 #[derive(Debug, Hash)]
 pub struct Framebuffer {
     pub(crate) raw: vk::Framebuffer,
-    pub(crate) owned: bool,
 }
 
 #[derive(Debug)]

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -1,6 +1,10 @@
 use crate::{Backend, RawDevice};
 use ash::{version::DeviceV1_0, vk};
-use hal::{device::OutOfMemory, image::{Layer, SubresourceRange}, pso};
+use hal::{
+    device::OutOfMemory,
+    image::{Layer, SubresourceRange},
+    pso,
+};
 use std::{borrow::Borrow, sync::Arc};
 
 #[derive(Debug, Hash)]

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -1,46 +1,17 @@
-use std::{
-    borrow::Borrow,
-    fmt, hash,
-    os::raw::c_void,
-    sync::{Arc, Mutex},
-    time::Instant,
-};
+use std::{borrow::Borrow, fmt, os::raw::c_void, sync::Arc, time::Instant};
 
 use ash::{extensions::khr, version::DeviceV1_0 as _, vk};
 use hal::{format::Format, window as w};
-use smallvec::SmallVec;
 
 use crate::{
     conv, info, native, Backend, Device, Instance, PhysicalDevice, QueueFamily, RawDevice,
     RawInstance, VK_ENTRY,
 };
 
-#[derive(Debug, Default)]
-pub struct FramebufferCache {
-    // We expect exactly one framebuffer per frame, but can support more.
-    pub framebuffers: SmallVec<[vk::Framebuffer; 1]>,
-}
-
-#[derive(Debug, Default)]
-pub struct FramebufferCachePtr(pub Arc<Mutex<FramebufferCache>>);
-
-impl hash::Hash for FramebufferCachePtr {
-    fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
-        (self.0.as_ref() as *const Mutex<FramebufferCache>).hash(hasher)
-    }
-}
-impl PartialEq for FramebufferCachePtr {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &other.0)
-    }
-}
-impl Eq for FramebufferCachePtr {}
-
 #[derive(Debug)]
 struct SurfaceFrame {
     image: vk::Image,
     view: vk::ImageView,
-    framebuffers: FramebufferCachePtr,
 }
 
 #[derive(Debug)]
@@ -53,15 +24,13 @@ pub struct SurfaceSwapchain {
 }
 
 impl SurfaceSwapchain {
-    unsafe fn release_resources(self, device: &ash::Device) -> Swapchain {
-        let _ = device.device_wait_idle();
-        device.destroy_fence(self.fence.0, None);
-        device.destroy_semaphore(self.semaphore.0, None);
+    unsafe fn release_resources(self, device: &RawDevice) -> Swapchain {
+        let _ = device.raw.device_wait_idle();
+        device.raw.destroy_fence(self.fence.0, None);
+        device.raw.destroy_semaphore(self.semaphore.0, None);
         for frame in self.frames {
-            device.destroy_image_view(frame.view, None);
-            for framebuffer in frame.framebuffers.0.lock().unwrap().framebuffers.drain(..) {
-                device.destroy_framebuffer(framebuffer, None);
-            }
+            device.raw.destroy_image_view(frame.view, None);
+            device.clear_framebuffers(|key| key.image_views.contains(&frame.view));
         }
         self.swapchain
     }
@@ -422,7 +391,7 @@ impl w::PresentationSurface<Backend> for Surface {
         let old = self
             .swapchain
             .take()
-            .map(|ssc| ssc.release_resources(&device.shared.raw));
+            .map(|ssc| ssc.release_resources(&device.shared));
 
         let (swapchain, images) = device.create_swapchain(self, config, old)?;
 
@@ -448,8 +417,7 @@ impl w::PresentationSurface<Backend> for Surface {
                         .unwrap();
                     SurfaceFrame {
                         image: view.image,
-                        view: view.view,
-                        framebuffers: Default::default(),
+                        view: view.raw,
                     }
                 })
                 .collect(),
@@ -460,7 +428,7 @@ impl w::PresentationSurface<Backend> for Surface {
 
     unsafe fn unconfigure_swapchain(&mut self, device: &Device) {
         if let Some(ssc) = self.swapchain.take() {
-            let swapchain = ssc.release_resources(&device.shared.raw);
+            let swapchain = ssc.release_resources(&device.shared);
             swapchain.functor.destroy_swapchain(swapchain.raw, None);
         }
     }
@@ -481,11 +449,6 @@ impl w::PresentationSurface<Backend> for Surface {
             Ok(()) => {
                 ssc.device.raw.reset_fences(fences).unwrap();
                 let frame = &ssc.frames[index as usize];
-                // We have just waited for the frame to be fully available on CPU.
-                // All the associated framebuffers are expected to be destroyed by now.
-                for framebuffer in frame.framebuffers.0.lock().unwrap().framebuffers.drain(..) {
-                    ssc.device.raw.destroy_framebuffer(framebuffer, None);
-                }
                 let image = Self::SwapchainImage {
                     index,
                     image: native::Image {
@@ -493,17 +456,16 @@ impl w::PresentationSurface<Backend> for Surface {
                         ty: vk::ImageType::TYPE_2D,
                         flags: vk::ImageCreateFlags::empty(),
                         extent: ssc.swapchain.extent,
+                        array_layers: 1,
                     },
                     view: native::ImageView {
+                        raw: frame.view,
                         image: frame.image,
-                        view: frame.view,
                         range: hal::image::SubresourceRange {
                             aspects: hal::format::Aspects::COLOR,
                             ..Default::default()
                         },
-                        owner: native::ImageViewOwner::Surface(FramebufferCachePtr(Arc::clone(
-                            &frame.framebuffers.0,
-                        ))),
+                        extent: ssc.swapchain.extent,
                     },
                 };
                 Ok((image, suboptimal))

--- a/src/hal/src/command/clear.rs
+++ b/src/hal/src/command/clear.rs
@@ -53,6 +53,14 @@ impl fmt::Debug for ClearValue {
     }
 }
 
+impl Default for ClearValue {
+    fn default() -> Self {
+        ClearValue {
+            _align: [0; 4],
+        }
+    }
+}
+
 /// Attachment clear description for the current subpass.
 #[derive(Clone, Copy, Debug)]
 pub enum AttachmentClear {

--- a/src/hal/src/command/clear.rs
+++ b/src/hal/src/command/clear.rs
@@ -55,9 +55,7 @@ impl fmt::Debug for ClearValue {
 
 impl Default for ClearValue {
     fn default() -> Self {
-        ClearValue {
-            _align: [0; 4],
-        }
+        ClearValue { _align: [0; 4] }
     }
 }
 

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -128,7 +128,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Begins recording a primary command buffer
     /// (that has no inheritance information).
     unsafe fn begin_primary(&mut self, flags: CommandBufferFlags) {
-        self.begin::<iter::Empty::<B::ImageView>>(flags, CommandBufferInheritanceInfo::default());
+        self.begin::<iter::Empty<B::ImageView>>(flags, CommandBufferInheritanceInfo::default());
     }
 
     /// Finish recording commands to a command buffer.

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -373,26 +373,6 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// which references the compute pipeline, has finished execution.
     unsafe fn destroy_compute_pipeline(&self, pipeline: B::ComputePipeline);
 
-    /// Create a new framebuffer object.
-    ///
-    /// # Safety
-    /// - `extent.width`, `extent.height` and `extent.depth` **must** be greater than `0`.
-    unsafe fn create_framebuffer<I>(
-        &self,
-        pass: &B::RenderPass,
-        attachments: I,
-        extent: image::Extent,
-    ) -> Result<B::Framebuffer, OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<B::ImageView>;
-
-    /// Destroy a framebuffer.
-    ///
-    /// The framebuffer shouldn't be destroy before any submitted command buffer,
-    /// which references the framebuffer, has finished execution.
-    unsafe fn destroy_framebuffer(&self, buf: B::Framebuffer);
-
     /// Create a new shader module object from the SPIR-V binary data.
     ///
     /// Once a shader module has been created, any [entry points][crate::pso::EntryPoint]
@@ -759,9 +739,6 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Associate a name with a fence, for easier debugging in external tools or with validation
     /// layers that can print a friendly name when referring to objects in error messages
     unsafe fn set_fence_name(&self, fence: &mut B::Fence, name: &str);
-    /// Associate a name with a framebuffer, for easier debugging in external tools or with
-    /// validation layers that can print a friendly name when referring to objects in error messages
-    unsafe fn set_framebuffer_name(&self, framebuffer: &mut B::Framebuffer, name: &str);
     /// Associate a name with a render pass, for easier debugging in external tools or with
     /// validation layers that can print a friendly name when referring to objects in error messages
     unsafe fn set_render_pass_name(&self, render_pass: &mut B::RenderPass, name: &str);

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -589,8 +589,6 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send
     type ShaderModule: fmt::Debug + Any + Send + Sync;
     /// The corresponding render pass type for this backend.
     type RenderPass: fmt::Debug + Any + Send + Sync;
-    /// The corresponding framebuffer type for this backend.
-    type Framebuffer: fmt::Debug + Any + Send + Sync;
 
     /// The corresponding memory type for this backend.
     type Memory: fmt::Debug + Any + Send + Sync;

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -147,11 +147,6 @@ pub enum Resource {
         shader: String,
         layout: String,
     },
-    Framebuffer {
-        pass: String,
-        views: HashMap<String, String>,
-        extent: hal::image::Extent,
-    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -240,13 +235,19 @@ pub struct DrawPass {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct RenderAttachment {
+    pub clear_value: ClearValue,
+    pub image_view: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub enum Job {
     Transfer {
         commands: Vec<TransferCommand>,
     },
     Graphics {
-        framebuffer: String,
-        clear_values: Vec<ClearValue>,
+        attachments: Vec<RenderAttachment>,
+        rect: hal::pso::Rect,
         pass: (String, HashMap<String, DrawPass>),
     },
     Compute {

--- a/work/scenes/basic.ron
+++ b/work/scenes/basic.ron
@@ -35,17 +35,6 @@
 				layer_count: None,
 			),
 		),
-		"fbo": Framebuffer(
-			pass: "pass",
-			views: {
-				"c": "image.color.view"
-			},
-			extent: (
-				width: 1,
-				height: 1,
-				depth: 1,
-			),
-		),
 		"pipe-layout": PipelineLayout(
 			set_layouts: [],
 			push_constant_ranges: [],
@@ -87,20 +76,26 @@
 	},
 	jobs: {
 		"empty": Graphics(
-			framebuffer: "fbo",
-			clear_values: [
-				Color(Float((0.8, 0.8, 0.8, 1.0))),
+			attachments: [
+				(
+					image_view: "image.color.view",
+					clear_value: Color(Float((0.8, 0.8, 0.8, 1.0))),
+				)
 			],
+			rect: ( x: 0, y: 0, w: 1, h: 1 ),
 			pass: ("pass", {
 				"main": (commands: [
 				]),
 			}),
 		),
 		"pass-through": Graphics(
-			framebuffer: "fbo",
-			clear_values: [
-				Color(Float((0.8, 0.8, 0.8, 1.0))),
+			attachments: [
+				(
+					image_view: "image.color.view",
+					clear_value: Color(Float((0.8, 0.8, 0.8, 1.0))),
+				)
 			],
+			rect: ( x: 0, y: 0, w: 1, h: 1 ),
 			pass: ("pass", {
 				"main": (commands: [
 					BindPipeline("pipe.passthrough"),

--- a/work/scenes/vertex-offset.ron
+++ b/work/scenes/vertex-offset.ron
@@ -40,17 +40,6 @@
 				layer_count: None,
 			),
 		),
-		"fbo": Framebuffer(
-			pass: "pass",
-			views: {
-				"c": "image.color.view"
-			},
-			extent: (
-				width: 1,
-				height: 1,
-				depth: 1,
-			),
-		),
 		"pipe-layout": PipelineLayout(
 			set_layouts: [],
 			push_constant_ranges: [],
@@ -158,10 +147,13 @@
 	},
 	jobs: {
 		"offset-aligned": Graphics(
-			framebuffer: "fbo",
-			clear_values: [
-				Color(Float((0.0, 0.0, 0.0, 0.0))),
+			attachments: [
+				(
+					image_view: "image.color.view",
+					clear_value: Color(Float((0.0, 0.0, 0.0, 0.0))),
+				)
 			],
+			rect: ( x: 0, y: 0, w: 1, h: 1 ),
 			pass: ("pass", {
 				"main": (commands: [
 					BindPipeline("pipe.vertex-offset"),
@@ -173,10 +165,13 @@
 			}),
 		),
 		"offset-overlap": Graphics(
-			framebuffer: "fbo",
-			clear_values: [
-				Color(Float((0.0, 0.0, 0.0, 0.0))),
+			attachments: [
+				(
+					image_view: "image.color.view",
+					clear_value: Color(Float((0.0, 0.0, 0.0, 0.0))),
+				)
 			],
+			rect: ( x: 0, y: 0, w: 1, h: 1 ),
 			pass: ("pass", {
 				"main": (commands: [
 					BindPipeline("pipe.vertex-offset-overlap"),


### PR DESCRIPTION
Closes #3552

### History and motivation

In the new swapchain model, which became the one and only model as of #3327, users are not able to pre-create framebuffers for every swapchain image in advance. We settled on the requirement for the user to create a framebuffer for every frame they render, and then remove it after presenting. This didn't fit into the low-level API too well, and Vulkan backend had to implement the smarts of tracking the use of swapchain-related framebuffers. See more detail by @thorjelly in #3552.

### Status
This PR removes framebuffer as a concept, leaving it to be an implementation detail of the backends.
Currently it's done for HAL, Vulkan, and Metal.
Biggest concerns:
  - OpenGL backend complexity/consistency

### Analysis

Effect on the API: great, simpler API. Especially the new `RenderAttachmentInfo` struct. We already had a slight divergence with Vulkan on the clear values in `begin_render_pass`, and this PR makes it look very solid and concise.

Effect on the user: great, less things to manage, especially the fact that we don't have "special" framebuffers versus the regular ones any more.

Effect on performance:
  - Vulkan: minimal.
    - It's now easier to internally reuse those framebuffers.
    - We have anecdotal evidence that of all the Vulkan implementors only one mobile vendor can actually do anything useful with the framebuffer object, and others don't use it.
  - OpenGL: negative, we can no longer create FBOs in advance
  - other: no effect

Effect on the code complexity:
  - Vulkan: positive, there is no special-casing any more, no managing of the "owner" of framebuffers.
  - Metal: positive, also less special-casing.
  - OpenGL: negative. Unlike Vulkan, we can't just create an FBO on the spot while recording, since it's done off-line. So we'll have to have internal commands elevated to higher level, i.e. `SetRenderTargets` instead of `BindFramebuffer`.

Finally, this helps streamlining the path from wgpu to the hardware, as WebGPU doesn't have framebuffers either.