### PR TITLE
[gl] fix x11 RWH handling, tiered configs, and fill_buffer

### DIFF
--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -100,6 +100,7 @@ pub enum Command {
     ClearBufferDepthStencil(Option<pso::DepthValue>, Option<pso::StencilValue>),
     /// Clear the currently bound texture with the given color.
     ClearTexture([f32; 4]),
+    FillBuffer(n::RawBuffer, Range<buffer::Offset>, u32),
 
     BindFramebuffer {
         target: FrameBufferTarget,
@@ -777,8 +778,11 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         // TODO
     }
 
-    unsafe fn fill_buffer(&mut self, _buffer: &n::Buffer, _range: buffer::SubRange, _data: u32) {
-        unimplemented!()
+    unsafe fn fill_buffer(&mut self, buffer: &n::Buffer, sub: buffer::SubRange, data: u32) {
+        let (raw_buffer, parent_range) = buffer.as_bound();
+        let range = crate::resolve_sub_range(&sub, parent_range);
+        self.data
+            .push_cmd(Command::FillBuffer(raw_buffer, range, data));
     }
 
     unsafe fn update_buffer(&mut self, _buffer: &n::Buffer, _offset: buffer::Offset, _data: &[u8]) {
@@ -990,7 +994,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         T: IntoIterator,
         T::Item: Borrow<command::ImageBlit>,
     {
-        unimplemented!()
+        error!("Blit is not implemented");
     }
 
     unsafe fn bind_index_buffer(

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -167,8 +167,8 @@ pub struct PlatformName {
 impl PlatformName {
     fn get(gl: &GlContainer) -> Self {
         PlatformName {
-            vendor: get_string(gl, glow::VENDOR).unwrap(),
-            renderer: get_string(gl, glow::RENDERER).unwrap(),
+            vendor: get_string(gl, glow::VENDOR).unwrap_or_default(),
+            renderer: get_string(gl, glow::RENDERER).unwrap_or_default(),
         }
     }
 }

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -543,6 +543,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         let gl = &self.0.context;
 
         if cfg!(debug_assertions) && !cfg!(target_arch = "wasm32") && gl.supports_debug() {
+            info!("Debug output is enabled");
             gl.enable(glow::DEBUG_OUTPUT);
             gl.debug_message_callback(debug_message_callback);
         }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -46,9 +46,9 @@ pub enum Buffer {
 impl Buffer {
     // Asserts that the buffer is bound and returns the raw gl buffer along with its sub-range.
     pub(crate) fn as_bound(&self) -> (RawBuffer, Range<u64>) {
-        match self {
+        match *self {
             Buffer::Unbound { .. } => panic!("Expected bound buffer!"),
-            Buffer::Bound { buffer, range, .. } => (*buffer, range.clone()),
+            Buffer::Bound { buffer, ref range } => (buffer, range.clone()),
         }
     }
 }

--- a/src/warden/Cargo.toml
+++ b/src/warden/Cargo.toml
@@ -33,7 +33,7 @@ hal = { path = "../hal", version = "0.6", package = "gfx-hal", features = ["serd
 log = "0.4"
 ron = "0.6"
 serde = { version = "1", features = ["serde_derive"] }
-env_logger = { version = "0.7", optional = true }
+env_logger = { version = "0.8", optional = true }
 glsl-to-spirv = { version = "0.1", optional = true }
 
 [dependencies.gfx-backend-vulkan]

--- a/work/scenes/transfer.ron
+++ b/work/scenes/transfer.ron
@@ -223,7 +223,7 @@
 				FillBuffer(
 					buffer: "buffer.fill-8-bytes",
 					offset: 4,
-					size: Some(8),
+					size: Some(4),
 					data: 0xFF,
 				),
 			]


### PR DESCRIPTION
Fixes the GL backend presentation on all platforms (yikes!).
Refactors the fbconfig request to check for tiers in a loop.
Finally, implements `fill_buffer`. We can now go through `make reftests` without crashes, albeit some unimplemented methods remain.

r? @Gordon-F 
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: GL
