### PR TITLE
Add a texture format filter.

### DIFF
--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -358,6 +358,183 @@ impl Info {
     }
 }
 
+/// This structure checks whether a given image format is whitelisted to be used
+/// or not in the backend.
+///
+/// Unlike with Vulkan, OpenGL gives its users no easy way to query for valid
+/// image formats. Instead, it relies heavily on semantics, which are laid out
+/// in its specifications and function documentations.
+///
+/// This structure is intended to condense all of the supported formats into a
+/// single queryable location, acquired once when the adapter is created.
+#[derive(Debug)]
+pub struct TextureFormatFilter {
+    whitelist: HashSet<(u32, u32, u32)>
+}
+impl TextureFormatFilter {
+    /// This is the fixed, spec-defined list of all triplets in the form
+    /// `(Internal Format, Format, Type)` that are supported by OpenGL ES 3 and
+    /// WebGL for image creation via the `glTexImage` family of functions.
+    ///
+    /// Combinations of these parameters other than the ones in this table are
+    /// not supported by the core specifications. Though that does not mean they
+    /// can't be used or can't work under any circumstance. What it does mean is
+    /// that using anything outside this list is relying on permissive drivers
+    /// to not trigger undefined behavior.
+    ///
+    /// This is a one to one copy of the tables provided to us in
+    /// [the documentation of `glTexImage2D`], which is the same table as the
+    /// for `glTexImage3D`. The contents of the table are copied pretty much
+    /// verbatim in order to facilitate maintenance.
+    ///
+    /// [the documentation of `glTexImage2D`]: https://www.khronos.org/registry/OpenGL-Refpages/es3/html/glTexImage2D.xhtml
+    const ES3_TABLE: &'static [(u32, u32, u32)] = &[
+        /* Taken from Table 1. Unsized Internal Formats. */
+        (glow::RGB,             glow::RGB,             glow::UNSIGNED_BYTE),
+        (glow::RGB,             glow::RGB,             glow::UNSIGNED_SHORT_5_6_5),
+        (glow::RGBA,            glow::RGBA,            glow::UNSIGNED_BYTE),
+        (glow::RGBA,            glow::RGBA,            glow::UNSIGNED_SHORT_4_4_4_4),
+        (glow::RGBA,            glow::RGBA,            glow::UNSIGNED_SHORT_5_5_5_1),
+        (glow::LUMINANCE_ALPHA, glow::LUMINANCE_ALPHA, glow::UNSIGNED_BYTE),
+        (glow::LUMINANCE,       glow::LUMINANCE,       glow::UNSIGNED_BYTE),
+        (glow::ALPHA,           glow::ALPHA,           glow::UNSIGNED_BYTE),
+
+        /* Taken from Table 2. Sized Internal Formats. */
+        (glow::R8,             glow::RED,          glow::UNSIGNED_BYTE),
+        (glow::R8_SNORM,       glow::RED,          glow::BYTE),
+        (glow::R16F,           glow::RED,          glow::HALF_FLOAT),
+        (glow::R16F,           glow::RED,          glow::FLOAT),
+        (glow::R32F,           glow::RED,          glow::FLOAT),
+        (glow::R8UI,           glow::RED_INTEGER,  glow::UNSIGNED_BYTE),
+        (glow::R8I,            glow::RED_INTEGER,  glow::BYTE),
+        (glow::R16UI,          glow::RED_INTEGER,  glow::UNSIGNED_SHORT),
+        (glow::R16I,           glow::RED_INTEGER,  glow::SHORT),
+        (glow::R32UI,          glow::RED_INTEGER,  glow::UNSIGNED_INT),
+        (glow::R32I,           glow::RED_INTEGER,  glow::INT),
+        (glow::RG8,            glow::RG,           glow::UNSIGNED_BYTE),
+        (glow::RG8_SNORM,      glow::RG,           glow::BYTE),
+        (glow::RG16F,          glow::RG,           glow::HALF_FLOAT),
+        (glow::RG16F,          glow::RG,           glow::FLOAT),
+        (glow::RG32F,          glow::RG,           glow::FLOAT),
+        (glow::RG8UI,          glow::RG_INTEGER,   glow::UNSIGNED_BYTE),
+        (glow::RG8I,           glow::RG_INTEGER,   glow::BYTE),
+        (glow::RG16UI,         glow::RG_INTEGER,   glow::UNSIGNED_SHORT),
+        (glow::RG16I,          glow::RG_INTEGER,   glow::SHORT),
+        (glow::RG32UI,         glow::RG_INTEGER,   glow::UNSIGNED_INT),
+        (glow::RG32I,          glow::RG_INTEGER,   glow::INT),
+        (glow::RGB8,           glow::RGB,          glow::UNSIGNED_BYTE),
+        (glow::SRGB8,          glow::RGB,          glow::UNSIGNED_BYTE),
+        (glow::RGB565,         glow::RGB,          glow::UNSIGNED_BYTE),
+        (glow::RGB565,         glow::RGB,          glow::UNSIGNED_SHORT_5_6_5),
+        (glow::RGB8_SNORM,     glow::RGB,          glow::BYTE),
+        (glow::R11F_G11F_B10F, glow::RGB,          glow::UNSIGNED_INT_10F_11F_11F_REV),
+        (glow::R11F_G11F_B10F, glow::RGB,          glow::HALF_FLOAT),
+        (glow::R11F_G11F_B10F, glow::RGB,          glow::FLOAT),
+        (glow::RGB9_E5,        glow::RGB,          glow::UNSIGNED_INT_5_9_9_9_REV),
+        (glow::RGB9_E5,        glow::RGB,          glow::HALF_FLOAT),
+        (glow::RGB9_E5,        glow::RGB,          glow::FLOAT),
+        (glow::RGB16F,         glow::RGB,          glow::HALF_FLOAT),
+        (glow::RGB16F,         glow::RGB,          glow::FLOAT),
+        (glow::RGB32F,         glow::RGB,          glow::FLOAT),
+        (glow::RGB8UI,         glow::RGB_INTEGER,  glow::UNSIGNED_BYTE),
+        (glow::RGB8I,          glow::RGB_INTEGER,  glow::BYTE),
+        (glow::RGB16UI,        glow::RGB_INTEGER,  glow::UNSIGNED_SHORT),
+        (glow::RGB16I,         glow::RGB_INTEGER,  glow::SHORT),
+        (glow::RGB32UI,        glow::RGB_INTEGER,  glow::UNSIGNED_INT),
+        (glow::RGB32I,         glow::RGB_INTEGER,  glow::INT),
+        (glow::RGBA8,          glow::RGBA,         glow::UNSIGNED_BYTE),
+        (glow::SRGB8_ALPHA8,   glow::RGBA,         glow::UNSIGNED_BYTE),
+        (glow::RGBA8_SNORM,    glow::RGBA,         glow::BYTE),
+        (glow::RGB5_A1,        glow::RGBA,         glow::UNSIGNED_BYTE),
+        (glow::RGB5_A1,        glow::RGBA,         glow::UNSIGNED_SHORT_5_5_5_1),
+        (glow::RGB5_A1,        glow::RGBA,         glow::UNSIGNED_INT_2_10_10_10_REV),
+        (glow::RGBA4,          glow::RGBA,         glow::UNSIGNED_BYTE),
+        (glow::RGBA4,          glow::RGBA,         glow::UNSIGNED_SHORT_4_4_4_4),
+        (glow::RGB10_A2,       glow::RGBA,         glow::UNSIGNED_INT_2_10_10_10_REV),
+        (glow::RGBA16F,        glow::RGBA,         glow::HALF_FLOAT),
+        (glow::RGBA16F,        glow::RGBA,         glow::FLOAT),
+        (glow::RGBA32F,        glow::RGBA,         glow::FLOAT),
+        (glow::RGBA8UI,        glow::RGBA_INTEGER, glow::UNSIGNED_BYTE),
+        (glow::RGBA8I,         glow::RGBA_INTEGER, glow::BYTE),
+        (glow::RGB10_A2UI,     glow::RGBA_INTEGER, glow::UNSIGNED_INT_2_10_10_10_REV),
+        (glow::RGBA16UI,       glow::RGBA_INTEGER, glow::UNSIGNED_SHORT),
+        (glow::RGBA16I,        glow::RGBA_INTEGER, glow::SHORT),
+        (glow::RGBA32I,        glow::RGBA_INTEGER, glow::INT),
+        (glow::RGBA32UI,       glow::RGBA_INTEGER, glow::UNSIGNED_INT),
+
+        (glow::DEPTH_COMPONENT16,  glow::DEPTH_COMPONENT, glow::UNSIGNED_SHORT),
+        (glow::DEPTH_COMPONENT16,  glow::DEPTH_COMPONENT, glow::UNSIGNED_INT),
+        (glow::DEPTH_COMPONENT24,  glow::DEPTH_COMPONENT, glow::UNSIGNED_INT),
+        (glow::DEPTH_COMPONENT32F, glow::DEPTH_COMPONENT, glow::FLOAT),
+        (glow::DEPTH24_STENCIL8,   glow::DEPTH_STENCIL,   glow::UNSIGNED_INT_24_8),
+        (glow::DEPTH32F_STENCIL8,  glow::DEPTH_STENCIL,   glow::FLOAT_32_UNSIGNED_INT_24_8_REV),
+        (glow::STENCIL_INDEX8,     glow::STENCIL_INDEX,   glow::UNSIGNED_BYTE),
+    ];
+
+    /// Fixed list of format and type combinations supported by both OpenGL ES 1
+    /// and OpenGL ES 2. These values stayed the same between these two
+    /// versions, so we can just lump them together.
+    ///
+    /// This is a one to one copy of the tables provided to us in
+    /// [the documentation of `glTexImage2D`], which is the same table as the
+    /// for `glTexImage3D`. The contents of the table are copied pretty much
+    /// verbatim in order to facilitate maintenance.
+    ///
+    /// [the documentation of `glTexImage2D`]: https://khronos.org/registry/OpenGL-Refpages/es1.1/xhtml/
+    const ES1_ES2_TABLE: &'static [(u32, u32, u32)] = &[
+        (glow::ALPHA,           glow::ALPHA,           glow::UNSIGNED_BYTE),
+        (glow::RGB,             glow::RGB,             glow::UNSIGNED_BYTE),
+        (glow::RGB,             glow::RGB,             glow::UNSIGNED_SHORT_5_6_5),
+        (glow::RGBA,            glow::RGBA,            glow::UNSIGNED_BYTE),
+        (glow::RGBA,            glow::RGBA,            glow::UNSIGNED_SHORT_4_4_4_4),
+        (glow::RGBA,            glow::RGBA,            glow::UNSIGNED_SHORT_5_5_5_1),
+        (glow::LUMINANCE,       glow::LUMINANCE,       glow::UNSIGNED_BYTE),
+        (glow::LUMINANCE_ALPHA, glow::LUMINANCE_ALPHA, glow::UNSIGNED_BYTE)
+    ];
+
+    /// Creates a new filter for OpenGL ES 3.
+    fn new_es3() -> Self {
+        Self {
+            whitelist: {
+                let mut whitelist = HashSet::<(u32, u32, u32)>::default();
+                whitelist.extend(Self::ES3_TABLE);
+
+                whitelist
+            }
+        }
+    }
+
+    /// Creates a new filter for OpenGL ES 2 and OpenGL ES 1.
+    fn new_es1_es2() -> Self {
+        Self {
+            whitelist: {
+                let mut whitelist = HashSet::<(u32, u32, u32)>::default();
+                whitelist.extend(Self::ES1_ES2_TABLE);
+
+                whitelist
+            }
+        }
+    }
+
+    /// Creates a new, empty filter.
+    fn new() -> Self {
+        Self {
+            whitelist: Default::default()
+        }
+    }
+
+    /// This function checks whether a given format description is allowed by
+    /// this filter.
+    pub fn check(
+        &self,
+        internal_format: u32,
+        format: u32,
+        type_: u32) -> bool {
+
+        self.whitelist.contains(&(internal_format, format, type_))
+    }
+}
+
 /// Load the information pertaining to the driver and the corresponding device
 /// capabilities.
 pub(crate) fn query_all(
@@ -368,6 +545,7 @@ pub(crate) fn query_all(
     LegacyFeatures,
     PhysicalDeviceProperties,
     PrivateCaps,
+    TextureFormatFilter,
 ) {
     use self::Requirement::*;
     let info = Info::get(gl);
@@ -566,7 +744,20 @@ pub(crate) fn query_all(
         memory_barrier: info.is_supported(&[Core(4, 2), Es(3, 1)]),
     };
 
-    (info, features, legacy, properties, private)
+    let filter = if info.is_supported(&[Es(3, 0)]) {
+        /* Use the OpenGL ES 3 format filter. */
+        TextureFormatFilter::new_es3()
+    } else if info.is_supported(&[Es(1, 0)]) {
+        /* Use the OpenGL ES 1 and OpenGL ES 2 format filter. */
+        TextureFormatFilter::new_es1_es2()
+    } else {
+        /* We're using the core specification. We can assume all of the
+         * combinations are valid, provided the OpenGL enums values are also
+         * valid for textures. */
+        TextureFormatFilter::new()
+    };
+
+    (info, features, legacy, properties, private, filter)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## General
This commit adds a structure called `info::TextureFormatFilter` and changes the
code in `info::query_all` so that, when detecting OpenGL ES it can select a
set of valid texture property combinations.

This provides `PhysicalDevice::image_format_properties` with a way of more
accurately filtering out formats that aren't valid for textures and whose
use would lead to a crash.

Fixes #3683
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends:
1. OpenGL
2. Vulkan

## Remarks
One thing to keep in mind about this PR is that the current filter implementation overblocks formats. This is due to a limitation with the definition of `PhysicalDevice::image_format_properties`. Since the image creation function picks the underlying OpenGL function based on not just the format and usage, as `image_format_properties` assumes, but also based on the mipmap levels. There's no way for us to figure out for certain which function is gonna be picked for an image from `image_format_properties`. Thus, overblocking is the only viable solution I could think of that doesn't involve major changes to `image_format_properties`.

Other important thing to note is that this PR does not back port this change to `hal-0.7`, which I think is also important. I have already got that back port implemented in my own fork, but I'll leave it for another PR.