### PR TITLE
Add fences between command pool resets. Fix for #3625

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -377,13 +377,23 @@ impl<B: Backend> RendererState<B> {
             self.framebuffer.get_frame_data(frame_idx);
 
         unsafe {
+            // Rendering
+            let (mut cmd_buffer, mut fence) = match command_buffers.pop() {
+                Some((cmd_buffer, fence)) => (cmd_buffer, fence),
+                None => (
+                    command_pool.allocate_one(command::Level::Primary),
+                    self.device.borrow().device.create_fence(true).unwrap(),
+                ),
+            };
+
+            self.device
+                .borrow()
+                .device
+                .wait_for_fence(&mut fence, u64::MAX);
+            self.device.borrow().device.reset_fence(&mut fence);
+            // cmd_buffer.reset(true);
             command_pool.reset(false);
 
-            // Rendering
-            let mut cmd_buffer = match command_buffers.pop() {
-                Some(cmd_buffer) => cmd_buffer,
-                None => command_pool.allocate_one(command::Level::Primary),
-            };
             cmd_buffer.begin_primary(command::CommandBufferFlags::ONE_TIME_SUBMIT);
             cmd_buffer.begin_debug_marker("setup", 0);
             cmd_buffer.set_viewports(0, iter::once(self.viewport.clone()));
@@ -428,9 +438,9 @@ impl<B: Backend> RendererState<B> {
                 iter::once(&cmd_buffer),
                 iter::empty(),
                 iter::once(&*sem_image_present),
-                None,
+                Some(&mut fence),
             );
-            command_buffers.push(cmd_buffer);
+            command_buffers.push((cmd_buffer, fence));
 
             // present frame
             if let Err(_) = self.device.borrow_mut().queues.queues[0].present(
@@ -1382,7 +1392,7 @@ impl SwapchainState {
 struct FramebufferState<B: Backend> {
     framebuffer: Option<B::Framebuffer>,
     command_pools: Option<Vec<B::CommandPool>>,
-    command_buffer_lists: Vec<Vec<B::CommandBuffer>>,
+    command_buffer_lists: Vec<Vec<(B::CommandBuffer, B::Fence)>>,
     present_semaphores: Option<Vec<B::Semaphore>>,
     device: Rc<RefCell<DeviceState<B>>>,
 }
@@ -1428,7 +1438,7 @@ impl<B: Backend> FramebufferState<B> {
     ) -> (
         &B::Framebuffer,
         &mut B::CommandPool,
-        &mut Vec<B::CommandBuffer>,
+        &mut Vec<(B::CommandBuffer, B::Fence)>,
         &mut B::Semaphore,
     ) {
         (
@@ -1445,8 +1455,9 @@ impl<B: Backend> Drop for FramebufferState<B> {
         let device = &self.device.borrow().device;
 
         unsafe {
-            device.destroy_framebuffer(self.framebuffer.take().unwrap());
-
+            if let Some(fb) = self.framebuffer.take() {
+                device.destroy_framebuffer(fb);
+            }
             for (mut command_pool, comamnd_buffer_list) in self
                 .command_pools
                 .take()
@@ -1454,7 +1465,8 @@ impl<B: Backend> Drop for FramebufferState<B> {
                 .into_iter()
                 .zip(self.command_buffer_lists.drain(..))
             {
-                command_pool.free(comamnd_buffer_list.into_iter());
+                
+                command_pool.free(comamnd_buffer_list.into_iter().map(|(c,f)| {device.destroy_fence(f); c}));
                 device.destroy_command_pool(command_pool);
             }
 

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -797,6 +797,7 @@ where
         self.viewport.rect.h = extent.height as _;
 
         unsafe {
+            self.device.wait_idle();
             self.device
                 .destroy_framebuffer(ManuallyDrop::into_inner(ptr::read(&self.framebuffer)));
             self.framebuffer = ManuallyDrop::new(


### PR DESCRIPTION
Fixes #3625
PR checklist:
- [ ] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan
