### PR TITLE
Be explicit about Iterator in the API

### DIFF
--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -92,7 +92,7 @@ fn main() {
                     stage_flags: pso::ShaderStageFlags::COMPUTE,
                     immutable_samplers: false,
                 }),
-                &[],
+                iter::empty(),
             )
         }
         .expect("Can't create descriptor set layout");
@@ -172,7 +172,7 @@ fn main() {
             set: &mut desc_set,
             binding: 0,
             array_offset: 0,
-            descriptors: Some(pso::Descriptor::Buffer(
+            descriptors: iter::once(pso::Descriptor::Buffer(
                 &device_buffer,
                 buffer::SubRange::WHOLE,
             )),
@@ -199,7 +199,7 @@ fn main() {
         command_buffer.pipeline_barrier(
             pso::PipelineStage::TRANSFER..pso::PipelineStage::COMPUTE_SHADER,
             memory::Dependencies::empty(),
-            Some(memory::Barrier::Buffer {
+            iter::once(memory::Barrier::Buffer {
                 states: buffer::Access::TRANSFER_WRITE
                     ..buffer::Access::SHADER_READ | buffer::Access::SHADER_WRITE,
                 families: None,
@@ -218,7 +218,7 @@ fn main() {
         command_buffer.pipeline_barrier(
             pso::PipelineStage::COMPUTE_SHADER..pso::PipelineStage::TRANSFER,
             memory::Dependencies::empty(),
-            Some(memory::Barrier::Buffer {
+            iter::once(memory::Barrier::Buffer {
                 states: buffer::Access::SHADER_READ | buffer::Access::SHADER_WRITE
                     ..buffer::Access::TRANSFER_READ,
                 families: None,
@@ -245,7 +245,7 @@ fn main() {
         );
 
         device.wait_for_fence(&fence, !0).unwrap();
-        command_pool.free(Some(command_buffer));
+        command_pool.free(iter::once(command_buffer));
     }
 
     unsafe {

--- a/examples/mesh-shading/main.rs
+++ b/examples/mesh-shading/main.rs
@@ -235,7 +235,7 @@ where
                         stage_flags: ShaderStageFlags::MESH,
                         immutable_samplers: false,
                     }),
-                    &[],
+                    iter::empty(),
                 )
             }
             .expect("Can't create descriptor set layout"),
@@ -324,7 +324,7 @@ where
                 set: &mut desc_set,
                 binding: 0,
                 array_offset: 0,
-                descriptors: Some(pso::Descriptor::Buffer(
+                descriptors: iter::once(pso::Descriptor::Buffer(
                     &*positions_buffer,
                     buffer::SubRange::WHOLE,
                 )),

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -260,8 +260,9 @@ where
                             stage_flags: ShaderStageFlags::FRAGMENT,
                             immutable_samplers: false,
                         },
-                    ],
-                    &[],
+                    ]
+                    .into_iter(),
+                    iter::empty(),
                 )
             }
             .expect("Can't create descriptor set layout"),
@@ -285,7 +286,8 @@ where
                             ty: pso::DescriptorType::Sampler,
                             count: 1,
                         },
-                    ],
+                    ]
+                    .into_iter(),
                     pso::DescriptorPoolCreateFlags::empty(),
                 )
             }
@@ -447,7 +449,8 @@ where
                 descriptors: vec![
                     pso::Descriptor::Image(&*image_srv, i::Layout::ShaderReadOnlyOptimal),
                     pso::Descriptor::Sampler(&*sampler),
-                ],
+                ]
+                .into_iter(),
             });
         }
 
@@ -861,7 +864,7 @@ where
             cmd_buffer.bind_graphics_descriptor_sets(
                 &self.pipeline_layout,
                 0,
-                self.desc_set.as_ref(),
+                self.desc_set.as_ref().into_iter(),
                 iter::empty(),
             );
 

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -863,13 +863,12 @@ impl device::Device<Backend> for Device {
         _dependencies: Id,
     ) -> Result<RenderPass, device::OutOfMemory>
     where
-        Ia: IntoIterator<Item = pass::Attachment>,
-        Is: IntoIterator<Item = pass::SubpassDesc<'a>>,
+        Ia: Iterator<Item = pass::Attachment>,
+        Is: Iterator<Item = pass::SubpassDesc<'a>>,
     {
         Ok(RenderPass {
-            attachments: attachments.into_iter().collect(),
+            attachments: attachments.collect(),
             subpasses: subpasses
-                .into_iter()
                 .map(|desc| SubpassDesc {
                     color_attachments: desc.colors.to_vec(),
                     depth_stencil_attachment: desc.depth_stencil.cloned(),
@@ -886,8 +885,8 @@ impl device::Device<Backend> for Device {
         _push_constant_ranges: Ic,
     ) -> Result<PipelineLayout, device::OutOfMemory>
     where
-        Is: IntoIterator<Item = &'a DescriptorSetLayout>,
-        Ic: IntoIterator<Item = (pso::ShaderStageFlags, Range<u32>)>,
+        Is: Iterator<Item = &'a DescriptorSetLayout>,
+        Ic: Iterator<Item = (pso::ShaderStageFlags, Range<u32>)>,
     {
         let mut res_offsets = MultiStageData::<RegisterData<RegisterAccumulator>>::default();
         let mut sets = Vec::new();
@@ -954,7 +953,7 @@ impl device::Device<Backend> for Device {
         _: I,
     ) -> Result<(), device::OutOfMemory>
     where
-        I: IntoIterator<Item = &'a ()>,
+        I: Iterator<Item = &'a ()>,
     {
         //empty
         Ok(())
@@ -1880,7 +1879,7 @@ impl device::Device<Backend> for Device {
         _flags: pso::DescriptorPoolCreateFlags,
     ) -> Result<DescriptorPool, device::OutOfMemory>
     where
-        I: IntoIterator<Item = pso::DescriptorRangeDesc>,
+        I: Iterator<Item = pso::DescriptorRangeDesc>,
     {
         let mut total = RegisterData::default();
         for range in ranges {
@@ -1899,11 +1898,11 @@ impl device::Device<Backend> for Device {
         _immutable_samplers: J,
     ) -> Result<DescriptorSetLayout, device::OutOfMemory>
     where
-        I: IntoIterator<Item = pso::DescriptorSetLayoutBinding>,
-        J: IntoIterator<Item = &'a Sampler>,
+        I: Iterator<Item = pso::DescriptorSetLayoutBinding>,
+        J: Iterator<Item = &'a Sampler>,
     {
         let mut total = MultiStageData::<RegisterData<_>>::default();
-        let mut bindings = layout_bindings.into_iter().collect::<Vec<_>>();
+        let mut bindings = layout_bindings.collect::<Vec<_>>();
 
         for binding in bindings.iter() {
             let content = DescriptorContent::from(binding.ty);
@@ -1940,7 +1939,7 @@ impl device::Device<Backend> for Device {
 
     unsafe fn write_descriptor_set<'a, I>(&self, op: pso::DescriptorSetWrite<'a, Backend, I>)
     where
-        I: IntoIterator<Item = pso::Descriptor<'a, Backend>>,
+        I: Iterator<Item = pso::Descriptor<'a, Backend>>,
     {
         // Get baseline mapping
         let mut mapping = op
@@ -2112,12 +2111,12 @@ impl device::Device<Backend> for Device {
 
     unsafe fn flush_mapped_memory_ranges<'a, I>(&self, ranges: I) -> Result<(), device::OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a Memory, memory::Segment)>,
+        I: Iterator<Item = (&'a Memory, memory::Segment)>,
     {
         let _scope = debug_scope!(&self.context, "FlushMappedRanges");
 
         // go through every range we wrote to
-        for (memory, ref segment) in ranges.into_iter() {
+        for (memory, ref segment) in ranges {
             let range = memory.resolve(segment);
             let _scope = debug_scope!(&self.context, "Range({:?})", range);
             memory.flush(&self.context, range);
@@ -2131,12 +2130,12 @@ impl device::Device<Backend> for Device {
         ranges: I,
     ) -> Result<(), device::OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a Memory, memory::Segment)>,
+        I: Iterator<Item = (&'a Memory, memory::Segment)>,
     {
         let _scope = debug_scope!(&self.context, "InvalidateMappedRanges");
 
         // go through every range we want to read from
-        for (memory, ref segment) in ranges.into_iter() {
+        for (memory, ref segment) in ranges {
             let range = memory.resolve(segment);
             let _scope = debug_scope!(&self.context, "Range({:?})", range);
             memory.invalidate(

--- a/src/backend/dx11/src/internal.rs
+++ b/src/backend/dx11/src/internal.rs
@@ -654,7 +654,7 @@ impl Internal {
         dst: &Image,
         regions: T,
     ) where
-        T: IntoIterator<Item = command::ImageCopy>,
+        T: Iterator<Item = command::ImageCopy>,
     {
         let key = (
             src.decomposed_format.copy_srv.unwrap(),
@@ -674,7 +674,7 @@ impl Internal {
                 context.CSSetConstantBuffers(0, 1, &const_buf.buffer.as_raw());
                 context.CSSetShaderResources(0, 1, [srv].as_ptr());
 
-                for info in regions.into_iter() {
+                for info in regions {
                     let image = ImageCopy {
                         src: [
                             info.src_offset.x as _,
@@ -775,7 +775,7 @@ impl Internal {
         dst: &Buffer,
         regions: T,
     ) where
-        T: IntoIterator<Item = command::BufferImageCopy>,
+        T: Iterator<Item = command::BufferImageCopy>,
     {
         let _scope = debug_scope!(
             context,
@@ -883,7 +883,7 @@ impl Internal {
         dst: &Image,
         regions: T,
     ) where
-        T: IntoIterator<Item = command::BufferImageCopy>,
+        T: Iterator<Item = command::BufferImageCopy>,
     {
         let _scope = debug_scope!(
             context,
@@ -1047,7 +1047,7 @@ impl Internal {
         filter: image::Filter,
         regions: T,
     ) where
-        T: IntoIterator<Item = command::ImageBlit>,
+        T: Iterator<Item = command::ImageBlit>,
     {
         use std::cmp;
 
@@ -1154,13 +1154,13 @@ impl Internal {
         rects: U,
         cache: &RenderPassCache,
     ) where
-        T: IntoIterator<Item = command::AttachmentClear>,
-        U: IntoIterator<Item = pso::ClearRect>,
+        T: Iterator<Item = command::AttachmentClear>,
+        U: Iterator<Item = pso::ClearRect>,
     {
         use hal::format::ChannelType as Ct;
         let _scope = debug_scope!(context, "ClearAttachments");
 
-        let clear_rects: SmallVec<[pso::ClearRect; 8]> = rects.into_iter().collect();
+        let clear_rects: SmallVec<[pso::ClearRect; 8]> = rects.collect();
         let mut const_buf = self.internal_buffer.lock();
 
         unsafe {

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -1268,9 +1268,9 @@ impl d::Device<B> for Device {
         dependencies: Id,
     ) -> Result<r::RenderPass, d::OutOfMemory>
     where
-        Ia: IntoIterator<Item = pass::Attachment>,
-        Is: IntoIterator<Item = pass::SubpassDesc<'a>>,
-        Id: IntoIterator<Item = pass::SubpassDependency>,
+        Ia: Iterator<Item = pass::Attachment>,
+        Is: Iterator<Item = pass::SubpassDesc<'a>>,
+        Id: Iterator<Item = pass::SubpassDependency>,
     {
         #[derive(Copy, Clone, Debug, PartialEq)]
         enum SubState {
@@ -1296,16 +1296,15 @@ impl d::Device<B> for Device {
             barrier_start_index: usize,
         }
 
-        let attachments = attachments.into_iter().collect::<SmallVec<[_; 5]>>();
+        let attachments = attachments.collect::<SmallVec<[_; 5]>>();
         let mut sub_infos = subpasses
-            .into_iter()
             .map(|desc| SubInfo {
                 desc: desc.clone(),
                 external_dependencies: image::Access::empty()..image::Access::empty(),
                 unresolved_dependencies: 0,
             })
             .collect::<SmallVec<[_; 1]>>();
-        let dependencies = dependencies.into_iter().collect::<SmallVec<[_; 2]>>();
+        let dependencies = dependencies.collect::<SmallVec<[_; 2]>>();
 
         let mut att_infos = (0..attachments.len())
             .map(|_| AttachmentInfo {
@@ -1519,8 +1518,8 @@ impl d::Device<B> for Device {
         push_constant_ranges: Ic,
     ) -> Result<r::PipelineLayout, d::OutOfMemory>
     where
-        Is: IntoIterator<Item = &'a r::DescriptorSetLayout>,
-        Ic: IntoIterator<Item = (pso::ShaderStageFlags, Range<u32>)>,
+        Is: Iterator<Item = &'a r::DescriptorSetLayout>,
+        Ic: Iterator<Item = (pso::ShaderStageFlags, Range<u32>)>,
     {
         // Pipeline layouts are implemented as RootSignature for D3D12.
         //
@@ -1546,7 +1545,7 @@ impl d::Device<B> for Device {
         // Root Descriptors 1
         //     ...
 
-        let sets = sets.into_iter().collect::<Vec<_>>();
+        let sets = sets.collect::<Vec<_>>();
 
         let mut root_offset = 0u32;
         let root_constants = root_constants::split(push_constant_ranges)
@@ -1788,7 +1787,7 @@ impl d::Device<B> for Device {
 
     unsafe fn merge_pipeline_caches<'a, I>(&self, _: &mut (), _: I) -> Result<(), d::OutOfMemory>
     where
-        I: IntoIterator<Item = &'a ()>,
+        I: Iterator<Item = &'a ()>,
     {
         //empty
         Ok(())
@@ -2883,7 +2882,7 @@ impl d::Device<B> for Device {
         _flags: pso::DescriptorPoolCreateFlags,
     ) -> Result<r::DescriptorPool, d::OutOfMemory>
     where
-        I: IntoIterator<Item = pso::DescriptorRangeDesc>,
+        I: Iterator<Item = pso::DescriptorRangeDesc>,
     {
         // Descriptor pools are implemented as slices of the global descriptor heaps.
         // A descriptor pool will occupy a contiguous space in each heap (CBV/SRV/UAV and Sampler) depending
@@ -2892,7 +2891,7 @@ impl d::Device<B> for Device {
         let mut num_srv_cbv_uav = 0;
         let mut num_samplers = 0;
 
-        let ranges = ranges.into_iter().collect::<Vec<_>>();
+        let ranges = ranges.collect::<Vec<_>>();
 
         info!("create_descriptor_pool with {} max sets", max_sets);
         for desc in &ranges {
@@ -2956,17 +2955,17 @@ impl d::Device<B> for Device {
         _immutable_samplers: J,
     ) -> Result<r::DescriptorSetLayout, d::OutOfMemory>
     where
-        I: IntoIterator<Item = pso::DescriptorSetLayoutBinding>,
-        J: IntoIterator<Item = &'a r::Sampler>,
+        I: Iterator<Item = pso::DescriptorSetLayoutBinding>,
+        J: Iterator<Item = &'a r::Sampler>,
     {
         Ok(r::DescriptorSetLayout {
-            bindings: bindings.into_iter().collect(),
+            bindings: bindings.collect(),
         })
     }
 
     unsafe fn write_descriptor_set<'a, I>(&self, op: pso::DescriptorSetWrite<'a, B, I>)
     where
-        I: IntoIterator<Item = pso::Descriptor<'a, B>>,
+        I: Iterator<Item = pso::Descriptor<'a, B>>,
     {
         let mut descriptor_updater = self.descriptor_updater.lock();
         descriptor_updater.reset();
@@ -3221,7 +3220,7 @@ impl d::Device<B> for Device {
 
     unsafe fn flush_mapped_memory_ranges<'a, I>(&self, ranges: I) -> Result<(), d::OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a r::Memory, memory::Segment)>,
+        I: Iterator<Item = (&'a r::Memory, memory::Segment)>,
     {
         for (memory, ref segment) in ranges {
             if let Some(mem) = memory.resource {
@@ -3250,7 +3249,7 @@ impl d::Device<B> for Device {
 
     unsafe fn invalidate_mapped_memory_ranges<'a, I>(&self, ranges: I) -> Result<(), d::OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a r::Memory, memory::Segment)>,
+        I: Iterator<Item = (&'a r::Memory, memory::Segment)>,
     {
         for (memory, ref segment) in ranges {
             if let Some(mem) = memory.resource {
@@ -3301,7 +3300,7 @@ impl d::Device<B> for Device {
         timeout_ns: u64,
     ) -> Result<bool, d::WaitError>
     where
-        I: IntoIterator<Item = &'a r::Fence>,
+        I: Iterator<Item = &'a r::Fence>,
     {
         let mut count = 0;
         let mut events = self.events.lock();

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -274,7 +274,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         device.features = requested_features;
 
         let queue_groups = families
-            .into_iter()
+            .iter()
             .map(|&(&family, priorities)| {
                 use hal::queue::QueueFamily as _;
                 let mut group = q::QueueGroup::new(family.id());
@@ -503,9 +503,9 @@ impl q::CommandQueue<Backend> for CommandQueue {
         _signal_semaphores: Is,
         fence: Option<&mut resource::Fence>,
     ) where
-        Ic: IntoIterator<Item = &'a command::CommandBuffer>,
-        Iw: IntoIterator<Item = (&'a resource::Semaphore, PipelineStage)>,
-        Is: IntoIterator<Item = &'a resource::Semaphore>,
+        Ic: Iterator<Item = &'a command::CommandBuffer>,
+        Iw: Iterator<Item = (&'a resource::Semaphore, PipelineStage)>,
+        Is: Iterator<Item = &'a resource::Semaphore>,
     {
         // Reset idle fence and event
         // That's safe here due to exclusive access to the queue
@@ -514,7 +514,6 @@ impl q::CommandQueue<Backend> for CommandQueue {
 
         // TODO: semaphores
         let lists = command_buffers
-            .into_iter()
             .map(|cmd_buf| cmd_buf.as_raw_list())
             .collect::<SmallVec<[_; 4]>>();
         self.raw

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -113,7 +113,7 @@ impl pool::CommandPool<Backend> for CommandPool {
 
     unsafe fn free<I>(&mut self, cbufs: I)
     where
-        I: IntoIterator<Item = CommandBuffer>,
+        I: Iterator<Item = CommandBuffer>,
     {
         let mut allocators = self.pool_shared.allocators.lock();
         let mut lists = self.pool_shared.lists.lock();

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -844,7 +844,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
 
     unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
-        I: IntoIterator<Item = DescriptorSet>,
+        I: Iterator<Item = DescriptorSet>,
     {
         for descriptor_set in descriptor_sets {
             for binding_info in descriptor_set.binding_infos {

--- a/src/backend/empty/src/descriptor.rs
+++ b/src/backend/empty/src/descriptor.rs
@@ -17,7 +17,7 @@ impl pso::DescriptorPool<crate::Backend> for DescriptorPool {
 
     unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
-        I: IntoIterator<Item = DescriptorSet>,
+        I: Iterator<Item = DescriptorSet>,
     {
         for _ in descriptor_sets {
             // Let the descriptor set drop

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -164,7 +164,7 @@ pub struct CommandQueue;
 impl queue::CommandQueue<Backend> for CommandQueue {
     unsafe fn submit<'a, Ic, Iw, Is>(&mut self, _: Ic, _: Iw, _: Is, _: Option<&mut ()>)
     where
-        Ic: IntoIterator<Item = &'a CommandBuffer>,
+        Ic: Iterator<Item = &'a CommandBuffer>,
     {
     }
 
@@ -211,7 +211,7 @@ impl device::Device<Backend> for Device {
         _: Id,
     ) -> Result<(), device::OutOfMemory>
     where
-        Is: IntoIterator<Item = pass::SubpassDesc<'a>>,
+        Is: Iterator<Item = pass::SubpassDesc<'a>>,
     {
         Ok(())
     }
@@ -222,7 +222,7 @@ impl device::Device<Backend> for Device {
         _: Ic,
     ) -> Result<(), device::OutOfMemory>
     where
-        Is: IntoIterator<Item = &'a DescriptorSetLayout>,
+        Is: Iterator<Item = &'a DescriptorSetLayout>,
     {
         Ok(())
     }
@@ -264,7 +264,7 @@ impl device::Device<Backend> for Device {
         _: I,
     ) -> Result<(), device::OutOfMemory>
     where
-        I: IntoIterator<Item = &'a ()>,
+        I: Iterator<Item = &'a ()>,
     {
         Ok(())
     }
@@ -383,7 +383,7 @@ impl device::Device<Backend> for Device {
         _samplers: J,
     ) -> Result<DescriptorSetLayout, device::OutOfMemory>
     where
-        J: IntoIterator<Item = &'a ()>,
+        J: Iterator<Item = &'a ()>,
     {
         let layout = DescriptorSetLayout {
             name: String::new(),
@@ -393,7 +393,7 @@ impl device::Device<Backend> for Device {
 
     unsafe fn write_descriptor_set<'a, I>(&self, _: pso::DescriptorSetWrite<'a, Backend, I>)
     where
-        I: IntoIterator<Item = pso::Descriptor<'a, Backend>>,
+        I: Iterator<Item = pso::Descriptor<'a, Backend>>,
     {
     }
 
@@ -460,14 +460,14 @@ impl device::Device<Backend> for Device {
 
     unsafe fn flush_mapped_memory_ranges<'a, I>(&self, _: I) -> Result<(), device::OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a Memory, hal::memory::Segment)>,
+        I: Iterator<Item = (&'a Memory, hal::memory::Segment)>,
     {
         Ok(())
     }
 
     unsafe fn invalidate_mapped_memory_ranges<'a, I>(&self, _: I) -> Result<(), device::OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a Memory, hal::memory::Segment)>,
+        I: Iterator<Item = (&'a Memory, hal::memory::Segment)>,
     {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
@@ -625,7 +625,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: hal::memory::Dependencies,
         _: T,
     ) where
-        T: IntoIterator<Item = hal::memory::Barrier<'a, Backend>>,
+        T: Iterator<Item = hal::memory::Barrier<'a, Backend>>,
     {
     }
 
@@ -685,7 +685,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn bind_vertex_buffers<'a, T>(&mut self, _: u32, _: T)
     where
-        T: IntoIterator<Item = (&'a Buffer, hal::buffer::SubRange)>,
+        T: Iterator<Item = (&'a Buffer, hal::buffer::SubRange)>,
     {
     }
 
@@ -729,7 +729,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: T,
         _: command::SubpassContents,
     ) where
-        T: IntoIterator<Item = command::RenderAttachmentInfo<'a, Backend>>,
+        T: Iterator<Item = command::RenderAttachmentInfo<'a, Backend>>,
     {
     }
 
@@ -743,7 +743,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn bind_graphics_descriptor_sets<'a, I, J>(&mut self, _: &(), _: usize, _: I, _: J)
     where
-        I: IntoIterator<Item = &'a DescriptorSet>,
+        I: Iterator<Item = &'a DescriptorSet>,
     {
         // Do nothing
     }
@@ -754,7 +754,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn bind_compute_descriptor_sets<'a, I, J>(&mut self, _: &(), _: usize, _: I, _: J)
     where
-        I: IntoIterator<Item = &'a DescriptorSet>,
+        I: Iterator<Item = &'a DescriptorSet>,
     {
         // Do nothing
     }
@@ -887,7 +887,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn wait_events<'a, I, J>(&mut self, _: I, _: Range<pso::PipelineStage>, _: J)
     where
-        J: IntoIterator<Item = hal::memory::Barrier<'a, Backend>>,
+        J: Iterator<Item = hal::memory::Barrier<'a, Backend>>,
     {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }
@@ -936,7 +936,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn execute_commands<'a, T>(&mut self, _: T)
     where
-        T: IntoIterator<Item = &'a CommandBuffer>,
+        T: Iterator<Item = &'a CommandBuffer>,
     {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
     }

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -656,12 +656,12 @@ impl CommandBuffer {
         layout: &n::PipelineLayout,
         first_set: usize,
         sets: I,
-        offsets: J,
+        mut offsets: J,
     ) where
-        I: IntoIterator<Item = &'a n::DescriptorSet>,
-        J: IntoIterator<Item = command::DescriptorSetOffset>,
+        I: Iterator<Item = &'a n::DescriptorSet>,
+        J: Iterator<Item = command::DescriptorSetOffset>,
     {
-        if let Some(_) = offsets.into_iter().next() {
+        if let Some(_) = offsets.next() {
             warn!("Dynamic offsets are not supported yet");
         }
 
@@ -754,7 +754,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _dependencies: memory::Dependencies,
         barriers: T,
     ) where
-        T: IntoIterator<Item = memory::Barrier<'a, Backend>>,
+        T: Iterator<Item = memory::Barrier<'a, Backend>>,
     {
         //TODO: this needs to be much more detailed. Problem is that the affected
         // resources by a barrier have to be bound to specific slots, so, for example,
@@ -811,7 +811,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         attachment_infos: T,
         _first_subpass: command::SubpassContents,
     ) where
-        T: IntoIterator<Item = command::RenderAttachmentInfo<'a, Backend>>,
+        T: Iterator<Item = command::RenderAttachmentInfo<'a, Backend>>,
     {
         // TODO: load ops: clearing strategy
         //  1.  < GL 3.0 / GL ES 2.0: glClear, only single color attachment?
@@ -882,7 +882,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         value: command::ClearValue,
         _subresource_ranges: T,
     ) where
-        T: IntoIterator<Item = image::SubresourceRange>,
+        T: Iterator<Item = image::SubresourceRange>,
     {
         // TODO: clearing strategies
         //  1.  < GL 3.0 / GL ES 3.0: glClear
@@ -962,8 +962,8 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn clear_attachments<T, U>(&mut self, _: T, _: U)
     where
-        T: IntoIterator<Item = command::AttachmentClear>,
-        U: IntoIterator<Item = pso::ClearRect>,
+        T: Iterator<Item = command::AttachmentClear>,
+        U: Iterator<Item = pso::ClearRect>,
     {
         unimplemented!()
     }
@@ -976,7 +976,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _dst_layout: image::Layout,
         _regions: T,
     ) where
-        T: IntoIterator<Item = command::ImageResolve>,
+        T: Iterator<Item = command::ImageResolve>,
     {
         unimplemented!()
     }
@@ -990,7 +990,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _filter: image::Filter,
         _regions: T,
     ) where
-        T: IntoIterator<Item = command::ImageBlit>,
+        T: Iterator<Item = command::ImageBlit>,
     {
         error!("Blit is not implemented");
     }
@@ -1009,9 +1009,9 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn bind_vertex_buffers<'a, T>(&mut self, first_binding: pso::BufferIndex, buffers: T)
     where
-        T: IntoIterator<Item = (&'a n::Buffer, buffer::SubRange)>,
+        T: Iterator<Item = (&'a n::Buffer, buffer::SubRange)>,
     {
-        for (i, (buffer, sub)) in buffers.into_iter().enumerate() {
+        for (i, (buffer, sub)) in buffers.enumerate() {
             let index = first_binding as usize + i;
             if self.cache.vertex_buffers.len() <= index {
                 self.cache.vertex_buffers.resize(index + 1, None);
@@ -1025,7 +1025,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn set_viewports<T>(&mut self, first_viewport: u32, viewports: T)
     where
-        T: IntoIterator<Item = pso::Viewport>,
+        T: Iterator<Item = pso::Viewport>,
     {
         // OpenGL has two functions for setting the viewports.
         // Configuring the rectangle area and setting the depth bounds are separated.
@@ -1070,7 +1070,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn set_scissors<T>(&mut self, first_scissor: u32, scissors: T)
     where
-        T: IntoIterator<Item = pso::Rect>,
+        T: Iterator<Item = pso::Rect>,
     {
         let mut scissors_ptr = BufferSlice { offset: 0, size: 0 };
         let mut len = 0;
@@ -1226,8 +1226,8 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         sets: I,
         offsets: J,
     ) where
-        I: IntoIterator<Item = &'a n::DescriptorSet>,
-        J: IntoIterator<Item = command::DescriptorSetOffset>,
+        I: Iterator<Item = &'a n::DescriptorSet>,
+        J: Iterator<Item = command::DescriptorSetOffset>,
     {
         self.bind_descriptor_sets(layout, first_set, sets, offsets)
     }
@@ -1246,8 +1246,8 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         sets: I,
         offsets: J,
     ) where
-        I: IntoIterator<Item = &'a n::DescriptorSet>,
-        J: IntoIterator<Item = command::DescriptorSetOffset>,
+        I: Iterator<Item = &'a n::DescriptorSet>,
+        J: Iterator<Item = command::DescriptorSetOffset>,
     {
         self.bind_descriptor_sets(layout, first_set, sets, offsets)
     }
@@ -1264,7 +1264,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn copy_buffer<T>(&mut self, src: &n::Buffer, dst: &n::Buffer, regions: T)
     where
-        T: IntoIterator<Item = command::BufferCopy>,
+        T: Iterator<Item = command::BufferCopy>,
     {
         let old_size = self.data.buf.size;
 
@@ -1290,7 +1290,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _dst_layout: image::Layout,
         regions: T,
     ) where
-        T: IntoIterator<Item = command::ImageCopy>,
+        T: Iterator<Item = command::ImageCopy>,
     {
         let old_size = self.data.buf.size;
 
@@ -1321,7 +1321,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         _: image::Layout,
         regions: T,
     ) where
-        T: IntoIterator<Item = command::BufferImageCopy>,
+        T: Iterator<Item = command::BufferImageCopy>,
     {
         let old_size = self.data.buf.size;
 
@@ -1362,7 +1362,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         dst: &n::Buffer,
         regions: T,
     ) where
-        T: IntoIterator<Item = command::BufferImageCopy>,
+        T: Iterator<Item = command::BufferImageCopy>,
     {
         let old_size = self.data.buf.size;
         let (dst_raw, dst_range) = dst.as_bound();
@@ -1561,8 +1561,8 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn wait_events<'a, I, J>(&mut self, _: I, _: Range<pso::PipelineStage>, _: J)
     where
-        I: IntoIterator<Item = &'a ()>,
-        J: IntoIterator<Item = memory::Barrier<'a, Backend>>,
+        I: Iterator<Item = &'a ()>,
+        J: Iterator<Item = memory::Barrier<'a, Backend>>,
     {
         unimplemented!()
     }
@@ -1635,7 +1635,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn execute_commands<'a, T>(&mut self, _buffers: T)
     where
-        T: IntoIterator<Item = &'a CommandBuffer>,
+        T: Iterator<Item = &'a CommandBuffer>,
     {
         unimplemented!()
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -849,11 +849,10 @@ impl d::Device<B> for Device {
         _dependencies: Id,
     ) -> Result<n::RenderPass, d::OutOfMemory>
     where
-        Ia: IntoIterator<Item = pass::Attachment>,
-        Is: IntoIterator<Item = pass::SubpassDesc<'a>>,
+        Ia: Iterator<Item = pass::Attachment>,
+        Is: Iterator<Item = pass::SubpassDesc<'a>>,
     {
         let subpasses = subpasses
-            .into_iter()
             .map(|subpass| {
                 assert!(
                     subpass.colors.len() <= self.share.limits.max_color_attachments,
@@ -871,7 +870,7 @@ impl d::Device<B> for Device {
             .collect();
 
         Ok(n::RenderPass {
-            attachments: attachments.into_iter().collect::<Vec<_>>(),
+            attachments: attachments.collect::<Vec<_>>(),
             subpasses,
         })
     }
@@ -882,7 +881,7 @@ impl d::Device<B> for Device {
         _: Ic,
     ) -> Result<n::PipelineLayout, d::OutOfMemory>
     where
-        Is: IntoIterator<Item = &'a n::DescriptorSetLayout>,
+        Is: Iterator<Item = &'a n::DescriptorSetLayout>,
     {
         use std::convert::TryInto;
         let mut sets = Vec::new();
@@ -940,7 +939,7 @@ impl d::Device<B> for Device {
 
     unsafe fn merge_pipeline_caches<'a, I>(&self, _: &mut (), _: I) -> Result<(), d::OutOfMemory>
     where
-        I: IntoIterator<Item = &'a ()>,
+        I: Iterator<Item = &'a ()>,
     {
         //empty
         Ok(())
@@ -1085,7 +1084,7 @@ impl d::Device<B> for Device {
 
         /*
         let attachments: Vec<_> = attachments
-            .into_iter()
+
             .map(|at| at.borrow().clone())
             .collect();
         debug!("create_framebuffer {:?}", attachments);
@@ -1336,7 +1335,7 @@ impl d::Device<B> for Device {
 
     unsafe fn flush_mapped_memory_ranges<'a, I>(&self, ranges: I) -> Result<(), d::OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a n::Memory, memory::Segment)>,
+        I: Iterator<Item = (&'a n::Memory, memory::Segment)>,
     {
         let gl = &self.share.context;
 
@@ -1368,7 +1367,7 @@ impl d::Device<B> for Device {
 
     unsafe fn invalidate_mapped_memory_ranges<'a, I>(&self, ranges: I) -> Result<(), d::OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a n::Memory, memory::Segment)>,
+        I: Iterator<Item = (&'a n::Memory, memory::Segment)>,
     {
         let gl = &self.share.context;
 
@@ -1664,7 +1663,7 @@ impl d::Device<B> for Device {
         _: pso::DescriptorPoolCreateFlags,
     ) -> Result<n::DescriptorPool, d::OutOfMemory>
     where
-        I: IntoIterator<Item = pso::DescriptorRangeDesc>,
+        I: Iterator<Item = pso::DescriptorRangeDesc>,
     {
         Ok(n::DescriptorPool {})
     }
@@ -1675,10 +1674,10 @@ impl d::Device<B> for Device {
         _immutable_samplers: J,
     ) -> Result<n::DescriptorSetLayout, d::OutOfMemory>
     where
-        I: IntoIterator<Item = pso::DescriptorSetLayoutBinding>,
-        J: IntoIterator<Item = &'a n::FatSampler>,
+        I: Iterator<Item = pso::DescriptorSetLayoutBinding>,
+        J: Iterator<Item = &'a n::FatSampler>,
     {
-        let mut bindings = layout.into_iter().collect::<Vec<_>>();
+        let mut bindings = layout.collect::<Vec<_>>();
         // all operations rely on the ascending bindings order
         bindings.sort_by_key(|b| b.binding);
         Ok(Arc::new(bindings))
@@ -1686,7 +1685,7 @@ impl d::Device<B> for Device {
 
     unsafe fn write_descriptor_set<'a, I>(&self, op: pso::DescriptorSetWrite<'a, B, I>)
     where
-        I: IntoIterator<Item = pso::Descriptor<'a, B>>,
+        I: Iterator<Item = pso::Descriptor<'a, B>>,
     {
         let mut layout_index = op
             .set
@@ -1843,7 +1842,7 @@ impl d::Device<B> for Device {
         timeout_ns: u64,
     ) -> Result<bool, d::WaitError>
     where
-        I: IntoIterator<Item = &'a n::Fence>,
+        I: Iterator<Item = &'a n::Fence>,
     {
         let performance = web_sys::window().unwrap().performance().unwrap();
         let start = performance.now();
@@ -1867,7 +1866,7 @@ impl d::Device<B> for Device {
             d::WaitFor::Any => {
                 const FENCE_WAIT_NS: u64 = 100_000;
 
-                let fences: Vec<_> = fences.into_iter().collect();
+                let fences: Vec<_> = fences.collect();
                 loop {
                     for fence in &fences {
                         if self.wait_for_fence(fence, FENCE_WAIT_NS)? {

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -573,7 +573,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         Ok(adapter::Gpu {
             device: Device::new(self.0.clone(), requested_features),
             queue_groups: families
-                .into_iter()
+                .iter()
                 .map(|&(_family, priorities)| {
                     assert_eq!(priorities.len(), 1);
                     let mut family = q::QueueGroup::new(q::QueueFamilyId(0));

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -264,7 +264,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
 
     unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
-        I: IntoIterator<Item = DescriptorSet>,
+        I: Iterator<Item = DescriptorSet>,
     {
         for _set in descriptor_sets {
             // Poof!  Does nothing, because OpenGL doesn't have a meaningful concept of a `DescriptorSet`.

--- a/src/backend/gl/src/pool.rs
+++ b/src/backend/gl/src/pool.rs
@@ -95,7 +95,7 @@ impl hal::pool::CommandPool<Backend> for CommandPool {
 
     unsafe fn free<I>(&mut self, buffers: I)
     where
-        I: IntoIterator<Item = CommandBuffer>,
+        I: Iterator<Item = CommandBuffer>,
     {
         let mut memory = self
             .memory

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -1077,9 +1077,9 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
         _signal_semaphores: Is,
         fence: Option<&mut native::Fence>,
     ) where
-        Ic: IntoIterator<Item = &'a com::CommandBuffer>,
-        Iw: IntoIterator<Item = (&'a native::Semaphore, hal::pso::PipelineStage)>,
-        Is: IntoIterator<Item = &'a native::Semaphore>,
+        Ic: Iterator<Item = &'a com::CommandBuffer>,
+        Iw: Iterator<Item = (&'a native::Semaphore, hal::pso::PipelineStage)>,
+        Is: Iterator<Item = &'a native::Semaphore>,
     {
         use crate::pool::BufferMemory;
         {

--- a/src/backend/gl/src/window/egl.rs
+++ b/src/backend/gl/src/window/egl.rs
@@ -313,7 +313,7 @@ impl hal::Instance<crate::Backend> for Instance {
         vec![PhysicalDevice::new_adapter(context)]
     }
 
-    #[cfg_attr(target_os = "macos", allow(unused, unreachable_code))]
+    #[cfg_attr(target_os = "macos", allow(unused, unused_mut, unreachable_code))]
     unsafe fn create_surface(
         &self,
         has_handle: &impl raw_window_handle::HasRawWindowHandle,

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -960,13 +960,12 @@ impl hal::device::Device<Backend> for Device {
         _dependencies: Id,
     ) -> Result<n::RenderPass, d::OutOfMemory>
     where
-        Ia: IntoIterator<Item = pass::Attachment>,
-        Is: IntoIterator<Item = pass::SubpassDesc<'a>>,
+        Ia: Iterator<Item = pass::Attachment>,
+        Is: Iterator<Item = pass::SubpassDesc<'a>>,
     {
-        let attachments: Vec<pass::Attachment> = attachments.into_iter().collect();
+        let attachments: Vec<pass::Attachment> = attachments.collect();
 
         let mut subpasses: Vec<n::Subpass> = subpasses
-            .into_iter()
             .map(|sub| {
                 let mut colors: ArrayVec<[_; MAX_COLOR_ATTACHMENTS]> = sub
                     .colors
@@ -1063,8 +1062,8 @@ impl hal::device::Device<Backend> for Device {
         push_constant_ranges: Ic,
     ) -> Result<n::PipelineLayout, d::OutOfMemory>
     where
-        Is: IntoIterator<Item = &'a n::DescriptorSetLayout>,
-        Ic: IntoIterator<Item = (pso::ShaderStageFlags, Range<u32>)>,
+        Is: Iterator<Item = &'a n::DescriptorSetLayout>,
+        Ic: Iterator<Item = (pso::ShaderStageFlags, Range<u32>)>,
     {
         let mut stage_infos = [
             (
@@ -1137,7 +1136,7 @@ impl hal::device::Device<Backend> for Device {
         }
 
         // Second, place the descripted resources
-        for (set_index, set_layout) in set_layouts.into_iter().enumerate() {
+        for (set_index, set_layout) in set_layouts.enumerate() {
             // remember where the resources for this set start at each shader stage
             let mut dynamic_buffers = Vec::new();
             let offsets = n::MultiStageResourceCounters {
@@ -1395,7 +1394,7 @@ impl hal::device::Device<Backend> for Device {
         sources: I,
     ) -> Result<(), d::OutOfMemory>
     where
-        I: IntoIterator<Item = &'a n::PipelineCache>,
+        I: Iterator<Item = &'a n::PipelineCache>,
     {
         //TODO: reduce the locking here
         let mut dst = target.modules.whole_write();
@@ -1894,7 +1893,7 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn flush_mapped_memory_ranges<'a, I>(&self, iter: I) -> Result<(), d::OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a n::Memory, memory::Segment)>,
+        I: Iterator<Item = (&'a n::Memory, memory::Segment)>,
     {
         debug!("flush_mapped_memory_ranges");
         for (memory, ref segment) in iter {
@@ -1921,7 +1920,7 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn invalidate_mapped_memory_ranges<'a, I>(&self, iter: I) -> Result<(), d::OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a n::Memory, memory::Segment)>,
+        I: Iterator<Item = (&'a n::Memory, memory::Segment)>,
     {
         let mut num_syncs = 0;
         debug!("invalidate_mapped_memory_ranges");
@@ -1981,7 +1980,7 @@ impl hal::device::Device<Backend> for Device {
         _flags: pso::DescriptorPoolCreateFlags,
     ) -> Result<n::DescriptorPool, d::OutOfMemory>
     where
-        I: IntoIterator<Item = pso::DescriptorRangeDesc>,
+        I: Iterator<Item = pso::DescriptorRangeDesc>,
     {
         if self.shared.private_caps.argument_buffers {
             let mut arguments = n::ArgumentArray::default();
@@ -2031,8 +2030,8 @@ impl hal::device::Device<Backend> for Device {
         immutable_samplers: J,
     ) -> Result<n::DescriptorSetLayout, d::OutOfMemory>
     where
-        I: IntoIterator<Item = pso::DescriptorSetLayoutBinding>,
-        J: IntoIterator<Item = &'a n::Sampler>,
+        I: Iterator<Item = pso::DescriptorSetLayoutBinding>,
+        J: Iterator<Item = &'a n::Sampler>,
     {
         if self.shared.private_caps.argument_buffers {
             let mut stage_flags = pso::ShaderStageFlags::empty();
@@ -2114,7 +2113,7 @@ impl hal::device::Device<Backend> for Device {
                 binding: pso::DescriptorBinding,
                 array_index: pso::DescriptorArrayIndex,
             }
-            let mut immutable_sampler_iter = immutable_samplers.into_iter();
+            let mut immutable_sampler_iter = immutable_samplers;
             let mut tmp_samplers = Vec::new();
             let mut desc_layouts = Vec::new();
             let mut total = n::ResourceData::new();
@@ -2174,7 +2173,7 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn write_descriptor_set<'a, I>(&self, op: pso::DescriptorSetWrite<'a, Backend, I>)
     where
-        I: IntoIterator<Item = pso::Descriptor<'a, Backend>>,
+        I: Iterator<Item = pso::Descriptor<'a, Backend>>,
     {
         debug!("write_descriptor_set");
         match *op.set {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -668,7 +668,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
 
     unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
-        I: IntoIterator<Item = DescriptorSet>,
+        I: Iterator<Item = DescriptorSet>,
     {
         match self {
             DescriptorPool::Emulated {

--- a/src/backend/vulkan/src/native.rs
+++ b/src/backend/vulkan/src/native.rs
@@ -172,7 +172,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
         list: &mut E,
     ) -> Result<(), pso::AllocationError>
     where
-        I: IntoIterator<Item = &'a DescriptorSetLayout>,
+        I: Iterator<Item = &'a DescriptorSetLayout>,
         E: Extend<DescriptorSet>,
     {
         self.temp_raw_layouts.clear();
@@ -210,9 +210,9 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
 
     unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
-        I: IntoIterator<Item = DescriptorSet>,
+        I: Iterator<Item = DescriptorSet>,
     {
-        let sets_iter = descriptor_sets.into_iter().map(|d| d.raw);
+        let sets_iter = descriptor_sets.map(|d| d.raw);
         inplace_or_alloc_from_iter(sets_iter, |sets| {
             self.device.raw.free_descriptor_sets(self.raw, sets);
         })

--- a/src/backend/vulkan/src/pool.rs
+++ b/src/backend/vulkan/src/pool.rs
@@ -48,10 +48,9 @@ impl pool::CommandPool<Backend> for RawCommandPool {
 
     unsafe fn free<I>(&mut self, cbufs: I)
     where
-        I: IntoIterator<Item = CommandBuffer>,
+        I: Iterator<Item = CommandBuffer>,
     {
-        let buffers: SmallVec<[vk::CommandBuffer; 16]> =
-            cbufs.into_iter().map(|buffer| buffer.raw).collect();
+        let buffers: SmallVec<[vk::CommandBuffer; 16]> = cbufs.map(|buffer| buffer.raw).collect();
         self.device.raw.free_command_buffers(self.raw, &buffers);
     }
 }

--- a/src/backend/webgpu/src/command.rs
+++ b/src/backend/webgpu/src/command.rs
@@ -30,7 +30,7 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
         _: Is,
         _fence: Option<&mut <Backend as hal::Backend>::Fence>,
     ) where
-        Ic: IntoIterator<Item = &'a <Backend as hal::Backend>::CommandBuffer>,
+        Ic: Iterator<Item = &'a <Backend as hal::Backend>::CommandBuffer>,
     {
         todo!()
     }
@@ -62,7 +62,7 @@ impl hal::pool::CommandPool<Backend> for CommandPool {
 
     unsafe fn free<I>(&mut self, _buffers: I)
     where
-        I: IntoIterator<Item = CommandBuffer>,
+        I: Iterator<Item = CommandBuffer>,
     {
         todo!()
     }
@@ -97,7 +97,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _dependencies: Dependencies,
         _barriers: T,
     ) where
-        T: IntoIterator<Item = Barrier<'a, Backend>>,
+        T: Iterator<Item = Barrier<'a, Backend>>,
     {
         todo!()
     }
@@ -127,7 +127,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _value: ClearValue,
         _subresource_ranges: T,
     ) where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<SubresourceRange>,
     {
         todo!()
@@ -135,9 +135,9 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn clear_attachments<T, U>(&mut self, _clears: T, _rects: U)
     where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<AttachmentClear>,
-        U: IntoIterator,
+        U: Iterator,
         U::Item: Borrow<pso::ClearRect>,
     {
         todo!()
@@ -151,7 +151,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _dst_layout: Layout,
         _regions: T,
     ) where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<ImageResolve>,
     {
         todo!()
@@ -166,7 +166,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _filter: Filter,
         _regions: T,
     ) where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<ImageBlit>,
     {
         todo!()
@@ -183,7 +183,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn bind_vertex_buffers<I, T>(&mut self, _first_binding: pso::BufferIndex, _buffers: I)
     where
-        I: IntoIterator<Item = (T, buffer::SubRange)>,
+        I: Iterator<Item = (T, buffer::SubRange)>,
         T: Borrow<<Backend as hal::Backend>::Buffer>,
     {
         todo!()
@@ -191,7 +191,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn set_viewports<T>(&mut self, _first_viewport: u32, _viewports: T)
     where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<pso::Viewport>,
     {
         todo!()
@@ -199,7 +199,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
 
     unsafe fn set_scissors<T>(&mut self, _first_scissor: u32, _rects: T)
     where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<pso::Rect>,
     {
         todo!()
@@ -241,7 +241,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _clear_values: T,
         _first_subpass: SubpassContents,
     ) where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<ClearValue>,
     {
         todo!()
@@ -269,9 +269,9 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _sets: I,
         _offsets: J,
     ) where
-        I: IntoIterator,
+        I: Iterator,
         I::Item: Borrow<<Backend as hal::Backend>::DescriptorSet>,
-        J: IntoIterator,
+        J: Iterator,
         J::Item: Borrow<DescriptorSetOffset>,
     {
         todo!()
@@ -291,9 +291,9 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _sets: I,
         _offsets: J,
     ) where
-        I: IntoIterator,
+        I: Iterator,
         I::Item: Borrow<<Backend as hal::Backend>::DescriptorSet>,
-        J: IntoIterator,
+        J: Iterator,
         J::Item: Borrow<DescriptorSetOffset>,
     {
         todo!()
@@ -317,7 +317,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _dst: &<Backend as hal::Backend>::Buffer,
         _regions: T,
     ) where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<BufferCopy>,
     {
         todo!()
@@ -331,7 +331,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _dst_layout: Layout,
         _regions: T,
     ) where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<ImageCopy>,
     {
         todo!()
@@ -344,7 +344,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _dst_layout: Layout,
         _regions: T,
     ) where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<BufferImageCopy>,
     {
         todo!()
@@ -357,7 +357,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _dst: &<Backend as hal::Backend>::Buffer,
         _regions: T,
     ) where
-        T: IntoIterator,
+        T: Iterator,
         T::Item: Borrow<BufferImageCopy>,
     {
         todo!()
@@ -468,9 +468,9 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
         _stages: Range<pso::PipelineStage>,
         _barriers: J,
     ) where
-        I: IntoIterator,
+        I: Iterator,
         I::Item: Borrow<<Backend as hal::Backend>::Event>,
-        J: IntoIterator<Item = Barrier<'a, Backend>>,
+        J: Iterator<Item = Barrier<'a, Backend>>,
     {
         todo!()
     }
@@ -533,7 +533,7 @@ impl hal::command::CommandBuffer<Backend> for CommandBuffer {
     unsafe fn execute_commands<'a, T, I>(&mut self, _cmd_buffers: I)
     where
         T: 'a + Borrow<<Backend as hal::Backend>::CommandBuffer>,
-        I: IntoIterator<Item = &'a T>,
+        I: Iterator<Item = &'a T>,
     {
         todo!()
     }

--- a/src/backend/webgpu/src/device.rs
+++ b/src/backend/webgpu/src/device.rs
@@ -53,7 +53,7 @@ impl hal::device::Device<Backend> for Device {
         _dependencies: Id,
     ) -> Result<<Backend as hal::Backend>::RenderPass, OutOfMemory>
     where
-        Is: IntoIterator<Item = pass::SubpassDesc<'a>>,
+        Is: Iterator<Item = pass::SubpassDesc<'a>>,
     {
         todo!()
     }
@@ -68,7 +68,7 @@ impl hal::device::Device<Backend> for Device {
         _push_constant: Ic,
     ) -> Result<<Backend as hal::Backend>::PipelineLayout, OutOfMemory>
     where
-        Is: IntoIterator<Item = &'a <Backend as hal::Backend>::DescriptorSetLayout>,
+        Is: Iterator<Item = &'a <Backend as hal::Backend>::DescriptorSetLayout>,
     {
         todo!()
     }
@@ -97,7 +97,7 @@ impl hal::device::Device<Backend> for Device {
         _sources: I,
     ) -> Result<(), OutOfMemory>
     where
-        I: IntoIterator<Item = &'a <Backend as hal::Backend>::PipelineCache>,
+        I: Iterator<Item = &'a <Backend as hal::Backend>::PipelineCache>,
     {
         todo!()
     }
@@ -143,7 +143,7 @@ impl hal::device::Device<Backend> for Device {
         _extent: hal::image::Extent,
     ) -> Result<<Backend as hal::Backend>::Framebuffer, OutOfMemory>
     where
-        I: IntoIterator,
+        I: Iterator,
     {
         todo!()
     }
@@ -289,7 +289,7 @@ impl hal::device::Device<Backend> for Device {
         _immutable_samplers: J,
     ) -> Result<<Backend as hal::Backend>::DescriptorSetLayout, OutOfMemory>
     where
-        J: IntoIterator<Item = &'a <Backend as hal::Backend>::Sampler>,
+        J: Iterator<Item = &'a <Backend as hal::Backend>::Sampler>,
     {
         todo!()
     }
@@ -303,7 +303,7 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn write_descriptor_set<'a, I>(&self, _op: pso::DescriptorSetWrite<'a, Backend, I>)
     where
-        I: IntoIterator<Item = pso::Descriptor<'a, Backend>>,
+        I: Iterator<Item = pso::Descriptor<'a, Backend>>,
     {
         todo!()
     }
@@ -322,14 +322,14 @@ impl hal::device::Device<Backend> for Device {
 
     unsafe fn flush_mapped_memory_ranges<'a, I>(&self, _ranges: I) -> Result<(), OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a <Backend as hal::Backend>::Memory, Segment)>,
+        I: Iterator<Item = (&'a <Backend as hal::Backend>::Memory, Segment)>,
     {
         todo!()
     }
 
     unsafe fn invalidate_mapped_memory_ranges<'a, I>(&self, _ranges: I) -> Result<(), OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a <Backend as hal::Backend>::Memory, Segment)>,
+        I: Iterator<Item = (&'a <Backend as hal::Backend>::Memory, Segment)>,
     {
         todo!()
     }
@@ -375,7 +375,7 @@ impl hal::device::Device<Backend> for Device {
         _timeout_ns: u64,
     ) -> Result<bool, WaitError>
     where
-        I: IntoIterator<Item = &'a <Backend as hal::Backend>::Fence>,
+        I: Iterator<Item = &'a <Backend as hal::Backend>::Fence>,
     {
         todo!()
     }

--- a/src/backend/webgpu/src/lib.rs
+++ b/src/backend/webgpu/src/lib.rs
@@ -109,13 +109,11 @@ impl Instance {
         // we can return them and let the application choose.
         if high_performance_adapter != low_power_adapter {
             high_performance_adapter
-                .into_iter()
                 .chain(low_power_adapter)
                 .map(map_wgpu_adapter_to_hal_adapter)
                 .collect()
         } else {
             high_performance_adapter
-                .into_iter()
                 .map(map_wgpu_adapter_to_hal_adapter)
                 .collect()
         }
@@ -235,7 +233,7 @@ impl hal::pso::DescriptorPool<Backend> for DescriptorPool {
 
     unsafe fn free<I>(&mut self, _descriptor_sets: I)
     where
-        I: IntoIterator<Item = <Backend as hal::Backend>::DescriptorSet>,
+        I: Iterator<Item = <Backend as hal::Backend>::DescriptorSet>,
     {
         todo!()
     }

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -136,7 +136,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         dependencies: Dependencies,
         barriers: T,
     ) where
-        T: IntoIterator<Item = Barrier<'a, B>>;
+        T: Iterator<Item = Barrier<'a, B>>;
 
     /// Fill a buffer with the given `u32` value.
     unsafe fn fill_buffer(&mut self, buffer: &B::Buffer, range: buffer::SubRange, data: u32);
@@ -152,14 +152,14 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         value: ClearValue,
         subresource_ranges: T,
     ) where
-        T: IntoIterator<Item = SubresourceRange>;
+        T: Iterator<Item = SubresourceRange>;
 
     /// Takes an iterator of attachments and an iterator of rect's,
     /// and clears the given rect's for *each* attachment.
     unsafe fn clear_attachments<T, U>(&mut self, clears: T, rects: U)
     where
-        T: IntoIterator<Item = AttachmentClear>,
-        U: IntoIterator<Item = pso::ClearRect>;
+        T: Iterator<Item = AttachmentClear>,
+        U: Iterator<Item = pso::ClearRect>;
 
     /// "Resolves" a multisampled image, converting it into a non-multisampled
     /// image. Takes an iterator of regions to apply the resolution to.
@@ -171,7 +171,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         dst_layout: Layout,
         regions: T,
     ) where
-        T: IntoIterator<Item = ImageResolve>;
+        T: Iterator<Item = ImageResolve>;
 
     /// Copies regions from the source to destination image,
     /// applying scaling, filtering and potentially format conversion.
@@ -184,7 +184,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         filter: Filter,
         regions: T,
     ) where
-        T: IntoIterator<Item = ImageBlit>;
+        T: Iterator<Item = ImageBlit>;
 
     /// Bind the index buffer view, making it the "current" one that draw commands
     /// will operate on.
@@ -212,7 +212,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// in bytes, into that buffer where the vertex data that should be bound.
     unsafe fn bind_vertex_buffers<'a, T>(&mut self, first_binding: pso::BufferIndex, buffers: T)
     where
-        T: IntoIterator<Item = (&'a B::Buffer, buffer::SubRange)>;
+        T: Iterator<Item = (&'a B::Buffer, buffer::SubRange)>;
 
     /// Set the [viewport][crate::pso::Viewport] parameters for the rasterizer.
     ///
@@ -233,7 +233,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     ///   draw call.
     unsafe fn set_viewports<T>(&mut self, first_viewport: u32, viewports: T)
     where
-        T: IntoIterator<Item = pso::Viewport>;
+        T: Iterator<Item = pso::Viewport>;
 
     /// Set the scissor rectangles for the rasterizer.
     ///
@@ -254,7 +254,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     ///   call.
     unsafe fn set_scissors<T>(&mut self, first_scissor: u32, rects: T)
     where
-        T: IntoIterator<Item = pso::Rect>;
+        T: Iterator<Item = pso::Rect>;
 
     /// Sets the stencil reference value for comparison operations and store operations.
     /// Will be used on the LHS of stencil compare ops and as store value when the
@@ -299,7 +299,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         attachments: T,
         first_subpass: SubpassContents,
     ) where
-        T: IntoIterator<Item = RenderAttachmentInfo<'a, B>>;
+        T: Iterator<Item = RenderAttachmentInfo<'a, B>>;
 
     /// Steps to the next subpass in the current render pass.
     unsafe fn next_subpass(&mut self, contents: SubpassContents);
@@ -327,8 +327,8 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         sets: I,
         offsets: J,
     ) where
-        I: IntoIterator<Item = &'a B::DescriptorSet>,
-        J: IntoIterator<Item = DescriptorSetOffset>;
+        I: Iterator<Item = &'a B::DescriptorSet>,
+        J: Iterator<Item = DescriptorSetOffset>;
 
     /// Bind a compute pipeline.
     ///
@@ -350,8 +350,8 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         sets: I,
         offsets: J,
     ) where
-        I: IntoIterator<Item = &'a B::DescriptorSet>,
-        J: IntoIterator<Item = DescriptorSetOffset>;
+        I: Iterator<Item = &'a B::DescriptorSet>,
+        J: Iterator<Item = DescriptorSetOffset>;
 
     /// Execute a workgroup in the compute pipeline. `x`, `y` and `z` are the
     /// number of local workgroups to dispatch along each "axis"; a total of `x`*`y`*`z`
@@ -378,7 +378,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Adds a command to copy regions from the source to destination buffer.
     unsafe fn copy_buffer<T>(&mut self, src: &B::Buffer, dst: &B::Buffer, regions: T)
     where
-        T: IntoIterator<Item = BufferCopy>;
+        T: Iterator<Item = BufferCopy>;
 
     /// Copies regions from the source to the destination images, which
     /// have the given layouts.  No format conversion is done; the source and destination
@@ -392,7 +392,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         dst_layout: Layout,
         regions: T,
     ) where
-        T: IntoIterator<Item = ImageCopy>;
+        T: Iterator<Item = ImageCopy>;
 
     /// Copies regions from the source buffer to the destination image.
     unsafe fn copy_buffer_to_image<T>(
@@ -402,7 +402,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         dst_layout: Layout,
         regions: T,
     ) where
-        T: IntoIterator<Item = BufferImageCopy>;
+        T: Iterator<Item = BufferImageCopy>;
 
     /// Copies regions from the source image to the destination buffer.
     unsafe fn copy_image_to_buffer<T>(
@@ -412,7 +412,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         dst: &B::Buffer,
         regions: T,
     ) where
-        T: IntoIterator<Item = BufferImageCopy>;
+        T: Iterator<Item = BufferImageCopy>;
 
     // TODO: This explanation needs improvement.
     /// Performs a non-indexed drawing operation, fetching vertex attributes
@@ -546,8 +546,8 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
         stages: Range<pso::PipelineStage>,
         barriers: J,
     ) where
-        I: IntoIterator<Item = &'a B::Event>,
-        J: IntoIterator<Item = Barrier<'a, B>>;
+        I: Iterator<Item = &'a B::Event>,
+        J: Iterator<Item = Barrier<'a, B>>;
 
     /// Begins a query operation.  Queries count operations or record timestamps
     /// resulting from commands that occur between the beginning and end of the query,
@@ -602,7 +602,7 @@ pub trait CommandBuffer<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Execute the given secondary command buffers.
     unsafe fn execute_commands<'a, T>(&mut self, cmd_buffers: T)
     where
-        T: IntoIterator<Item = &'a B::CommandBuffer>;
+        T: Iterator<Item = &'a B::CommandBuffer>;
 
     /// Debug mark the current spot in the command buffer.
     unsafe fn insert_debug_marker(&mut self, name: &str, color: u32);

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -231,9 +231,9 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         dependencies: Id,
     ) -> Result<B::RenderPass, OutOfMemory>
     where
-        Ia: IntoIterator<Item = pass::Attachment>,
-        Is: IntoIterator<Item = pass::SubpassDesc<'a>>,
-        Id: IntoIterator<Item = pass::SubpassDependency>;
+        Ia: Iterator<Item = pass::Attachment>,
+        Is: Iterator<Item = pass::SubpassDesc<'a>>,
+        Id: Iterator<Item = pass::SubpassDependency>;
 
     /// Destroys a *render pass* created by this device.
     unsafe fn destroy_render_pass(&self, rp: B::RenderPass);
@@ -260,8 +260,8 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         push_constant: Ic,
     ) -> Result<B::PipelineLayout, OutOfMemory>
     where
-        Is: IntoIterator<Item = &'a B::DescriptorSetLayout>,
-        Ic: IntoIterator<Item = (pso::ShaderStageFlags, Range<u32>)>;
+        Is: Iterator<Item = &'a B::DescriptorSetLayout>,
+        Ic: Iterator<Item = (pso::ShaderStageFlags, Range<u32>)>;
 
     /// Destroy a pipeline layout object
     unsafe fn destroy_pipeline_layout(&self, layout: B::PipelineLayout);
@@ -285,7 +285,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         sources: I,
     ) -> Result<(), OutOfMemory>
     where
-        I: IntoIterator<Item = &'a B::PipelineCache>;
+        I: Iterator<Item = &'a B::PipelineCache>;
 
     /// Destroy a pipeline cache object.
     unsafe fn destroy_pipeline_cache(&self, cache: B::PipelineCache);
@@ -335,7 +335,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         extent: image::Extent,
     ) -> Result<B::Framebuffer, OutOfMemory>
     where
-        I: IntoIterator<Item = image::FramebufferAttachment>;
+        I: Iterator<Item = image::FramebufferAttachment>;
 
     /// Destroy a framebuffer.
     ///
@@ -474,7 +474,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         flags: DescriptorPoolCreateFlags,
     ) -> Result<B::DescriptorPool, OutOfMemory>
     where
-        I: IntoIterator<Item = pso::DescriptorRangeDesc>;
+        I: Iterator<Item = pso::DescriptorRangeDesc>;
 
     /// Destroy a descriptor pool object
     ///
@@ -495,8 +495,8 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         immutable_samplers: J,
     ) -> Result<B::DescriptorSetLayout, OutOfMemory>
     where
-        I: IntoIterator<Item = pso::DescriptorSetLayoutBinding>,
-        J: IntoIterator<Item = &'a B::Sampler>;
+        I: Iterator<Item = pso::DescriptorSetLayoutBinding>,
+        J: Iterator<Item = &'a B::Sampler>;
 
     /// Destroy a descriptor set layout object
     unsafe fn destroy_descriptor_set_layout(&self, layout: B::DescriptorSetLayout);
@@ -504,7 +504,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Specifying the parameters of a descriptor set write operation.
     unsafe fn write_descriptor_set<'a, I>(&self, op: pso::DescriptorSetWrite<'a, B, I>)
     where
-        I: IntoIterator<Item = pso::Descriptor<'a, B>>;
+        I: Iterator<Item = pso::Descriptor<'a, B>>;
 
     /// Structure specifying a copy descriptor set operation.
     unsafe fn copy_descriptor_set<'a>(&self, op: pso::DescriptorSetCopy<'a, B>);
@@ -521,12 +521,12 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Flush mapped memory ranges
     unsafe fn flush_mapped_memory_ranges<'a, I>(&self, ranges: I) -> Result<(), OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a B::Memory, Segment)>;
+        I: Iterator<Item = (&'a B::Memory, Segment)>;
 
     /// Invalidate ranges of non-coherent memory from the host caches
     unsafe fn invalidate_mapped_memory_ranges<'a, I>(&self, ranges: I) -> Result<(), OutOfMemory>
     where
-        I: IntoIterator<Item = (&'a B::Memory, Segment)>;
+        I: Iterator<Item = (&'a B::Memory, Segment)>;
 
     /// Unmap a memory object once host access to it is no longer needed by the application
     unsafe fn unmap_memory(&self, memory: &mut B::Memory);
@@ -578,7 +578,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         timeout_ns: u64,
     ) -> Result<bool, WaitError>
     where
-        I: IntoIterator<Item = &'a B::Fence>,
+        I: Iterator<Item = &'a B::Fence>,
     {
         use std::{thread, time};
         fn to_ns(duration: time::Duration) -> u64 {
@@ -602,7 +602,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
                 Ok(true)
             }
             WaitFor::Any => {
-                let fences: Vec<_> = fences.into_iter().collect();
+                let fences: Vec<_> = fences.collect();
                 loop {
                     for &fence in &fences {
                         if self.wait_for_fence(fence, 0)? {

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -603,8 +603,8 @@ impl From<usize> for MemoryTypeId {
 struct PseudoVec<T>(Option<T>);
 
 impl<T> Extend<T> for PseudoVec<T> {
-    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        let mut iter = iter.into_iter();
+    fn extend<I: IntoIterator<Item = T>>(&mut self, into_iter: I) {
+        let mut iter = into_iter.into_iter();
         self.0 = iter.next();
         assert!(iter.next().is_none());
     }

--- a/src/hal/src/pool.rs
+++ b/src/hal/src/pool.rs
@@ -59,5 +59,5 @@ pub trait CommandPool<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Free [command buffers][crate::command::CommandBuffer] allocated from this pool.
     unsafe fn free<I>(&mut self, buffers: I)
     where
-        I: IntoIterator<Item = B::CommandBuffer>;
+        I: Iterator<Item = B::CommandBuffer>;
 }

--- a/src/hal/src/pso/descriptor.rs
+++ b/src/hal/src/pso/descriptor.rs
@@ -192,7 +192,7 @@ pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
     /// [`DescriptorSetCopy`]: struct.DescriptorSetCopy.html
     unsafe fn allocate<'a, I, E>(&mut self, layouts: I, list: &mut E) -> Result<(), AllocationError>
     where
-        I: IntoIterator<Item = &'a B::DescriptorSetLayout>,
+        I: Iterator<Item = &'a B::DescriptorSetLayout>,
         E: Extend<B::DescriptorSet>,
     {
         for layout in layouts {
@@ -205,7 +205,7 @@ pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
     /// Free the given descriptor sets provided as an iterator.
     unsafe fn free<I>(&mut self, descriptor_sets: I)
     where
-        I: IntoIterator<Item = B::DescriptorSet>;
+        I: Iterator<Item = B::DescriptorSet>;
 
     /// Resets a descriptor pool, releasing all resources from all the descriptor sets
     /// allocated from it and freeing the descriptor sets. Invalidates all descriptor
@@ -220,7 +220,7 @@ pub trait DescriptorPool<B: Backend>: Send + Sync + fmt::Debug {
 #[derive(Debug)]
 pub struct DescriptorSetWrite<'a, B: Backend, I>
 where
-    I: IntoIterator<Item = Descriptor<'a, B>>,
+    I: Iterator<Item = Descriptor<'a, B>>,
 {
     /// The descriptor set to modify.
     pub set: &'a mut B::DescriptorSet,

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -89,9 +89,9 @@ pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
         signal_semaphores: Is,
         fence: Option<&mut B::Fence>,
     ) where
-        Ic: IntoIterator<Item = &'a B::CommandBuffer>,
-        Iw: IntoIterator<Item = (&'a B::Semaphore, pso::PipelineStage)>,
-        Is: IntoIterator<Item = &'a B::Semaphore>;
+        Ic: Iterator<Item = &'a B::CommandBuffer>,
+        Iw: Iterator<Item = (&'a B::Semaphore, pso::PipelineStage)>,
+        Is: Iterator<Item = &'a B::Semaphore>;
 
     /// Present a swapchain image directly to a surface, after waiting on `wait_semaphore`.
     ///


### PR DESCRIPTION
Doesn't fix anything, but makes our API a little bit more explicit.

Original motivation for `IntoIterator` was driven by general Rust best practices, including the idea that users would already pass containers to us, such as `Vec`, or `Option`. However, at this point I believe the minor convenience is not worth the additional type layer of `IntoIterator`. In most cases we don't expect actual containers, we expect users to store the data in their own containers, and then iterator to extract it and provide to us. Overall, in gfx-hal we are trying to be explicit about the costs, and seeing an iterator on the call side helps this a bit.

Finally, as an interesting fact, in most cases in Warden the fix was to just... remove `collect()`. Generally, we don't want to build an API that promotes passing `Vec` around. We should discourage this instead.
