### PR TITLE
Update naga, egl, and metal

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -30,12 +30,12 @@ spirv_cross = { version = "0.23", features = ["glsl"]}
 raw-window-handle = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egl = { package = "khronos-egl", git = "https://github.com/timothee-haudebourg/khronos-egl", rev = "4b769b8f2d068fa78db9285a8557cd11365fa314", features = ["dynamic"] }
+egl = { package = "khronos-egl", version = "3", features = ["dynamic"] }
 libloading = "0.6"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-6"
+tag = "gfx-7"
 #TODO: remove `spv-out` once spirv-cross is deprecated
 features = ["spv-out", "glsl-out"]
 optional = true

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -30,7 +30,7 @@ bitflags = "1.0"
 copyless = "0.1.4"
 log = { version = "0.4" }
 dispatch = { version = "0.2", optional = true }
-metal = { git = "https://github.com/gfx-rs/metal-rs", rev="ba08f5f98c70ab941020b8997936c9c75363b9aa", features = ["private"] }
+metal = { git = "https://github.com/gfx-rs/metal-rs", rev="9a12f4e7e7030f41675d1b438c88f9dd75a994cd", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"
@@ -42,7 +42,7 @@ raw-window-handle = "0.3"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-6"
+tag = "gfx-7"
 #TODO: remove `spv-out` once spirv-cross is deprecated
 features = ["spv-out", "msl-out"]
 optional = true

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -103,7 +103,7 @@ fn get_final_function(
             Some(c) => unsafe {
                 let ptr = &specialization.data[c.range.start as usize] as *const u8 as *const _;
                 let ty: metal::MTLDataType = msg_send![object, type];
-                constants.set_constant_value_at_index(c.id as NSUInteger, ty, ptr);
+                constants.set_constant_value_at_index(ptr, ty, c.id as NSUInteger);
             },
             None if required != NO => {
                 //TODO: get name
@@ -2577,7 +2577,7 @@ impl hal::device::Device<Backend> for Device {
         let stride = (col_count * (format_desc.bits as u64 / 8) + align_mask) & !align_mask;
 
         Ok(n::BufferView {
-            raw: raw.new_texture_from_contents(&descriptor, start, stride),
+            raw: raw.new_texture_with_descriptor(&descriptor, start, stride),
         })
     }
 

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -33,7 +33,7 @@ inplace_it = "0.3.2"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-6"
+tag = "gfx-7"
 features = ["spv-out"]
 optional = true
 

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.0"
-naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-6" }
+naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-7" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"


### PR DESCRIPTION
Gets gfx-7 tag for naga, also picks up https://github.com/timothee-haudebourg/khronos-egl/issues/11
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
