### PR TITLE
[gl] Detect XLib display mismatch

### DIFF
--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -534,7 +534,7 @@ pub(crate) fn query_all(
         emulate_map,
         depth_range_f64_precision: !info.version.is_embedded, // TODO
         draw_buffers: info.is_supported(&[Core(2, 0), Es(3, 0)]),
-        per_slot_color_mask: info.is_supported(&[Core(3, 0)])
+        per_slot_color_mask: info.is_supported(&[Core(3, 0)]),
     };
 
     (info, features, legacy, limits, capabilities, private)

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -988,8 +988,8 @@ impl CommandQueue {
                     );
                 } else {
                     if slot.is_some() {
-                        /// TODO: the generator of these commands should coalesce identical masks to prevent this warning
-                        ///       as much as is possible.
+                        // TODO: the generator of these commands should coalesce identical masks to prevent this warning
+                        //       as much as is possible.
                         warn!("GLES and WebGL do not support per-target color masks. Falling back on global mask.");
                     }
                     self.share.context.color_mask(


### PR DESCRIPTION
Fixes #3588
The problem was that the RWH handle was of a different XLib display from the one used for `Instance` creation. Now we detect this and react accordingly. Running the example is still not possible on those Intel+NV machines, but that should be resolved separately. There was already `supports_native_window = false` in the instance.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Linux
