### PR TITLE
[vk] Support Vulkan 1.1 and 1.2 and refactor extension loading

### DIFF
--- a/src/backend/vulkan/src/extensions_resolver.rs
+++ b/src/backend/vulkan/src/extensions_resolver.rs
@@ -1,0 +1,170 @@
+use std::{
+    collections::{HashMap, HashSet},
+    ffi::CStr,
+};
+
+use ash::vk;
+
+use crate::{PhysicalDevice, Version};
+
+/// A declaration of an extension and its dependencies.
+#[derive(Debug)]
+pub(crate) struct Extension {
+    name: &'static CStr,
+    required_version: Version,
+    dependencies: Vec<&'static CStr>,
+    promoted_version: Option<Version>,
+}
+
+impl Extension {
+    pub fn new(name: &'static CStr, required_version: Version) -> Self {
+        Self {
+            name,
+            required_version,
+            dependencies: Vec::new(),
+            promoted_version: None,
+        }
+    }
+
+    /// Add the (device extension) dependencies of this extension.
+    pub fn with_dependencies(mut self, dependencies: Vec<&'static CStr>) -> Self {
+        self.dependencies = dependencies;
+        self
+    }
+
+    /// Add the api version in which this extension was promoted to core Vulkan.
+    pub fn promoted_to(mut self, promoted_version: Version) -> Self {
+        self.promoted_version = Some(promoted_version);
+        self
+    }
+
+    /// Return `true` if this extension is compatible with `device_version` and can be requested when creating the device.
+    pub fn is_compatible_with_version(&self, device_version: Version) -> bool {
+        self.required_version.0
+            <= vk::make_version(device_version.major(), device_version.minor(), 0)
+    }
+
+    /// Return `true` if this extension was promoted to core Vulkan in `device_version` and should not be explicitly requested when creating the device.
+    pub fn is_promoted_by_version(&self, device_version: Version) -> bool {
+        if let Some(promoted_version) = self.promoted_version {
+            vk::make_version(device_version.major(), device_version.minor(), 0)
+                >= promoted_version.0
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CouldNotResolveExtensionsError;
+
+/// Container to keep track of the extensions we use and their dependencies. Used for `Self::resolve_dependencies`.
+#[derive(Debug)]
+pub(crate) struct ExtensionsResolver {
+    extensions: HashMap<&'static CStr, Extension>,
+}
+
+impl ExtensionsResolver {
+    pub fn new<I>(registry: I) -> Self
+    where
+        I: IntoIterator<Item = Extension>,
+    {
+        Self {
+            extensions: registry
+                .into_iter()
+                .map(|extension| (extension.name, extension))
+                .collect(),
+        }
+    }
+
+    /// Resolve `requested_extensions` into the full list of transitive dependencies and filter out any extensions that are not supported or are no longer explicitly needed.
+    ///
+    /// In general, `requested_extensions` should include the extension list needed to support the oldest version of Vulkan.
+    ///
+    /// If there is an extension that could not be resolved because:
+    /// - The extension requires an instance version higher than the current instance version.
+    /// - The extension is not supported by the device.
+    ///
+    /// ...this function will return `Err`.
+    pub fn resolve_dependencies<I>(
+        &self,
+        physical_device: &PhysicalDevice,
+        requested_extensions: I,
+    ) -> Result<Vec<&'static CStr>, CouldNotResolveExtensionsError>
+    where
+        I: Iterator<Item = &'static CStr>,
+    {
+        let mut remaining = requested_extensions.collect::<Vec<_>>();
+        let mut extensions = Vec::new();
+        let mut marked = HashSet::new();
+
+        let mut failed_to_resolve = false;
+
+        while let Some(extension_name) = remaining.pop() {
+            if let Some(extension) = self.extensions.get(extension_name) {
+                if !extensions.contains(&extension.name) {
+                    if !extension.is_compatible_with_version(physical_device.api_version) {
+                        warn!(
+                            "Extension {} (requires {:?}) is unsupported in version {:?}",
+                            extension.name.to_string_lossy(),
+                            extension.required_version,
+                            physical_device.api_version
+                        );
+                        failed_to_resolve = true;
+                        continue;
+                    }
+
+                    if extension.is_promoted_by_version(physical_device.api_version) {
+                        // This extension was promoted to core, so we shouldn't request it.
+                        debug!(
+                            "Extension {} was promoted in {:?} and is no longer explicitly required.",
+                            extension.name.to_string_lossy(),
+                            extension.promoted_version,
+                        );
+                        continue;
+                    }
+
+                    // `VK_AMD_negative_viewport_height` is obsoleted by `VK_KHR_maintenance1`, so we should try to add that instead.
+                    // Note this is the only extension we currently require that has this obsolescence deprecation state. If we gain more it may be worth refactoring `Extension` to support it.
+                    if extension.name == vk::AmdNegativeViewportHeightFn::name()
+                        && physical_device.supports_extension(vk::KhrMaintenance1Fn::name())
+                    {
+                        debug!(
+                            "Extension {} was obsoleted by {}, which is supported by the device.",
+                            extension.name.to_string_lossy(),
+                            vk::KhrMaintenance1Fn::name().to_string_lossy()
+                        );
+                        remaining.push(vk::KhrMaintenance1Fn::name());
+                        continue;
+                    }
+
+                    if physical_device.supports_extension(extension.name) {
+                        extensions.push(extension.name);
+                    } else {
+                        warn!(
+                            "Unsupported extension requested: {}",
+                            extension.name.to_string_lossy()
+                        );
+                        failed_to_resolve = true;
+                    }
+                }
+
+                // Ensure we don't walk the dependency graph more than once.
+                if !marked.insert(extension.name) {
+                    continue;
+                }
+
+                remaining.extend_from_slice(&extension.dependencies)
+            } else {
+                // If this trips, we have an unhandled extension that we need to add to track.
+                unreachable!()
+            }
+        }
+
+        if failed_to_resolve {
+            Err(CouldNotResolveExtensionsError)
+        } else {
+            Ok(extensions)
+        }
+    }
+}

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -327,7 +327,21 @@ impl hal::Instance<Backend> for Instance {
             .application_version(version)
             .engine_name(CStr::from_bytes_with_nul(b"gfx-rs\0").unwrap())
             .engine_version(1)
-            .api_version(vk::make_version(1, 0, 0));
+            .api_version(
+                // Pick the latest version of Vulkan available.
+                match entry
+                    .try_enumerate_instance_version()
+                    // Ignore the possible `VK_ERROR_OUT_OF_HOST_MEMORY`.
+                    .unwrap()
+                {
+                    // Vulkan 1.1+
+                    Some(version) => {
+                        vk::make_version(vk::version_major(version), vk::version_minor(version), 0)
+                    }
+                    // Vulkan 1.0
+                    None => vk::make_version(1, 0, 0),
+                },
+            );
 
         let instance_extensions = entry
             .enumerate_instance_extension_properties()

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -412,6 +412,7 @@ impl hal::Instance<Backend> for Instance {
                     //  - Audit all extensions used by this backend:
                     //    - If any were promoted in the new API version and the behavior has changed, we must handle the new behavior in addition to the old behavior.
                     //    - If any were obsoleted in the new API version, we must implement a fallback for the new API version
+                    //    - If any are non-KHR-vendored, we must ensure the new behavior is still correct (since backwards-compatibility is not guaranteed).
                     //
                     // TODO: This should be replaced by `vk::HEADER_VERSION_COMPLETE` (added in `ash@6f488cd`) and this comment moved to either `README.md` or `Cargo.toml`.
                     Version::V1_2


### PR DESCRIPTION
This PR includes the following changes:
- Use `vkEnumerateInstanceVersion` to query for the Vulkan driver version and use `min(driver_version, 1.2)` to create the instance.
  - This does not expose any additional 1.1+ functionality in `gfx-hal`, but should allow for later adding features like descriptor indexing and ray tracing.
- Refactor the device extension code to include an extension resolver that correctly includes and excludes requested extensions based on extension promotion status.
- `PhysicalDevice::open` on Vulkan can now fail with `DeviceCreationError::MissingExtension` if a required extension is missing.

Note that while this change can create 1.1 and 1.2 instances, we must opt into 1.3+ whenever that is released.

Some things to consider moving forward:
- API version minor increments should be backwards compatible, per the spec, so we shouldn't need to worry about forward compatibility there.
- We must continue using runtime flags to gate features not available in core Vulkan 1.0.
- When adding an extension that was promoted to core, we must include both its original functionality and any changed functionality after its promotion.
- When adding non-KHR-vendored extensions, we must implement support for all possible versions of Vulkan (since backwards-compatibility is not guaranteed).

Fixes #3302
Related #3146

PR checklist:
- [x] `make` succeeds (on *nix)
  - [x] +succeeds on Windows 10
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan
