### PR TITLE
[GL] Fix WebGL version checking (0.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-gl-0.7.1 (24-02-2021)
+  - Fix WebGL adapter creation
+
 ## hal-0.7.0 (30-01-2021)
   - `Borrow` and `ExactSizeIterator` bounds are removed from the iterators
   - error improvements:

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-gl"
-version = "0.7.0"
+version = "0.7.1"
 description = "OpenGL backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -6,9 +6,9 @@ use std::{collections::HashSet, fmt, str};
 /// A version number for a specific component of an OpenGL implementation
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Version {
-    pub is_embedded: bool,
     pub major: u32,
     pub minor: u32,
+    pub is_embedded: bool,
     pub revision: Option<u32>,
     pub vendor_info: String,
 }
@@ -17,9 +17,9 @@ impl Version {
     /// Create a new OpenGL version number
     pub fn new(major: u32, minor: u32, revision: Option<u32>, vendor_info: String) -> Self {
         Version {
-            is_embedded: false,
             major: major,
             minor: minor,
+            is_embedded: false,
             revision: revision,
             vendor_info,
         }
@@ -27,9 +27,9 @@ impl Version {
     /// Create a new OpenGL ES version number
     pub fn new_embedded(major: u32, minor: u32, vendor_info: String) -> Self {
         Version {
-            is_embedded: true,
             major,
             minor,
+            is_embedded: true,
             revision: None,
             vendor_info,
         }
@@ -61,9 +61,9 @@ impl Version {
         let is_webgl = src.contains(webgl_sig);
         if is_webgl {
             return Ok(Version {
-                is_embedded: true,
                 major: 2,
                 minor: 0,
+                is_embedded: true,
                 revision: None,
                 vendor_info: "".to_string(),
             });
@@ -98,9 +98,9 @@ impl Version {
 
         match (major, minor, revision) {
             (Some(major), Some(minor), revision) => Ok(Version {
-                is_embedded: is_es,
                 major,
                 minor,
+                is_embedded: is_es,
                 revision,
                 vendor_info,
             }),
@@ -315,7 +315,7 @@ impl Info {
 
     pub fn is_embedded_version_supported(&self, major: u32, minor: u32) -> bool {
         self.version.is_embedded
-            && self.version >= Version::new(major, minor, None, String::from(""))
+            && self.version >= Version::new_embedded(major, minor, String::from(""))
     }
 
     /// Returns `true` if the implementation supports the extension


### PR DESCRIPTION
0.7 version https://github.com/gfx-rs/gfx/pull/3646

Fixes #3644
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: WebGL

