### PR TITLE
[vk] Only enable sampler_filter_minmax and imageless_framebuffer on 1.2 when device supports it

### DIFF
--- a/src/backend/vulkan/src/physical_device.rs
+++ b/src/backend/vulkan/src/physical_device.rs
@@ -64,6 +64,7 @@ impl PhysicalDeviceFeatures {
         api_version: Version,
         enabled_extensions: &[&'static CStr],
         requested_features: Features,
+        supports_vulkan12_sampler_filter_minmax: bool,
     ) -> PhysicalDeviceFeatures {
         // This must follow the "Valid Usage" requirements of [`VkDeviceCreateInfo`](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceCreateInfo.html).
         let features = requested_features;
@@ -165,7 +166,7 @@ impl PhysicalDeviceFeatures {
                         .descriptor_indexing(
                             features.intersects(Features::DESCRIPTOR_INDEXING_MASK),
                         )
-                        .sampler_filter_minmax(true)
+                        .sampler_filter_minmax(supports_vulkan12_sampler_filter_minmax)
                         .imageless_framebuffer(true)
                         .build(),
                 )
@@ -785,6 +786,9 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                     self.device_info.api_version(),
                     &enabled_extensions,
                     requested_features,
+                    self.device_features
+                        .vulkan_1_2
+                        .map_or(false, |features| features.sampler_filter_minmax == vk::TRUE),
                 );
             let info = vk::DeviceCreateInfo::builder()
                 .queue_create_infos(&family_infos)

--- a/src/backend/vulkan/src/physical_device.rs
+++ b/src/backend/vulkan/src/physical_device.rs
@@ -64,6 +64,7 @@ impl PhysicalDeviceFeatures {
         api_version: Version,
         enabled_extensions: &[&'static CStr],
         requested_features: Features,
+        supports_vulkan12_imageless_framebuffer: bool,
         supports_vulkan12_sampler_filter_minmax: bool,
     ) -> PhysicalDeviceFeatures {
         // This must follow the "Valid Usage" requirements of [`VkDeviceCreateInfo`](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceCreateInfo.html).
@@ -167,7 +168,7 @@ impl PhysicalDeviceFeatures {
                             features.intersects(Features::DESCRIPTOR_INDEXING_MASK),
                         )
                         .sampler_filter_minmax(supports_vulkan12_sampler_filter_minmax)
-                        .imageless_framebuffer(true)
+                        .imageless_framebuffer(supports_vulkan12_imageless_framebuffer)
                         .build(),
                 )
             } else {
@@ -771,6 +772,11 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 })
         };
 
+        let supports_vulkan12_imageless_framebuffer = self
+            .device_features
+            .vulkan_1_2
+            .map_or(false, |features| features.imageless_framebuffer == vk::TRUE);
+
         // Create device
         let device_raw = {
             let str_pointers = enabled_extensions
@@ -786,6 +792,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                     self.device_info.api_version(),
                     &enabled_extensions,
                     requested_features,
+                    supports_vulkan12_imageless_framebuffer,
                     self.device_features
                         .vulkan_1_2
                         .map_or(false, |features| features.sampler_filter_minmax == vk::TRUE),
@@ -883,7 +890,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                     || self
                         .device_info
                         .supports_extension(vk::KhrMaintenance1Fn::name()),
-                imageless_framebuffers: self.device_info.api_version() >= Version::V1_2
+                imageless_framebuffers: supports_vulkan12_imageless_framebuffer
                     || self
                         .device_info
                         .supports_extension(vk::KhrImagelessFramebufferFn::name()),


### PR DESCRIPTION
Clients with a device that is running Vulkan 1.2 but does not support `sampler_filter_minmax` would crash on physical device creation. This can happen as well with `imageless_framebuffer` on e.g. Android devices.

This change makes it so the features are only enabled if they are available.

Fixes #3677

Note I can't effectively test this outside of the device simulator because I don't have real hardware in this configuration.