### PR TITLE
Use libc for the use-rtld-next Vulkan backend feature

### DIFF
--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [features]
 default = []
-use-rtld-next = ["shared_library"]
+use-rtld-next = ["libc"]
 
 [lib]
 name = "gfx_backend_vulkan"
@@ -23,7 +23,7 @@ name = "gfx_backend_vulkan"
 arrayvec = "0.5"
 byteorder = "1"
 log = { version = "0.4" }
-shared_library = { version = "0.1.9", optional = true }
+libc = { version = "0.2", optional = true }
 ash = "0.31"
 hal = { path = "../../hal", version = "0.7", package = "gfx-hal" }
 parking_lot = "0.11"

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -61,8 +61,6 @@ use std::{
 
 #[cfg(feature = "use-rtld-next")]
 use ash::EntryCustom;
-#[cfg(feature = "use-rtld-next")]
-use shared_library::dynamic_library::{DynamicLibrary, SpecialHandles};
 
 mod command;
 mod conv;
@@ -376,8 +374,7 @@ impl hal::Instance<Backend> for Instance {
 
         #[cfg(feature = "use-rtld-next")]
         let entry = EntryCustom::new_custom((), |_, name| unsafe {
-            DynamicLibrary::symbol_special(SpecialHandles::Next, &*name.to_string_lossy())
-                .unwrap_or(std::ptr::null_mut())
+            libc::dlsym(libc::RTLD_NEXT, name.as_ptr())
         });
 
         let driver_api_version = match entry.try_enumerate_instance_version() {


### PR DESCRIPTION
`RTLD_NEXT` is a GNU-specific flag which isn't supported currently by libloading, so we can't replace shared_library with it. However, we can simply use `dlsym` directly, and since libc is already present in the dependency chain, in practice it still means building one less dependency.

Closes #3540

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan
