### PR TITLE
Transfer benchmarking example, dx12 query resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-### hal-unreleased
+### unreleased
+  - the new "bench" example is added
+  - timestamp period query is moved to the `Queue`
+
+## hal-0.7.0 (30-01-2021)
   - `Borrow` and `ExactSizeIterator` bounds are removed from the iterators
   - error improvements:
     - use `thiserror` for errors
@@ -32,7 +36,6 @@
     - now only uses OpenGL ES on Linux/Android/Web targets
     - binding model has been completely rewritten
     - various number of fixed in rendering, memory mapping, and other areas
-
 
 ### backend-dx12-unreleased
   - fix SPIR-V entry point selection

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -30,6 +30,10 @@ path = "compute/main.rs"
 name = "mesh-shading"
 path = "mesh-shading/main.rs"
 
+[[bin]]
+name = "bench"
+path = "bench/main.rs"
+
 [dependencies]
 image = "0.23.12"
 log = "0.4"

--- a/examples/bench/main.rs
+++ b/examples/bench/main.rs
@@ -348,7 +348,7 @@ fn main() {
 
         println!("Benchmarking...");
 
-        let period = limits.timestamp_period as f64 / 1_000_000.0;
+        let period = queue_group.queues[0].timestamp_period() as f64 / 1_000_000.0;
         let mut timings = vec![0u8; num_queries as usize * 8];
         for i in 0..RUNS {
             device.reset_fence(&mut fence).unwrap();

--- a/examples/bench/main.rs
+++ b/examples/bench/main.rs
@@ -1,0 +1,389 @@
+#![cfg_attr(
+    not(any(
+        feature = "vulkan",
+        feature = "gl",
+        feature = "dx11",
+        feature = "dx12",
+        feature = "metal",
+    )),
+    allow(dead_code, unused_extern_crates, unused_imports)
+)]
+
+#[cfg(feature = "dx11")]
+extern crate gfx_backend_dx11 as back;
+#[cfg(feature = "dx12")]
+extern crate gfx_backend_dx12 as back;
+#[cfg(not(any(
+    feature = "vulkan",
+    feature = "gl",
+    feature = "dx11",
+    feature = "dx12",
+    feature = "metal",
+)))]
+extern crate gfx_backend_empty as back;
+#[cfg(feature = "gl")]
+extern crate gfx_backend_gl as back;
+#[cfg(feature = "metal")]
+extern crate gfx_backend_metal as back;
+#[cfg(feature = "vulkan")]
+extern crate gfx_backend_vulkan as back;
+
+use std::{iter, slice};
+
+use hal::{command as com, image as i, prelude::*};
+
+// AMD chokes on larger region counts...
+const SIZE: u32 = 1048;
+// when 1, we use one-time-submit commands
+const RUNS: usize = 2;
+const FORMAT: hal::format::Format = hal::format::Format::Rgba8Unorm;
+
+fn main() {
+    env_logger::init();
+
+    let instance =
+        back::Instance::create("gfx-rs bench", 1).expect("Failed to create an instance!");
+
+    let adapter = instance.enumerate_adapters().remove(0);
+    println!("Running on {}", adapter.info.name);
+
+    let memory_properties = adapter.physical_device.memory_properties();
+    let family = adapter
+        .queue_families
+        .iter()
+        .find(|family| family.queue_type().supports_compute())
+        .unwrap();
+
+    unsafe {
+        let mut gpu = adapter
+            .physical_device
+            .open(&[(family, &[1.0])], hal::Features::empty())
+            .unwrap();
+        let device = &gpu.device;
+        let queue_group = gpu.queue_groups.first_mut().unwrap();
+
+        // source image
+
+        let mut src_image = device
+            .create_image(
+                i::Kind::D2(1, 1, 1, 1),
+                1,
+                FORMAT,
+                i::Tiling::Linear,
+                i::Usage::TRANSFER_SRC | i::Usage::TRANSFER_DST,
+                i::ViewCapabilities::empty(),
+            )
+            .unwrap();
+        let src_image_requirements = device.get_image_requirements(&src_image);
+        let src_image_type = memory_properties
+            .memory_types
+            .iter()
+            .enumerate()
+            .position(|(id, memory_type)| {
+                src_image_requirements.type_mask & (1 << id) != 0
+                    && memory_type
+                        .properties
+                        .contains(hal::memory::Properties::DEVICE_LOCAL)
+            })
+            .unwrap()
+            .into();
+
+        let src_memory_image = device
+            .allocate_memory(src_image_type, src_image_requirements.size)
+            .unwrap();
+        device
+            .bind_image_memory(&src_memory_image, 0, &mut src_image)
+            .unwrap();
+
+        // source buffer
+        let bytes_per_texel = FORMAT.surface_desc().bits / 8;
+
+        let mut src_buffer = device
+            .create_buffer(bytes_per_texel as u64, hal::buffer::Usage::TRANSFER_SRC)
+            .unwrap();
+        let src_buffer_requirements = device.get_buffer_requirements(&src_buffer);
+        let src_buffer_type = memory_properties
+            .memory_types
+            .iter()
+            .enumerate()
+            .position(|(id, memory_type)| {
+                src_buffer_requirements.type_mask & (1 << id) != 0
+                    && memory_type
+                        .properties
+                        .contains(hal::memory::Properties::CPU_VISIBLE)
+            })
+            .unwrap()
+            .into();
+
+        let mut src_memory_buffer = device
+            .allocate_memory(src_buffer_type, src_buffer_requirements.size)
+            .unwrap();
+        device
+            .bind_buffer_memory(&src_memory_buffer, 0, &mut src_buffer)
+            .unwrap();
+
+        let ptr = device
+            .map_memory(&mut src_memory_buffer, hal::memory::Segment::default())
+            .unwrap();
+        *(ptr as *mut u32) = 1;
+        device.unmap_memory(&mut src_memory_buffer);
+        device
+            .flush_mapped_memory_ranges(iter::once((
+                &src_memory_buffer,
+                hal::memory::Segment::default(),
+            )))
+            .unwrap();
+
+        // destination image
+
+        let mut dst_image = device
+            .create_image(
+                i::Kind::D2(SIZE, SIZE, 1, 1),
+                1,
+                FORMAT,
+                i::Tiling::Linear,
+                i::Usage::TRANSFER_DST,
+                i::ViewCapabilities::empty(),
+            )
+            .unwrap();
+        let dst_requirements = device.get_image_requirements(&dst_image);
+        let dst_type = memory_properties
+            .memory_types
+            .iter()
+            .enumerate()
+            .position(|(id, memory_type)| {
+                dst_requirements.type_mask & (1 << id) != 0
+                    && memory_type
+                        .properties
+                        .contains(hal::memory::Properties::DEVICE_LOCAL)
+            })
+            .unwrap()
+            .into();
+
+        let dst_memory = device
+            .allocate_memory(dst_type, dst_requirements.size)
+            .unwrap();
+        device
+            .bind_image_memory(&dst_memory, 0, &mut dst_image)
+            .unwrap();
+
+        // Initializing commands
+        let subresource_layers = i::SubresourceLayers {
+            aspects: hal::format::Aspects::COLOR,
+            level: 0,
+            layers: 0..1,
+        };
+
+        let mut command_pool = device
+            .create_command_pool(family.id(), hal::pool::CommandPoolCreateFlags::empty())
+            .expect("Can't create command pool");
+        let mut fence = device.create_fence(false).unwrap();
+
+        {
+            let mut cmd_init = command_pool.allocate_one(com::Level::Primary);
+            cmd_init.begin_primary(com::CommandBufferFlags::ONE_TIME_SUBMIT);
+            cmd_init.pipeline_barrier(
+                hal::pso::PipelineStage::TOP_OF_PIPE..hal::pso::PipelineStage::TRANSFER,
+                hal::memory::Dependencies::empty(),
+                iter::once(hal::memory::Barrier::Image {
+                    states: (i::Access::empty(), i::Layout::Undefined)
+                        ..(i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal),
+                    families: None,
+                    target: &src_image,
+                    range: i::SubresourceRange {
+                        aspects: hal::format::Aspects::COLOR,
+                        ..i::SubresourceRange::default()
+                    },
+                })
+                .chain(iter::once(hal::memory::Barrier::Buffer {
+                    states: hal::buffer::Access::MEMORY_WRITE..hal::buffer::Access::TRANSFER_READ,
+                    families: None,
+                    target: &src_buffer,
+                    range: hal::buffer::SubRange::default(),
+                }))
+                .chain(iter::once(hal::memory::Barrier::Image {
+                    states: (i::Access::empty(), i::Layout::Undefined)
+                        ..(i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal),
+                    families: None,
+                    target: &dst_image,
+                    range: i::SubresourceRange {
+                        aspects: hal::format::Aspects::COLOR,
+                        ..i::SubresourceRange::default()
+                    },
+                })),
+            );
+            cmd_init.copy_buffer_to_image(
+                &src_buffer,
+                &src_image,
+                i::Layout::TransferDstOptimal,
+                iter::once(com::BufferImageCopy {
+                    buffer_offset: 0,
+                    buffer_width: 1,
+                    buffer_height: 1,
+                    image_layers: subresource_layers.clone(),
+                    image_offset: i::Offset::ZERO,
+                    image_extent: i::Extent {
+                        width: 1,
+                        height: 1,
+                        depth: 1,
+                    },
+                }),
+            );
+            cmd_init.pipeline_barrier(
+                hal::pso::PipelineStage::TRANSFER..hal::pso::PipelineStage::TRANSFER,
+                hal::memory::Dependencies::empty(),
+                iter::once(hal::memory::Barrier::Image {
+                    states: (i::Access::TRANSFER_WRITE, i::Layout::TransferDstOptimal)
+                        ..(i::Access::TRANSFER_READ, i::Layout::TransferSrcOptimal),
+                    families: None,
+                    target: &src_image,
+                    range: i::SubresourceRange {
+                        aspects: hal::format::Aspects::COLOR,
+                        ..i::SubresourceRange::default()
+                    },
+                }),
+            );
+            cmd_init.finish();
+
+            queue_group.queues[0].submit(
+                iter::once(&cmd_init),
+                iter::empty(),
+                iter::empty(),
+                Some(&mut fence),
+            );
+            device.wait_for_fence(&fence, !0).unwrap();
+        }
+
+        println!(
+            "Pre-recording commands for {}x{} {:?}...",
+            SIZE, SIZE, FORMAT
+        );
+
+        let num_queries = 3;
+        let query_pool = device
+            .create_query_pool(hal::query::Type::Timestamp, num_queries)
+            .unwrap();
+        let mut image_regions = Vec::new();
+        let mut buffer_regions = Vec::new();
+        for y in 0..SIZE {
+            for x in 0..SIZE {
+                image_regions.push(com::ImageCopy {
+                    src_subresource: subresource_layers.clone(),
+                    src_offset: i::Offset::ZERO,
+                    dst_subresource: subresource_layers.clone(),
+                    dst_offset: i::Offset {
+                        x: x as i32,
+                        y: y as i32,
+                        z: 0,
+                    },
+                    extent: i::Extent {
+                        width: 1,
+                        height: 1,
+                        depth: 1,
+                    },
+                });
+                buffer_regions.push(com::BufferImageCopy {
+                    buffer_offset: 0,
+                    buffer_width: 1,
+                    buffer_height: 1,
+                    image_layers: subresource_layers.clone(),
+                    image_offset: i::Offset {
+                        x: x as i32,
+                        y: y as i32,
+                        z: 0,
+                    },
+                    image_extent: i::Extent {
+                        width: 1,
+                        height: 1,
+                        depth: 1,
+                    },
+                });
+            }
+        }
+
+        let mut cmd_bench = command_pool.allocate_one(com::Level::Primary);
+        cmd_bench.begin_primary(if RUNS == 1 {
+            com::CommandBufferFlags::ONE_TIME_SUBMIT
+        } else {
+            com::CommandBufferFlags::empty()
+        });
+        cmd_bench.reset_query_pool(&query_pool, 0..num_queries);
+        cmd_bench.write_timestamp(
+            hal::pso::PipelineStage::TRANSFER,
+            hal::query::Query {
+                pool: &query_pool,
+                id: 0,
+            },
+        );
+        cmd_bench.copy_image(
+            &src_image,
+            i::Layout::TransferSrcOptimal,
+            &dst_image,
+            i::Layout::TransferDstOptimal,
+            image_regions.into_iter(),
+        );
+        cmd_bench.write_timestamp(
+            hal::pso::PipelineStage::TRANSFER,
+            hal::query::Query {
+                pool: &query_pool,
+                id: 1,
+            },
+        );
+        cmd_bench.copy_buffer_to_image(
+            &src_buffer,
+            &dst_image,
+            i::Layout::TransferDstOptimal,
+            buffer_regions.into_iter(),
+        );
+        cmd_bench.write_timestamp(
+            hal::pso::PipelineStage::TRANSFER,
+            hal::query::Query {
+                pool: &query_pool,
+                id: 2,
+            },
+        );
+        cmd_bench.finish();
+
+        println!("Benchmarking...");
+
+        let period = adapter.physical_device.limits().timestamp_period as f64 / 1_000_000.0;
+        let mut timings = vec![0u8; num_queries as usize * 8];
+        for i in 0..RUNS {
+            device.reset_fence(&mut fence).unwrap();
+            queue_group.queues[0].submit(
+                iter::once(&cmd_bench),
+                iter::empty(),
+                iter::empty(),
+                Some(&mut fence),
+            );
+            device.wait_for_fence(&fence, !0).unwrap();
+
+            device
+                .get_query_pool_results(
+                    &query_pool,
+                    0..num_queries,
+                    &mut timings,
+                    8,
+                    hal::query::ResultFlags::BITS_64 | hal::query::ResultFlags::WAIT,
+                )
+                .unwrap();
+            let ticks = slice::from_raw_parts(timings.as_ptr() as *const u64, num_queries as usize);
+            let copy_image_time = ((ticks[1] - ticks[0]) as f64 * period) as u32;
+            let copy_buffer_time = ((ticks[2] - ticks[1]) as f64 * period) as u32;
+            println!(
+                "\tRun[{}]: image->image({} ms), buffer->image({} ms)",
+                i, copy_image_time, copy_buffer_time
+            );
+        }
+
+        device.destroy_query_pool(query_pool);
+        device.destroy_command_pool(command_pool);
+        device.destroy_image(src_image);
+        device.destroy_buffer(src_buffer);
+        device.destroy_image(dst_image);
+        device.destroy_fence(fence);
+        device.free_memory(src_memory_image);
+        device.free_memory(src_memory_buffer);
+        device.free_memory(dst_memory);
+    }
+}

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -13,6 +13,14 @@
 extern crate gfx_backend_dx11 as back;
 #[cfg(feature = "dx12")]
 extern crate gfx_backend_dx12 as back;
+#[cfg(not(any(
+    feature = "vulkan",
+    feature = "gl",
+    feature = "dx11",
+    feature = "dx12",
+    feature = "metal",
+)))]
+extern crate gfx_backend_empty as back;
 #[cfg(feature = "gl")]
 extern crate gfx_backend_gl as back;
 #[cfg(feature = "metal")]
@@ -24,13 +32,6 @@ use std::{fs, iter, ptr, slice, str::FromStr};
 
 use hal::{adapter::MemoryType, buffer, command, memory, pool, prelude::*, pso};
 
-#[cfg(any(
-    feature = "vulkan",
-    feature = "gl",
-    feature = "dx11",
-    feature = "dx12",
-    feature = "metal",
-))]
 fn main() {
     env_logger::init();
 
@@ -298,15 +299,4 @@ unsafe fn create_buffer<B: hal::Backend>(
     device.bind_buffer_memory(&memory, 0, &mut buffer).unwrap();
 
     (memory, buffer, requirements.size)
-}
-
-#[cfg(not(any(
-    feature = "vulkan",
-    feature = "gl",
-    feature = "dx11",
-    feature = "dx12",
-    feature = "metal"
-)))]
-fn main() {
-    println!("You need to enable one of the next-gen API feature (vulkan, dx12, metal) to run this example.");
 }

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -755,7 +755,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 let mut group = queue::QueueGroup::new(queue::QueueFamilyId(0));
 
                 // TODO: multiple queues?
-                let queue = CommandQueue {
+                let queue = Queue {
                     context: device.context.clone(),
                 };
                 group.add_queue(queue);
@@ -1149,20 +1149,20 @@ impl queue::QueueFamily for QueueFamily {
 }
 
 #[derive(Clone)]
-pub struct CommandQueue {
+pub struct Queue {
     context: ComPtr<d3d11::ID3D11DeviceContext>,
 }
 
-impl fmt::Debug for CommandQueue {
+impl fmt::Debug for Queue {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("CommandQueue")
+        fmt.write_str("Queue")
     }
 }
 
-unsafe impl Send for CommandQueue {}
-unsafe impl Sync for CommandQueue {}
+unsafe impl Send for Queue {}
+unsafe impl Sync for Queue {}
 
-impl queue::CommandQueue<Backend> for CommandQueue {
+impl queue::Queue<Backend> for Queue {
     unsafe fn submit<'a, Ic, Iw, Is>(
         &mut self,
         command_buffers: Ic,
@@ -1225,6 +1225,10 @@ impl queue::CommandQueue<Backend> for CommandQueue {
     fn wait_idle(&mut self) -> Result<(), hal::device::OutOfMemory> {
         // unimplemented!()
         Ok(())
+    }
+
+    fn timestamp_period(&self) -> f32 {
+        1.0
     }
 }
 
@@ -4215,7 +4219,7 @@ impl hal::Backend for Backend {
     type Surface = Surface;
 
     type QueueFamily = QueueFamily;
-    type CommandQueue = CommandQueue;
+    type Queue = Queue;
     type CommandBuffer = CommandBuffer;
 
     type Memory = Memory;

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -865,7 +865,7 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
 #[derive(Debug)]
 pub struct QueryPool {
     pub(crate) raw: native::QueryHeap,
-    pub(crate) ty: native::QueryHeapType,
+    pub(crate) ty: hal::query::Type,
 }
 
 unsafe impl Send for QueryPool {}

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -32,7 +32,7 @@ impl hal::Backend for Backend {
     type Surface = Surface;
 
     type QueueFamily = QueueFamily;
-    type CommandQueue = CommandQueue;
+    type Queue = Queue;
     type CommandBuffer = CommandBuffer;
 
     type Memory = Memory;
@@ -92,7 +92,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         // Create the queues
         let queue_groups = {
             let mut queue_group = queue::QueueGroup::new(QUEUE_FAMILY_ID);
-            queue_group.add_queue(CommandQueue);
+            queue_group.add_queue(Queue);
             vec![queue_group]
         };
         let gpu = adapter::Gpu {
@@ -160,8 +160,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 
 /// Dummy command queue doing nothing.
 #[derive(Debug)]
-pub struct CommandQueue;
-impl queue::CommandQueue<Backend> for CommandQueue {
+pub struct Queue;
+impl queue::Queue<Backend> for Queue {
     unsafe fn submit<'a, Ic, Iw, Is>(&mut self, _: Ic, _: Iw, _: Is, _: Option<&mut ()>)
     where
         Ic: Iterator<Item = &'a CommandBuffer>,
@@ -179,6 +179,10 @@ impl queue::CommandQueue<Backend> for CommandQueue {
 
     fn wait_idle(&mut self) -> Result<(), device::OutOfMemory> {
         unimplemented!("{}", NOT_SUPPORTED_MESSAGE)
+    }
+
+    fn timestamp_period(&self) -> f32 {
+        1.0
     }
 }
 

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -34,7 +34,8 @@ egl = { package = "khronos-egl", version = "3", features = ["dynamic"] }
 libloading = "0.6"
 
 [dependencies.naga]
-version = "0.3"
+git = "https://github.com/gfx-rs/naga"
+tag = "gfx-9"
 #TODO: remove `spv-out` once spirv-cross is deprecated
 features = ["spv-out", "glsl-out"]
 optional = true

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -89,7 +89,7 @@ impl hal::Backend for Backend {
     type Surface = Surface;
 
     type QueueFamily = QueueFamily;
-    type CommandQueue = queue::CommandQueue;
+    type Queue = queue::Queue;
     type CommandBuffer = command::CommandBuffer;
 
     type Memory = native::Memory;
@@ -577,7 +577,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 .map(|&(_family, priorities)| {
                     assert_eq!(priorities.len(), 1);
                     let mut family = q::QueueGroup::new(q::QueueFamilyId(0));
-                    let queue = queue::CommandQueue::new(&self.0, requested_features, vao);
+                    let queue = queue::Queue::new(&self.0, requested_features, vao);
                     family.add_queue(queue);
                     family
                 })

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -53,7 +53,7 @@ impl State {
 }
 
 #[derive(Debug)]
-pub struct CommandQueue {
+pub struct Queue {
     pub(crate) share: Starc<Share>,
     features: hal::Features,
     vao: Option<native::VertexArray>,
@@ -64,7 +64,7 @@ pub struct CommandQueue {
 
 const FILL_DATA_WORDS: usize = 16 << 10;
 
-impl CommandQueue {
+impl Queue {
     /// Create a new command queue.
     pub(crate) fn new(
         share: &Starc<Share>,
@@ -83,7 +83,7 @@ impl CommandQueue {
             gl.bind_buffer(glow::COPY_READ_BUFFER, None);
             buffer
         };
-        CommandQueue {
+        Queue {
             share: share.clone(),
             features,
             vao,
@@ -1069,7 +1069,7 @@ impl CommandQueue {
     }
 }
 
-impl hal::queue::CommandQueue<Backend> for CommandQueue {
+impl hal::queue::Queue<Backend> for Queue {
     unsafe fn submit<'a, Ic, Iw, Is>(
         &mut self,
         command_buffers: Ic,
@@ -1134,5 +1134,9 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
             self.share.context.finish();
         }
         Ok(())
+    }
+
+    fn timestamp_period(&self) -> f32 {
+        1.0
     }
 }

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -30,7 +30,7 @@ bitflags = "1.0"
 copyless = "0.1.4"
 log = { version = "0.4" }
 dispatch = { version = "0.2", optional = true }
-metal = { version = "0.21", features = ["private"] }
+metal = { git = "https://github.com/gfx-rs/metal-rs", rev="439c986eb7a9b91e88b61def2daa66e4043fcbef", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -41,7 +41,8 @@ storage-map = "0.3"
 raw-window-handle = "0.3"
 
 [dependencies.naga]
-version = "0.3"
+git = "https://github.com/gfx-rs/naga"
+tag = "gfx-9"
 #TODO: remove `spv-out` once spirv-cross is deprecated
 features = ["spv-out", "msl-out"]
 optional = true

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -2137,7 +2137,7 @@ struct PerformanceCounters {
 }
 
 #[derive(Debug)]
-pub struct CommandQueue {
+pub struct Queue {
     shared: Arc<Shared>,
     retained_buffers: Vec<metal::Buffer>,
     retained_textures: Vec<metal::Texture>,
@@ -2150,12 +2150,12 @@ pub struct CommandQueue {
     pub insert_dummy_encoders: bool,
 }
 
-unsafe impl Send for CommandQueue {}
-unsafe impl Sync for CommandQueue {}
+unsafe impl Send for Queue {}
+unsafe impl Sync for Queue {}
 
-impl CommandQueue {
+impl Queue {
     pub(crate) fn new(shared: Arc<Shared>) -> Self {
-        CommandQueue {
+        Queue {
             shared,
             retained_buffers: Vec::new(),
             retained_textures: Vec::new(),
@@ -2189,7 +2189,7 @@ impl CommandQueue {
     }
 }
 
-impl hal::queue::CommandQueue<Backend> for CommandQueue {
+impl hal::queue::Queue<Backend> for Queue {
     unsafe fn submit<'a, Ic, Iw, Is>(
         &mut self,
         command_buffers: Ic,
@@ -2427,6 +2427,11 @@ impl hal::queue::CommandQueue<Backend> for CommandQueue {
     fn wait_idle(&mut self) -> Result<(), OutOfMemory> {
         QueueInner::wait_idle(&self.shared.queue);
         Ok(())
+    }
+
+    fn timestamp_period(&self) -> f32 {
+        //TODO: https://github.com/gpuweb/gpuweb/issues/1325#issue-774251467
+        1.0
     }
 }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -280,7 +280,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         assert_eq!(families[0].1.len(), 1);
         let mut queue_group = QueueGroup::new(families[0].0.id());
         for _ in 0..self.shared.private_caps.exposed_queues {
-            queue_group.add_queue(command::CommandQueue::new(self.shared.clone()));
+            queue_group.add_queue(command::Queue::new(self.shared.clone()));
         }
 
         let device = Device {

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -447,7 +447,7 @@ impl hal::Backend for Backend {
     type Surface = Surface;
 
     type QueueFamily = QueueFamily;
-    type CommandQueue = command::CommandQueue;
+    type Queue = command::Queue;
     type CommandBuffer = command::CommandBuffer;
 
     type Memory = native::Memory;

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -32,7 +32,8 @@ raw-window-handle = "0.3"
 inplace_it = "0.3.3"
 
 [dependencies.naga]
-version = "0.3"
+git = "https://github.com/gfx-rs/naga"
+tag = "gfx-9"
 features = ["spv-out"]
 optional = true
 

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -681,7 +681,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         inplace_or_alloc_from_iter(regions_iter, |regions| {
             self.device
                 .raw
-                .cmd_copy_buffer(self.raw, src.raw, dst.raw, &regions)
+                .cmd_copy_buffer(self.raw, src.raw, dst.raw, regions)
         })
     }
 
@@ -710,7 +710,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                 conv::map_image_layout(src_layout),
                 dst.raw,
                 conv::map_image_layout(dst_layout),
-                &regions,
+                regions,
             );
         });
     }
@@ -732,7 +732,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                 src.raw,
                 dst.raw,
                 conv::map_image_layout(dst_layout),
-                &regions,
+                regions,
             );
         });
     }
@@ -754,7 +754,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                 src.raw,
                 conv::map_image_layout(src_layout),
                 dst.raw,
-                &regions,
+                regions,
             );
         });
     }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1115,6 +1115,12 @@ impl d::Device<B> for super::Device {
             image::Kind::D3(..) => vk::ImageType::TYPE_3D,
         };
 
+        //Note: this is a hack, we should expose this in the API instead
+        let layout = match tiling {
+            image::Tiling::Linear => vk::ImageLayout::PREINITIALIZED,
+            image::Tiling::Optimal => vk::ImageLayout::UNDEFINED,
+        };
+
         let info = vk::ImageCreateInfo::builder()
             .flags(flags)
             .image_type(image_type)
@@ -1126,7 +1132,7 @@ impl d::Device<B> for super::Device {
             .tiling(conv::map_tiling(tiling))
             .usage(conv::map_image_usage(usage))
             .sharing_mode(vk::SharingMode::EXCLUSIVE) // TODO:
-            .initial_layout(vk::ImageLayout::UNDEFINED);
+            .initial_layout(layout);
 
         let result = self.shared.raw.create_image(&info, None);
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -849,6 +849,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 },
                 maintenance_level,
                 imageless_framebuffers,
+                timestamp_period: self.properties.limits.timestamp_period,
             }),
             vendor_id: self.properties.vendor_id,
             valid_ash_memory_types,
@@ -862,7 +863,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                     queue::QueueGroup::new(queue::QueueFamilyId(family.index as usize));
                 for id in 0..priorities.len() {
                     let queue_raw = device_arc.raw.get_device_queue(family.index, id as _);
-                    family_raw.add_queue(CommandQueue {
+                    family_raw.add_queue(Queue {
                         raw: Arc::new(queue_raw),
                         device: device_arc.clone(),
                         swapchain_fn: swapchain_fn.clone(),
@@ -1282,7 +1283,6 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             framebuffer_stencil_sample_counts: limits.framebuffer_stencil_sample_counts.as_raw()
                 as _,
             timestamp_compute_and_graphics: limits.timestamp_compute_and_graphics != 0,
-            timestamp_period: limits.timestamp_period,
             max_color_attachments: limits.max_color_attachments as _,
             buffer_image_granularity: limits.buffer_image_granularity,
             non_coherent_atom_size: limits.non_coherent_atom_size as _,
@@ -1426,6 +1426,7 @@ pub struct RawDevice {
     extension_fns: DeviceExtensionFunctions,
     maintenance_level: u8,
     imageless_framebuffers: bool,
+    timestamp_period: f32,
 }
 
 impl fmt::Debug for RawDevice {
@@ -1497,19 +1498,19 @@ impl RawDevice {
 // Need to explicitly synchronize on submission and present.
 pub type RawCommandQueue = Arc<vk::Queue>;
 
-pub struct CommandQueue {
+pub struct Queue {
     raw: RawCommandQueue,
     device: Arc<RawDevice>,
     swapchain_fn: Swapchain,
 }
 
-impl fmt::Debug for CommandQueue {
+impl fmt::Debug for Queue {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("CommandQueue")
+        fmt.write_str("Queue")
     }
 }
 
-impl queue::CommandQueue<Backend> for CommandQueue {
+impl queue::Queue<Backend> for Queue {
     unsafe fn submit<'a, Ic, Iw, Is>(
         &mut self,
         command_buffers: Ic,
@@ -1598,6 +1599,10 @@ impl queue::CommandQueue<Backend> for CommandQueue {
             Err(_) => unreachable!(),
         }
     }
+
+    fn timestamp_period(&self) -> f32 {
+        self.device.timestamp_period
+    }
 }
 
 #[derive(Debug)]
@@ -1616,7 +1621,7 @@ impl hal::Backend for Backend {
     type Surface = window::Surface;
 
     type QueueFamily = QueueFamily;
-    type CommandQueue = CommandQueue;
+    type Queue = Queue;
     type CommandBuffer = command::CommandBuffer;
 
     type Memory = native::Memory;

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -1546,7 +1546,9 @@ impl queue::CommandQueue<Backend> for CommandQueue {
         let fence_raw = fence.map(|fence| fence.0).unwrap_or(vk::Fence::null());
 
         let result = self.device.raw.queue_submit(*self.raw, &[*info], fence_raw);
-        assert_eq!(Ok(()), result);
+        if let Err(e) = result {
+            error!("Submit resulted in {:?}", e);
+        }
     }
 
     unsafe fn present(

--- a/src/backend/webgpu/src/command.rs
+++ b/src/backend/webgpu/src/command.rs
@@ -20,9 +20,9 @@ use hal::{
 use crate::Backend;
 
 #[derive(Debug)]
-pub struct CommandQueue;
+pub struct Queue;
 
-impl hal::queue::CommandQueue<Backend> for CommandQueue {
+impl hal::queue::Queue<Backend> for Queue {
     unsafe fn submit<'a, Ic, Iw, Is>(
         &mut self,
         _: Ic,

--- a/src/backend/webgpu/src/lib.rs
+++ b/src/backend/webgpu/src/lib.rs
@@ -14,7 +14,7 @@ mod command;
 mod device;
 mod window;
 
-pub use crate::command::{CommandBuffer, CommandPool, CommandQueue};
+pub use crate::command::{CommandBuffer, CommandPool, Queue};
 pub use crate::device::Device;
 pub use crate::window::{Surface, Swapchain};
 
@@ -28,7 +28,7 @@ impl hal::Backend for Backend {
     type Surface = Surface;
 
     type QueueFamily = QueueFamily;
-    type CommandQueue = command::CommandQueue;
+    type Queue = command::Queue;
     type CommandBuffer = command::CommandBuffer;
 
     type Memory = ();

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.0"
-naga = "0.3"
+naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-9" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -56,7 +56,7 @@ pub struct MemoryProperties {
 pub struct Gpu<B: Backend> {
     /// [Logical device][crate::device::Device] for a given backend.
     pub device: B::Device,
-    /// The [command queues][crate::queue::CommandQueue] that the device provides.
+    /// The [command queues][crate::queue::Queue] that the device provides.
     pub queue_groups: Vec<QueueGroup<B>>,
 }
 

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -544,7 +544,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Fences have two states - signaled and unsignaled.
     ///
     /// A fence **can** be signaled as part of the execution of a
-    /// [queue submission][crate::queue::CommandQueue::submit] command.
+    /// [queue submission][crate::queue::Queue::submit] command.
     ///
     /// Fences **can** be unsignaled on the host with
     /// [`reset_fences`][Device::reset_fences].

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -70,7 +70,7 @@ pub mod prelude {
         device::Device,
         pool::CommandPool,
         pso::DescriptorPool,
-        queue::{CommandQueue, QueueFamily},
+        queue::{Queue, QueueFamily},
         window::{PresentationSurface, Surface},
         Instance,
     };
@@ -453,8 +453,6 @@ pub struct Limits {
     pub framebuffer_stencil_sample_counts: image::NumSamples,
     /// Timestamp queries are supported on all compute and graphics queues.
     pub timestamp_compute_and_graphics: bool,
-    /// The amount of nanoseconds that causes a timestamp query value to increment by one.
-    pub timestamp_period: f32,
     /// Maximum number of color attachments that can be used by a subpass in a render pass.
     pub max_color_attachments: usize,
     ///
@@ -626,8 +624,8 @@ pub trait Backend: 'static + Sized + Eq + Clone + Hash + fmt::Debug + Any + Send
 
     /// The corresponding [queue family][queue::QueueFamily] type for this backend.
     type QueueFamily: queue::QueueFamily;
-    /// The corresponding [command queue][queue::CommandQueue] type for this backend.
-    type CommandQueue: queue::CommandQueue<Self>;
+    /// The corresponding [command queue][queue::Queue] type for this backend.
+    type Queue: queue::Queue<Self>;
     /// The corresponding [command buffer][command::CommandBuffer] type for this backend.
     type CommandBuffer: command::CommandBuffer<Self>;
 

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -32,7 +32,7 @@ pub struct QueueGroup<B: Backend> {
     /// Family index for the queues in this group.
     pub family: QueueFamilyId,
     /// List of queues.
-    pub queues: Vec<B::CommandQueue>,
+    pub queues: Vec<B::Queue>,
 }
 
 impl<B: Backend> QueueGroup<B> {
@@ -47,7 +47,7 @@ impl<B: Backend> QueueGroup<B> {
     /// Add a command queue to the group.
     ///
     /// The queue needs to be created from this queue family.
-    pub fn add_queue(&mut self, queue: B::CommandQueue) {
+    pub fn add_queue(&mut self, queue: B::Queue) {
         self.queues.push(queue);
     }
 }

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -4,7 +4,7 @@
 //! submitted commands buffers.
 //!
 //! There are different types of queues, which can only handle associated command buffers.
-//! `CommandQueue<B, C>` has the capability defined by `C`: graphics, compute and transfer.
+//! `Queue<B, C>` has the capability defined by `C`: graphics, compute and transfer.
 
 pub mod family;
 
@@ -64,7 +64,7 @@ pub type QueuePriority = f32;
 ///
 /// Queues can also be used for presenting to a surface
 /// (that is, flip the front buffer with the next one in the chain).
-pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
+pub trait Queue<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// Submit command buffers to queue for execution.
     ///
     /// # Arguments
@@ -97,7 +97,7 @@ pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
     ///
     /// # Safety
     ///
-    /// Unsafe for the same reasons as [`submit`][CommandQueue::submit].
+    /// Unsafe for the same reasons as [`submit`][Queue::submit].
     /// No checks are performed to verify that this queue supports present operations.
     unsafe fn present(
         &mut self,
@@ -108,4 +108,7 @@ pub trait CommandQueue<B: Backend>: fmt::Debug + Any + Send + Sync {
 
     /// Wait for the queue to be idle.
     fn wait_idle(&mut self) -> Result<(), OutOfMemory>;
+
+    /// The amount of nanoseconds that causes a timestamp query value to increment by one.
+    fn timestamp_period(&self) -> f32;
 }

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -35,7 +35,7 @@
 //!
 //! # let mut surface: empty::Surface = return;
 //! # let device: empty::Device = return;
-//! # let mut present_queue: empty::CommandQueue = return;
+//! # let mut present_queue: empty::Queue = return;
 //! # unsafe {
 //! let mut render_semaphore = device.create_semaphore().unwrap();
 //!


### PR DESCRIPTION
Introduces a new example for benchmarking small transfers!
Fixes a small case where Linearly tiled image is created on the known memory. This is still a hack, but more useful than the old code.

Interestingly, the AMD machine on windows totally craps out when the total number of copy regions exceeds 4M per submission. So I had to keep the size down.

Results for 1K by 1K:
| API         | OS             | Hardware | image->image | buffer->image |
| -------  | ----------- | ---------  | -------------- | --------------- |
| Vulkan | Win7 | AMD Rx470 | 320ms | 18 ms|
| Vulkan | Win10 | Gtx1080 | 19ms | 19ms |
| Vulkan | Win10 | Iris 530 | 620ms | 620ms |

Results for 512 by 512:
| API         | OS             | Hardware | image->image | buffer->image |
| -------  | ----------- | ---------  | -------------- | --------------- |
| DX12 | Win10 | AMD 3500U | 836ms | 600 ms|
| Vulkan | Win10 | AMD 3500U | 95ms | 6ms |

On Metal and DX11, timestamps are not implemented yet.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan
