### PR TITLE
[hal] Merge `Limits` and `Capabilities` as `PhysicalDeviceProperties`

### DIFF
--- a/examples/bench/main.rs
+++ b/examples/bench/main.rs
@@ -48,7 +48,7 @@ fn main() {
     println!("Running on {}", adapter.info.name);
 
     let memory_properties = adapter.physical_device.memory_properties();
-    let limits = adapter.physical_device.limits();
+    let limits = adapter.physical_device.properties().limits;
     let family = adapter
         .queue_families
         .iter()

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -591,7 +591,7 @@ impl<B: Backend> AdapterState<B> {
 
     fn new_adapter(adapter: Adapter<B>) -> Self {
         let memory_types = adapter.physical_device.memory_properties().memory_types;
-        let limits = adapter.physical_device.limits();
+        let limits = adapter.physical_device.properties().limits;
         println!("{:?}", limits);
 
         AdapterState {

--- a/examples/mesh-shading/main.rs
+++ b/examples/mesh-shading/main.rs
@@ -195,7 +195,7 @@ where
         adapter: hal::adapter::Adapter<B>,
     ) -> Renderer<B> {
         let memory_types = adapter.physical_device.memory_properties().memory_types;
-        let limits = adapter.physical_device.limits();
+        let limits = adapter.physical_device.properties().limits;
 
         // Build a new device and associated command queues
         let family = adapter

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -213,7 +213,7 @@ where
         adapter: hal::adapter::Adapter<B>,
     ) -> Renderer<B> {
         let memory_types = adapter.physical_device.memory_properties().memory_types;
-        let limits = adapter.physical_device.limits();
+        let limits = adapter.physical_device.properties().limits;
 
         // Build a new device and associated command queues
         let family = adapter

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -145,14 +145,13 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         hal::Features::empty()
     }
 
-    fn capabilities(&self) -> hal::Capabilities {
-        Default::default()
-    }
-
-    fn limits(&self) -> hal::Limits {
-        hal::Limits {
-            non_coherent_atom_size: 1,
-            optimal_buffer_copy_pitch_alignment: 1,
+    fn properties(&self) -> hal::PhysicalDeviceProperties {
+        hal::PhysicalDeviceProperties {
+            limits: hal::Limits {
+                non_coherent_atom_size: 1,
+                optimal_buffer_copy_pitch_alignment: 1,
+                ..Default::default()
+            },
             ..Default::default()
         }
     }

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -849,7 +849,7 @@ impl d::Device<B> for Device {
         flags: CommandPoolCreateFlags,
     ) -> Result<CommandPool, d::OutOfMemory> {
         let fbo = create_fbo_internal(&self.share);
-        let limits = self.share.limits.into();
+        let limits = self.share.public_caps.limits.into();
         let memory = if flags.contains(CommandPoolCreateFlags::RESET_INDIVIDUAL) {
             BufferMemory::Individual {
                 storage: FastHashMap::default(),
@@ -889,7 +889,7 @@ impl d::Device<B> for Device {
         let subpasses = subpasses
             .map(|subpass| {
                 assert!(
-                    subpass.colors.len() <= self.share.limits.max_color_attachments,
+                    subpass.colors.len() <= self.share.public_caps.limits.max_color_attachments,
                     "Color attachment limit exceeded"
                 );
                 let color_attachments = subpass.colors.iter().map(|&(index, _)| index).collect();
@@ -1082,7 +1082,7 @@ impl d::Device<B> for Device {
         desc: &pso::ComputePipelineDesc<'a, B>,
         _cache: Option<&()>,
     ) -> Result<n::ComputePipeline, pso::CreationError> {
-        if self.share.limits.max_compute_work_group_count[0] == 0 {
+        if self.share.public_caps.limits.max_compute_work_group_count[0] == 0 {
             return Err(pso::CreationError::UnsupportedPipeline);
         }
         let shader = (naga::ShaderStage::Compute, Some(&desc.shader));

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -1,6 +1,6 @@
 use crate::{Error, GlContainer, MAX_COLOR_ATTACHMENTS};
 use glow::HasContext;
-use hal::{Capabilities, DynamicStates, Features, Limits, PerformanceCaveats};
+use hal::{PhysicalDeviceProperties, DynamicStates, Features, Limits, PerformanceCaveats};
 use std::{collections::HashSet, fmt, str};
 
 /// A version number for a specific component of an OpenGL implementation
@@ -349,14 +349,7 @@ impl Info {
 /// capabilities.
 pub(crate) fn query_all(
     gl: &GlContainer,
-) -> (
-    Info,
-    Features,
-    LegacyFeatures,
-    Limits,
-    Capabilities,
-    PrivateCaps,
-) {
+) -> (Info, Features, LegacyFeatures, PhysicalDeviceProperties, PrivateCaps) {
     use self::Requirement::*;
     let info = Info::get(gl);
     let max_texture_size = get_usize(gl, glow::MAX_TEXTURE_SIZE).unwrap_or(64) as u32;
@@ -512,9 +505,11 @@ pub(crate) fn query_all(
     if !info.is_supported(&[Core(4, 2)]) {
         performance_caveats |= PerformanceCaveats::BASE_VERTEX_INSTANCE_DRAWING;
     }
-    let capabilities = Capabilities {
+    let properties = PhysicalDeviceProperties {
+        limits,
         performance_caveats,
         dynamic_pipeline_states: DynamicStates::all(),
+        ..PhysicalDeviceProperties::default()
     };
 
     let buffer_storage = info.is_supported(&[
@@ -546,7 +541,7 @@ pub(crate) fn query_all(
         memory_barrier: info.is_supported(&[Core(4, 2), Es(3, 1)]),
     };
 
-    (info, features, legacy, limits, capabilities, private)
+    (info, features, legacy, properties, private)
 }
 
 #[cfg(test)]

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -206,8 +206,7 @@ struct Share {
     info: Info,
     supported_features: hal::Features,
     legacy_features: info::LegacyFeatures,
-    limits: hal::Limits,
-    public_caps: hal::Capabilities,
+    public_caps: hal::PhysicalDeviceProperties,
     private_caps: info::PrivateCaps,
     // Indicates if there is an active logical device.
     open: Cell<bool>,
@@ -357,7 +356,7 @@ impl PhysicalDevice {
     fn new_adapter(context: GlContext) -> adapter::Adapter<Backend> {
         let gl = GlContainer { context };
         // query information
-        let (info, supported_features, legacy_features, limits, public_caps, private_caps) =
+        let (info, supported_features, legacy_features, public_caps, private_caps) =
             info::query_all(&gl);
         info!("Vendor: {:?}", info.platform_name.vendor);
         info!("Renderer: {:?}", info.platform_name.renderer);
@@ -435,7 +434,6 @@ impl PhysicalDevice {
             info,
             supported_features,
             legacy_features,
-            limits,
             public_caps,
             private_caps,
             open: Cell::new(false),
@@ -646,12 +644,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
         self.0.supported_features
     }
 
-    fn capabilities(&self) -> hal::Capabilities {
+    fn properties(&self) -> hal::PhysicalDeviceProperties {
         self.0.public_caps
-    }
-
-    fn limits(&self) -> hal::Limits {
-        self.0.limits
     }
 }
 

--- a/src/backend/gl/src/queue.rs
+++ b/src/backend/gl/src/queue.rs
@@ -394,7 +394,10 @@ impl Queue {
 
                 let num_viewports = viewports.len();
                 assert_eq!(num_viewports, depth_ranges.len());
-                assert!(0 < num_viewports && num_viewports <= self.share.limits.max_viewports);
+                assert!(
+                    0 < num_viewports
+                        && num_viewports <= self.share.public_caps.limits.max_viewports
+                );
 
                 if num_viewports == 1 {
                     let view = viewports[0];
@@ -430,7 +433,9 @@ impl Queue {
                 let gl = &self.share.context;
                 let scissors = Self::get::<[i32; 4]>(data_buf, data_ptr);
                 let num_scissors = scissors.len();
-                assert!(0 < num_scissors && num_scissors <= self.share.limits.max_viewports);
+                assert!(
+                    0 < num_scissors && num_scissors <= self.share.public_caps.limits.max_viewports
+                );
 
                 if num_scissors == 1 {
                     let scissor = scissors[0];

--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -520,11 +520,7 @@ pub(crate) fn map_device_features(
             .variable_multisample_rate(features.contains(Features::VARIABLE_MULTISAMPLE_RATE))
             .inherited_queries(features.contains(Features::INHERITED_QUERIES))
             .build(),
-        descriptor_indexing: if features.intersects(
-            Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING
-                | Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING
-                | Features::UNSIZED_DESCRIPTOR_ARRAY,
-        ) {
+        descriptor_indexing: if features.intersects(Features::DESCRIPTOR_INDEXING_MASK) {
             Some(
                 vk::PhysicalDeviceDescriptorIndexingFeaturesEXT::builder()
                     .shader_sampled_image_array_non_uniform_indexing(
@@ -539,7 +535,7 @@ pub(crate) fn map_device_features(
         } else {
             None
         },
-        mesh_shaders: if features.intersects(Features::TASK_SHADER | Features::MESH_SHADER) {
+        mesh_shaders: if features.intersects(Features::MESH_SHADER_MASK) {
             Some(
                 vk::PhysicalDeviceMeshShaderFeaturesNV::builder()
                     .task_shader(features.contains(Features::TASK_SHADER))

--- a/src/backend/webgpu/src/lib.rs
+++ b/src/backend/webgpu/src/lib.rs
@@ -187,11 +187,7 @@ impl hal::adapter::PhysicalDevice<Backend> for PhysicalDevice {
         todo!()
     }
 
-    fn capabilities(&self) -> hal::Capabilities {
-        todo!()
-    }
-
-    fn limits(&self) -> hal::Limits {
+    fn properties(&self) -> hal::PhysicalDeviceProperties {
         todo!()
     }
 }

--- a/src/hal/src/adapter.rs
+++ b/src/hal/src/adapter.rs
@@ -11,7 +11,7 @@
 use crate::{
     device, format, image, memory,
     queue::{QueueGroup, QueuePriority},
-    Backend, Capabilities, Features, Limits,
+    Backend, Features, PhysicalDeviceProperties,
 };
 
 use std::{any::Any, fmt};
@@ -119,12 +119,9 @@ pub trait PhysicalDevice<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// used, as well as the actual platform underneath.
     fn features(&self) -> Features;
 
-    /// Returns the capabilities of this `PhysicalDevice`. Similarly to `Features`, they
+    /// Returns the properties of this `PhysicalDevice`. Similarly to `Features`, they
     // depend on the platform, but unlike features, these are immutable and can't be switched on.
-    fn capabilities(&self) -> Capabilities;
-
-    /// Returns the resource limits of this `PhysicalDevice`.
-    fn limits(&self) -> Limits;
+    fn properties(&self) -> PhysicalDeviceProperties;
 
     /// Check cache compatibility with the `PhysicalDevice`.
     fn is_valid_cache(&self, _cache: &[u8]) -> bool {

--- a/src/warden/src/bin/bench.rs
+++ b/src/warden/src/bin/bench.rs
@@ -105,7 +105,7 @@ impl Harness {
             let mut adapters = instance.enumerate_adapters();
             let adapter = adapters.remove(0);
             let supported_features = adapter.physical_device.features();
-            let limits = adapter.physical_device.limits();
+            let limits = adapter.physical_device.properties().limits;
             //println!("\t{:?}", adapter.info);
             println!("\tScene '{}':", tg.name);
 

--- a/src/warden/src/bin/reftest.rs
+++ b/src/warden/src/bin/reftest.rs
@@ -118,7 +118,7 @@ impl Harness {
             let mut adapters = instance.enumerate_adapters();
             let adapter = adapters.remove(0);
             let supported_features = adapter.physical_device.features();
-            let limits = adapter.physical_device.limits();
+            let limits = adapter.physical_device.properties().limits;
             //println!("\t{:?}", adapter.info);
             println!("\tScene '{}':", tg.name);
 

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -190,7 +190,7 @@ impl<B: hal::Backend> Scene<B> {
     ) -> Result<Self, ()> {
         info!("creating Scene from {:?}", data_path);
         let memory_types = adapter.physical_device.memory_properties().memory_types;
-        let limits = adapter.physical_device.limits();
+        let limits = adapter.physical_device.properties().limits;
 
         // initialize graphics
         let mut gpu = unsafe {


### PR DESCRIPTION
This PR:
- Merges `hal::Limits` and `hal::Capabilities` as `PhysicalDeviceProperties`.
  - The name was chosen to be more similar to Vulkan.
- Adds properties structs for mesh shaders and descriptor indexing.
- Adds a `DescriptorLimits` struct to hold descriptor limits and makes the values `u32`.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
  - [x] bench: dx12, vulkan
  - [x] colour-uniform: dx12, vulkan
  - [x] compute: dx12, vulkan
  - [x] quad: dx12, vulkan