### PR TITLE
[GL] Add empty fragment shader when only vertex shader present

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -27,7 +27,7 @@ auxil = { path = "../../auxil/auxil", version = "0.5", package = "gfx-auxil", fe
 smallvec = "1.0"
 glow = "0.7.1"
 parking_lot = "0.11"
-spirv_cross = { version = "0.22", features = ["glsl"]}
+spirv_cross = { version = "0.22.2", features = ["glsl"]}
 raw-window-handle = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
Fixes #3580
Possible fixes #3562
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: OpenGL ES
