### PR TITLE
Add uniform and storage buffer descriptor indexing

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1340,12 +1340,17 @@ impl hal::Instance<Backend> for Instance {
                     Features::MUTABLE_COMPARISON_SAMPLER |
                     Features::SAMPLER_ANISOTROPY |
                     Features::TEXTURE_DESCRIPTOR_ARRAY |
+                    Features::BUFFER_DESCRIPTOR_ARRAY |
                     Features::SAMPLER_MIRROR_CLAMP_EDGE |
                     Features::NDC_Y_UP |
                     Features::SHADER_SAMPLED_IMAGE_ARRAY_DYNAMIC_INDEXING |
                     Features::SHADER_STORAGE_IMAGE_ARRAY_DYNAMIC_INDEXING |
+                    Features::SHADER_STORAGE_BUFFER_ARRAY_DYNAMIC_INDEXING |
+                    Features::SHADER_UNIFORM_BUFFER_ARRAY_DYNAMIC_INDEXING |
                     Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING |
                     Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING |
+                    Features::STORAGE_BUFFER_DESCRIPTOR_INDEXING |
+                    Features::UNIFORM_BUFFER_DESCRIPTOR_INDEXING |
                     Features::UNSIZED_DESCRIPTOR_ARRAY |
                     Features::DRAW_INDIRECT_COUNT |
                     tiled_resource_features |

--- a/src/backend/vulkan/src/physical_device.rs
+++ b/src/backend/vulkan/src/physical_device.rs
@@ -183,6 +183,12 @@ impl PhysicalDeviceFeatures {
                         .shader_storage_image_array_non_uniform_indexing(
                             features.contains(Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING),
                         )
+                        .shader_storage_buffer_array_non_uniform_indexing(
+                            features.contains(Features::STORAGE_BUFFER_DESCRIPTOR_INDEXING),
+                        )
+                        .shader_uniform_buffer_array_non_uniform_indexing(
+                            features.contains(Features::UNIFORM_BUFFER_DESCRIPTOR_INDEXING),
+                        )
                         .runtime_descriptor_array(
                             features.contains(Features::UNSIZED_DESCRIPTOR_ARRAY),
                         )
@@ -224,7 +230,8 @@ impl PhysicalDeviceFeatures {
             | Features::SAMPLER_BORDER_COLOR
             | Features::MUTABLE_COMPARISON_SAMPLER
             | Features::MUTABLE_UNNORMALIZED_SAMPLER
-            | Features::TEXTURE_DESCRIPTOR_ARRAY;
+            | Features::TEXTURE_DESCRIPTOR_ARRAY
+            | Features::BUFFER_DESCRIPTOR_ARRAY;
 
         if self.core.robust_buffer_access != 0 {
             bits |= Features::ROBUST_BUFFER_ACCESS;
@@ -421,6 +428,12 @@ impl PhysicalDeviceFeatures {
             if vulkan_1_2.shader_storage_image_array_non_uniform_indexing != 0 {
                 bits |= Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING;
             }
+            if vulkan_1_2.shader_storage_buffer_array_non_uniform_indexing != 0 {
+                bits |= Features::STORAGE_BUFFER_DESCRIPTOR_INDEXING;
+            }
+            if vulkan_1_2.shader_uniform_buffer_array_non_uniform_indexing != 0 {
+                bits |= Features::UNIFORM_BUFFER_DESCRIPTOR_INDEXING;
+            }
             if vulkan_1_2.runtime_descriptor_array != 0 {
                 bits |= Features::UNSIZED_DESCRIPTOR_ARRAY;
             }
@@ -438,6 +451,12 @@ impl PhysicalDeviceFeatures {
             }
             if descriptor_indexing.shader_storage_image_array_non_uniform_indexing != 0 {
                 bits |= Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING;
+            }
+            if descriptor_indexing.shader_storage_buffer_array_non_uniform_indexing != 0 {
+                bits |= Features::STORAGE_BUFFER_DESCRIPTOR_INDEXING;
+            }
+            if descriptor_indexing.shader_uniform_buffer_array_non_uniform_indexing != 0 {
+                bits |= Features::UNIFORM_BUFFER_DESCRIPTOR_INDEXING;
             }
             if descriptor_indexing.runtime_descriptor_array != 0 {
                 bits |= Features::UNSIZED_DESCRIPTOR_ARRAY;

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -241,7 +241,7 @@ bitflags! {
         /// Allow descriptor arrays to be unsized in shaders
         const UNSIZED_DESCRIPTOR_ARRAY = 0x0800_0000_0000_0000;
         /// Mask for all the features associated with descriptor indexing.
-        const DESCRIPTOR_INDEXING_MASK = Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING.bits | Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING.bits | Features::UNSIZED_DESCRIPTOR_ARRAY.bits;
+        const DESCRIPTOR_INDEXING_MASK = Features::SAMPLED_TEXTURE_DESCRIPTOR_INDEXING.bits | Features::STORAGE_TEXTURE_DESCRIPTOR_INDEXING.bits | Features::UNSIZED_DESCRIPTOR_ARRAY.bits | Features::UNIFORM_BUFFER_DESCRIPTOR_INDEXING.bits | Features::STORAGE_BUFFER_DESCRIPTOR_INDEXING.bits;
 
         /// Enable draw_indirect_count and draw_indexed_indirect_count
         const DRAW_INDIRECT_COUNT = 0x1000_0000_0000_0000;
@@ -249,6 +249,13 @@ bitflags! {
         /// Support for conservative rasterization. Presence of this flag only indicates basic overestimation rasterization for triangles only.
         /// (no guarantee on underestimation, overestimation, handling of degenerate primitives, fragment shader coverage reporting and uncertainty ranges)
         const CONSERVATIVE_RASTERIZATION = 0x2000_0000_0000_0000;
+
+        /// Support for arrays of buffer descriptors
+        const BUFFER_DESCRIPTOR_ARRAY = 0x4000_0000_0000_0000;
+        /// Allow indexing uniform buffer descriptor arrays with dynamically non-uniform data
+        const UNIFORM_BUFFER_DESCRIPTOR_INDEXING = 0x8000_0000_0000_0000;
+        /// Allow indexing storage buffer descriptor arrays with dynamically non-uniform data
+        const STORAGE_BUFFER_DESCRIPTOR_INDEXING = 0x0001_0000_0000_0000_0000;
 
         // Bits for Vulkan Portability features
 


### PR DESCRIPTION
Exposes storage buffer and uniform buffer arrays features in the same way as textures.

- Doesn't expose new features on gl or metal

PR checklist:
- [x] `make` succeeds (on windows)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: vulkan, dx12 (apart from mesh-shading)