### PR TITLE
Expose dynamic state capabilities in the backends

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -536,13 +536,11 @@ impl hal::Instance<Backend> for Instance {
             let limits = get_limits(feature_level);
             let features = get_features(device.clone(), feature_level);
             let format_properties = get_format_properties(device.clone());
-            let hints = hal::Hints::BASE_VERTEX_INSTANCE_DRAWING;
 
             let physical_device = PhysicalDevice {
                 adapter,
                 library_d3d11: Arc::clone(&self.library_d3d11),
                 features,
-                hints,
                 limits,
                 memory_properties,
                 format_properties,
@@ -581,7 +579,6 @@ pub struct PhysicalDevice {
     adapter: ComPtr<IDXGIAdapter>,
     library_d3d11: Arc<libloading::Library>,
     features: hal::Features,
-    hints: hal::Hints,
     limits: hal::Limits,
     memory_properties: adapter::MemoryProperties,
     format_properties: [format::Properties; format::NUM_FORMATS],
@@ -854,8 +851,16 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         self.features
     }
 
-    fn hints(&self) -> hal::Hints {
-        self.hints
+    fn capabilities(&self) -> hal::Capabilities {
+        use hal::DynamicStates as Ds;
+        hal::Capabilities {
+            performance_caveats: hal::PerformanceCaveats::empty(),
+            dynamic_pipeline_states: Ds::VIEWPORT
+                | Ds::SCISSOR
+                | Ds::BLEND_COLOR
+                | Ds::DEPTH_BOUNDS
+                | Ds::STENCIL_REFERENCE,
+        }
     }
 
     fn limits(&self) -> Limits {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -142,11 +142,11 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn features(&self) -> hal::Features {
-        unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
+        hal::Features::empty()
     }
 
-    fn hints(&self) -> hal::Hints {
-        unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
+    fn capabilities(&self) -> hal::Capabilities {
+        Default::default()
     }
 
     fn limits(&self) -> hal::Limits {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -203,8 +203,8 @@ struct Share {
     info: Info,
     supported_features: hal::Features,
     legacy_features: info::LegacyFeatures,
-    hints: hal::Hints,
     limits: hal::Limits,
+    public_caps: hal::Capabilities,
     private_caps: info::PrivateCaps,
     // Indicates if there is an active logical device.
     open: Cell<bool>,
@@ -354,7 +354,7 @@ impl PhysicalDevice {
     fn new_adapter(context: GlContext) -> adapter::Adapter<Backend> {
         let gl = GlContainer { context };
         // query information
-        let (info, supported_features, legacy_features, hints, limits, private_caps) =
+        let (info, supported_features, legacy_features, limits, public_caps, private_caps) =
             info::query_all(&gl);
         info!("Vendor: {:?}", info.platform_name.vendor);
         info!("Renderer: {:?}", info.platform_name.renderer);
@@ -362,6 +362,7 @@ impl PhysicalDevice {
         info!("Shading Language: {:?}", info.shading_language);
         info!("Supported Features: {:?}", supported_features);
         info!("Legacy Features: {:?}", legacy_features);
+        debug!("Public capabilities: {:#?}", public_caps);
         debug!("Private capabilities: {:#?}", private_caps);
         debug!("Loaded Extensions:");
         for extension in info.extensions.iter() {
@@ -431,8 +432,8 @@ impl PhysicalDevice {
             info,
             supported_features,
             legacy_features,
-            hints,
             limits,
+            public_caps,
             private_caps,
             open: Cell::new(false),
             memory_types,
@@ -642,8 +643,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         self.0.supported_features
     }
 
-    fn hints(&self) -> hal::Hints {
-        self.0.hints
+    fn capabilities(&self) -> hal::Capabilities {
+        self.0.public_caps
     }
 
     fn limits(&self) -> hal::Limits {

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -297,7 +297,7 @@ impl CommandQueue {
             } => {
                 let gl = &self.share.context;
                 let legacy = &self.share.legacy_features;
-                let hints = &self.share.hints;
+                let caveats = &self.share.public_caps.performance_caveats;
 
                 if instances == &(0u32..1) {
                     if base_vertex == 0 {
@@ -348,7 +348,12 @@ impl CommandQueue {
                         }
                     } else if instances.start == 0 {
                         error!("Base vertex with instanced indexed drawing is not supported");
-                    } else if hints.contains(hal::Hints::BASE_VERTEX_INSTANCE_DRAWING) {
+                    } else if caveats
+                        .contains(hal::PerformanceCaveats::BASE_VERTEX_INSTANCE_DRAWING)
+                    {
+                        //TODO: this is supposed to be a workaround, not an error
+                        error!("Instance bases with instanced indexed drawing is not supported");
+                    } else {
                         unsafe {
                             gl.draw_elements_instanced_base_vertex_base_instance(
                                 primitive,
@@ -360,8 +365,6 @@ impl CommandQueue {
                                 instances.start as _,
                             );
                         }
-                    } else {
-                        error!("Instance bases with instanced indexed drawing is not supported");
                     }
                 } else {
                     error!("Instanced indexed drawing is not supported");

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -442,11 +442,14 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             | F::NDC_Y_UP
     }
 
-    fn hints(&self) -> hal::Hints {
-        if self.shared.private_caps.base_vertex_instance_drawing {
-            hal::Hints::BASE_VERTEX_INSTANCE_DRAWING
-        } else {
-            hal::Hints::empty()
+    fn capabilities(&self) -> hal::Capabilities {
+        let mut caveats = hal::PerformanceCaveats::empty();
+        if !self.shared.private_caps.base_vertex_instance_drawing {
+            caveats |= hal::PerformanceCaveats::BASE_VERTEX_INSTANCE_DRAWING;
+        }
+        hal::Capabilities {
+            performance_caveats: caveats,
+            dynamic_pipeline_states: hal::DynamicStates::all(),
         }
     }
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -47,7 +47,7 @@ use hal::{
     pso::{PatchSize, PipelineStage},
     queue,
     window::{OutOfDate, PresentError, Suboptimal, SurfaceLost},
-    Features, Hints, Limits,
+    Capabilities, DynamicStates, Features, Limits,
 };
 
 use std::{
@@ -1220,8 +1220,11 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         bits
     }
 
-    fn hints(&self) -> Hints {
-        Hints::BASE_VERTEX_INSTANCE_DRAWING
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            performance_caveats: Default::default(),
+            dynamic_pipeline_states: DynamicStates::all(),
+        }
     }
 
     fn limits(&self) -> Limits {

--- a/src/backend/webgpu/src/lib.rs
+++ b/src/backend/webgpu/src/lib.rs
@@ -189,7 +189,7 @@ impl hal::adapter::PhysicalDevice<Backend> for PhysicalDevice {
         todo!()
     }
 
-    fn hints(&self) -> hal::Hints {
+    fn capabilities(&self) -> hal::Capabilities {
         todo!()
     }
 

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -11,7 +11,7 @@
 use crate::{
     device, format, image, memory,
     queue::{QueueGroup, QueuePriority},
-    Backend, Features, Hints, Limits,
+    Backend, Capabilities, Features, Limits,
 };
 
 use std::{any::Any, fmt};
@@ -116,11 +116,12 @@ pub trait PhysicalDevice<B: Backend>: fmt::Debug + Any + Send + Sync {
     fn memory_properties(&self) -> MemoryProperties;
 
     /// Returns the features of this `PhysicalDevice`. This usually depends on the graphics API being
-    /// used.
+    /// used, as well as the actual platform underneath.
     fn features(&self) -> Features;
 
-    /// Returns the performance hints of this `PhysicalDevice`.
-    fn hints(&self) -> Hints;
+    /// Returns the capabilities of this `PhysicalDevice`. Similarly to `Features`, they
+    // depend on the platform, but unlike features, these are immutable and can't be switched on.
+    fn capabilities(&self) -> Capabilities;
 
     /// Returns the resource limits of this `PhysicalDevice`.
     fn limits(&self) -> Limits;

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -265,12 +265,52 @@ bitflags! {
 }
 
 bitflags! {
-    /// Features that the device supports natively, but is able to emulate.
+    /// Features that the device doesn't support natively, but is able to emulate
+    /// at some performance cost.
+    #[derive(Default)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct Hints: u32 {
-        /// Support indexed, instanced drawing with base vertex and instance.
+    pub struct PerformanceCaveats: u32 {
+        /// Emulate indexed, instanced drawing with base vertex and instance.
         const BASE_VERTEX_INSTANCE_DRAWING = 0x0001;
     }
+}
+
+bitflags! {
+    /// Dynamic pipeline states.
+    #[derive(Default)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct DynamicStates: u32 {
+        /// Supports `BakedStates::viewport == None`
+        const VIEWPORT = 0x0001;
+        /// Supports `BakedStates::scissor == None`
+        const SCISSOR = 0x0002;
+        /// Supports `Rasterizer::line_width == State::Dynamic(_)`
+        const LINE_WIDTH = 0x0004;
+        /// Supports `BakedStates::blend_color == None`
+        const BLEND_COLOR = 0x0008;
+        /// Supports `Rasterizer::depth_bias == Some(State::Dynamic(_))`
+        const DEPTH_BIAS = 0x0010;
+        /// Supports `BakedStates::depth_bounds == None`
+        const DEPTH_BOUNDS = 0x0020;
+        /// Supports `StencilTest::read_masks == State::Dynamic(_)`
+        const STENCIL_READ_MASK = 0x0100;
+        /// Supports `StencilTest::write_masks == State::Dynamic(_)`
+        const STENCIL_WRITE_MASK = 0x0200;
+        /// Supports `StencilTest::reference_values == State::Dynamic(_)`
+        const STENCIL_REFERENCE = 0x0400;
+    }
+}
+
+/// Capabilities of physical devices that are exposed but
+/// do not need to be explicitly opted into.
+//TODO: should we move `Limits` in here?
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Capabilities {
+    /// Performance caveats.
+    pub performance_caveats: PerformanceCaveats,
+    /// Dynamic pipeline states.
+    pub dynamic_pipeline_states: DynamicStates,
 }
 
 /// Resource limits of a particular graphics device.


### PR DESCRIPTION
Fixes  #3441
Reverses the semantic of "hints", also renaming them to "performance_caveats", and placing inside a new struct called `Capabilities`. Unlike features, this struct represent properties of the adapter that do not need to be enabled.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
