### PR TITLE
basic conservative rasterization support for Vulkan & DX12

### DIFF
--- a/src/backend/dx12/src/conv.rs
+++ b/src/backend/dx12/src/conv.rs
@@ -293,7 +293,6 @@ pub fn map_rasterizer(rasterizer: &pso::Rasterizer, multisample: bool) -> D3D12_
         ForcedSampleCount: 0,         // TODO: currently not supported
         AntialiasedLineEnable: FALSE, // TODO: currently not supported
         ConservativeRaster: if rasterizer.conservative {
-            // TODO: check support
             D3D12_CONSERVATIVE_RASTERIZATION_MODE_ON
         } else {
             D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1310,6 +1310,14 @@ impl hal::Instance<Backend> for Instance {
                 tiled_resource_features |= Features::SPARSE_RESIDENCY_IMAGE_3D;
             }
 
+            let conservative_faster_features = if features.ConservativeRasterizationTier
+                == d3d12::D3D12_CONSERVATIVE_RASTERIZATION_TIER_NOT_SUPPORTED
+            {
+                Features::empty()
+            } else {
+                Features::CONSERVATIVE_RASTERIZATION
+            };
+
             let physical_device = PhysicalDevice {
                 library: Arc::clone(&self.library),
                 adapter,
@@ -1340,7 +1348,8 @@ impl hal::Instance<Backend> for Instance {
                     Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING |
                     Features::UNSIZED_DESCRIPTOR_ARRAY |
                     Features::DRAW_INDIRECT_COUNT |
-                    tiled_resource_features,
+                    tiled_resource_features |
+                    conservative_faster_features,
                 properties: PhysicalDeviceProperties {
                     limits: Limits {
                         //TODO: verify all of these not linked to constants

--- a/src/backend/vulkan/src/physical_device.rs
+++ b/src/backend/vulkan/src/physical_device.rs
@@ -410,6 +410,10 @@ impl PhysicalDeviceFeatures {
             bits |= Features::DRAW_INDIRECT_COUNT
         }
 
+        if info.supports_extension(vk::ExtConservativeRasterizationFn::name()) {
+            bits |= Features::CONSERVATIVE_RASTERIZATION
+        }
+
         if let Some(ref vulkan_1_2) = self.vulkan_1_2 {
             if vulkan_1_2.shader_sampled_image_array_non_uniform_indexing != 0 {
                 bits |= Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING;
@@ -525,6 +529,11 @@ impl PhysicalDeviceInfo {
             && requested_features.contains(Features::DRAW_INDIRECT_COUNT)
         {
             requested_extensions.push(DrawIndirectCount::name());
+        }
+
+        if requested_features.contains(Features::CONSERVATIVE_RASTERIZATION) {
+            requested_extensions.push(vk::ExtConservativeRasterizationFn::name());
+            requested_extensions.push(vk::KhrGetDisplayProperties2Fn::name()); // TODO NOT NEEDED, RIGHT?
         }
 
         requested_extensions

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -246,6 +246,10 @@ bitflags! {
         /// Enable draw_indirect_count and draw_indexed_indirect_count
         const DRAW_INDIRECT_COUNT = 0x1000_0000_0000_0000;
 
+        /// Support for conservative rasterization. Presence of this flag only indicates basic overestimation rasterization for triangles only.
+        /// (no guarantee on underestimation, overestimation, handling of degenerate primitives, fragment shader coverage reporting and uncertainty ranges)
+        const CONSERVATIVE_RASTERIZATION = 0x2000_0000_0000_0000;
+
         // Bits for Vulkan Portability features
 
         /// Support triangle fan primitive topology.


### PR DESCRIPTION
Sorta fixes #3637 

Only provides the very basic option of enabling/disabling overestimation rasterization. This is almost everything DX12 has to offer anyways except the optional `SV_InnerCoverage` support, but leaves out even more Vulkan goodies (e.g. underestimation, various device properties, configurable extra-over-estimation, conservative raster of lines...).
Availability of the coverage variable is the most important missing thing but could later be exposed as an additional feature flag (debatable, since this is not how Vulkan does it, so more of a device property?)

Probably more controversial about this PR: `validate_creation_desc_support`
I didn't want to repeat feature check code over all devices so I created a function on the desc that validates against features (and made unallowed use of DEPTH_CLAMP an error since this was close by..). Imho this is the only sane way forward for stuff like this since more often than not there needs to be a check _somewhere_ but the philosophy of having this on this level and in that particular place might be questionable.

Tested this with wgpu - I already have wgpu and wgpu-rs branches ready with a sample that can swap back and forth between enabled and disabled conservative rasterization. Going to look like this:

![image](https://user-images.githubusercontent.com/1220815/111027412-7d268c00-83f0-11eb-98e2-2f27e19becda.png)



PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds -- failed in alloc, seems unrelated `thread 'main' panicked at 'removal index (is 0) should be < len (is 0)', library/alloc/src/vec.rs:1066:13`
- [x] tested examples with the following backends: Vulkan, DX12
