### PR TITLE
Update naga to gfx-14

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -47,7 +47,7 @@ optional = true
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-13"
+tag = "gfx-14"
 features = ["spv-in", "glsl-out"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -537,8 +537,8 @@ impl Device {
             };
             //TODO: make Naga reflect all the names, not just textures
             let slot = match var.binding {
-                Some(naga::Binding::Resource { group, binding }) => {
-                    context.layout.sets[group as usize].bindings[binding as usize]
+                Some(ref br) => {
+                    context.layout.sets[br.group as usize].bindings[br.binding as usize]
                 }
                 ref other => panic!("Unexpected resource binding {:?}", other),
             };
@@ -549,8 +549,8 @@ impl Device {
 
         for (name, mapping) in texture_mapping {
             let texture_linear_index = match module.global_variables[mapping.texture].binding {
-                Some(naga::Binding::Resource { group, binding }) => {
-                    context.layout.sets[group as usize].bindings[binding as usize]
+                Some(ref br) => {
+                    context.layout.sets[br.group as usize].bindings[br.binding as usize]
                 }
                 ref other => panic!("Unexpected texture binding {:?}", other),
             };
@@ -559,8 +559,8 @@ impl Device {
                 .insert(name, (n::BindingRegister::Textures, texture_linear_index));
             if let Some(sampler_handle) = mapping.sampler {
                 let sampler_linear_index = match module.global_variables[sampler_handle].binding {
-                    Some(naga::Binding::Resource { group, binding }) => {
-                        context.layout.sets[group as usize].bindings[binding as usize]
+                    Some(ref br) => {
+                        context.layout.sets[br.group as usize].bindings[br.binding as usize]
                     }
                     ref other => panic!("Unexpected sampler binding {:?}", other),
                 };
@@ -609,11 +609,11 @@ impl Device {
             )))?;
 
         match writer.write() {
-            Ok(texture_mapping) => {
+            Ok(reflection_info) => {
                 Self::reflect_shader(
                     &shader.module,
                     shader.analysis.get_entry_point(entry_point_index),
-                    texture_mapping,
+                    reflection_info.texture_mapping,
                     context,
                 );
                 let source = String::from_utf8(output).unwrap();

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -53,7 +53,7 @@ optional = true
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-13"
+tag = "gfx-14"
 features = ["spv-in", "msl-out"]
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -33,7 +33,7 @@ inplace_it = "0.3.3"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-13"
+tag = "gfx-14"
 features = ["spv-out"]
 optional = true
 

--- a/src/backend/vulkan/src/physical_device.rs
+++ b/src/backend/vulkan/src/physical_device.rs
@@ -12,7 +12,7 @@ use hal::{
     queue, DescriptorLimits, DynamicStates, Features, Limits, PhysicalDeviceProperties,
 };
 
-use std::{ffi::CStr, fmt, mem, ptr, sync::Arc, unreachable};
+use std::{ffi::CStr, fmt, mem, ptr, sync::Arc};
 
 use crate::{
     conv, info, Backend, Device, DeviceExtensionFunctions, ExtensionFn, Queue, QueueFamily,

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.0"
-naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-13" }
+naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-14" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"


### PR DESCRIPTION
Picks up https://github.com/gfx-rs/naga/pull/552 and https://github.com/gfx-rs/naga/pull/564, which doesn't affect gfx-rs in any way.