### PR TITLE
[mtl] separate entry points by stage

### DIFF
--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -27,7 +27,7 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
-pub type EntryPointMap = FastHashMap<String, spirv::EntryPoint>;
+pub type EntryPointMap = FastHashMap<(auxil::ShaderStage, String), spirv::EntryPoint>;
 /// An index of a resource within descriptor pool.
 pub type PoolResourceIndex = u32;
 


### PR DESCRIPTION
Fixes the new WGSL shaders in wgpu-rs.
Instead of treating the entry point name as unique within a module, we are treating the pair of `(Stage, Name)` as unique.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
