### PR TITLE
[vk] Fix some issues caused by #3654

### DIFF
--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -1,10 +1,15 @@
-use ash::{version::DeviceV1_0, vk};
+use ash::{
+    version::{DeviceV1_0, DeviceV1_2},
+    vk,
+};
 use smallvec::SmallVec;
 use std::{collections::hash_map::Entry, ffi::CString, mem, ops::Range, slice, sync::Arc};
 
 use inplace_it::inplace_or_alloc_from_iter;
 
-use crate::{conv, native as n, Backend, DebugMessenger, RawDevice, ROUGH_MAX_ATTACHMENT_COUNT};
+use crate::{
+    conv, native as n, Backend, DebugMessenger, ExtensionFn, RawDevice, ROUGH_MAX_ATTACHMENT_COUNT,
+};
 use hal::{
     buffer, command as com,
     format::Aspects,
@@ -815,6 +820,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             .mesh_shaders
             .as_ref()
             .expect("Draw command not supported. You must request feature MESH_SHADER.")
+            .unwrap_extension()
             .cmd_draw_mesh_tasks(self.raw, task_count, first_task);
     }
 
@@ -830,6 +836,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             .mesh_shaders
             .as_ref()
             .expect("Draw command not supported. You must request feature MESH_SHADER.")
+            .unwrap_extension()
             .cmd_draw_mesh_tasks_indirect(self.raw, buffer.raw, offset, draw_count, stride);
     }
 
@@ -847,6 +854,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
             .mesh_shaders
             .as_ref()
             .expect("Draw command not supported. You must request feature MESH_SHADER.")
+            .unwrap_extension()
             .cmd_draw_mesh_tasks_indirect_count(
                 self.raw,
                 buffer.raw,
@@ -867,20 +875,36 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         max_draw_count: DrawCount,
         stride: buffer::Stride,
     ) {
-        self.device
+        match self
+            .device
             .extension_fns
             .draw_indirect_count
             .as_ref()
             .expect("Feature DRAW_INDIRECT_COUNT must be enabled to call draw_indirect_count")
-            .cmd_draw_indirect_count(
-                self.raw,
-                buffer.raw,
-                offset,
-                count_buffer.raw,
-                count_buffer_offset,
-                max_draw_count,
-                stride,
-            );
+        {
+            ExtensionFn::Extension(t) => {
+                t.cmd_draw_indirect_count(
+                    self.raw,
+                    buffer.raw,
+                    offset,
+                    count_buffer.raw,
+                    count_buffer_offset,
+                    max_draw_count,
+                    stride,
+                );
+            }
+            ExtensionFn::Promoted => {
+                self.device.raw.cmd_draw_indirect_count(
+                    self.raw,
+                    buffer.raw,
+                    offset,
+                    count_buffer.raw,
+                    count_buffer_offset,
+                    max_draw_count,
+                    stride,
+                );
+            }
+        }
     }
 
     unsafe fn draw_indexed_indirect_count(
@@ -892,22 +916,36 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         max_draw_count: DrawCount,
         stride: buffer::Stride,
     ) {
-        self.device
+        match self
+            .device
             .extension_fns
             .draw_indirect_count
             .as_ref()
-            .expect(
-                "Feature DRAW_INDIRECT_COUNT must be enabled to call draw_indexed_indirect_count",
-            )
-            .cmd_draw_indexed_indirect_count(
-                self.raw,
-                buffer.raw,
-                offset,
-                count_buffer.raw,
-                count_buffer_offset,
-                max_draw_count,
-                stride,
-            );
+            .expect("Feature DRAW_INDIRECT_COUNT must be enabled to call draw_indirect_count")
+        {
+            ExtensionFn::Extension(t) => {
+                t.cmd_draw_indexed_indirect_count(
+                    self.raw,
+                    buffer.raw,
+                    offset,
+                    count_buffer.raw,
+                    count_buffer_offset,
+                    max_draw_count,
+                    stride,
+                );
+            }
+            ExtensionFn::Promoted => {
+                self.device.raw.cmd_draw_indexed_indirect_count(
+                    self.raw,
+                    buffer.raw,
+                    offset,
+                    count_buffer.raw,
+                    count_buffer_offset,
+                    max_draw_count,
+                    stride,
+                );
+            }
+        }
     }
 
     unsafe fn set_event(&mut self, event: &n::Event, stage_mask: pso::PipelineStage) {

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -667,8 +667,27 @@ impl queue::QueueFamily for QueueFamily {
 }
 
 struct DeviceExtensionFunctions {
-    mesh_shaders: Option<MeshShader>,
-    draw_indirect_count: Option<DrawIndirectCount>,
+    mesh_shaders: Option<ExtensionFn<MeshShader>>,
+    draw_indirect_count: Option<ExtensionFn<DrawIndirectCount>>,
+}
+
+// TODO there's no reason why this can't be unified--the function pointers should all be the same--it's not clear how to do this with `ash`.
+enum ExtensionFn<T> {
+    /// The loaded function pointer struct for an extension.
+    Extension(T),
+    /// The extension was promoted to a core version of Vulkan and the functions on `ash`'s `DeviceV1_x` traits should be used.
+    Promoted,
+}
+
+impl<T> ExtensionFn<T> {
+    /// Expect `self` to be `ExtensionFn::Extension` and return the inner value.
+    fn unwrap_extension(&self) -> &T {
+        if let ExtensionFn::Extension(t) = self {
+            t
+        } else {
+            panic!()
+        }
+    }
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Fixes a couple issues caused by #3654
- `Features::NDC_Y_UP` was not advertised correctly for 1.1
- `Features::SAMPLER_MIRROR_CLAMP_EDGE` could be missed in 1.2 if the driver does not explicitly support `VK_KHR_sampler_mirror_clamp_edge`.
- `Features::DRAW_INDIRECT_COUNT` could be missed in 1.2 if the driver does not explicitly support `VK_KHR_draw_indirect_count`.
- `VK_KHR_draw_indirect_count` was not correctly excluded in 1.2
- `cmd_draw_indirect_count` and `cmd_draw_indexed_indirect_count` were not correctly being loaded in 1.2
  - I'm unsure if there's a way in `ash` to load both the extension function pointer and the core promoted function pointer into the same Rust function, but that would certainly make this code simpler.