### PR TITLE
[vk] don't forget to enable maintenance-1

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -36,7 +36,7 @@ log = "0.4"
 hal = { path = "../src/hal", version = "0.6", package = "gfx-hal" }
 auxil = { path = "../src/auxil/auxil", version = "0.5", package = "gfx-auxil" }
 gfx-backend-empty = { path = "../src/backend/empty", version = "0.6" }
-winit = { version = "0.23", features = ["web-sys"] }
+winit = { version = "0.24", features = ["web-sys"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.8"

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -319,29 +319,29 @@ impl Device {
         let version = self.share.info.shading_language.tuple();
         compile_options.version = if is_embedded {
             match version {
-                (3, 20) | (3, 2) => glsl::Version::V3_20Es,
-                (3, 10) | (3, 1) => glsl::Version::V3_10Es,
-                (3, 00) | (3, 0) => glsl::Version::V3_00Es,
-                (1, 00) => glsl::Version::V1_00Es,
-                other if other > (3, 20) => glsl::Version::V3_20Es,
+                (3, 2) => glsl::Version::V3_20Es,
+                (3, 1) => glsl::Version::V3_10Es,
+                (3, 0) => glsl::Version::V3_00Es,
+                (1, 0) => glsl::Version::V1_00Es,
+                other if other > (3, 2) => glsl::Version::V3_20Es,
                 other => panic!("GLSL version is not recognized: {:?}", other),
             }
         } else {
             match version {
-                (4, 60) => glsl::Version::V4_60,
-                (4, 50) => glsl::Version::V4_50,
-                (4, 40) => glsl::Version::V4_40,
-                (4, 30) => glsl::Version::V4_30,
-                (4, 20) => glsl::Version::V4_20,
-                (4, 10) => glsl::Version::V4_10,
-                (4, 00) => glsl::Version::V4_00,
-                (3, 30) => glsl::Version::V3_30,
-                (1, 50) => glsl::Version::V1_50,
-                (1, 40) => glsl::Version::V1_40,
-                (1, 30) => glsl::Version::V1_30,
-                (1, 20) => glsl::Version::V1_20,
-                (1, 10) => glsl::Version::V1_10,
-                other if other > (4, 60) => glsl::Version::V4_60,
+                (4, 6) => glsl::Version::V4_60,
+                (4, 5) => glsl::Version::V4_50,
+                (4, 4) => glsl::Version::V4_40,
+                (4, 3) => glsl::Version::V4_30,
+                (4, 2) => glsl::Version::V4_20,
+                (4, 1) => glsl::Version::V4_10,
+                (4, 0) => glsl::Version::V4_00,
+                (3, 3) => glsl::Version::V3_30,
+                (1, 5) => glsl::Version::V1_50,
+                (1, 4) => glsl::Version::V1_40,
+                (1, 3) => glsl::Version::V1_30,
+                (1, 2) => glsl::Version::V1_20,
+                (1, 1) => glsl::Version::V1_10,
+                other if other > (4, 6) => glsl::Version::V4_60,
                 other => panic!("GLSL version is not recognized: {:?}", other),
             }
         };

--- a/src/backend/gl/src/window/egl.rs
+++ b/src/backend/gl/src/window/egl.rs
@@ -308,7 +308,7 @@ impl hal::Instance<crate::Backend> for Instance {
         use raw_window_handle::RawWindowHandle as Rwh;
 
         let mut inner = self.inner.lock();
-        let mut native_window_ptr = match has_handle.raw_window_handle() {
+        let native_window_ptr = match has_handle.raw_window_handle() {
             #[cfg(not(target_os = "android"))]
             Rwh::Xlib(handle) => handle.window as *mut std::ffi::c_void,
             #[cfg(not(target_os = "android"))]

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -731,6 +731,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                     enabled_extensions.push(vk::KhrMaintenance1Fn::name());
                 }
                 2 => {
+                    enabled_extensions.push(vk::KhrMaintenance1Fn::name());
                     enabled_extensions.push(vk::KhrMaintenance2Fn::name());
                 }
                 _ => unreachable!(),


### PR DESCRIPTION
Apparently, enabling maintenance-2 doesn't auto-enable maintenance-1. Who'd new? That manifests in our NDC inversion going broke:
> [1.285790 ERROR]()(no module): 
VALIDATION [VUID-VkViewport-height-01772 (-1596201395)] : Validation Error: [ VUID-VkViewport-height-01772 ] Object 0: handle = 0x559394238118, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xa0dbe64d | vkCmdSetViewport: pViewports[0].height (=-600.000000) is not greater 0.0. The Vulkan spec states: height must be greater than 0.0 (https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#VUID-VkViewport-height-01772)
object info: (type: COMMAND_BUFFER, hndl: 94092333908248)
