### PR TITLE
Update naga to gfx-8, fix metal naga-parse feature

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -35,7 +35,7 @@ libloading = "0.6"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-7"
+tag = "gfx-8"
 #TODO: remove `spv-out` once spirv-cross is deprecated
 features = ["spv-out", "glsl-out"]
 optional = true

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -42,7 +42,7 @@ raw-window-handle = "0.3"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-7"
+tag = "gfx-8"
 #TODO: remove `spv-out` once spirv-cross is deprecated
 features = ["spv-out", "msl-out"]
 optional = true

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1802,9 +1802,9 @@ impl hal::device::Device<Backend> for Device {
         //TODO: we can probably at least parse here and save the `Ast`
         Ok(n::ShaderModule {
             spv: raw_data.to_vec(),
-            #[cfg(all(feature = "naga", not(feature = "naga-in")))]
+            #[cfg(all(feature = "naga", not(feature = "naga-parse")))]
             naga: None,
-            #[cfg(feature = "naga-in")]
+            #[cfg(feature = "naga-parse")]
             naga: {
                 let parser =
                     naga::front::spv::Parser::new(raw_data.iter().cloned(), &Default::default());

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -33,7 +33,7 @@ inplace_it = "0.3.3"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-7"
+tag = "gfx-8"
 features = ["spv-out"]
 optional = true
 

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.0"
-naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-7" }
+naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-8" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"


### PR DESCRIPTION
Gets us lots of new good things, including https://github.com/gfx-rs/naga/pull/366
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
