### PR TITLE
[dx12] catch device lost during fence wait

### DIFF
--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3346,6 +3346,7 @@ impl d::Device<B> for Device {
         match hr {
             winbase::WAIT_OBJECT_0..=WAIT_OBJECT_LAST => Ok(true),
             winbase::WAIT_ABANDONED_0..=WAIT_ABANDONED_LAST => Ok(true), //TODO?
+            winbase::WAIT_FAILED => Err(d::WaitError::DeviceLost(d::DeviceLost)),
             winerror::WAIT_TIMEOUT => Ok(false),
             _ => panic!("Unexpected wait status 0x{:X}", hr),
         }


### PR DESCRIPTION
Fixes a panic on device lost in DX12
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
