### PR TITLE
Use Binary Archives as a pipeline cache on the metal backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ members = [
 ]
 
 [patch."https://github.com/gfx-rs/naga"]
-naga = { git = "https://github.com/expenses/naga", branch = "impl-hash-for-msl-options" }
+#naga = { path = "../naga" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ members = [
 ]
 
 [patch."https://github.com/gfx-rs/naga"]
-naga = { path = "../naga" }
+naga = { git = "https://github.com/expenses/naga", branch = "impl-hash-for-msl-options" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [patch."https://github.com/gfx-rs/naga"]
-naga = { path = "../naga" }
+naga = { git = "https://github.com/expenses/naga", branch = "metal-serialize-entry-point-error-gfx-20" }
 
 [patch."crates-io"]
-spirv_cross = { path = "../spirv_cross/spirv_cross" }
+spirv_cross = { git = "https://github.com/expenses/spirv_cross", branch = "serialize-feature" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,7 @@ members = [
 ]
 
 [patch."https://github.com/gfx-rs/naga"]
-#naga = { path = "../naga" }
+naga = { path = "../naga" }
+
+[patch."crates-io"]
+spirv_cross = { path = "../spirv_cross/spirv_cross" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ members = [
 ]
 
 [patch."https://github.com/gfx-rs/naga"]
-#naga = { path = "../naga" }
+naga = { path = "../naga" }

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -708,7 +708,9 @@ where
             cmd_buffers.push(unsafe { cmd_pools[i].allocate_one(command::Level::Primary) });
         }
 
-        let previous_pipeline_cache_data = std::fs::read("quad_pipeline_cache");
+        let pipeline_cache_path = "quad_pipeline_cache";
+
+        let previous_pipeline_cache_data = std::fs::read(pipeline_cache_path);
 
         if let Err(error) = previous_pipeline_cache_data.as_ref() {
             println!("Error loading the previous pipeline cache data: {}", error);
@@ -814,14 +816,6 @@ where
                 unsafe { device.create_graphics_pipeline(&pipeline_desc, Some(&pipeline_cache)) }
             };
 
-            let data = unsafe { device.get_pipeline_cache_data(&pipeline_cache).unwrap() };
-
-            std::fs::write("quad_pipeline_cache", &data).unwrap();
-            println!(
-                "Wrote the pipeline cache to quad_pipeline_cache ({} bytes)",
-                data.len()
-            );
-
             unsafe {
                 device.destroy_shader_module(vs_module);
             }
@@ -831,6 +825,16 @@ where
 
             ManuallyDrop::new(pipeline.unwrap())
         };
+
+        let pipeline_cache_data =
+            unsafe { device.get_pipeline_cache_data(&pipeline_cache).unwrap() };
+
+        std::fs::write(pipeline_cache_path, &pipeline_cache_data).unwrap();
+        println!(
+            "Wrote the pipeline cache to {} ({} bytes)",
+            pipeline_cache_path,
+            pipeline_cache_data.len()
+        );
 
         // Rendering setup
         let viewport = pso::Viewport {

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -830,7 +830,7 @@ where
             unsafe { device.get_pipeline_cache_data(&pipeline_cache).unwrap() };
 
         std::fs::write(pipeline_cache_path, &pipeline_cache_data).unwrap();
-        println!(
+        log::info!(
             "Wrote the pipeline cache to {} ({} bytes)",
             pipeline_cache_path,
             pipeline_cache_data.len()

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -47,7 +47,7 @@ optional = true
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-21"
+# tag = "gfx-21"
 features = ["spv-in", "glsl-out"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -47,7 +47,7 @@ optional = true
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-# tag = "gfx-21"
+tag = "gfx-22"
 features = ["spv-in", "glsl-out"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -15,7 +15,8 @@ edition = "2018"
 [features]
 default = []
 signpost = []
-cross = ["spirv_cross", "auxil", "naga/spv-out"]
+cross = ["spirv_cross", "auxil", "naga/spv-out", "serde-cache"]
+serde-cache = ["serde", "naga/serialize", "naga/deserialize", "bincode"]
 
 [lib]
 name = "gfx_backend_metal"
@@ -38,6 +39,8 @@ parking_lot = "0.11"
 storage-map = "0.3"
 raw-window-handle = "0.3"
 tempfile = "3.2"
+serde = { version = "1", features = ["serde_derive"], optional = true }
+bincode = { version = "1", optional = true }
 
 [dependencies.auxil]
 package = "gfx-auxil"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -15,8 +15,7 @@ edition = "2018"
 [features]
 default = []
 signpost = []
-cross = ["spirv_cross", "auxil", "naga/spv-out", "serde-cache"]
-serde-cache = ["naga/serialize", "naga/deserialize"]
+cross = ["spirv_cross", "auxil"]
 
 [lib]
 name = "gfx_backend_metal"
@@ -56,7 +55,7 @@ optional = true
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-features = ["spv-in", "msl-out"]
+features = ["spv-in", "msl-out", "spv-out", "serialize", "deserialize"]
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 default = []
 signpost = []
 cross = ["spirv_cross", "auxil", "naga/spv-out", "serde-cache"]
-serde-cache = ["serde", "naga/serialize", "naga/deserialize", "bincode", "spirv_cross/serialize"]
+serde-cache = ["naga/serialize", "naga/deserialize", "spirv_cross/serialize"]
 
 [lib]
 name = "gfx_backend_metal"
@@ -30,7 +30,7 @@ copyless = "0.1.4"
 fxhash = "0.2.1"
 log = { version = "0.4" }
 dispatch = { version = "0.2", optional = true }
-metal = { git = "https://github.com/expenses/metal-rs", branch="binary-archive", features = ["private"] }
+metal = { git = "https://github.com/gfx-rs/metal-rs", rev="78f632d194c7c16d18b71d7373c4080847d110b0", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"
@@ -39,8 +39,8 @@ parking_lot = "0.11"
 storage-map = "0.3"
 raw-window-handle = "0.3"
 tempfile = "3.2"
-serde = { version = "1", features = ["serde_derive"], optional = true }
-bincode = { version = "1", optional = true }
+serde = { version = "1", features = ["serde_derive"] }
+bincode = "1"
 
 [dependencies.auxil]
 package = "gfx-auxil"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -57,7 +57,7 @@ optional = true
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-# tag = "gfx-21"
+tag = "gfx-22"
 features = ["spv-in", "msl-out"]
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -56,7 +56,7 @@ optional = true
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-21"
+# tag = "gfx-21"
 features = ["spv-in", "msl-out"]
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 default = []
 signpost = []
 cross = ["spirv_cross", "auxil", "naga/spv-out", "serde-cache"]
-serde-cache = ["serde", "naga/serialize", "naga/deserialize", "bincode"]
+serde-cache = ["serde", "naga/serialize", "naga/deserialize", "bincode", "spirv_cross/serialize"]
 
 [lib]
 name = "gfx_backend_metal"

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -15,7 +15,8 @@ edition = "2018"
 [features]
 default = []
 signpost = []
-cross = ["spirv_cross", "auxil"]
+cross = ["spirv_cross", "auxil", "naga/spv-out"]
+pipeline-cache = ["tempfile", "serde", "bincode", "naga/serialize", "naga/deserialize", "naga/spv-out"]
 
 [lib]
 name = "gfx_backend_metal"
@@ -37,9 +38,9 @@ cocoa-foundation = "0.1"
 parking_lot = "0.11"
 storage-map = "0.3"
 raw-window-handle = "0.3"
-tempfile = "3.2"
-serde = { version = "1", features = ["serde_derive"] }
-bincode = "1"
+tempfile = { version = "3.2", optional = true }
+serde = { version = "1", features = ["serde_derive"], optional = true }
+bincode = { version = "1", optional = true }
 
 [dependencies.auxil]
 package = "gfx-auxil"
@@ -56,7 +57,7 @@ optional = true
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
 tag = "gfx-21"
-features = ["spv-in", "msl-out", "spv-out", "serialize", "deserialize"]
+features = ["spv-in", "msl-out"]
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -55,6 +55,7 @@ optional = true
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
+tag = "gfx-21"
 features = ["spv-in", "msl-out", "spv-out", "serialize", "deserialize"]
 
 # This forces docs.rs to build the crate on mac, otherwise the build fails

--- a/src/backend/metal/Cargo.toml
+++ b/src/backend/metal/Cargo.toml
@@ -29,7 +29,7 @@ copyless = "0.1.4"
 fxhash = "0.2.1"
 log = { version = "0.4" }
 dispatch = { version = "0.2", optional = true }
-metal = { git = "https://github.com/gfx-rs/metal-rs", rev="439c986eb7a9b91e88b61def2daa66e4043fcbef", features = ["private"] }
+metal = { git = "https://github.com/expenses/metal-rs", branch="binary-archive", features = ["private"] }
 foreign-types = "0.3"
 objc = "0.2.5"
 block = "0.1"
@@ -37,6 +37,7 @@ cocoa-foundation = "0.1"
 parking_lot = "0.11"
 storage-map = "0.3"
 raw-window-handle = "0.3"
+tempfile = "3.2"
 
 [dependencies.auxil]
 package = "gfx-auxil"

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1479,16 +1479,15 @@ impl hal::device::Device<Backend> for Device {
         //drop
     }
 
-    #[cfg_attr(not(feature = "cross"), allow(unused_variables))]
     unsafe fn merge_pipeline_caches<'a, I>(
         &self,
-        target: &mut n::PipelineCache,
-        sources: I,
+        _target: &mut n::PipelineCache,
+        _sources: I,
     ) -> Result<(), d::OutOfMemory>
     where
         I: Iterator<Item = &'a n::PipelineCache>,
     {
-        // todo: not possible with the metal api, but we could store a vec of pipeline caches perhaps? That would make serializing harder.
+        warn!("`merge_pipeline_caches` is not currently implemented on the Metal backend.");
         Ok(())
     }
 

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -1420,7 +1420,7 @@ impl hal::device::Device<Backend> for Device {
 
         // We need to keep the temp file alive so that it doesn't get deleted until after a
         // binary archive has been created.
-        let _temp_file = if let Some(data) = data {
+        let _temp_file = if let Some(data) = data.filter(|data| !data.is_empty()) {
             // It would be nice to use a `data:text/plain;base64` url here and just pass in a
             // base64-encoded version of the data, but metal validation doesn't like that:
             // -[MTLDebugDevice newBinaryArchiveWithDescriptor:error:]:1046: failed assertion `url, if not nil, must be a file URL.'

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -69,6 +69,7 @@ use cocoa_foundation::foundation::NSInteger;
 use dispatch;
 use foreign_types::ForeignTypeRef;
 use metal::MTLFeatureSet;
+use metal::MTLGPUFamily;
 use metal::MTLLanguageVersion;
 use metal::{CGFloat, CGSize, MetalLayer, MetalLayerRef};
 use objc::{
@@ -746,6 +747,7 @@ struct PrivateCapabilities {
     max_total_threadgroup_memory: u32,
     sample_count_mask: u8,
     supports_debug_markers: bool,
+    supports_binary_archives: bool,
 }
 
 impl PrivateCapabilities {
@@ -1042,6 +1044,8 @@ impl PrivateCapabilities {
                     MTLFeatureSet::tvOS_GPUFamily2_v1,
                 ],
             ),
+            supports_binary_archives: device.supports_family(MTLGPUFamily::Apple3)
+                || device.supports_family(MTLGPUFamily::Mac1),
         }
     }
 

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -92,6 +92,8 @@ mod conversions;
 mod device;
 mod internal;
 mod native;
+#[cfg(feature = "pipeline-cache")]
+mod pipeline_cache;
 mod soft;
 mod window;
 

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -28,7 +28,10 @@ use std::{
 };
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "pipeline-cache", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "pipeline-cache",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct EntryPoint {
     pub internal_name: Result<String, naga::back::msl::EntryPointError>,
     pub work_group_size: [u32; 3],
@@ -220,7 +223,10 @@ unsafe impl Send for BinaryArchive {}
 unsafe impl Sync for BinaryArchive {}
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "pipeline-cache", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "pipeline-cache",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct SerializableModuleInfo {
     pub source: String,
     pub entry_point_map: EntryPointMap,

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -267,6 +267,13 @@ pub(crate) fn serialize_spv_to_msl_cache(cache: &SpvToMsl) -> SerializableSpvToM
         .collect()
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct SerializablePipelineCache<'a> {
+    pub(crate) binary_archive: &'a [u8],
+    #[cfg(feature = "cross")]
+    pub(crate) spirv_cross_spv_to_msl: SerializableSpvToMsl,
+}
+
 pub struct PipelineCache {
     pub(crate) binary_archive: Option<BinaryArchive>,
     #[cfg(feature = "cross")]

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -219,23 +219,16 @@ pub struct SerializableModuleInfo {
     pub rasterization_enabled: bool,
 }
 
-pub(crate) type SpvToMsl = FastStorageMap<
-    (
-        naga::back::msl::Options,
-        naga::back::msl::PipelineOptions,
-        u64,
-    ),
-    SerializableModuleInfo,
->;
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SpvToMslKey {
+    pub(crate) options: naga::back::msl::Options,
+    pub(crate) pipeline_options: naga::back::msl::PipelineOptions,
+    pub(crate) spv_hash: u64,
+}
 
-pub(crate) type SerializableSpvToMsl = Vec<(
-    (
-        naga::back::msl::Options,
-        naga::back::msl::PipelineOptions,
-        u64,
-    ),
-    SerializableModuleInfo,
-)>;
+pub(crate) type SpvToMsl = FastStorageMap<SpvToMslKey, SerializableModuleInfo>;
+
+pub(crate) type SerializableSpvToMsl = Vec<(SpvToMslKey, SerializableModuleInfo)>;
 
 pub(crate) fn load_spv_to_msl_cache(serializable: SerializableSpvToMsl) -> SpvToMsl {
     let cache = FastStorageMap::default();
@@ -269,6 +262,12 @@ impl fmt::Debug for PipelineCache {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "PipelineCache")
     }
+}
+
+pub(crate) fn pipeline_cache_to_binary_archive(
+    pipeline_cache: Option<&PipelineCache>,
+) -> Option<&BinaryArchive> {
+    pipeline_cache.and_then(|cache| cache.binary_archive.as_ref())
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -202,15 +202,15 @@ pub struct ModuleInfo {
     pub rasterization_enabled: bool,
 }
 
-pub(crate) struct PipelineCacheInner {
-    pub(crate) binary_archive: metal::BinaryArchive,
+pub(crate) struct BinaryArchive {
+    pub(crate) inner: metal::BinaryArchive,
     pub(crate) is_empty: bool,
 }
 
-unsafe impl Send for PipelineCacheInner {}
+unsafe impl Send for BinaryArchive {}
 
 pub struct PipelineCache {
-    pub(crate) inner: Mutex<PipelineCacheInner>,
+    pub(crate) binary_archive: Option<Mutex<BinaryArchive>>,
 }
 
 impl fmt::Debug for PipelineCache {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "cross")]
+use crate::internal::FastStorageMap;
 use crate::{
     internal::Channel, Backend, BufferPtr, FastHashMap, ResourceIndex, SamplerPtr, TexturePtr,
     MAX_COLOR_ATTACHMENTS,
@@ -26,6 +28,7 @@ use std::{
 };
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde-cache", derive(serde::Serialize, serde::Deserialize))]
 pub struct EntryPoint {
     pub internal_name: Result<String, naga::back::msl::EntryPointError>,
     pub work_group_size: [u32; 3],
@@ -210,8 +213,64 @@ pub(crate) struct BinaryArchive {
 unsafe impl Send for BinaryArchive {}
 unsafe impl Sync for BinaryArchive {}
 
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde-cache", derive(serde::Serialize, serde::Deserialize))]
+pub struct SerializableModuleInfo {
+    pub shader_code: String,
+    pub entry_point_map: EntryPointMap,
+    pub rasterization_enabled: bool,
+}
+
+#[cfg(feature = "cross")]
+pub(crate) type SpvToMsl = FastStorageMap<
+    spirv_cross::msl::CompilerOptions,
+    FastStorageMap<Vec<u32>, SerializableModuleInfo>,
+>;
+
+#[cfg(feature = "cross")]
+pub(crate) type SerializableSpvToMsl = Vec<(
+    spirv_cross::msl::CompilerOptions,
+    Vec<(Vec<u32>, SerializableModuleInfo)>,
+)>;
+
+#[cfg(feature = "cross")]
+pub(crate) fn load_spv_to_msl_cache(serializable: SerializableSpvToMsl) -> SpvToMsl {
+    let cache = FastStorageMap::default();
+    for (options, values) in serializable.into_iter() {
+        cache.get_or_create_with(&options, || {
+            let inner_cache = FastStorageMap::default();
+            for (spv, msl) in values {
+                inner_cache.get_or_create_with(&spv, || msl);
+            }
+            inner_cache
+        });
+    }
+
+    cache
+}
+
+#[cfg(feature = "cross")]
+pub(crate) fn serialize_spv_to_msl_cache(cache: &SpvToMsl) -> SerializableSpvToMsl {
+    cache
+        .whole_write()
+        .iter()
+        .map(|(options, values)| {
+            (
+                options.clone(),
+                values
+                    .whole_write()
+                    .iter()
+                    .map(|(spv, msl)| (spv.clone(), msl.clone()))
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect()
+}
+
 pub struct PipelineCache {
     pub(crate) binary_archive: Option<BinaryArchive>,
+    #[cfg(feature = "cross")]
+    pub(crate) spirv_cross_spv_to_msl: SpvToMsl,
 }
 
 impl fmt::Debug for PipelineCache {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "cross")]
-use crate::internal::FastStorageMap;
 use crate::{
     internal::Channel, Backend, BufferPtr, FastHashMap, ResourceIndex, SamplerPtr, TexturePtr,
     MAX_COLOR_ATTACHMENTS,
@@ -17,7 +15,7 @@ use range_alloc::RangeAllocator;
 
 use arrayvec::ArrayVec;
 use metal;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 
 use std::{
     fmt,
@@ -204,10 +202,15 @@ pub struct ModuleInfo {
     pub rasterization_enabled: bool,
 }
 
+pub(crate) struct PipelineCacheInner {
+    pub(crate) binary_archive: metal::BinaryArchive,
+    pub(crate) is_empty: bool,
+}
+
+unsafe impl Send for PipelineCacheInner {}
+
 pub struct PipelineCache {
-    #[cfg(feature = "cross")] //TODO: Naga path
-    pub(crate) modules:
-        FastStorageMap<spirv_cross::msl::CompilerOptions, FastStorageMap<Vec<u32>, ModuleInfo>>,
+    pub(crate) inner: Mutex<PipelineCacheInner>,
 }
 
 impl fmt::Debug for PipelineCache {

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -15,7 +15,7 @@ use range_alloc::RangeAllocator;
 
 use arrayvec::ArrayVec;
 use metal;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 
 use std::{
     fmt,
@@ -204,13 +204,14 @@ pub struct ModuleInfo {
 
 pub(crate) struct BinaryArchive {
     pub(crate) inner: metal::BinaryArchive,
-    pub(crate) is_empty: bool,
+    pub(crate) is_empty: AtomicBool,
 }
 
 unsafe impl Send for BinaryArchive {}
+unsafe impl Sync for BinaryArchive {}
 
 pub struct PipelineCache {
-    pub(crate) binary_archive: Option<Mutex<BinaryArchive>>,
+    pub(crate) binary_archive: Option<BinaryArchive>,
 }
 
 impl fmt::Debug for PipelineCache {

--- a/src/backend/metal/src/pipeline_cache.rs
+++ b/src/backend/metal/src/pipeline_cache.rs
@@ -1,0 +1,64 @@
+use crate::internal::FastStorageMap;
+use crate::native::SerializableModuleInfo;
+use std::fmt;
+use std::sync::atomic::AtomicBool;
+
+pub(crate) struct BinaryArchive {
+    pub(crate) inner: metal::BinaryArchive,
+    pub(crate) is_empty: AtomicBool,
+}
+
+unsafe impl Send for BinaryArchive {}
+
+unsafe impl Sync for BinaryArchive {}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SpvToMslKey {
+    pub(crate) options: naga::back::msl::Options,
+    pub(crate) pipeline_options: naga::back::msl::PipelineOptions,
+    pub(crate) spv_hash: u64,
+}
+
+pub(crate) type SpvToMsl = FastStorageMap<SpvToMslKey, SerializableModuleInfo>;
+
+pub(crate) type SerializableSpvToMsl = Vec<(SpvToMslKey, SerializableModuleInfo)>;
+
+pub(crate) fn load_spv_to_msl_cache(serializable: SerializableSpvToMsl) -> SpvToMsl {
+    let cache = FastStorageMap::default();
+    for (options, values) in serializable.into_iter() {
+        cache.get_or_create_with(&options, || values);
+    }
+
+    cache
+}
+
+pub(crate) fn serialize_spv_to_msl_cache(cache: &SpvToMsl) -> SerializableSpvToMsl {
+    cache
+        .whole_write()
+        .iter()
+        .map(|(options, values)| (options.clone(), values.clone()))
+        .collect()
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct SerializablePipelineCache<'a> {
+    pub(crate) binary_archive: &'a [u8],
+    pub(crate) spv_to_msl: SerializableSpvToMsl,
+}
+
+pub struct PipelineCache {
+    pub(crate) binary_archive: Option<BinaryArchive>,
+    pub(crate) spv_to_msl: SpvToMsl,
+}
+
+impl fmt::Debug for PipelineCache {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "PipelineCache")
+    }
+}
+
+pub(crate) fn pipeline_cache_to_binary_archive(
+    pipeline_cache: Option<&PipelineCache>,
+) -> Option<&BinaryArchive> {
+    pipeline_cache.and_then(|cache| cache.binary_archive.as_ref())
+}

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -33,7 +33,7 @@ inplace_it = "0.3.3"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-tag = "gfx-21"
+# tag = "gfx-21"
 features = ["spv-out"]
 optional = true
 

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -33,7 +33,7 @@ inplace_it = "0.3.3"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"
-# tag = "gfx-21"
+tag = "gfx-22"
 features = ["spv-out"]
 optional = true
 

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.0"
-naga = { git = "https://github.com/gfx-rs/naga" }
+naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-21" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.0"
-naga = { git = "https://github.com/gfx-rs/naga" }
+naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-22" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"

--- a/src/hal/Cargo.toml
+++ b/src/hal/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitflags = "1.0"
-naga = { git = "https://github.com/gfx-rs/naga", tag = "gfx-21" }
+naga = { git = "https://github.com/gfx-rs/naga" }
 raw-window-handle = "0.3"
 serde = { version = "1", features = ["serde_derive"], optional = true }
 thiserror = "1"


### PR DESCRIPTION
See #3716. This PR builds on-top of https://github.com/gfx-rs/metal-rs/pull/207 to add an implementation of `get_pipeline_cache_data` for the metal backend. This PR is not ready for reviews.

Todo:

- [x] Get rid of the Mutex around the pipeline cache and replace `is_empty` with an `AtomicBool`, as `unsafe impl Sync` is probably fine for the binary archive.
- [x] Check the availability of binary archives on the target with `device.supports_binary_archive()`.
- [x] Potentially use a second cache to store SPIR-V -> MSL transformations.
- [x] Come up with a test suite to test pipeline caches. Something with hundreds/thousands of pipelines (maybe using shaders from shadertoy?) would be nice.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: `metal`
