### PR TITLE
[dx11] Fix some panics with multiple entries spirv

### DIFF
--- a/src/backend/dx11/src/conv.rs
+++ b/src/backend/dx11/src/conv.rs
@@ -763,7 +763,7 @@ pub(crate) fn map_depth_stencil_desc(
     )
 }
 
-pub fn map_execution_model(model: spirv::ExecutionModel) -> ShaderStage {
+pub fn _map_execution_model(model: spirv::ExecutionModel) -> ShaderStage {
     match model {
         spirv::ExecutionModel::Vertex => ShaderStage::Vertex,
         spirv::ExecutionModel::Fragment => ShaderStage::Fragment,

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -3844,7 +3844,7 @@ impl DescriptorSetInfo {
         &self,
         stage: ShaderStage,
         binding_index: pso::DescriptorBinding,
-    ) -> (DescriptorContent, RegisterData<ResourceIndex>) {
+    ) -> Option<(DescriptorContent, RegisterData<ResourceIndex>)> {
         let mut res_offsets = self
             .registers
             .map_register(|info| info.res_index as DescriptorIndex)
@@ -3855,11 +3855,11 @@ impl DescriptorSetInfo {
             }
             let content = DescriptorContent::from(binding.ty);
             if binding.binding == binding_index {
-                return (content, res_offsets.map(|offset| *offset as ResourceIndex));
+                return Some((content, res_offsets.map(|offset| *offset as ResourceIndex)));
             }
             res_offsets.add_content_many(content, 1);
         }
-        panic!("Unable to find binding {:?}", binding_index);
+        None
     }
 
     fn find_uav_register(

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -541,7 +541,6 @@ impl Device {
                     .get_cleansed_entry_point_name(source.entry, execution_model)
                     .map_err(gen_query_error)?;
 
-                let stage = conv::map_execution_model(execution_model);
                 let shader = compile_shader(
                     stage,
                     shader_model,


### PR DESCRIPTION
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: dx11 dx12

fixes:
`error X4502: invalid vs_5_0 output semantic 'SV_Target0'`
`Unable to find binding 1`

note: on my machine win10 rx580, wgpu-rs shadow example and texture-arrays are still broken. gfx example compute not working but wgpu-rs hello-compute works. also gfx example colour-uniform is broken. this pr does not impact those issues.
on a win7 machine with nvidia 930m or intel 5500, almost everything does not work except use renderdoc.

