### PR TITLE
Bump `khronos-egl` dependency to version 4

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -30,7 +30,7 @@ parking_lot = "0.11"
 raw-window-handle = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-egl = { package = "khronos-egl", version = "3", features = ["dynamic"] }
+egl = { package = "khronos-egl", version = "4", features = ["dynamic"] }
 libloading = "0.7"
 
 [dependencies.auxil]


### PR DESCRIPTION
This pulls in a fix for timothee-haudebourg/khronos-egl#14,
which prevents segfaults when using this crate from another thread
(e.g. gfx-rs/wgpu#246)


PR checklist:
- [X] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends:
  - GL
