### PR TITLE
Add a feature for non-normalized samplers

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -390,22 +390,10 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 
     fn features(&self) -> hal::Features {
         use hal::Features as F;
-        F::empty()
-            | F::FULL_DRAW_INDEX_U32
-            | if self.shared.private_caps.texture_cube_array {
-                F::IMAGE_CUBE_ARRAY
-            } else {
-                F::empty()
-            }
+        let mut features = F::FULL_DRAW_INDEX_U32
             | F::INDEPENDENT_BLENDING
-            | if self.shared.private_caps.dual_source_blending {
-                F::DUAL_SRC_BLENDING
-            } else {
-                F::empty()
-            }
             | F::DRAW_INDIRECT_FIRST_INSTANCE
             | F::DEPTH_CLAMP
-            //| F::DEPTH_BOUNDS
             | F::SAMPLER_ANISOTROPY
             | F::FORMAT_BC
             | F::PRECISE_OCCLUSION_QUERY
@@ -414,32 +402,40 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             | F::FRAGMENT_STORES_AND_ATOMICS
             | F::INSTANCE_RATE
             | F::SEPARATE_STENCIL_REF_VALUES
-            | if self.shared.private_caps.expose_line_mode {
-                F::NON_FILL_POLYGON_MODE
-            } else {
-                F::empty()
-            }
             | F::SHADER_CLIP_DISTANCE
-            | if self.shared.private_caps.msl_version >= metal::MTLLanguageVersion::V2_0 {
-                F::TEXTURE_DESCRIPTOR_ARRAY |
-                    F::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING |
-                    F::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING |
-                    F::STORAGE_TEXTURE_DESCRIPTOR_INDEXING
-            } else {
-                F::empty()
-            }
-            //| F::SAMPLER_MIRROR_CLAMP_EDGE
-            | if self.shared.private_caps.sampler_clamp_to_border {
-                F::SAMPLER_BORDER_COLOR
-            } else {
-                F::empty()
-            }
-            | if self.shared.private_caps.mutable_comparison_samplers {
-                F::MUTABLE_COMPARISON_SAMPLER
-            } else {
-                F::empty()
-            }
-            | F::NDC_Y_UP
+            | F::MUTABLE_UNNORMALIZED_SAMPLER
+            | F::NDC_Y_UP;
+
+        features.set(
+            F::IMAGE_CUBE_ARRAY,
+            self.shared.private_caps.texture_cube_array,
+        );
+        features.set(
+            F::DUAL_SRC_BLENDING,
+            self.shared.private_caps.dual_source_blending,
+        );
+        features.set(
+            F::NON_FILL_POLYGON_MODE,
+            self.shared.private_caps.expose_line_mode,
+        );
+        if self.shared.private_caps.msl_version >= metal::MTLLanguageVersion::V2_0 {
+            features |= F::TEXTURE_DESCRIPTOR_ARRAY
+                | F::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING
+                | F::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING
+                | F::STORAGE_TEXTURE_DESCRIPTOR_INDEXING;
+        }
+        features.set(
+            F::SAMPLER_BORDER_COLOR,
+            self.shared.private_caps.sampler_clamp_to_border,
+        );
+        features.set(
+            F::MUTABLE_COMPARISON_SAMPLER,
+            self.shared.private_caps.mutable_comparison_samplers,
+        );
+
+        //TODO: F::DEPTH_BOUNDS
+        //TODO: F::SAMPLER_MIRROR_CLAMP_EDGE
+        features
     }
 
     fn hints(&self) -> hal::Hints {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1021,6 +1021,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             | Features::SAMPLER_MIP_LOD_BIAS
             | Features::SAMPLER_BORDER_COLOR
             | Features::MUTABLE_COMPARISON_SAMPLER
+            | Features::MUTABLE_UNNORMALIZED_SAMPLER
             | Features::TEXTURE_DESCRIPTOR_ARRAY;
 
         if self.supports_extension(vk::AmdNegativeViewportHeightFn::name())

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -253,6 +253,8 @@ bitflags! {
         const SAMPLER_BORDER_COLOR = 0x0010 << 64;
         /// Can create comparison samplers in regular descriptor sets.
         const MUTABLE_COMPARISON_SAMPLER = 0x0020 << 64;
+        /// Can create non-normalized samplers in regular descriptor sets.
+        const MUTABLE_UNNORMALIZED_SAMPLER = 0x0040 << 64;
 
         /// Make the NDC coordinate system pointing Y up, to match D3D and Metal.
         const NDC_Y_UP = 0x0001 << 80;


### PR DESCRIPTION
This is a limitation of D3D, which we want to expose one way or the other.