### PR TITLE
[vk] Don't advertise `format::ImageFeature::SAMPLED_MINMAX` if the device does not support it.

### DIFF
--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -382,6 +382,7 @@ pub fn map_query_result_flags(flags: query::ResultFlags) -> vk::QueryResultFlags
 pub fn map_image_features(
     features: vk::FormatFeatureFlags,
     supports_transfer_bits: bool,
+    supports_sampler_filter_minmax: bool,
 ) -> format::ImageFeature {
     let mut mapped_flags = format::ImageFeature::empty();
     if features.contains(vk::FormatFeatureFlags::SAMPLED_IMAGE) {
@@ -390,7 +391,9 @@ pub fn map_image_features(
     if features.contains(vk::FormatFeatureFlags::SAMPLED_IMAGE_FILTER_LINEAR) {
         mapped_flags |= format::ImageFeature::SAMPLED_LINEAR;
     }
-    if features.contains(vk::FormatFeatureFlags::SAMPLED_IMAGE_FILTER_MINMAX) {
+    if supports_sampler_filter_minmax
+        && features.contains(vk::FormatFeatureFlags::SAMPLED_IMAGE_FILTER_MINMAX)
+    {
         mapped_flags |= format::ImageFeature::SAMPLED_MINMAX;
     }
 

--- a/src/backend/vulkan/src/physical_device.rs
+++ b/src/backend/vulkan/src/physical_device.rs
@@ -937,14 +937,24 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             .device_info
             .supports_extension(vk::KhrMaintenance1Fn::name());
 
+        let supports_sampler_filter_minmax = self
+            .device_info
+            .supports_extension(vk::ExtSamplerFilterMinmaxFn::name())
+            || self
+                .device_features
+                .vulkan_1_2
+                .map_or(false, |features| features.sampler_filter_minmax == vk::TRUE);
+
         format::Properties {
             linear_tiling: conv::map_image_features(
                 properties.linear_tiling_features,
                 supports_transfer_bits,
+                supports_sampler_filter_minmax,
             ),
             optimal_tiling: conv::map_image_features(
                 properties.optimal_tiling_features,
                 supports_transfer_bits,
+                supports_sampler_filter_minmax,
             ),
             buffer_features: conv::map_buffer_features(properties.buffer_features),
         }


### PR DESCRIPTION
Follow-up to #3677
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
