### PR TITLE
Update naga to gfx-18

### DIFF
--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -47,7 +47,7 @@ optional = true
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-17"
+tag = "gfx-18"
 features = ["spv-in", "glsl-out"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -53,7 +53,7 @@ optional = true
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-17"
+tag = "gfx-18"
 features = ["spv-in", "msl-out"]
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -33,7 +33,7 @@ inplace_it = "0.3.3"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-17"
+tag = "gfx-18"
 features = ["spv-out"]
 optional = true
 

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -963,7 +963,7 @@ impl d::Device<B> for super::Device {
         &self,
         shader: d::NagaShader,
     ) -> Result<n::ShaderModule, (d::ShaderError, d::NagaShader)> {
-        match naga::back::spv::write_vec(&shader.module, &shader.analysis, &self.naga_options) {
+        match naga::back::spv::write_vec(&shader.module, &shader.info, &self.naga_options) {
             Ok(spv) => self.create_shader_module(&spv).map_err(|e| (e, shader)),
             Err(e) => return Err((d::ShaderError::CompilationFailed(format!("{}", e)), shader)),
         }

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.0"
-naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-17" }
+naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-18" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -163,8 +163,8 @@ pub enum ShaderModuleDesc<'a> {
 pub struct NagaShader {
     /// Shader module IR.
     pub module: naga::Module,
-    /// Analysis of the module.
-    pub analysis: naga::proc::analyzer::Analysis,
+    /// Analysis information of the module.
+    pub info: naga::valid::ModuleInfo,
 }
 
 /// Logical device handle, responsible for creating and managing resources


### PR DESCRIPTION
When trying to update my dev environment to the latest `naga`, I saw that api changes a little bit. This PR update to latest available naga (a0b5717fed0bd1c8536fb2204f308d6db39d295f)

Hope this will be helpful 😄 

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: OpenGL
