### PR TITLE
Cleanup Empty backend, remove AcquireMode from Metal

### DIFF
--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -168,10 +168,7 @@ impl queue::CommandQueue<Backend> for CommandQueue {
         _: Option<&mut ()>,
     ) where
         T: 'a + Borrow<CommandBuffer>,
-        Ic: IntoIterator<Item = &'a T>,
         S: 'a + Borrow<()>,
-        Iw: IntoIterator<Item = (&'a S, pso::PipelineStage)>,
-        Is: IntoIterator<Item = &'a S>,
     {
     }
 
@@ -218,23 +215,17 @@ impl device::Device<Backend> for Device {
         _: ID,
     ) -> Result<(), device::OutOfMemory>
     where
-        IA: IntoIterator,
-        IA::Item: Borrow<pass::Attachment>,
         IS: IntoIterator,
         IS::Item: Borrow<pass::SubpassDesc<'a>>,
-        ID: IntoIterator,
-        ID::Item: Borrow<pass::SubpassDependency>,
     {
         Ok(())
     }
 
-    unsafe fn create_pipeline_layout<IS, IR>(&self, _: IS, _: IR) -> Result<(), device::OutOfMemory>
-    where
-        IS: IntoIterator,
-        IS::Item: Borrow<DescriptorSetLayout>,
-        IR: IntoIterator,
-        IR::Item: Borrow<(pso::ShaderStageFlags, Range<u32>)>,
-    {
+    unsafe fn create_pipeline_layout<IS, IR>(
+        &self,
+        _: IS,
+        _: IR,
+    ) -> Result<(), device::OutOfMemory> {
         Ok(())
     }
 
@@ -269,11 +260,7 @@ impl device::Device<Backend> for Device {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn merge_pipeline_caches<I>(&self, _: &(), _: I) -> Result<(), device::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<()>,
-    {
+    unsafe fn merge_pipeline_caches<I>(&self, _: &(), _: I) -> Result<(), device::OutOfMemory> {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -282,11 +269,7 @@ impl device::Device<Backend> for Device {
         _: &(),
         _: I,
         _: hal::image::Extent,
-    ) -> Result<(), device::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<()>,
-    {
+    ) -> Result<(), device::OutOfMemory> {
         Ok(())
     }
 
@@ -385,11 +368,7 @@ impl device::Device<Backend> for Device {
         _: usize,
         _: I,
         _: pso::DescriptorPoolCreateFlags,
-    ) -> Result<DescriptorPool, device::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorRangeDesc>,
-    {
+    ) -> Result<DescriptorPool, device::OutOfMemory> {
         Ok(DescriptorPool)
     }
 
@@ -397,13 +376,7 @@ impl device::Device<Backend> for Device {
         &self,
         _bindings: I,
         _samplers: J,
-    ) -> Result<DescriptorSetLayout, device::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<pso::DescriptorSetLayoutBinding>,
-        J: IntoIterator,
-        J::Item: Borrow<()>,
-    {
+    ) -> Result<DescriptorSetLayout, device::OutOfMemory> {
         let layout = DescriptorSetLayout {
             name: String::new(),
         };
@@ -619,10 +592,7 @@ impl pool::CommandPool<Backend> for CommandPool {
 
     unsafe fn reset(&mut self, _: bool) {}
 
-    unsafe fn free<I>(&mut self, _: I)
-    where
-        I: IntoIterator<Item = CommandBuffer>,
-    {
+    unsafe fn free<I>(&mut self, _: I) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 }
@@ -669,20 +639,11 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: hal::image::Layout,
         _: command::ClearValue,
         _: T,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<hal::image::SubresourceRange>,
-    {
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn clear_attachments<T, U>(&mut self, _: T, _: U)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<command::AttachmentClear>,
-        U: IntoIterator,
-        U::Item: Borrow<pso::ClearRect>,
-    {
+    unsafe fn clear_attachments<T, U>(&mut self, _: T, _: U) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -693,10 +654,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Image,
         _: hal::image::Layout,
         _: T,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ImageResolve>,
-    {
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -708,10 +666,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: hal::image::Layout,
         _: hal::image::Filter,
         _: T,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ImageBlit>,
-    {
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -724,26 +679,11 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn bind_vertex_buffers<I, T>(&mut self, _: u32, _: I)
-    where
-        I: IntoIterator<Item = (T, hal::buffer::SubRange)>,
-        T: Borrow<Buffer>,
-    {
-    }
+    unsafe fn bind_vertex_buffers<I, T>(&mut self, _: u32, _: I) {}
 
-    unsafe fn set_viewports<T>(&mut self, _: u32, _: T)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<pso::Viewport>,
-    {
-    }
+    unsafe fn set_viewports<T>(&mut self, _: u32, _: T) {}
 
-    unsafe fn set_scissors<T>(&mut self, _: u32, _: T)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<pso::Rect>,
-    {
-    }
+    unsafe fn set_scissors<T>(&mut self, _: u32, _: T) {}
 
     unsafe fn set_stencil_reference(&mut self, _: pso::Face, _: pso::StencilValue) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
@@ -780,10 +720,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: pso::Rect,
         _: T,
         _: command::SubpassContents,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ClearValue>,
-    {
+    ) {
     }
 
     unsafe fn next_subpass(&mut self, _: command::SubpassContents) {
@@ -794,13 +731,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn bind_graphics_pipeline(&mut self, _: &()) {}
 
-    unsafe fn bind_graphics_descriptor_sets<I, J>(&mut self, _: &(), _: usize, _: I, _: J)
-    where
-        I: IntoIterator,
-        I::Item: Borrow<DescriptorSet>,
-        J: IntoIterator,
-        J::Item: Borrow<command::DescriptorSetOffset>,
-    {
+    unsafe fn bind_graphics_descriptor_sets<I, J>(&mut self, _: &(), _: usize, _: I, _: J) {
         // Do nothing
     }
 
@@ -808,13 +739,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn bind_compute_descriptor_sets<I, J>(&mut self, _: &(), _: usize, _: I, _: J)
-    where
-        I: IntoIterator,
-        I::Item: Borrow<DescriptorSet>,
-        J: IntoIterator,
-        J::Item: Borrow<command::DescriptorSetOffset>,
-    {
+    unsafe fn bind_compute_descriptor_sets<I, J>(&mut self, _: &(), _: usize, _: I, _: J) {
         // Do nothing
     }
 
@@ -826,11 +751,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn copy_buffer<T>(&mut self, _: &Buffer, _: &Buffer, _: T)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<command::BufferCopy>,
-    {
+    unsafe fn copy_buffer<T>(&mut self, _: &Buffer, _: &Buffer, _: T) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -841,25 +762,26 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: &Image,
         _: hal::image::Layout,
         _: T,
-    ) where
-        T: IntoIterator,
-        T::Item: Borrow<command::ImageCopy>,
-    {
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn copy_buffer_to_image<T>(&mut self, _: &Buffer, _: &Image, _: hal::image::Layout, _: T)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<command::BufferImageCopy>,
-    {
+    unsafe fn copy_buffer_to_image<T>(
+        &mut self,
+        _: &Buffer,
+        _: &Image,
+        _: hal::image::Layout,
+        _: T,
+    ) {
     }
 
-    unsafe fn copy_image_to_buffer<T>(&mut self, _: &Image, _: hal::image::Layout, _: &Buffer, _: T)
-    where
-        T: IntoIterator,
-        T::Item: Borrow<command::BufferImageCopy>,
-    {
+    unsafe fn copy_image_to_buffer<T>(
+        &mut self,
+        _: &Image,
+        _: hal::image::Layout,
+        _: &Buffer,
+        _: T,
+    ) {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
@@ -949,8 +871,6 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn wait_events<'a, I, J>(&mut self, _: I, _: Range<pso::PipelineStage>, _: J)
     where
-        I: IntoIterator,
-        I::Item: Borrow<()>,
         J: IntoIterator,
         J::Item: Borrow<hal::memory::Barrier<'a, Backend>>,
     {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -93,7 +93,7 @@ mod window;
 
 pub use crate::command::CommandPool;
 pub use crate::device::{Device, LanguageVersion, PhysicalDevice};
-pub use crate::window::{AcquireMode, Surface};
+pub use crate::window::Surface;
 
 pub type GraphicsCommandPool = CommandPool;
 

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -142,18 +142,6 @@ impl Surface {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum AcquireMode {
-    Wait,
-    Oldest,
-}
-
-impl Default for AcquireMode {
-    fn default() -> Self {
-        AcquireMode::Oldest
-    }
-}
-
 #[derive(Debug)]
 pub struct SwapchainImage {
     image: native::Image,

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -389,7 +389,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
 
     /// Destroy a framebuffer.
     ///
-    /// The framebuffer shouldn't be destroy before any submitted command buffer,
+    /// The framebuffer shouldn't be destroyed before any submitted command buffer,
     /// which references the framebuffer, has finished execution.
     unsafe fn destroy_framebuffer(&self, buf: B::Framebuffer);
 


### PR DESCRIPTION
Just a maintenance PR to clean up some code.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
