### PR TITLE
Add image features for transfers and min/max sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,34 @@
 # Change Log
 
 ### hal-unreleased
-  - use `thiserror` for errors
-  - error variants and a few names are refactored
+  - error improvements:
+    - use `thiserror` for errors
+    - variants and a few names are refactored
+  - API external synchronization constraints now match Vulkan, `&mut` changes affected the following parameters:
+    - event in `Device::set_event` and `Device::reset_event`
+    - fence in `Device::reset_fences` and `Queue::submit`
+    - destination sets in `write_descriptor_sets` and `copy_descriptor_sets`
+    - memory in `map_memory` and `unmap_memory`
+    - queue in `Queue::wait_idle`
+    - semaphore in `Queue::present`
+  - `ImageFeature` improvements:
+    - new `STORAGE_READ_WRITE` bit, indicating that the storage can be read and written within the same draw/dispatch call
+    - new `TRANSFER_SRC` and `TRANSFER_DST` bits, following `VK_KHR_maintenance1`
+    - new `SAMPLED_MINMAX` bit, following `VK_EXT_sampling_minmax`
+  - Framebuffers become image-less, following `VK_KHR_imageless_framebuffer`
+  - the old swapchain model is removed, and the new one is updated to match the backends even better
+  - debug names are supported for all objectr
+  - other API changes:
+    - `bind_index_buffer` now doesn't need a separate structure
+    - swapchain images can be used for transfer operations
+    - separate feature for comparison mutable samplers
+    - pipeline descriptor vectors are replaced with slices
+  - OpenGL backend improvements:
+    - finally has the API fully matching gfx-hal
+    - now only uses OpenGL ES on Linux/Android/Web targets
+    - binding model has been completely rewritten
+    - various number of fixed in rendering, memory mapping, and other areas
+
 
 ### backend-dx12-unreleased
   - fix SPIR-V entry point selection

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -355,11 +355,10 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 image::Tiling::Linear => format_info.properties.linear_tiling,
             };
             let mut flags = U::empty();
-            // Note: these checks would have been nicer if we had explicit BLIT usage
-            if props.contains(f::ImageFeature::BLIT_SRC) {
+            if props.contains(f::ImageFeature::TRANSFER_SRC) {
                 flags |= U::TRANSFER_SRC;
             }
-            if props.contains(f::ImageFeature::BLIT_DST) {
+            if props.contains(f::ImageFeature::TRANSFER_DST) {
                 flags |= U::TRANSFER_DST;
             }
             if props.contains(f::ImageFeature::SAMPLED) {
@@ -1416,10 +1415,15 @@ impl FormatProperties {
                         | d3d12::D3D12_FORMAT_SUPPORT1_TEXTURECUBE);
             let can_linear = can_image && !is_compressed;
             if can_image {
-                props.optimal_tiling |= f::ImageFeature::SAMPLED | f::ImageFeature::BLIT_SRC;
+                props.optimal_tiling |= f::ImageFeature::TRANSFER_SRC
+                    | f::ImageFeature::TRANSFER_DST
+                    | f::ImageFeature::SAMPLED;
             }
             if can_linear {
-                props.linear_tiling |= f::ImageFeature::SAMPLED | f::ImageFeature::BLIT_SRC;
+                props.linear_tiling |= f::ImageFeature::TRANSFER_SRC
+                    | f::ImageFeature::TRANSFER_DST
+                    | f::ImageFeature::SAMPLED
+                    | f::ImageFeature::BLIT_SRC;
             }
             if data.Support1 & d3d12::D3D12_FORMAT_SUPPORT1_IA_VERTEX_BUFFER != 0 {
                 props.buffer_features |= f::BufferFeature::VERTEX;

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -585,14 +585,13 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn format_properties(&self, _: Option<hal::format::Format>) -> hal::format::Properties {
-        use hal::format::BufferFeature;
-        use hal::format::ImageFeature;
+        use hal::format::{BufferFeature as Bf, ImageFeature as If};
 
         // TODO: These are for show
         hal::format::Properties {
-            linear_tiling: ImageFeature::SAMPLED,
-            optimal_tiling: ImageFeature::SAMPLED,
-            buffer_features: BufferFeature::VERTEX,
+            linear_tiling: If::TRANSFER_SRC | If::TRANSFER_DST | If::empty(),
+            optimal_tiling: If::TRANSFER_SRC | If::TRANSFER_DST | If::SAMPLED,
+            buffer_features: Bf::VERTEX,
         }
     }
 

--- a/src/backend/metal/src/conversions.rs
+++ b/src/backend/metal/src/conversions.rs
@@ -174,11 +174,6 @@ impl PrivateCapabilities {
         use self::hal::format::{BufferFeature as Bf, ImageFeature as If};
         use metal::MTLPixelFormat::*;
 
-        let buffer_features = Bf::all();
-        let color_if = If::SAMPLED | If::BLIT_SRC | If::BLIT_DST;
-        let compressed_if = color_if | If::SAMPLED_LINEAR;
-        let depth_if = color_if | If::DEPTH_STENCIL_ATTACHMENT;
-
         // Affected formats documented at:
         // https://developer.apple.com/documentation/metal/mtlreadwritetexturetier/mtlreadwritetexturetier1?language=objc
         // https://developer.apple.com/documentation/metal/mtlreadwritetexturetier/mtlreadwritetexturetier2?language=objc
@@ -188,748 +183,291 @@ impl PrivateCapabilities {
             MTLReadWriteTextureTier::Tier2 => (If::STORAGE_READ_WRITE, If::STORAGE_READ_WRITE),
         };
 
-        match self.map_format(format) {
-            Some(A8Unorm) => Properties {
-                optimal_tiling: compressed_if,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R8Unorm) => Properties {
-                optimal_tiling: color_if
-                    | read_write_tier2_if
+        let mtl_format = match self.map_format(format) {
+            Some(mtl_format) => mtl_format,
+            None => {
+                return Properties {
+                    buffer_features: if map_vertex_format(format).is_some() {
+                        Bf::VERTEX
+                    } else {
+                        Bf::empty()
+                    },
+                    optimal_tiling: If::empty(),
+                    linear_tiling: If::empty(),
+                }
+            }
+        };
+        let extra_optimal = match mtl_format {
+            A8Unorm => If::SAMPLED_LINEAR,
+            R8Unorm => {
+                read_write_tier2_if
                     | If::SAMPLED_LINEAR
                     | If::STORAGE
                     | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R8Unorm_sRGB) if self.format_any8_unorm_srgb_all => Properties {
-                optimal_tiling: color_if
+                    | If::COLOR_ATTACHMENT_BLEND
+            }
+            R8Unorm_sRGB if self.format_any8_unorm_srgb_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            R8Unorm_sRGB if self.format_any8_unorm_srgb_no_write => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            R8Snorm if self.format_any8_snorm_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            R8Uint => read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
+            R8Sint => read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
+            R16Unorm if self.format_r16_norm_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            R16Snorm if self.format_r16_norm_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            R16Uint => read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
+            R16Sint => read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
+            R16Float => {
+                read_write_tier2_if
                     | If::SAMPLED_LINEAR
                     | If::STORAGE
                     | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R8Unorm_sRGB) if self.format_any8_unorm_srgb_no_write => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R8Snorm) if self.format_any8_snorm_all => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R8Uint) => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R8Sint) => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R16Unorm) if self.format_r16_norm_all => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R16Snorm) if self.format_r16_norm_all => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R16Uint) => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R16Sint) => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R16Float) => Properties {
-                optimal_tiling: color_if
-                    | read_write_tier2_if
+                    | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG8Unorm => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG8Unorm_sRGB if self.format_any8_unorm_srgb_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG8Unorm_sRGB if self.format_any8_unorm_srgb_no_write => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG8Snorm if self.format_any8_snorm_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG8Uint => If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT,
+            RG8Sint => If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT,
+            B5G6R5Unorm if self.format_b5 => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            A1BGR5Unorm if self.format_b5 => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            ABGR4Unorm if self.format_b5 => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            BGR5A1Unorm if self.format_b5 => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            R32Uint if self.format_r32_all => {
+                read_write_tier1_if | If::STORAGE | If::COLOR_ATTACHMENT
+            }
+            R32Uint if self.format_r32_no_write => If::COLOR_ATTACHMENT,
+            R32Sint if self.format_r32_all => {
+                read_write_tier1_if | If::STORAGE | If::COLOR_ATTACHMENT
+            }
+            R32Sint if self.format_r32_no_write => If::COLOR_ATTACHMENT,
+            R32Float if self.format_r32float_no_write_no_filter => {
+                If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            R32Float if self.format_r32float_no_filter => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            R32Float if self.format_r32float_all => {
+                read_write_tier1_if
                     | If::SAMPLED_LINEAR
                     | If::STORAGE
                     | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG8Unorm) => Properties {
-                optimal_tiling: color_if
+                    | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG16Unorm => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG16Snorm => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG16Float => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGBA8Unorm => {
+                read_write_tier2_if
                     | If::SAMPLED_LINEAR
                     | If::STORAGE
                     | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG8Unorm_sRGB) if self.format_any8_unorm_srgb_all => Properties {
-                optimal_tiling: color_if
+                    | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGBA8Unorm_sRGB if self.format_rgba8_srgb_no_write => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGBA8Unorm_sRGB if self.format_rgba8_srgb_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGBA8Snorm => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGBA8Uint => read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
+            RGBA8Sint => read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
+            BGRA8Unorm => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            BGRA8Unorm_sRGB if self.format_rgba8_srgb_no_write => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            BGRA8Unorm_sRGB if self.format_rgba8_srgb_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGB10A2Unorm if self.format_rgb10a2_unorm_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGB10A2Unorm if self.format_rgb10a2_unorm_no_write => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGB10A2Uint if self.format_rgb10a2_uint_color => If::COLOR_ATTACHMENT,
+            RGB10A2Uint if self.format_rgb10a2_uint_color_write => {
+                If::STORAGE | If::COLOR_ATTACHMENT
+            }
+            RG11B10Float if self.format_rg11b10_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG11B10Float if self.format_rg11b10_no_write => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGB9E5Float if self.format_rgb9e5_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGB9E5Float if self.format_rgb9e5_filter_only => If::SAMPLED_LINEAR,
+            RGB9E5Float if self.format_rgb9e5_no_write => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG32Uint if self.format_rg32_color => If::COLOR_ATTACHMENT,
+            RG32Sint if self.format_rg32_color => If::COLOR_ATTACHMENT,
+            RG32Uint if self.format_rg32_color_write => If::COLOR_ATTACHMENT | If::STORAGE,
+            RG32Sint if self.format_rg32_color_write => If::COLOR_ATTACHMENT | If::STORAGE,
+            RG32Float if self.format_rg32float_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG32Float if self.format_rg32float_color_blend => {
+                If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RG32Float if self.format_rg32float_no_filter => {
+                If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGBA16Unorm => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGBA16Snorm => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGBA16Uint => read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
+            RGBA16Sint => read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
+            RGBA16Float => {
+                read_write_tier2_if
                     | If::SAMPLED_LINEAR
                     | If::STORAGE
                     | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG8Unorm_sRGB) if self.format_any8_unorm_srgb_no_write => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG8Snorm) if self.format_any8_snorm_all => Properties {
-                optimal_tiling: color_if
+                    | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGBA32Uint if self.format_rgba32int_color => If::COLOR_ATTACHMENT,
+            RGBA32Uint if self.format_rgba32int_color_write => {
+                read_write_tier2_if | If::COLOR_ATTACHMENT | If::STORAGE
+            }
+            RGBA32Sint if self.format_rgba32int_color => If::COLOR_ATTACHMENT,
+            RGBA32Sint if self.format_rgba32int_color_write => {
+                read_write_tier2_if | If::COLOR_ATTACHMENT | If::STORAGE
+            }
+            RGBA32Float if self.format_rgba32float_all => {
+                read_write_tier2_if
                     | If::SAMPLED_LINEAR
                     | If::STORAGE
                     | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG8Uint) => Properties {
-                optimal_tiling: color_if | If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG8Sint) => Properties {
-                optimal_tiling: color_if | If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(B5G6R5Unorm) if self.format_b5 => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(A1BGR5Unorm) if self.format_b5 => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(ABGR4Unorm) if self.format_b5 => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(BGR5A1Unorm) if self.format_b5 => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R32Uint) if self.format_r32_all => Properties {
-                optimal_tiling: color_if | read_write_tier1_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R32Uint) if self.format_r32_no_write => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R32Sint) if self.format_r32_all => Properties {
-                optimal_tiling: color_if | read_write_tier1_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R32Sint) if self.format_r32_no_write => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R32Float) if self.format_r32float_no_write_no_filter => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R32Float) if self.format_r32float_no_filter => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(R32Float) if self.format_r32float_all => Properties {
-                optimal_tiling: color_if
-                    | read_write_tier1_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG16Unorm) => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG16Snorm) => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG16Float) => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA8Unorm) => Properties {
-                optimal_tiling: color_if
-                    | read_write_tier2_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA8Unorm_sRGB) if self.format_rgba8_srgb_no_write => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA8Unorm_sRGB) if self.format_rgba8_srgb_all => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA8Snorm) => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA8Uint) => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA8Sint) => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(BGRA8Unorm) => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(BGRA8Unorm_sRGB) if self.format_rgba8_srgb_no_write => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(BGRA8Unorm_sRGB) if self.format_rgba8_srgb_all => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGB10A2Unorm) if self.format_rgb10a2_unorm_all => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGB10A2Unorm) if self.format_rgb10a2_unorm_no_write => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGB10A2Uint) if self.format_rgb10a2_uint_color => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGB10A2Uint) if self.format_rgb10a2_uint_color_write => Properties {
-                optimal_tiling: color_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG11B10Float) if self.format_rg11b10_all => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG11B10Float) if self.format_rg11b10_no_write => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGB9E5Float) if self.format_rgb9e5_all => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGB9E5Float) if self.format_rgb9e5_filter_only => Properties {
-                optimal_tiling: compressed_if,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGB9E5Float) if self.format_rgb9e5_no_write => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG32Uint) if self.format_rg32_color => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG32Sint) if self.format_rg32_color => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG32Uint) if self.format_rg32_color_write => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT | If::STORAGE,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG32Sint) if self.format_rg32_color_write => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT | If::STORAGE,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG32Float) if self.format_rg32float_all => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG32Float) if self.format_rg32float_color_blend => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RG32Float) if self.format_rg32float_no_filter => Properties {
-                optimal_tiling: color_if
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA16Unorm) => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA16Snorm) => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA16Uint) => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA16Sint) => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::STORAGE | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA16Float) => Properties {
-                optimal_tiling: color_if
-                    | read_write_tier2_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA32Uint) if self.format_rgba32int_color => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA32Uint) if self.format_rgba32int_color_write => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::COLOR_ATTACHMENT | If::STORAGE,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA32Sint) if self.format_rgba32int_color => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA32Sint) if self.format_rgba32int_color_write => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::COLOR_ATTACHMENT | If::STORAGE,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA32Float) if self.format_rgba32float_all => Properties {
-                optimal_tiling: color_if
-                    | read_write_tier2_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA32Float) if self.format_rgba32float_color => Properties {
-                optimal_tiling: color_if | If::COLOR_ATTACHMENT,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(RGBA32Float) if self.format_rgba32float_color_write => Properties {
-                optimal_tiling: color_if | read_write_tier2_if | If::COLOR_ATTACHMENT | If::STORAGE,
-                buffer_features,
-                ..Properties::default()
-            },
-            Some(EAC_R11Unorm) if self.format_eac_etc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(EAC_R11Snorm) if self.format_eac_etc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(EAC_RG11Unorm) if self.format_eac_etc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(EAC_RG11Snorm) if self.format_eac_etc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ETC2_RGB8) if self.format_eac_etc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ETC2_RGB8_sRGB) if self.format_eac_etc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ETC2_RGB8A1) if self.format_eac_etc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ETC2_RGB8A1_sRGB) if self.format_eac_etc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_4x4_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_4x4_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_5x4_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_5x4_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_5x5_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_5x5_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_6x5_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_6x5_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_6x6_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_6x6_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_8x5_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_8x5_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_8x6_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_8x6_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_8x8_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_8x8_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_10x5_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_10x5_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_10x6_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_10x6_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_10x8_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_10x8_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_10x10_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_10x10_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_12x10_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_12x10_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_12x12_LDR) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(ASTC_12x12_sRGB) if self.format_astc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC1_RGBA) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC1_RGBA_sRGB) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC2_RGBA) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC2_RGBA_sRGB) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC3_RGBA) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC3_RGBA_sRGB) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC4_RUnorm) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC4_RSnorm) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC5_RGUnorm) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC5_RGSnorm) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC6H_RGBUfloat) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC6H_RGBFloat) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC7_RGBAUnorm) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(BC7_RGBAUnorm_sRGB) if self.format_bc => Properties {
-                optimal_tiling: compressed_if,
-                ..Properties::default()
-            },
-            Some(Depth16Unorm) if self.format_depth16unorm => Properties {
-                optimal_tiling: depth_if | If::SAMPLED_LINEAR,
-                ..Properties::default()
-            },
-            Some(Depth32Float) if self.format_depth32float_filter => Properties {
-                optimal_tiling: depth_if | If::SAMPLED_LINEAR,
-                ..Properties::default()
-            },
-            Some(Depth32Float) if self.format_depth32float_none => Properties {
-                optimal_tiling: depth_if,
-                ..Properties::default()
-            },
-            Some(Stencil8) => Properties {
-                ..Properties::default()
-            },
-            Some(Depth24Unorm_Stencil8) if self.format_depth24_stencil8 => Properties {
-                optimal_tiling: depth_if,
-                ..Properties::default()
-            },
-            Some(Depth32Float_Stencil8) if self.format_depth32_stencil8_filter => Properties {
-                optimal_tiling: depth_if | If::SAMPLED_LINEAR,
-                ..Properties::default()
-            },
-            Some(Depth32Float_Stencil8) if self.format_depth32_stencil8_none => Properties {
-                optimal_tiling: depth_if,
-                ..Properties::default()
-            },
-            Some(BGR10A2Unorm) if self.format_bgr10a2_all => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::STORAGE
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                ..Properties::default()
-            },
-            Some(BGR10A2Unorm) if self.format_bgr10a2_no_write => Properties {
-                optimal_tiling: color_if
-                    | If::SAMPLED_LINEAR
-                    | If::COLOR_ATTACHMENT
-                    | If::COLOR_ATTACHMENT_BLEND,
-                ..Properties::default()
-            },
-            _ if map_vertex_format(format).is_some() => Properties {
-                buffer_features: Bf::VERTEX,
-                ..Properties::default()
-            },
-            _ => Properties::default(),
+                    | If::COLOR_ATTACHMENT_BLEND
+            }
+            RGBA32Float if self.format_rgba32float_color => If::COLOR_ATTACHMENT,
+            RGBA32Float if self.format_rgba32float_color_write => {
+                read_write_tier2_if | If::COLOR_ATTACHMENT | If::STORAGE
+            }
+            EAC_R11Unorm if self.format_eac_etc => If::SAMPLED_LINEAR,
+            EAC_R11Snorm if self.format_eac_etc => If::SAMPLED_LINEAR,
+            EAC_RG11Unorm if self.format_eac_etc => If::SAMPLED_LINEAR,
+            EAC_RG11Snorm if self.format_eac_etc => If::SAMPLED_LINEAR,
+            ETC2_RGB8 if self.format_eac_etc => If::SAMPLED_LINEAR,
+            ETC2_RGB8_sRGB if self.format_eac_etc => If::SAMPLED_LINEAR,
+            ETC2_RGB8A1 if self.format_eac_etc => If::SAMPLED_LINEAR,
+            ETC2_RGB8A1_sRGB if self.format_eac_etc => If::SAMPLED_LINEAR,
+            ASTC_4x4_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_4x4_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_5x4_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_5x4_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_5x5_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_5x5_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_6x5_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_6x5_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_6x6_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_6x6_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_8x5_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_8x5_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_8x6_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_8x6_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_8x8_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_8x8_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_10x5_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_10x5_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_10x6_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_10x6_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_10x8_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_10x8_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_10x10_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_10x10_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_12x10_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_12x10_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_12x12_LDR if self.format_astc => If::SAMPLED_LINEAR,
+            ASTC_12x12_sRGB if self.format_astc => If::SAMPLED_LINEAR,
+            BC1_RGBA if self.format_bc => If::SAMPLED_LINEAR,
+            BC1_RGBA_sRGB if self.format_bc => If::SAMPLED_LINEAR,
+            BC2_RGBA if self.format_bc => If::SAMPLED_LINEAR,
+            BC2_RGBA_sRGB if self.format_bc => If::SAMPLED_LINEAR,
+            BC3_RGBA if self.format_bc => If::SAMPLED_LINEAR,
+            BC3_RGBA_sRGB if self.format_bc => If::SAMPLED_LINEAR,
+            BC4_RUnorm if self.format_bc => If::SAMPLED_LINEAR,
+            BC4_RSnorm if self.format_bc => If::SAMPLED_LINEAR,
+            BC5_RGUnorm if self.format_bc => If::SAMPLED_LINEAR,
+            BC5_RGSnorm if self.format_bc => If::SAMPLED_LINEAR,
+            BC6H_RGBUfloat if self.format_bc => If::SAMPLED_LINEAR,
+            BC6H_RGBFloat if self.format_bc => If::SAMPLED_LINEAR,
+            BC7_RGBAUnorm if self.format_bc => If::SAMPLED_LINEAR,
+            BC7_RGBAUnorm_sRGB if self.format_bc => If::SAMPLED_LINEAR,
+            Depth16Unorm if self.format_depth16unorm => {
+                If::DEPTH_STENCIL_ATTACHMENT | If::SAMPLED_LINEAR
+            }
+            Depth32Float if self.format_depth32float_filter => {
+                If::DEPTH_STENCIL_ATTACHMENT | If::SAMPLED_LINEAR
+            }
+            Depth32Float if self.format_depth32float_none => If::DEPTH_STENCIL_ATTACHMENT,
+            Stencil8 => If::empty(),
+            Depth24Unorm_Stencil8 if self.format_depth24_stencil8 => If::DEPTH_STENCIL_ATTACHMENT,
+            Depth32Float_Stencil8 if self.format_depth32_stencil8_filter => {
+                If::DEPTH_STENCIL_ATTACHMENT | If::SAMPLED_LINEAR
+            }
+            Depth32Float_Stencil8 if self.format_depth32_stencil8_none => {
+                If::DEPTH_STENCIL_ATTACHMENT
+            }
+            BGR10A2Unorm if self.format_bgr10a2_all => {
+                If::SAMPLED_LINEAR | If::STORAGE | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            BGR10A2Unorm if self.format_bgr10a2_no_write => {
+                If::SAMPLED_LINEAR | If::COLOR_ATTACHMENT | If::COLOR_ATTACHMENT_BLEND
+            }
+            _ => If::empty(),
+        };
+
+        Properties {
+            linear_tiling: If::TRANSFER_SRC | If::TRANSFER_DST,
+            optimal_tiling: If::SAMPLED
+                | If::BLIT_SRC
+                | If::BLIT_DST
+                | If::TRANSFER_SRC
+                | If::TRANSFER_DST
+                | extra_optimal,
+            buffer_features: Bf::all(),
         }
     }
 }

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -377,13 +377,19 @@ pub fn map_query_result_flags(flags: query::ResultFlags) -> vk::QueryResultFlags
     vk::QueryResultFlags::from_raw(flags.bits() & vk::QueryResultFlags::all().as_raw())
 }
 
-pub fn map_image_features(features: vk::FormatFeatureFlags) -> format::ImageFeature {
+pub fn map_image_features(
+    features: vk::FormatFeatureFlags,
+    supports_transfer_bits: bool,
+) -> format::ImageFeature {
     let mut mapped_flags = format::ImageFeature::empty();
     if features.contains(vk::FormatFeatureFlags::SAMPLED_IMAGE) {
         mapped_flags |= format::ImageFeature::SAMPLED;
     }
     if features.contains(vk::FormatFeatureFlags::SAMPLED_IMAGE_FILTER_LINEAR) {
         mapped_flags |= format::ImageFeature::SAMPLED_LINEAR;
+    }
+    if features.contains(vk::FormatFeatureFlags::SAMPLED_IMAGE_FILTER_MINMAX) {
+        mapped_flags |= format::ImageFeature::SAMPLED_MINMAX;
     }
 
     if features.contains(vk::FormatFeatureFlags::STORAGE_IMAGE) {
@@ -406,9 +412,23 @@ pub fn map_image_features(features: vk::FormatFeatureFlags) -> format::ImageFeat
 
     if features.contains(vk::FormatFeatureFlags::BLIT_SRC) {
         mapped_flags |= format::ImageFeature::BLIT_SRC;
+        if !supports_transfer_bits {
+            mapped_flags |= format::ImageFeature::TRANSFER_SRC;
+        }
     }
     if features.contains(vk::FormatFeatureFlags::BLIT_DST) {
         mapped_flags |= format::ImageFeature::BLIT_DST;
+        if !supports_transfer_bits {
+            mapped_flags |= format::ImageFeature::TRANSFER_DST;
+        }
+    }
+    if supports_transfer_bits {
+        if features.contains(vk::FormatFeatureFlags::TRANSFER_SRC) {
+            mapped_flags |= format::ImageFeature::TRANSFER_SRC;
+        }
+        if features.contains(vk::FormatFeatureFlags::TRANSFER_DST) {
+            mapped_flags |= format::ImageFeature::TRANSFER_DST;
+        }
     }
 
     mapped_flags

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -706,6 +706,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         }
 
         let imageless_framebuffers = self.supports_extension(vk::KhrImagelessFramebufferFn::name());
+        let minmax_samplers = self.supports_extension(vk::ExtSamplerFilterMinmaxFn::name());
         let maintenance_level = if imageless_framebuffers {
             2
         } else if self.supports_extension(vk::KhrMaintenance1Fn::name()) {
@@ -738,6 +739,9 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             if imageless_framebuffers {
                 enabled_extensions.push(vk::KhrImageFormatListFn::name());
                 enabled_extensions.push(vk::KhrImagelessFramebufferFn::name());
+            }
+            if minmax_samplers {
+                enabled_extensions.push(vk::ExtSamplerFilterMinmaxFn::name());
             }
 
             if requested_features.intersects(
@@ -884,10 +888,17 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 format.map_or(vk::Format::UNDEFINED, conv::map_format),
             )
         };
+        let supports_transfer_bits = self.supports_extension(vk::KhrMaintenance1Fn::name());
 
         format::Properties {
-            linear_tiling: conv::map_image_features(properties.linear_tiling_features),
-            optimal_tiling: conv::map_image_features(properties.optimal_tiling_features),
+            linear_tiling: conv::map_image_features(
+                properties.linear_tiling_features,
+                supports_transfer_bits,
+            ),
+            optimal_tiling: conv::map_image_features(
+                properties.optimal_tiling_features,
+                supports_transfer_bits,
+            ),
             buffer_features: conv::map_buffer_features(properties.buffer_features),
         }
     }

--- a/src/hal/src/format.rs
+++ b/src/hal/src/format.rs
@@ -151,7 +151,7 @@ bitflags!(
         const SAMPLED = 0x1;
         /// Image can be sampled with a linear sampler or as blit source with linear sampling.
         const SAMPLED_LINEAR = 0x2;
-        /// Image can be sampled with a
+        /// Image can be sampled with a min/max reduction sampler.
         const SAMPLED_MINMAX = 0x4;
 
         /// Image view can be used as storage image with exclusive read & write access.

--- a/src/hal/src/format.rs
+++ b/src/hal/src/format.rs
@@ -141,6 +141,7 @@ pub struct Properties {
     pub buffer_features: BufferFeature,
 }
 
+//Note: these are detached from Vulkan!
 bitflags!(
     /// Image feature flags.
     #[derive(Default)]
@@ -148,9 +149,10 @@ bitflags!(
     pub struct ImageFeature: u32 {
         /// Image view can be sampled.
         const SAMPLED = 0x1;
-        /// Image can be sampled with a (mipmap) linear sampler or as blit source with linear sampling.
-        /// (implies SAMPLED and BLIT_SRC support)
+        /// Image can be sampled with a linear sampler or as blit source with linear sampling.
         const SAMPLED_LINEAR = 0x2;
+        /// Image can be sampled with a
+        const SAMPLED_MINMAX = 0x4;
 
         /// Image view can be used as storage image with exclusive read & write access.
         const STORAGE = 0x10;
@@ -170,6 +172,10 @@ bitflags!(
         const BLIT_SRC = 0x1000;
         /// Image can be used as destination for blit commands.
         const BLIT_DST = 0x2000;
+        /// Image can be copied from.
+        const TRANSFER_SRC = 0x4000;
+        /// Image can be copied to.
+        const TRANSFER_DST = 0x8000;
     }
 );
 


### PR DESCRIPTION
Fixes #3575 
Having distinct `TRANSFER_SRC` and `TRANSFER_DST` flags follows Vulkan's maintenance-1 extension and allows for better separation between "blit" and "transfer" capabilities.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
