### PR TITLE
Add pso ShaderCreationError

### DIFF
--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -292,7 +292,10 @@ impl Device {
         if winerror::SUCCEEDED(hr) {
             Ok(unsafe { ComPtr::from_raw(vs) })
         } else {
-            Err(pso::CreationError::Other)
+            Err(pso::CreationError::ShaderCreationError(
+                pso::ShaderStageFlags::VERTEX,
+                String::from("Failed to create a vertex shader"),
+            ))
         }
     }
 
@@ -314,7 +317,10 @@ impl Device {
         if winerror::SUCCEEDED(hr) {
             Ok(unsafe { ComPtr::from_raw(ps) })
         } else {
-            Err(pso::CreationError::Other)
+            Err(pso::CreationError::ShaderCreationError(
+                pso::ShaderStageFlags::FRAGMENT,
+                String::from("Failed to create a pixel shader"),
+            ))
         }
     }
 
@@ -336,7 +342,10 @@ impl Device {
         if winerror::SUCCEEDED(hr) {
             Ok(unsafe { ComPtr::from_raw(gs) })
         } else {
-            Err(pso::CreationError::Other)
+            Err(pso::CreationError::ShaderCreationError(
+                pso::ShaderStageFlags::GEOMETRY,
+                String::from("Failed to create a geometry shader"),
+            ))
         }
     }
 
@@ -358,7 +367,10 @@ impl Device {
         if winerror::SUCCEEDED(hr) {
             Ok(unsafe { ComPtr::from_raw(hs) })
         } else {
-            Err(pso::CreationError::Other)
+            Err(pso::CreationError::ShaderCreationError(
+                pso::ShaderStageFlags::HULL,
+                String::from("Failed to create a hull shader"),
+            ))
         }
     }
 
@@ -380,7 +392,10 @@ impl Device {
         if winerror::SUCCEEDED(hr) {
             Ok(unsafe { ComPtr::from_raw(ds) })
         } else {
-            Err(pso::CreationError::Other)
+            Err(pso::CreationError::ShaderCreationError(
+                pso::ShaderStageFlags::DOMAIN,
+                String::from("Failed to create a domain shader"),
+            ))
         }
     }
 
@@ -402,7 +417,10 @@ impl Device {
         if winerror::SUCCEEDED(hr) {
             Ok(unsafe { ComPtr::from_raw(cs) })
         } else {
-            Err(pso::CreationError::Other)
+            Err(pso::CreationError::ShaderCreationError(
+                pso::ShaderStageFlags::COMPUTE,
+                String::from("Failed to create a compute shader"),
+            ))
         }
     }
 
@@ -415,10 +433,10 @@ impl Device {
     ) -> Result<Option<ComPtr<d3dcommon::ID3DBlob>>, pso::CreationError> {
         // TODO: entrypoint stuff
         match *source.module {
-            ShaderModule::Dxbc(ref _shader) => {
-                error!("DXBC modules are not supported yet");
-                Err(pso::CreationError::Other)
-            }
+            ShaderModule::Dxbc(ref _shader) => Err(pso::CreationError::ShaderCreationError(
+                pso::ShaderStageFlags::ALL,
+                String::from("DXBC modules are not supported yet"),
+            )),
             ShaderModule::Spirv(ref raw_data) => Ok(shader::compile_spirv_entrypoint(
                 raw_data, stage, source, layout, features,
             )?),

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -170,8 +170,8 @@ impl Device {
                 let shader = self
                     .compile_shader(point, stage, context.reborrow())
                     .map_err(|err| {
-                        error!("Compilation failed: {:?}", err);
-                        pso::CreationError::Other
+                        let error = format!("{} shader compilation failed: {:?}", err, stage);
+                        pso::CreationError::ShaderCreationError(stage.into(), error)
                     })?;
                 unsafe {
                     gl.attach_shader(program, shader);
@@ -217,8 +217,8 @@ impl Device {
         let linked_ok = unsafe { gl.get_program_link_status(program) };
         let log = unsafe { gl.get_program_info_log(program) };
         if !linked_ok {
-            error!("\tLog: {}", log);
-            return Err(pso::CreationError::Other);
+            let error = format!("Program {:?} linking error:{}", program, log);
+            return Err(pso::CreationError::ShaderCreationError(pso::ShaderStageFlags::GRAPHICS, error));
         }
         if !log.is_empty() {
             warn!("\tLog: {}", log);

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -811,8 +811,8 @@ impl Device {
                     }
                 }
                 info_owned = result.map_err(|e| {
-                    error!("Error compiling the shader {:?}", e);
-                    pso::CreationError::Other
+                    let error = format!("Error compiling the shader {:?}", e);
+                    pso::CreationError::ShaderCreationError(stage.into(), error)
                 })?;
                 &info_owned
             }
@@ -847,8 +847,8 @@ impl Device {
             self.shared.private_caps.function_specialization,
         )
         .map_err(|e| {
-            error!("Invalid shader entry point '{}': {:?}", name, e);
-            pso::CreationError::Other
+            let error = format!("Invalid shader entry point '{}': {:?}", name, e);
+            pso::CreationError::ShaderCreationError(stage.into(), error)
         })?;
 
         Ok((lib, mtl_function, wg_size, info.rasterization_enabled))

--- a/src/hal/src/pso/mod.rs
+++ b/src/hal/src/pso/mod.rs
@@ -21,6 +21,9 @@ pub enum CreationError {
     /// Unknown other error.
     #[error("Implementation specific error occurred")]
     Other,
+    /// Shader module creation error.
+    #[error("{0:?} shader creation failed: {1:}")]
+    ShaderCreationError(ShaderStageFlags, String),
     /// Unsupported pipeline on hardware or implementation. Example: mesh shaders on DirectX 11.
     #[error("Pipeline kind is not supported")]
     UnsupportedPipeline,


### PR DESCRIPTION
As discussed in the matrix. Add new pso creation error - ShaderCreationError.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: GL (CI should check all other errors)
