### PR TITLE
[mtl] fix sample count check for secondary command buffers

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -633,7 +633,6 @@ impl Device {
 
         // done
         debug!("SPIRV-Cross generated shader:\n{}", shader_code);
-
         let options = metal::CompileOptions::new();
         options.set_language_version(msl_version);
 
@@ -1022,12 +1021,20 @@ impl hal::device::Device<Backend> for Device {
                     }
                 });
 
+                let samples = colors
+                    .iter()
+                    .chain(depth_stencil.as_ref())
+                    .map(|at_info| attachments[at_info.id].samples)
+                    .max()
+                    .unwrap_or(1);
+
                 n::Subpass {
                     attachments: n::SubpassData {
                         colors,
                         depth_stencil,
                     },
                     inputs: sub.inputs.iter().map(|&(id, _)| id).collect(),
+                    samples,
                 }
             })
             .collect();

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -90,6 +90,7 @@ pub struct AttachmentInfo {
 pub struct Subpass {
     pub attachments: SubpassData<AttachmentInfo>,
     pub inputs: Vec<AttachmentId>,
+    pub samples: image::NumSamples,
 }
 
 #[derive(Debug)]

--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -217,10 +217,10 @@ impl w::Surface<Backend> for Surface {
                 height: 4096,
             },
             max_image_layers: 1,
-            usage: image::Usage::COLOR_ATTACHMENT
-                | image::Usage::SAMPLED
-                | image::Usage::TRANSFER_SRC
-                | image::Usage::TRANSFER_DST,
+            usage: image::Usage::COLOR_ATTACHMENT,
+            //| image::Usage::SAMPLED
+            //| image::Usage::TRANSFER_SRC
+            //| image::Usage::TRANSFER_DST,
         }
     }
 


### PR DESCRIPTION
Let's us run Dota2 again!
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
