### PR TITLE
[GL] Workaround WebGL's Lack of Per-Target Color Masks

### DIFF
--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -204,6 +204,8 @@ pub struct PrivateCaps {
     pub depth_range_f64_precision: bool,
     /// Whether draw buffers are supported
     pub draw_buffers: bool,
+    /// Whether separate color masks per output buffer are supported.
+    pub per_slot_color_mask: bool,
 }
 
 /// OpenGL implementation information
@@ -532,6 +534,7 @@ pub(crate) fn query_all(
         emulate_map,
         depth_range_f64_precision: !info.version.is_embedded, // TODO
         draw_buffers: info.is_supported(&[Core(2, 0), Es(3, 0)]),
+        per_slot_color_mask: info.is_supported(&[Core(3, 0)])
     };
 
     (info, features, legacy, limits, capabilities, private)


### PR DESCRIPTION
Fixes #3593

This works around the issue. To avoid redundant state changes in the future, as mentioned in the comment, we should coalesce on the command-generator side to a single global call.
