### PR TITLE
Adding supports_sparse_binding to QueueFamily

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -1144,6 +1144,9 @@ impl queue::QueueFamily for QueueFamily {
     fn id(&self) -> queue::QueueFamilyId {
         queue::QueueFamilyId(0)
     }
+    fn supports_sparse_binding(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Clone)]

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -178,6 +178,9 @@ impl q::QueueFamily for QueueFamily {
             _ => unreachable!(),
         })
     }
+    fn supports_sparse_binding(&self) -> bool {
+        true
+    }
 }
 
 impl QueueFamily {

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -583,6 +583,9 @@ impl queue::QueueFamily for QueueFamily {
     fn id(&self) -> queue::QueueFamilyId {
         QUEUE_FAMILY_ID
     }
+    fn supports_sparse_binding(&self) -> bool {
+        true
+    }
 }
 
 const QUEUE_FAMILY_ID: queue::QueueFamilyId = queue::QueueFamilyId(0);

--- a/src/backend/gl/src/lib.rs
+++ b/src/backend/gl/src/lib.rs
@@ -664,6 +664,9 @@ impl q::QueueFamily for QueueFamily {
     fn id(&self) -> q::QueueFamilyId {
         q::QueueFamilyId(0)
     }
+    fn supports_sparse_binding(&self) -> bool {
+        false
+    }
 }
 
 fn resolve_sub_range(

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -169,6 +169,9 @@ impl hal::queue::QueueFamily for QueueFamily {
     fn id(&self) -> QueueFamilyId {
         QueueFamilyId(0)
     }
+    fn supports_sparse_binding(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Debug)]

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -664,6 +664,9 @@ impl queue::QueueFamily for QueueFamily {
     fn id(&self) -> queue::QueueFamilyId {
         queue::QueueFamilyId(self.index as _)
     }
+    fn supports_sparse_binding(&self) -> bool {
+        self.properties.queue_flags.contains(vk::QueueFlags::SPARSE_BINDING)
+    }
 }
 
 struct DeviceExtensionFunctions {

--- a/src/backend/webgpu/src/lib.rs
+++ b/src/backend/webgpu/src/lib.rs
@@ -212,6 +212,10 @@ impl hal::queue::QueueFamily for QueueFamily {
     fn id(&self) -> QueueFamilyId {
         WEBGPU_QUEUE_FAMILY_ID
     }
+
+    fn supports_sparse_binding(&self) -> bool {
+        false
+    }
 }
 
 use hal::pso::AllocationError;

--- a/src/hal/src/queue/family.rs
+++ b/src/hal/src/queue/family.rs
@@ -17,6 +17,8 @@ pub trait QueueFamily: Debug + Any + Send + Sync {
     fn max_queues(&self) -> usize;
     /// Returns the queue family ID.
     fn id(&self) -> QueueFamilyId;
+    /// Returns true if the queue family supports sparse binding
+    fn supports_sparse_binding(&self) -> bool;
 }
 
 /// Identifier for a queue family of a physical device.


### PR DESCRIPTION
Followup #3521 and alternative implementation for #3665.

PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Metal
