### PR TITLE
Fix Vulkan extension checks

### DIFF
--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -73,10 +73,6 @@ pub enum CreationError {
     /// Device initialization failed due to implementation specific errors.
     #[error("Implementation specific error occurred")]
     InitializationFailed,
-    /// At least one of the user requested extensions if not supported by the
-    /// physical device.
-    #[error("Requested extension is missing")]
-    MissingExtension,
     /// At least one of the user requested features if not supported by the
     /// physical device.
     ///


### PR DESCRIPTION
Fixes #3648 
What happened is an internal miscommunication between which extensions are required, and which aren't.
I also removed the `MissingExtension` error from the API because the API has no extensions.