### PR TITLE
Use non-ARB functions in bind_blend_slot

### DIFF
--- a/src/backend/gl/src/state.rs
+++ b/src/backend/gl/src/state.rs
@@ -253,13 +253,12 @@ pub fn bind_blend_slot(gl: &gl::Gl, slot: ColorSlot, color: s::Color) {
     let buf = slot as gl::types::GLuint;
     match color.blend {
         Some(b) => unsafe {
-            //Note: using ARB functions as they are more compatible
             gl.Enablei(gl::BLEND, buf);
-            gl.BlendEquationSeparateiARB(buf,
+            gl.BlendEquationSeparatei(buf,
                 map_equation(b.color.equation),
                 map_equation(b.alpha.equation)
             );
-            gl.BlendFuncSeparateiARB(buf,
+            gl.BlendFuncSeparatei(buf,
                 map_factor(b.color.source),
                 map_factor(b.color.destination),
                 map_factor(b.alpha.source),


### PR DESCRIPTION
Fixes #2685

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
- gl
