### PR TITLE
List all features in colour-uniform error message

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1578,6 +1578,7 @@ fn main() {
 )))]
 fn main() {
     println!(
-        "You need to enable the native API feature (vulkan/metal) in order to run the example"
+        "You need to enable the native API feature (vulkan/metal/dx11/dx12/gl) in order to run \
+        the example"
     );
 }


### PR DESCRIPTION
Ran into this when I forgot to add `--features dx12` to the colour-uniform example
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
