### PR TITLE
Dynamic version detection for EGL

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -31,7 +31,7 @@ spirv_cross = { version = "0.22.2", features = ["glsl"]}
 raw-window-handle = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egl = { package = "khronos-egl", git = "https://github.com/timothee-haudebourg/khronos-egl", rev = "9568b2ee3b02f2c17cc9479f824db16daecf1664", features = ["dynamic"] }
+egl = { package = "khronos-egl", git = "https://github.com/timothee-haudebourg/khronos-egl", rev = "4b769b8f2d068fa78db9285a8557cd11365fa314", features = ["dynamic"] }
 libloading = "0.6"
 
 [dependencies.naga]


### PR DESCRIPTION
Fixes https://github.com/timothee-haudebourg/khronos-egl/issues/11 (is there an according issue in this repo?)
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds: fails on my machine (Arch Linux, X11, i3, NVIDIA proprietary driver, RTX 2070 Super), but so does the `master` branch
- [x] tested examples with the following backends: `gfx-backend-gl`
