### PR TITLE
Update libloading to 0.7

### DIFF
--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -24,7 +24,7 @@ auxil = { path = "../../auxil/auxil", version = "0.8", package = "gfx-auxil", fe
 hal = { path = "../../hal", version = "0.7", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1" }
 bitflags = "1"
-libloading = "0.6"
+libloading = "0.7"
 log = { version = "0.4" }
 smallvec = "1.0"
 spirv_cross = { version = "0.23", features = ["hlsl"] }

--- a/src/backend/dx11/src/dxgi.rs
+++ b/src/backend/dx11/src/dxgi.rs
@@ -90,7 +90,7 @@ fn create_dxgi_factory1(
 pub(crate) fn get_dxgi_factory(
 ) -> Result<(libloading::Library, ComPtr<dxgi::IDXGIFactory>, DxgiVersion), winerror::HRESULT> {
     // The returned Com-pointer is only safe to use for the lifetime of the Library.
-    let library = libloading::Library::new("dxgi.dll").map_err(|_| -1)?;
+    let library = unsafe { libloading::Library::new("dxgi.dll").map_err(|_| -1)? };
     let func: libloading::Symbol<DxgiFun> =
         unsafe { library.get(b"CreateDXGIFactory1") }.map_err(|_| -1)?;
 

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -442,7 +442,7 @@ impl hal::Instance<Backend> for Instance {
             Ok((library_dxgi, factory, dxgi_version)) => {
                 info!("DXGI version: {:?}", dxgi_version);
                 let library_d3d11 = Arc::new(
-                    libloading::Library::new("d3d11.dll").map_err(|_| hal::UnsupportedBackend)?,
+                    unsafe { libloading::Library::new("d3d11.dll").map_err(|_| hal::UnsupportedBackend)? },
                 );
                 Ok(Instance {
                     factory,

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -25,7 +25,7 @@ hal = { path = "../../hal", version = "0.7", package = "gfx-hal" }
 range-alloc = { path = "../../auxil/range-alloc", version = "0.1.1" }
 bitflags = "1"
 bit-set = "0.5"
-native = { package = "d3d12", version = "0.3", features = ["libloading"] }
+native = { git = "https://github.com/gfx-rs/d3d12-rs", package = "d3d12", rev = "be19a243b86e0bafb9937d661fc8eabb3e42b44e", features = ["libloading"] }
 log = "0.4"
 parking_lot = "0.11"
 smallvec = "1"

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -31,7 +31,7 @@ raw-window-handle = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 egl = { package = "khronos-egl", version = "3", features = ["dynamic"] }
-libloading = "0.6"
+libloading = "0.7"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"


### PR DESCRIPTION
Just a (hopefully) harmless update. Updated in `d2d12-rs` too: https://github.com/gfx-rs/d3d12-rs/pull/28

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: GL