### PR TITLE
Image-less framebuffer API

### DIFF
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -177,6 +177,7 @@ struct Renderer<B: hal::Backend> {
     dimensions: window::Extent2D,
     viewport: pso::Viewport,
     render_pass: ManuallyDrop<B::RenderPass>,
+    framebuffer: ManuallyDrop<B::Framebuffer>,
     pipeline: ManuallyDrop<B::GraphicsPipeline>,
     pipeline_layout: ManuallyDrop<B::PipelineLayout>,
     desc_set: Option<B::DescriptorSet>,
@@ -537,6 +538,7 @@ where
         });
 
         let swap_config = window::SwapchainConfig::from_caps(&caps, format, DIMS);
+        let fat = swap_config.framebuffer_attachment();
         println!("{:?}", swap_config);
         let extent = swap_config.extent;
         unsafe {
@@ -570,6 +572,20 @@ where
                     .expect("Can't create render pass"),
             )
         };
+
+        let framebuffer = ManuallyDrop::new(unsafe {
+            device
+                .create_framebuffer(
+                    &render_pass,
+                    iter::once(fat),
+                    i::Extent {
+                        width: DIMS.width,
+                        height: DIMS.height,
+                        depth: 1,
+                    },
+                )
+                .unwrap()
+        });
 
         // Define maximum number of frames we want to be able to be "in flight" (being computed
         // simultaneously) at once
@@ -736,6 +752,7 @@ where
             dimensions: DIMS,
             viewport,
             render_pass,
+            framebuffer,
             pipeline,
             pipeline_layout,
             desc_set: Some(desc_set),
@@ -761,16 +778,30 @@ where
         let caps = self.surface.capabilities(&self.adapter.physical_device);
         let swap_config = window::SwapchainConfig::from_caps(&caps, self.format, self.dimensions);
         println!("{:?}", swap_config);
+
         let extent = swap_config.extent.to_extent();
+        self.viewport.rect.w = extent.width as _;
+        self.viewport.rect.h = extent.height as _;
+
+        unsafe {
+            self.device
+                .destroy_framebuffer(ManuallyDrop::into_inner(ptr::read(&self.framebuffer)));
+            self.framebuffer = ManuallyDrop::new(
+                self.device
+                    .create_framebuffer(
+                        &self.render_pass,
+                        iter::once(swap_config.framebuffer_attachment()),
+                        extent,
+                    )
+                    .unwrap(),
+            )
+        };
 
         unsafe {
             self.surface
                 .configure_swapchain(&self.device, swap_config)
                 .expect("Can't create swapchain");
         }
-
-        self.viewport.rect.w = extent.width as _;
-        self.viewport.rect.h = extent.height as _;
     }
 
     fn render(&mut self) {
@@ -782,20 +813,6 @@ where
                     return;
                 }
             }
-        };
-
-        let framebuffer = unsafe {
-            self.device
-                .create_framebuffer(
-                    &self.render_pass,
-                    iter::once(surface_image.borrow()),
-                    i::Extent {
-                        width: self.dimensions.width,
-                        height: self.dimensions.height,
-                        depth: 1,
-                    },
-                )
-                .unwrap()
         };
 
         // Compute index into our resource ring buffers based on the frame number
@@ -840,13 +857,16 @@ where
 
             cmd_buffer.begin_render_pass(
                 &self.render_pass,
-                &framebuffer,
+                &self.framebuffer,
                 self.viewport.rect,
-                &[command::ClearValue {
-                    color: command::ClearColor {
-                        float32: [0.8, 0.8, 0.8, 1.0],
+                iter::once(command::RenderAttachmentInfo {
+                    image_view: surface_image.borrow(),
+                    clear_value: command::ClearValue {
+                        color: command::ClearColor {
+                            float32: [0.8, 0.8, 0.8, 1.0],
+                        },
                     },
-                }],
+                }),
                 command::SubpassContents::Inline,
             );
             cmd_buffer.draw(0..6, 0..1);
@@ -869,8 +889,6 @@ where
                 surface_image,
                 Some(&mut self.submission_complete_semaphores[frame_idx]),
             );
-
-            self.device.destroy_framebuffer(framebuffer);
 
             if result.is_err() {
                 self.recreate_swapchain();
@@ -921,6 +939,8 @@ where
             }
             self.device
                 .destroy_render_pass(ManuallyDrop::into_inner(ptr::read(&self.render_pass)));
+            self.device
+                .destroy_framebuffer(ManuallyDrop::into_inner(ptr::read(&self.framebuffer)));
             self.surface.unconfigure_swapchain(&self.device);
             self.device
                 .free_memory(ManuallyDrop::into_inner(ptr::read(&self.buffer_memory)));

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1112,18 +1112,10 @@ impl device::Device<Backend> for Device {
     unsafe fn create_framebuffer<I>(
         &self,
         _renderpass: &RenderPass,
-        attachments: I,
+        _attachments: I,
         extent: image::Extent,
-    ) -> Result<Framebuffer, device::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<ImageView>,
-    {
+    ) -> Result<Framebuffer, device::OutOfMemory> {
         Ok(Framebuffer {
-            attachments: attachments
-                .into_iter()
-                .map(|att| att.borrow().clone())
-                .collect(),
             layers: extent.depth as _,
         })
     }

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -1207,7 +1207,7 @@ impl Internal {
 
                     let attachment = {
                         let rtv_id = subpass.color_attachments[index];
-                        &cache.framebuffer.attachments[rtv_id.0]
+                        &cache.attachments[rtv_id.0].view
                     };
 
                     unsafe {
@@ -1256,7 +1256,7 @@ impl Internal {
 
                     let attachment = {
                         let dsv_id = subpass.depth_stencil_attachment.unwrap();
-                        &cache.framebuffer.attachments[dsv_id.0]
+                        &cache.attachments[dsv_id.0].view
                     };
 
                     unsafe {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2224,15 +2224,10 @@ impl d::Device<B> for Device {
     unsafe fn create_framebuffer<I>(
         &self,
         _renderpass: &r::RenderPass,
-        attachments: I,
+        _attachments: I,
         extent: image::Extent,
-    ) -> Result<r::Framebuffer, d::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<r::ImageView>,
-    {
+    ) -> Result<r::Framebuffer, d::OutOfMemory> {
         Ok(r::Framebuffer {
-            attachments: attachments.into_iter().map(|att| *att.borrow()).collect(),
             layers: extent.depth as _,
         })
     }

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -168,8 +168,7 @@ pub struct PipelineLayout {
 
 #[derive(Debug, Clone)]
 pub struct Framebuffer {
-    pub(crate) attachments: Vec<ImageView>,
-    // Number of layers in the render area. Required for subpass resolves.
+    /// Number of layers in the render area. Required for subpass resolves.
     pub(crate) layers: image::Layer,
 }
 

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -713,14 +713,16 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
 
-    unsafe fn begin_render_pass<T>(
+    unsafe fn begin_render_pass<'a, T>(
         &mut self,
         _: &(),
         _: &(),
         _: pso::Rect,
         _: T,
         _: command::SubpassContents,
-    ) {
+    ) where
+        T: IntoIterator<Item = command::RenderAttachmentInfo<'a, Backend>>,
+    {
     }
 
     unsafe fn next_subpass(&mut self, _: command::SubpassContents) {

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -1,4 +1,4 @@
-use crate::{Error, GlContainer};
+use crate::{Error, GlContainer, MAX_COLOR_ATTACHMENTS};
 use glow::HasContext;
 use hal::{Features, Hints, Limits};
 use std::{collections::HashSet, fmt, str};
@@ -376,7 +376,9 @@ pub(crate) fn query_all(
         min_storage_buffer_offset_alignment,
         framebuffer_color_sample_counts: max_samples_mask,
         non_coherent_atom_size: 1,
-        max_color_attachments: get_usize(gl, glow::MAX_COLOR_ATTACHMENTS).unwrap_or(1),
+        max_color_attachments: get_usize(gl, glow::MAX_COLOR_ATTACHMENTS)
+            .unwrap_or(1)
+            .min(MAX_COLOR_ATTACHMENTS),
         ..Limits::default()
     };
 

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -65,6 +65,7 @@ type ColorSlot = u8;
 const MAX_SAMPLERS: usize = 16;
 //TODO: has to be within glow::MAX_COMBINED_TEXTURE_IMAGE_UNITS
 const MAX_TEXTURE_SLOTS: usize = 16;
+const MAX_COLOR_ATTACHMENTS: usize = 16;
 
 struct GlContainer {
     context: GlContext,
@@ -96,7 +97,7 @@ impl hal::Backend for Backend {
 
     type ShaderModule = native::ShaderModule;
     type RenderPass = native::RenderPass;
-    type Framebuffer = native::FrameBuffer;
+    type Framebuffer = native::Framebuffer;
 
     type Buffer = native::Buffer;
     type BufferView = native::BufferView;

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -56,7 +56,7 @@ pub enum BufferMemory {
 
 #[derive(Debug)]
 pub struct CommandPool {
-    pub(crate) fbo: Option<n::RawFrameBuffer>,
+    pub(crate) fbo: Option<n::RawFramebuffer>,
     pub(crate) limits: command::Limits,
     pub(crate) memory: Arc<Mutex<BufferMemory>>,
     pub(crate) legacy_features: info::LegacyFeatures,

--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -1,14 +1,6 @@
 use crate::{ColorSlot, GlContainer};
 use glow::HasContext;
 use hal::pso;
-use smallvec::SmallVec;
-
-pub(crate) fn bind_draw_color_buffers(gl: &GlContainer, num: usize) {
-    let attachments: SmallVec<[u32; 16]> = (0..num)
-        .map(|x| glow::COLOR_ATTACHMENT0 + x as u32)
-        .collect();
-    unsafe { gl.draw_buffers(&attachments) };
-}
 
 pub fn map_comparison(cmp: pso::Comparison) -> u32 {
     use hal::pso::Comparison::*;

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1800,20 +1800,10 @@ impl hal::device::Device<Backend> for Device {
     unsafe fn create_framebuffer<I>(
         &self,
         _render_pass: &n::RenderPass,
-        attachments: I,
+        _attachments: I,
         extent: image::Extent,
-    ) -> Result<n::Framebuffer, d::OutOfMemory>
-    where
-        I: IntoIterator,
-        I::Item: Borrow<n::ImageView>,
-    {
-        Ok(n::Framebuffer {
-            extent,
-            attachments: attachments
-                .into_iter()
-                .map(|at| at.borrow().texture.clone())
-                .collect(),
-        })
+    ) -> Result<n::Framebuffer, d::OutOfMemory> {
+        Ok(n::Framebuffer { extent })
     }
 
     unsafe fn create_shader_module(
@@ -2377,7 +2367,7 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn destroy_compute_pipeline(&self, _pipeline: n::ComputePipeline) {}
 
-    unsafe fn destroy_framebuffer(&self, _buffer: n::Framebuffer) {}
+    unsafe fn destroy_framebuffer(&self, _framebuffer: n::Framebuffer) {}
 
     unsafe fn destroy_semaphore(&self, _semaphore: n::Semaphore) {}
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -102,11 +102,7 @@ pub struct RenderPass {
 #[derive(Debug)]
 pub struct Framebuffer {
     pub(crate) extent: image::Extent,
-    pub(crate) attachments: Vec<metal::Texture>,
 }
-
-unsafe impl Send for Framebuffer {}
-unsafe impl Sync for Framebuffer {}
 
 #[derive(Clone, Debug)]
 pub struct ResourceData<T> {

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -26,6 +26,7 @@ log = { version = "0.4" }
 shared_library = { version = "0.1.9", optional = true }
 ash = "0.31"
 hal = { path = "../../hal", version = "0.6", package = "gfx-hal" }
+parking_lot = "0.11"
 smallvec = "1.0"
 raw-window-handle = "0.3"
 inplace_it = "0.3.2"

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -418,7 +418,10 @@ pub fn map_buffer_features(features: vk::FormatFeatureFlags) -> format::BufferFe
     format::BufferFeature::from_bits_truncate(features.as_raw())
 }
 
-pub(crate) fn map_device_features(features: Features) -> crate::DeviceCreationFeatures {
+pub(crate) fn map_device_features(
+    features: Features,
+    imageless_framebuffers: bool,
+) -> crate::DeviceCreationFeatures {
     crate::DeviceCreationFeatures {
         // vk::PhysicalDeviceFeatures is a struct composed of Bool32's while
         // Features is a bitfield so we need to map everything manually
@@ -523,6 +526,15 @@ pub(crate) fn map_device_features(features: Features) -> crate::DeviceCreationFe
                 vk::PhysicalDeviceMeshShaderFeaturesNV::builder()
                     .task_shader(features.contains(Features::TASK_SHADER))
                     .mesh_shader(features.contains(Features::MESH_SHADER))
+                    .build(),
+            )
+        } else {
+            None
+        },
+        imageless_framebuffers: if imageless_framebuffers {
+            Some(
+                vk::PhysicalDeviceImagelessFramebufferFeaturesKHR::builder()
+                    .imageless_framebuffer(imageless_framebuffers)
                     .build(),
             )
         } else {
@@ -668,7 +680,11 @@ pub fn map_descriptor_pool_create_flags(
     vk::DescriptorPoolCreateFlags::from_raw(flags.bits())
 }
 
-pub fn map_memory_properties(flags: vk::MemoryPropertyFlags) -> hal::memory::Properties {
+pub fn map_sample_count_flags(samples: image::NumSamples) -> vk::SampleCountFlags {
+    vk::SampleCountFlags::from_raw((samples as u32) & vk::SampleCountFlags::all().as_raw())
+}
+
+pub fn map_vk_memory_properties(flags: vk::MemoryPropertyFlags) -> hal::memory::Properties {
     use crate::memory::Properties;
     let mut properties = Properties::empty();
 
@@ -691,7 +707,7 @@ pub fn map_memory_properties(flags: vk::MemoryPropertyFlags) -> hal::memory::Pro
     properties
 }
 
-pub fn map_memory_heap_flags(flags: vk::MemoryHeapFlags) -> hal::memory::HeapFlags {
+pub fn map_vk_memory_heap_flags(flags: vk::MemoryHeapFlags) -> hal::memory::HeapFlags {
     use hal::memory::HeapFlags;
     let mut hal_flags = HeapFlags::empty();
 

--- a/src/hal/src/command/clear.rs
+++ b/src/hal/src/command/clear.rs
@@ -53,6 +53,12 @@ impl fmt::Debug for ClearValue {
     }
 }
 
+impl Default for ClearValue {
+    fn default() -> Self {
+        ClearValue { _align: [0; 4] }
+    }
+}
+
 /// Attachment clear description for the current subpass.
 #[derive(Clone, Copy, Debug)]
 pub enum AttachmentClear {

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -384,8 +384,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         extent: image::Extent,
     ) -> Result<B::Framebuffer, OutOfMemory>
     where
-        I: IntoIterator,
-        I::Item: Borrow<B::ImageView>;
+        I: IntoIterator<Item = image::FramebufferAttachment>;
 
     /// Destroy a framebuffer.
     ///
@@ -453,6 +452,8 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
 
     /// Destroy a buffer view object
     unsafe fn destroy_buffer_view(&self, view: B::BufferView);
+
+    //TODO: add a list of supported formats for casting the views
 
     /// Create a new image object
     unsafe fn create_image(

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -328,6 +328,7 @@ pub enum ViewKind {
 bitflags!(
     /// Capabilities to create views into an image.
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[derive(Default)]
     pub struct ViewCapabilities: u32 {
         /// Support creation of views with different formats.
         const MUTABLE_FORMAT = 0x0000_0008;
@@ -697,4 +698,17 @@ pub struct SubresourceFootprint {
     pub array_pitch: RawOffset,
     /// Byte distance between depth slices.
     pub depth_pitch: RawOffset,
+}
+
+/// Description of a framebuffer attachment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct FramebufferAttachment {
+    /// Usage that an image is created with.
+    pub usage: Usage,
+    /// View capabilities that an image is created with.
+    pub view_caps: ViewCapabilities,
+    //TODO: make this a list
+    /// The image view format.
+    pub format: format::Format,
 }

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -337,6 +337,15 @@ impl SwapchainConfig {
         }
     }
 
+    /// Return the framebuffer attachment corresponding to the swapchain image views.
+    pub fn framebuffer_attachment(&self) -> image::FramebufferAttachment {
+        image::FramebufferAttachment {
+            usage: self.image_usage,
+            view_caps: image::ViewCapabilities::empty(),
+            format: self.format,
+        }
+    }
+
     /// Create a swapchain configuration based on the capabilities
     /// returned from a physical device query. If the surface does not
     /// specify a current size, default_extent is clamped and used instead.

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -92,6 +92,8 @@ pub enum Resource {
         format: hal::format::Format,
         usage: hal::image::Usage,
         #[serde(default)]
+        view_caps: hal::image::ViewCapabilities,
+        #[serde(default)]
         data: String,
     },
     ImageView {
@@ -149,7 +151,7 @@ pub enum Resource {
     },
     Framebuffer {
         pass: String,
-        views: HashMap<String, String>,
+        attachments: HashMap<String, hal::image::FramebufferAttachment>,
         extent: hal::image::Extent,
     },
 }
@@ -240,13 +242,19 @@ pub struct DrawPass {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct RenderAttachmentInfo {
+    pub image_view: String,
+    pub clear_value: ClearValue,
+}
+
+#[derive(Debug, Deserialize)]
 pub enum Job {
     Transfer {
         commands: Vec<TransferCommand>,
     },
     Graphics {
         framebuffer: String,
-        clear_values: Vec<ClearValue>,
+        attachments: HashMap<String, RenderAttachmentInfo>,
         pass: (String, HashMap<String, DrawPass>),
     },
     Compute {

--- a/work/scenes/basic.ron
+++ b/work/scenes/basic.ron
@@ -5,6 +5,7 @@
 			num_levels: 1,
 			format: Rgba8Unorm,
 			usage: (bits: 0x15), //COLOR_ATTACHMENT | TRANSFER_SRC (for reading) | SAMPLED (temporary for GL)
+			view_caps: (bits: 0),
 		),
 		"pass": RenderPass(
 			attachments: {
@@ -37,8 +38,12 @@
 		),
 		"fbo": Framebuffer(
 			pass: "pass",
-			views: {
-				"c": "image.color.view"
+			attachments: {
+				"c": (
+					usage: (bits: 0x15),
+					view_caps: (bits: 0),
+					format: Rgba8Unorm,
+				),
 			},
 			extent: (
 				width: 1,
@@ -88,9 +93,12 @@
 	jobs: {
 		"empty": Graphics(
 			framebuffer: "fbo",
-			clear_values: [
-				Color(Float((0.8, 0.8, 0.8, 1.0))),
-			],
+			attachments: {
+				"c": (
+					image_view: "image.color.view",
+					clear_value: Color(Float((0.8, 0.8, 0.8, 1.0))),
+				),
+			},
 			pass: ("pass", {
 				"main": (commands: [
 				]),
@@ -98,9 +106,12 @@
 		),
 		"pass-through": Graphics(
 			framebuffer: "fbo",
-			clear_values: [
-				Color(Float((0.8, 0.8, 0.8, 1.0))),
-			],
+			attachments: {
+				"c": (
+					image_view: "image.color.view",
+					clear_value: Color(Float((0.8, 0.8, 0.8, 1.0))),
+				),
+			},
 			pass: ("pass", {
 				"main": (commands: [
 					BindPipeline("pipe.passthrough"),

--- a/work/scenes/large.ron
+++ b/work/scenes/large.ron
@@ -1,3 +1,4 @@
+//Note: this one has likely rot!
 (
 	resources: {
 		"image.src": Image(

--- a/work/scenes/vertex-offset.ron
+++ b/work/scenes/vertex-offset.ron
@@ -42,8 +42,12 @@
 		),
 		"fbo": Framebuffer(
 			pass: "pass",
-			views: {
-				"c": "image.color.view"
+			attachments: {
+				"c": (
+					usage: (bits: 0x15),
+					view_caps: (bits: 0),
+					format: Rgba32Uint,
+				),
 			},
 			extent: (
 				width: 1,
@@ -159,9 +163,12 @@
 	jobs: {
 		"offset-aligned": Graphics(
 			framebuffer: "fbo",
-			clear_values: [
-				Color(Float((0.0, 0.0, 0.0, 0.0))),
-			],
+			attachments: {
+				"c": (
+					image_view: "image.color.view",
+					clear_value: Color(Float((0.0, 0.0, 0.0, 0.0))),
+				),
+			},
 			pass: ("pass", {
 				"main": (commands: [
 					BindPipeline("pipe.vertex-offset"),
@@ -174,9 +181,12 @@
 		),
 		"offset-overlap": Graphics(
 			framebuffer: "fbo",
-			clear_values: [
-				Color(Float((0.0, 0.0, 0.0, 0.0))),
-			],
+			attachments: {
+				"c": (
+					image_view: "image.color.view",
+					clear_value: Color(Float((0.0, 0.0, 0.0, 0.0))),
+				),
+			},
 			pass: ("pass", {
 				"main": (commands: [
 					BindPipeline("pipe.vertex-offset-overlap"),


### PR DESCRIPTION
Fixes #3568
It will also solve the annoying validation error about Vulkan framebuffers being destroyed - #3015. Even though we still rely on the "acquire" to actually make the image available, the framebuffers in Vulkan are going to be more solid and persistent. No creation/removal each frame any more! 🎉 🚀 