### PR TITLE
[WebGL] Return only RGBA swapchain formats

### DIFF
--- a/src/backend/gl/src/window/web.rs
+++ b/src/backend/gl/src/window/web.rs
@@ -111,7 +111,7 @@ pub struct Surface {
 
 impl Surface {
     fn swapchain_formats(&self) -> Vec<f::Format> {
-        vec![f::Format::Rgba8Unorm, f::Format::Bgra8Unorm]
+        vec![f::Format::Rgba8Srgb, f::Format::Rgba8Unorm]
     }
 
     pub(crate) unsafe fn present(


### PR DESCRIPTION
WebGL doesn't supports BGRA texture formats

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: WebGL
