### PR TITLE
Refactoring & adding SPARSE_BINDING to QueueType

### DIFF
--- a/examples/bench/main.rs
+++ b/examples/bench/main.rs
@@ -52,7 +52,7 @@ fn main() {
     let family = adapter
         .queue_families
         .iter()
-        .find(|family| family.queue_type().supports_compute())
+        .find(|family| family.queue_flags().supports_compute())
         .unwrap();
 
     unsafe {

--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -624,7 +624,7 @@ impl<B: Backend> DeviceState<B> {
             .queue_families
             .iter()
             .find(|family| {
-                surface.supports_queue_family(family) && family.queue_type().supports_graphics()
+                surface.supports_queue_family(family) && family.queue_flags().supports_graphics()
             })
             .unwrap();
         let mut gpu = unsafe {

--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -54,7 +54,7 @@ fn main() {
         .find(|a| {
             a.queue_families
                 .iter()
-                .any(|family| family.queue_type().supports_compute())
+                .any(|family| family.queue_flags().supports_compute())
         })
         .expect("Failed to find a GPU with compute support!");
 
@@ -62,7 +62,7 @@ fn main() {
     let family = adapter
         .queue_families
         .iter()
-        .find(|family| family.queue_type().supports_compute())
+        .find(|family| family.queue_flags().supports_compute())
         .unwrap();
     let mut gpu = unsafe {
         adapter

--- a/examples/mesh-shading/main.rs
+++ b/examples/mesh-shading/main.rs
@@ -202,7 +202,7 @@ where
             .queue_families
             .iter()
             .find(|family| {
-                surface.supports_queue_family(family) && family.queue_type().supports_graphics()
+                surface.supports_queue_family(family) && family.queue_flags().supports_graphics()
             })
             .unwrap();
         let mut gpu = unsafe {

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -216,6 +216,9 @@ where
         let limits = adapter.physical_device.properties().limits;
 
         // Build a new device and associated command queues
+        for f in adapter.queue_families.iter() {
+            println!("{:?}", f.queue_type());
+        }
         let family = adapter
             .queue_families
             .iter()

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -217,13 +217,13 @@ where
 
         // Build a new device and associated command queues
         for f in adapter.queue_families.iter() {
-            println!("{:?}", f.queue_type());
+            println!("{:?}", f.queue_flags());
         }
         let family = adapter
             .queue_families
             .iter()
             .find(|family| {
-                surface.supports_queue_family(family) && family.queue_type().supports_graphics()
+                surface.supports_queue_family(family) && family.queue_flags().supports_graphics()
             })
             .expect("No queue family supports presentation");
 

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1135,8 +1135,8 @@ impl window::PresentationSurface<Backend> for Surface {
 pub struct QueueFamily;
 
 impl queue::QueueFamily for QueueFamily {
-    fn queue_type(&self) -> queue::QueueType {
-        queue::QueueType::GRAPHICS | queue::QueueType::COMPUTE | queue::QueueType::TRANSFER
+    fn queue_flags(&self) -> queue::QueueFlags {
+        queue::QueueFlags::all()
     }
     fn max_queues(&self) -> usize {
         1

--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1136,7 +1136,7 @@ pub struct QueueFamily;
 
 impl queue::QueueFamily for QueueFamily {
     fn queue_type(&self) -> queue::QueueType {
-        queue::QueueType::General
+        queue::QueueType::GRAPHICS | queue::QueueType::COMPUTE | queue::QueueType::TRANSFER
     }
     fn max_queues(&self) -> usize {
         1

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -150,15 +150,15 @@ pub enum QueueFamily {
     // It's basically a normal 3D queue but D3D12 swapchain creation requires an
     // associated queue, which we don't know on `create_swapchain`.
     Present,
-    Normal(q::QueueType),
+    Normal(q::QueueFlags),
 }
 
 const MAX_QUEUES: usize = 16; // infinite, to be fair
 
 impl q::QueueFamily for QueueFamily {
-    fn queue_type(&self) -> q::QueueType {
+    fn queue_flags(&self) -> q::QueueFlags {
         match *self {
-            QueueFamily::Present => q::QueueType::GRAPHICS | q::QueueType::TRANSFER,
+            QueueFamily::Present => q::QueueFlags::GRAPHICS | q::QueueFlags::TRANSFER,
             QueueFamily::Normal(ty) => ty,
         }
     }
@@ -172,12 +172,12 @@ impl q::QueueFamily for QueueFamily {
         // This must match the order exposed by `QUEUE_FAMILIES`
         q::QueueFamilyId(match *self {
             QueueFamily::Present => 0,
-            QueueFamily::Normal(queue_type) => {
-                if queue_type.contains(q::QueueType::GRAPHICS) {
+            QueueFamily::Normal(queue_flags) => {
+                if queue_flags.contains(q::QueueFlags::GRAPHICS) {
                     1
-                } else if queue_type.contains(q::QueueType::COMPUTE) {
+                } else if queue_flags.contains(q::QueueFlags::COMPUTE) {
                     2
-                } else if queue_type.contains(q::QueueType::TRANSFER) {
+                } else if queue_flags.contains(q::QueueFlags::TRANSFER) {
                     3
                 } else {
                     unreachable!()
@@ -193,12 +193,12 @@ impl QueueFamily {
         use hal::queue::QueueFamily as _;
         use native::CmdListType as Clt;
 
-        let queue_type = self.queue_type();
-        if queue_type.contains(q::QueueType::GRAPHICS) {
+        let queue_flags = self.queue_flags();
+        if queue_flags.contains(q::QueueFlags::GRAPHICS) {
             Clt::Direct
-        } else if queue_type.contains(q::QueueType::COMPUTE) {
+        } else if queue_flags.contains(q::QueueFlags::COMPUTE) {
             Clt::Compute
-        } else if queue_type.contains(q::QueueType::TRANSFER) {
+        } else if queue_flags.contains(q::QueueFlags::TRANSFER) {
             Clt::Copy
         } else {
             unreachable!()
@@ -208,9 +208,9 @@ impl QueueFamily {
 
 static QUEUE_FAMILIES: [QueueFamily; 4] = [
     QueueFamily::Present,
-    QueueFamily::Normal(q::QueueType::GRAPHICS_TRANSFER),
-    QueueFamily::Normal(q::QueueType::COMPUTE_TRANSFER),
-    QueueFamily::Normal(q::QueueType::TRANSFER),
+    QueueFamily::Normal(q::QueueFlags::GRAPHICS | q::QueueFlags::TRANSFER),
+    QueueFamily::Normal(q::QueueFlags::COMPUTE | q::QueueFlags::TRANSFER),
+    QueueFamily::Normal(q::QueueFlags::TRANSFER),
 ];
 
 #[derive(Default)]

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -182,7 +182,7 @@ impl q::QueueFamily for QueueFamily {
                 } else {
                     unreachable!()
                 }
-            },
+            }
             _ => unreachable!(),
         })
     }

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -574,8 +574,8 @@ impl device::Device<Backend> for Device {
 #[derive(Debug)]
 pub struct QueueFamily;
 impl queue::QueueFamily for QueueFamily {
-    fn queue_type(&self) -> queue::QueueType {
-        queue::QueueType::all()
+    fn queue_flags(&self) -> queue::QueueFlags {
+        queue::QueueFlags::all()
     }
     fn max_queues(&self) -> usize {
         1

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -575,7 +575,7 @@ impl device::Device<Backend> for Device {
 pub struct QueueFamily;
 impl queue::QueueFamily for QueueFamily {
     fn queue_type(&self) -> queue::QueueType {
-        queue::QueueType::General
+        queue::QueueType::all()
     }
     fn max_queues(&self) -> usize {
         1

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -655,8 +655,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 pub struct QueueFamily;
 
 impl q::QueueFamily for QueueFamily {
-    fn queue_type(&self) -> q::QueueType {
-        q::QueueType::GRAPHICS | q::QueueType::COMPUTE | q::QueueType::TRANSFER
+    fn queue_flags(&self) -> q::QueueFlags {
+        q::QueueFlags::all()
     }
     fn max_queues(&self) -> usize {
         1

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -656,7 +656,7 @@ pub struct QueueFamily;
 
 impl q::QueueFamily for QueueFamily {
     fn queue_type(&self) -> q::QueueType {
-        q::QueueType::General
+        q::QueueType::GRAPHICS | q::QueueType::COMPUTE | q::QueueType::TRANSFER
     }
     fn max_queues(&self) -> usize {
         1

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -161,7 +161,7 @@ pub struct QueueFamily {}
 
 impl hal::queue::QueueFamily for QueueFamily {
     fn queue_type(&self) -> QueueType {
-        QueueType::General
+        QueueType::GRAPHICS | QueueType::COMPUTE | QueueType::TRANSFER
     }
     fn max_queues(&self) -> usize {
         1

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -60,7 +60,7 @@ extern crate log;
 
 use hal::{
     adapter::{Adapter, AdapterInfo, DeviceType},
-    queue::{QueueFamilyId, QueueType},
+    queue::{QueueFamilyId, QueueFlags},
 };
 use range_alloc::RangeAllocator;
 
@@ -160,8 +160,8 @@ const MAX_BOUND_DESCRIPTOR_SETS: usize = 8;
 pub struct QueueFamily {}
 
 impl hal::queue::QueueFamily for QueueFamily {
-    fn queue_type(&self) -> QueueType {
-        QueueType::GRAPHICS | QueueType::COMPUTE | QueueType::TRANSFER
+    fn queue_flags(&self) -> QueueFlags {
+        QueueFlags::all()
     }
     fn max_queues(&self) -> usize {
         1

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -169,21 +169,20 @@ impl fmt::Debug for Instance {
 }
 
 fn map_queue_type(flags: vk::QueueFlags) -> queue::QueueType {
-    if flags.contains(vk::QueueFlags::GRAPHICS | vk::QueueFlags::COMPUTE) {
-        // TRANSFER_BIT optional
-        queue::QueueType::General
-    } else if flags.contains(vk::QueueFlags::GRAPHICS) {
-        // TRANSFER_BIT optional
-        queue::QueueType::Graphics
-    } else if flags.contains(vk::QueueFlags::COMPUTE) {
-        // TRANSFER_BIT optional
-        queue::QueueType::Compute
-    } else if flags.contains(vk::QueueFlags::TRANSFER) {
-        queue::QueueType::Transfer
-    } else {
-        // TODO: present only queues?
-        unimplemented!()
+    let mut ret = queue::QueueType::empty();
+    if flags.contains(vk::QueueFlags::GRAPHICS) {
+        ret |= queue::QueueType::GRAPHICS;
     }
+    if flags.contains(vk::QueueFlags::COMPUTE) {
+        ret |= queue::QueueType::COMPUTE;
+    }
+    if flags.contains(vk::QueueFlags::TRANSFER) {
+        ret |= queue::QueueType::TRANSFER;
+    }
+    if flags.contains(vk::QueueFlags::SPARSE_BINDING) {
+        ret |= queue::QueueType::SPARSE_BINDING;
+    }
+    ret
 }
 
 unsafe fn display_debug_utils_label_ext(

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -168,19 +168,19 @@ impl fmt::Debug for Instance {
     }
 }
 
-fn map_queue_type(flags: vk::QueueFlags) -> queue::QueueType {
-    let mut ret = queue::QueueType::empty();
+fn map_queue_flags(flags: vk::QueueFlags) -> queue::QueueFlags {
+    let mut ret = queue::QueueFlags::empty();
     if flags.contains(vk::QueueFlags::GRAPHICS) {
-        ret |= queue::QueueType::GRAPHICS;
+        ret |= queue::QueueFlags::GRAPHICS | queue::QueueFlags::TRANSFER;
     }
     if flags.contains(vk::QueueFlags::COMPUTE) {
-        ret |= queue::QueueType::COMPUTE;
+        ret |= queue::QueueFlags::COMPUTE | queue::QueueFlags::TRANSFER;
     }
     if flags.contains(vk::QueueFlags::TRANSFER) {
-        ret |= queue::QueueType::TRANSFER;
+        ret |= queue::QueueFlags::TRANSFER;
     }
     if flags.contains(vk::QueueFlags::SPARSE_BINDING) {
-        ret |= queue::QueueType::SPARSE_BINDING;
+        ret |= queue::QueueFlags::SPARSE_BINDING;
     }
     ret
 }
@@ -654,8 +654,8 @@ pub struct QueueFamily {
 }
 
 impl queue::QueueFamily for QueueFamily {
-    fn queue_type(&self) -> queue::QueueType {
-        map_queue_type(self.properties.queue_flags)
+    fn queue_flags(&self) -> queue::QueueFlags {
+        map_queue_flags(self.properties.queue_flags)
     }
     fn max_queues(&self) -> usize {
         self.properties.queue_count as _

--- a/src/backend/webgpu/src/lib.rs
+++ b/src/backend/webgpu/src/lib.rs
@@ -202,7 +202,7 @@ const WEBGPU_QUEUE_FAMILY_ID: QueueFamilyId = QueueFamilyId(1);
 
 impl hal::queue::QueueFamily for QueueFamily {
     fn queue_type(&self) -> QueueType {
-        QueueType::General
+        QueueType::GRAPHICS | QueueType::TRANSFER | QueueType::COMPUTE
     }
 
     fn max_queues(&self) -> usize {

--- a/src/backend/webgpu/src/lib.rs
+++ b/src/backend/webgpu/src/lib.rs
@@ -4,7 +4,7 @@ use hal::{
     adapter::{Adapter, AdapterInfo, DeviceType, Gpu, MemoryProperties},
     device::CreationError,
     format, image,
-    queue::{QueueFamilyId, QueuePriority, QueueFlags},
+    queue::{QueueFamilyId, QueueFlags, QueuePriority},
     Features,
 };
 

--- a/src/backend/webgpu/src/lib.rs
+++ b/src/backend/webgpu/src/lib.rs
@@ -4,7 +4,7 @@ use hal::{
     adapter::{Adapter, AdapterInfo, DeviceType, Gpu, MemoryProperties},
     device::CreationError,
     format, image,
-    queue::{QueueFamilyId, QueuePriority, QueueType},
+    queue::{QueueFamilyId, QueuePriority, QueueFlags},
     Features,
 };
 
@@ -201,8 +201,8 @@ pub struct QueueFamily;
 const WEBGPU_QUEUE_FAMILY_ID: QueueFamilyId = QueueFamilyId(1);
 
 impl hal::queue::QueueFamily for QueueFamily {
-    fn queue_type(&self) -> QueueType {
-        QueueType::GRAPHICS | QueueType::TRANSFER | QueueType::COMPUTE
+    fn queue_flags(&self) -> QueueFlags {
+        QueueFlags::all()
     }
 
     fn max_queues(&self) -> usize {

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -1,6 +1,6 @@
 //! Queue family and groups.
 
-use crate::{queue::QueueType, Backend};
+use crate::{queue::QueueFlags, Backend};
 
 use std::{any::Any, fmt::Debug};
 
@@ -11,8 +11,8 @@ use std::{any::Any, fmt::Debug};
 /// Can be obtained from an [adapter][crate::adapter::Adapter] through its
 /// [`queue_families`][crate::adapter::Adapter::queue_families] field.
 pub trait QueueFamily: Debug + Any + Send + Sync {
-    /// Returns the type of queues.
-    fn queue_type(&self) -> QueueType;
+    /// Returns the queue flags.
+    fn queue_flags(&self) -> QueueFlags;
     /// Returns maximum number of queues created from this family.
     fn max_queues(&self) -> usize;
     /// Returns the queue family ID.

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -22,7 +22,7 @@ use crate::memory::{SparseBind, SparseImageBind};
 bitflags! {
     /// The type of the queue, an enum encompassing `queue::Capability`
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct QueueType: u32 {
+    pub struct QueueFlags: u32 {
         /// Queue supports graphics operations
         const GRAPHICS = 0b1;
         /// Queue supports compute operations
@@ -31,28 +31,22 @@ bitflags! {
         const TRANSFER = 0b100;
         /// Queue supports sparse resource memory management operations
         const SPARSE_BINDING = 0b1000;
-
-        /// Queue supports both graphics operations and transfer operations
-        const GRAPHICS_TRANSFER = Self::GRAPHICS.bits | Self::TRANSFER.bits;
-
-        /// Queue supports both compute operations and transfer operations
-        const COMPUTE_TRANSFER = Self::GRAPHICS.bits | Self::COMPUTE.bits;
     }
 }
 
 
-impl QueueType {
+impl QueueFlags {
     /// Returns true if the queue supports graphics operations.
     pub fn supports_graphics(&self) -> bool {
-        self.contains(QueueType::GRAPHICS)
+        self.contains(QueueFlags::GRAPHICS)
     }
     /// Returns true if the queue supports compute operations.
     pub fn supports_compute(&self) -> bool {
-        self.contains(QueueType::COMPUTE)
+        self.contains(QueueFlags::COMPUTE)
     }
     /// Returns true if the queue supports transfer operations.
     pub fn supports_transfer(&self) -> bool {
-        self.contains(QueueType::TRANSFER)
+        self.contains(QueueFlags::TRANSFER)
     }
 }
 

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -34,7 +34,6 @@ bitflags! {
     }
 }
 
-
 impl QueueFlags {
     /// Returns true if the queue supports graphics operations.
     pub fn supports_graphics(&self) -> bool {

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -19,38 +19,40 @@ use std::{any::Any, fmt};
 pub use self::family::{QueueFamily, QueueFamilyId, QueueGroup};
 use crate::memory::{SparseBind, SparseImageBind};
 
-/// The type of the queue, an enum encompassing `queue::Capability`
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum QueueType {
-    /// Supports all operations.
-    General,
-    /// Only supports graphics and transfer operations.
-    Graphics,
-    /// Only supports compute and transfer operations.
-    Compute,
-    /// Only supports transfer operations.
-    Transfer,
+bitflags! {
+    /// The type of the queue, an enum encompassing `queue::Capability`
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    pub struct QueueType: u32 {
+        /// Queue supports graphics operations
+        const GRAPHICS = 0b1;
+        /// Queue supports compute operations
+        const COMPUTE = 0b10;
+        /// Queue supports transfer operations
+        const TRANSFER = 0b100;
+        /// Queue supports sparse resource memory management operations
+        const SPARSE_BINDING = 0b1000;
+
+        /// Queue supports both graphics operations and transfer operations
+        const GRAPHICS_TRANSFER = Self::GRAPHICS.bits | Self::TRANSFER.bits;
+
+        /// Queue supports both compute operations and transfer operations
+        const COMPUTE_TRANSFER = Self::GRAPHICS.bits | Self::COMPUTE.bits;
+    }
 }
+
 
 impl QueueType {
     /// Returns true if the queue supports graphics operations.
     pub fn supports_graphics(&self) -> bool {
-        match *self {
-            QueueType::General | QueueType::Graphics => true,
-            QueueType::Compute | QueueType::Transfer => false,
-        }
+        self.contains(QueueType::GRAPHICS)
     }
     /// Returns true if the queue supports compute operations.
     pub fn supports_compute(&self) -> bool {
-        match *self {
-            QueueType::General | QueueType::Graphics | QueueType::Compute => true,
-            QueueType::Transfer => false,
-        }
+        self.contains(QueueType::COMPUTE)
     }
     /// Returns true if the queue supports transfer operations.
     pub fn supports_transfer(&self) -> bool {
-        true
+        self.contains(QueueType::TRANSFER)
     }
 }
 


### PR DESCRIPTION
We now have sparse binding thanks to #3521 but currently 'SPARSE_BINDING' is missing from 'QueueType'. This PR adds the 'SPARSE_BINDING' bit to QueueType by converting it from a enum to a bitflags struct.

Reference: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueueFlagBits.html


PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Metal, DX12, DX11, Vulkan
