### PR TITLE
[GL] Testing with the Android Emulator on CI

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,8 @@
+[target.x86_64-linux-android]
+rustflags = [
+    "-C", "link-arg=-lc++_shared",
+    "-C", "link-arg=-lc++abi",
+    "-C", "link-arg=-lEGL",
+    "-C", "link-arg=-lGLESv3",
+    "-C", "link-arg=-llog",
+]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,105 +3,37 @@ name: CI
 on:
   push:
     branches-ignore: [staging.tmp]
+    paths:
+    #- 'examples/quad_android/**'
+    #- '!examples/quad_android/**.md'
+    #- 'src/backend/gl/**'
+    #- '!src/backend/gl/**.md'
   pull_request:
     branches-ignore: [staging.tmp]
-
+    paths:
+    #- 'examples/quad_android/**'
+    #- '!examples/quad_android/**.md'
+    #- 'src/backend/gl/**'
+    #- '!src/backend/gl/**.md'
 jobs:
-  ios_build:
-    name: iOS Stable
-    runs-on: macos-10.15
-    env:
-      TARGET: aarch64-apple-ios
-    steps:
-      - uses: actions/checkout@v2
-      - name: Prepare Rust
-        run: rustup target add ${{ env.TARGET }}
-      - run: cargo check --manifest-path src/backend/metal/Cargo.toml --target ${{ env.TARGET }}
-
-  android_build:
-    name: Android Stable
-    runs-on: ubuntu-18.04
-    env:
-      TARGET: aarch64-linux-android
-    steps:
-      - uses: actions/checkout@v2
-      - run: echo "$ANDROID_HOME/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
-      - name: Prepare Rust
-        run: rustup target add ${{ env.TARGET }}
-      - run: cargo check --manifest-path src/backend/vulkan/Cargo.toml --target ${{ env.TARGET }}
-      - run: cargo check --manifest-path src/backend/gl/Cargo.toml --target ${{ env.TARGET }}
-
-  webgl_build:
-    name: Web Assembly
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - run: rustup target add wasm32-unknown-unknown
-      - run: cargo build --manifest-path examples/Cargo.toml --features gl --target wasm32-unknown-unknown --bin quad
-
-  check-advisories:
-    name: Advisory Check
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: EmbarkStudios/cargo-deny-action@v1
+  test:
+      runs-on: macos-10.15
+      steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
         with:
-          command: check advisories
-
-  check-dependencies:
-    name: Dependency Check
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: EmbarkStudios/cargo-deny-action@v1
+          api-level: 29
+          arch: x86_64
+          # the `googleapis` emulator target considerably slower on CI.
+          target: default
+          profile: Nexus 5X
+          script: sh ./.github/workflows/android_test.sh
+      - uses: actions/upload-artifact@master
+        if: ${{ always() }}
         with:
-          command: check bans licenses sources
-
-  build:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        name:
-          [
-            MacOS Stable,
-            MacOS Nightly,
-            Ubuntu Stable,
-            Ubuntu Nightly,
-            Windows Stable,
-            Windows Nightly,
-          ]
-        include:
-          - os: macos-10.15
-            name: MacOS Stable
-            channel: stable
-          - os: macos-10.15
-            name: MacOS Nightly
-            channel: nightly
-          - os: ubuntu-18.04
-            name: Ubuntu Stable
-            channel: stable
-          - os: ubuntu-18.04
-            name: Ubuntu Nightly
-            channel: nightly
-          - os: windows-2019
-            name: Windows Stable
-            channel: stable
-          - os: windows-2019
-            name: Windows Nightly
-            channel: nightly
-    steps:
-      - uses: actions/checkout@v2
-      - if: matrix.channel == 'nightly'
-        name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-      - if: matrix.os == 'windows-2019'
-        name: Install make
-        run: choco install make
-      #- if: matrix.channel == 'stable'
-      #  run: rustup component add clippy
-      - run: make all
+          name: screenshot
+          path: |
+            ~/screenshot.png
+            ~/logcat.log

--- a/.github/workflows/android_test.sh
+++ b/.github/workflows/android_test.sh
@@ -10,7 +10,7 @@ sleep 30s
 
 adb shell /system/bin/screencap -p /sdcard/screenshot.png
 adb pull /sdcard/screenshot.png ~/screenshot.png
-adb logcat *:S RustStdoutStderr:V -d > ~/logcat.log
+adb logcat *:E RustStdoutStderr:V -d > ~/logcat.log
 
 if grep 'RustStdoutStderr' ~/logcat.log;
 then

--- a/.github/workflows/android_test.sh
+++ b/.github/workflows/android_test.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -ex
+
+rustup target install x86_64-linux-android
+cargo install cargo-apk
+cargo apk run --package quad_android --target x86_64-linux-android
+
+sleep 30s
+
+adb shell /system/bin/screencap -p /sdcard/screenshot.png
+adb pull /sdcard/screenshot.png ~/screenshot.png
+adb logcat *:S RustStdoutStderr:V -d > ~/logcat.log
+
+if grep 'RustStdoutStderr' ~/logcat.log;
+then
+    echo "App running"
+else
+    exit 1
+fi
+
+if grep -e 'thread.*panicked at' ~/logcat.log;
+then
+    exit 1
+else
+    exit 0
+fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "src/hal",
     "src/warden",
     "examples",
+    "examples/quad_android",
 ]
 
 [patch."https://github.com/gfx-rs/naga"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -38,7 +38,7 @@ auxil = { path = "../src/auxil/auxil", version = "0.5", package = "gfx-auxil" }
 gfx-backend-empty = { path = "../src/backend/empty", version = "0.6" }
 winit = { version = "0.24", features = ["web-sys"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(any(target_os = "android", target_arch = "wasm32")))'.dependencies]
 env_logger = "0.8"
 glsl-to-spirv = "0.1.4"
 
@@ -56,7 +56,7 @@ path = "../src/backend/vulkan"
 version = "0.6"
 optional = true
 
-[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos"), not(target_os = "android")))'.dependencies.gfx-backend-gl]
+[target.'cfg(all(unix, not(target_os = "ios"), not(target_os = "macos")))'.dependencies.gfx-backend-gl]
 path = "../src/backend/gl"
 version = "0.6"
 optional = true

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -71,6 +71,7 @@ const QUAD: [Vertex; 6] = [
     Vertex { a_Pos: [ -0.5,-0.33 ], a_Uv: [0.0, 0.0] },
 ];
 
+#[cfg(not(target_os = "android"))]
 fn main() {
     #[cfg(target_arch = "wasm32")]
     console_log::init_with_level(log::Level::Debug).unwrap();
@@ -89,6 +90,10 @@ fn main() {
         "You are running the example with the empty backend, no graphical output is to be expected"
     );
 
+    run();
+}
+
+fn run() {
     let event_loop = winit::event_loop::EventLoop::new();
 
     let wb = winit::window::WindowBuilder::new()

--- a/examples/quad_android/Cargo.toml
+++ b/examples/quad_android/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "quad_android"
+version = "0.1.0"
+publish = false
+workspace = "../.."
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["gl"]
+gl = ["gfx-backend-gl"]
+
+[target.'cfg(target_os = "android")'.dependencies]
+android_logger = "0.9"
+image = "0.23.12"
+log = "0.4"
+hal = { path = "../../src/hal", package = "gfx-hal" }
+auxil = { path = "../../src/auxil/auxil", package = "gfx-auxil" }
+gfx-backend-empty = { path = "../../src/backend/empty" }
+winit = "0.24"
+ndk-glue = "0.2"
+
+[target.'cfg(target_os = "android")'.dependencies.gfx-backend-gl]
+path = "../../src/backend/gl"
+optional = true
+
+[package.metadata.android]
+package_name = "com.rust.game"
+label = "GfxQuad"
+# Vulkan supports on devices running Android API level 24 or higher.
+target_sdk_version = 29
+min_sdk_version = 29
+fullscreen = true
+opengles_version = [3, 0]
+orientation = "sensorLandscape"

--- a/examples/quad_android/README.md
+++ b/examples/quad_android/README.md
@@ -1,0 +1,3 @@
+# Quad Android
+
+The following example is used only for the Android CI process.

--- a/examples/quad_android/src/lib.rs
+++ b/examples/quad_android/src/lib.rs
@@ -1,0 +1,22 @@
+include!(concat!(env!("CARGO_MANIFEST_DIR"), "/../quad/main.rs"));
+
+#[cfg(target_os = "android")]
+#[cfg_attr(target_os = "android", ndk_glue::main(backtrace = "full"))]
+fn main() {
+    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Trace));
+
+    {
+        log::info!("App started. Waiting for NativeScreen");
+        loop {
+            match ndk_glue::native_window().as_ref() {
+                Some(_) => {
+                    log::info!("NativeScreen Found:{:?}", ndk_glue::native_window());
+                    break;
+                }
+                None => (),
+            }
+        }
+    }
+
+    run();
+}


### PR DESCRIPTION
Just a proof-of-concept of how we can run a `quad example` on CI with the Android Emulator.

All other jobs temporary removed (for speed up).

TODO:
- [ ] Rollback all CI jobs
- [ ] Investigate why half of builds panicked with error: 
```thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', /Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/ndk-glue-0.2.1/src/lib.rs:255:34``` https://github.com/rust-windowing/android-ndk-rs/issues/116
- [ ] Investigate how we can run quad on Android without code duplication
- [ ] Add PR comments with results screenshot and logs
