### PR TITLE
max_value() is being deprecated, use ::MAX instead

### DIFF
--- a/src/auxil/auxil/src/lib.rs
+++ b/src/auxil/auxil/src/lib.rs
@@ -65,7 +65,7 @@ pub fn read_spirv<R: io::Read + io::Seek>(mut x: R) -> io::Result<Vec<u32>> {
             "input length not divisible by 4",
         ));
     }
-    if size > usize::max_value() as u64 {
+    if size > usize::MAX as u64 {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "input too long"));
     }
     let words = (size / 4) as usize;

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -2191,7 +2191,7 @@ impl d::Device<B> for Device {
             },
             SampleMask: match desc.multisampling {
                 Some(ref ms) => ms.sample_mask as u32,
-                None => UINT::max_value(),
+                None => UINT::MAX,
             },
             RasterizerState: conv::map_rasterizer(&desc.rasterizer, desc.multisampling.is_some()),
             DepthStencilState: conv::map_depth_stencil(&desc.depth_stencil),
@@ -3374,8 +3374,8 @@ impl d::Device<B> for Device {
             // This block handles overflow when converting to u32 and always rounds up
             // The Vulkan specification allows to wait more than specified
             let timeout_ms = {
-                if timeout_ns > (<u32>::max_value() as u64) * 1_000_000 {
-                    <u32>::max_value()
+                if timeout_ns > (<u32>::MAX as u64) * 1_000_000 {
+                    <u32>::MAX
                 } else {
                     ((timeout_ns + 999_999) / 1_000_000) as u32
                 }

--- a/src/hal/src/pso/specialization.rs
+++ b/src/hal/src/pso/specialization.rs
@@ -92,7 +92,7 @@ where
 {
     fn fold(self, storage: &mut SpecializationStorage) {
         let size = std::mem::size_of::<H>();
-        assert!(storage.data.len() + size <= u16::max_value() as usize);
+        assert!(storage.data.len() + size <= u16::MAX as usize);
         let offset = storage.data.len() as u16;
         storage.data.extend_from_slice(unsafe {
             // Inspecting bytes is always safe.


### PR DESCRIPTION
https://doc.rust-lang.org/std/primitive.u16.html#method.max_value
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: DX12
