### PR TITLE
Add image usage parameter to the view creation

### DIFF
--- a/examples/colour-uniform/main.rs
+++ b/examples/colour-uniform/main.rs
@@ -1063,6 +1063,7 @@ impl<B: Backend> ImageState<B> {
                 i::ViewKind::D2,
                 ColorFormat::SELF,
                 f::Swizzle::NO,
+                i::Usage::SAMPLED,
                 i::SubresourceRange {
                     aspects: f::Aspects::COLOR,
                     ..Default::default()

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -488,6 +488,7 @@ where
                     i::ViewKind::D2,
                     ColorFormat::SELF,
                     Swizzle::NO,
+                    i::Usage::SAMPLED,
                     i::SubresourceRange {
                         aspects: f::Aspects::COLOR,
                         ..Default::default()

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -1794,6 +1794,7 @@ impl device::Device<Backend> for Device {
         view_kind: image::ViewKind,
         format: format::Format,
         _swizzle: format::Swizzle,
+        usage: image::Usage,
         range: image::SubresourceRange,
     ) -> Result<ImageView, image::ViewCreationError> {
         let is_array = image.kind.num_layers() > 1;
@@ -1831,7 +1832,7 @@ impl device::Device<Backend> for Device {
                 range.level_start as _,
             ),
             format,
-            srv_handle: if image.usage.intersects(image::Usage::SAMPLED) {
+            srv_handle: if usage.intersects(image::Usage::SAMPLED) {
                 let srv = self.view_image_as_shader_resource(&srv_info)?;
 
                 if let Some(ref mut name) = debug_name {
@@ -1842,7 +1843,7 @@ impl device::Device<Backend> for Device {
             } else {
                 None
             },
-            rtv_handle: if image.usage.contains(image::Usage::COLOR_ATTACHMENT) {
+            rtv_handle: if usage.contains(image::Usage::COLOR_ATTACHMENT) {
                 let rtv = self.view_image_as_render_target(&info)?;
 
                 if let Some(ref mut name) = debug_name {
@@ -1853,7 +1854,7 @@ impl device::Device<Backend> for Device {
             } else {
                 None
             },
-            uav_handle: if image.usage.contains(image::Usage::STORAGE) {
+            uav_handle: if usage.contains(image::Usage::STORAGE) {
                 let uav = self.view_image_as_unordered_access(&info)?;
 
                 if let Some(ref mut name) = debug_name {
@@ -1864,7 +1865,7 @@ impl device::Device<Backend> for Device {
             } else {
                 None
             },
-            dsv_handle: if image.usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT) {
+            dsv_handle: if usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT) {
                 if let Some(dsv) = self.view_image_as_depth_stencil(&info, None).ok() {
                     if let Some(ref mut name) = debug_name {
                         set_debug_name_with_suffix(&dsv, name, " -- DSV");
@@ -1877,7 +1878,7 @@ impl device::Device<Backend> for Device {
             } else {
                 None
             },
-            rodsv_handle: if image.usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT)
+            rodsv_handle: if usage.contains(image::Usage::DEPTH_STENCIL_ATTACHMENT)
                 && self.internal.downlevel.read_only_depth_stencil
             {
                 if let Some(rodsv) = self

--- a/src/backend/dx12/src/resource.rs
+++ b/src/backend/dx12/src/resource.rs
@@ -251,7 +251,6 @@ pub struct ImageBound {
     pub(crate) surface_type: format::SurfaceType,
     pub(crate) kind: image::Kind,
     pub(crate) mip_levels: image::Level,
-    pub(crate) usage: image::Usage,
     pub(crate) default_view_format: Option<DXGI_FORMAT>,
     pub(crate) view_caps: image::ViewCapabilities,
     pub(crate) descriptor: d3d12::D3D12_RESOURCE_DESC,

--- a/src/backend/dx12/src/window.rs
+++ b/src/backend/dx12/src/window.rs
@@ -277,7 +277,6 @@ impl w::PresentationSurface<Backend> for Surface {
             surface_type: base_format.0,
             kind,
             mip_levels: 1,
-            usage: sc.usage,
             default_view_format: None,
             view_caps: i::ViewCapabilities::empty(),
             descriptor,

--- a/src/backend/empty/src/lib.rs
+++ b/src/backend/empty/src/lib.rs
@@ -368,6 +368,7 @@ impl device::Device<Backend> for Device {
         _: hal::image::ViewKind,
         _: format::Format,
         _: format::Swizzle,
+        _: hal::image::Usage,
         _: hal::image::SubresourceRange,
     ) -> Result<(), hal::image::ViewCreationError> {
         Ok(())

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1667,6 +1667,7 @@ impl d::Device<B> for Device {
         kind: i::ViewKind,
         view_format: Format,
         swizzle: Swizzle,
+        _usage: i::Usage,
         range: i::SubresourceRange,
     ) -> Result<n::ImageView, i::ViewCreationError> {
         assert_eq!(swizzle, Swizzle::NO);

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -2872,6 +2872,7 @@ impl hal::device::Device<Backend> for Device {
         kind: image::ViewKind,
         format: format::Format,
         swizzle: format::Swizzle,
+        _usage: image::Usage,
         range: image::SubresourceRange,
     ) -> Result<n::ImageView, image::ViewCreationError> {
         let mtl_format = match self

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1200,12 +1200,14 @@ impl d::Device<B> for super::Device {
         kind: image::ViewKind,
         format: format::Format,
         swizzle: format::Swizzle,
+        usage: image::Usage,
         range: image::SubresourceRange,
     ) -> Result<n::ImageView, image::ViewCreationError> {
         let is_cube = image
             .flags
             .intersects(vk::ImageCreateFlags::CUBE_COMPATIBLE);
-        let info = vk::ImageViewCreateInfo::builder()
+        let mut image_view_info;
+        let mut info = vk::ImageViewCreateInfo::builder()
             .flags(vk::ImageViewCreateFlags::empty())
             .image(image.raw)
             .view_type(match conv::map_view_kind(kind, image.ty, is_cube) {
@@ -1215,6 +1217,13 @@ impl d::Device<B> for super::Device {
             .format(conv::map_format(format))
             .components(conv::map_swizzle(swizzle))
             .subresource_range(conv::map_subresource_range(&range));
+
+        if self.shared.image_view_usage {
+            image_view_info = vk::ImageViewUsageCreateInfo::builder()
+                .usage(conv::map_image_usage(usage))
+                .build();
+            info = info.push_next(&mut image_view_info);
+        }
 
         let result = self.shared.raw.create_image_view(&info, None);
 

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -708,6 +708,7 @@ pub struct RawDevice {
     /// This flag is `true` if the device has `VK_KHR_maintenance1`/1.1+ and `false` otherwise (i.e. in the case of `VK_AMD_negative_viewport_height`).
     flip_y_requires_shift: bool,
     imageless_framebuffers: bool,
+    image_view_usage: bool,
     timestamp_period: f32,
 }
 

--- a/src/backend/vulkan/src/physical_device.rs
+++ b/src/backend/vulkan/src/physical_device.rs
@@ -912,6 +912,10 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                     || self
                         .device_info
                         .supports_extension(vk::KhrImagelessFramebufferFn::name()),
+                image_view_usage: self.device_info.api_version() >= Version::V1_1
+                    || self
+                        .device_info
+                        .supports_extension(vk::KhrMaintenance2Fn::name()),
                 timestamp_period: self.device_info.properties.limits.timestamp_period,
             }),
             vendor_id: self.device_info.properties.vendor_id,

--- a/src/backend/vulkan/src/window.rs
+++ b/src/backend/vulkan/src/window.rs
@@ -358,6 +358,7 @@ impl w::PresentationSurface<Backend> for Surface {
     ) -> Result<(), w::SwapchainError> {
         use hal::device::Device as _;
 
+        let usage = config.image_usage;
         let format = config.format;
         let old = self
             .swapchain
@@ -380,6 +381,7 @@ impl w::PresentationSurface<Backend> for Surface {
                             hal::image::ViewKind::D2,
                             format,
                             hal::format::Swizzle::NO,
+                            usage,
                             hal::image::SubresourceRange {
                                 aspects: hal::format::Aspects::COLOR,
                                 ..Default::default()

--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -455,6 +455,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
         view_kind: image::ViewKind,
         format: format::Format,
         swizzle: format::Swizzle,
+        usage: image::Usage,
         range: image::SubresourceRange,
     ) -> Result<B::ImageView, image::ViewCreationError>;
 

--- a/src/warden/src/gpu.rs
+++ b/src/warden/src/gpu.rs
@@ -745,11 +745,12 @@ impl<B: hal::Backend> Scene<B> {
                     kind,
                     format,
                     swizzle,
+                    usage,
                     ref range,
                 } => {
                     let img = &resources.images[image].handle;
                     let view = unsafe {
-                        device.create_image_view(img, kind, format, swizzle, range.clone())
+                        device.create_image_view(img, kind, format, swizzle, usage, range.clone())
                     }
                     .unwrap();
                     resources.image_views.insert(

--- a/src/warden/src/raw.rs
+++ b/src/warden/src/raw.rs
@@ -102,6 +102,7 @@ pub enum Resource {
         format: hal::format::Format,
         #[serde(default)]
         swizzle: hal::format::Swizzle,
+        usage: hal::image::Usage,
         range: hal::image::SubresourceRange,
     },
     Sampler {

--- a/work/scenes/basic.ron
+++ b/work/scenes/basic.ron
@@ -28,6 +28,7 @@
 			image: "image.color",
 			kind: D2,
 			format: Rgba8Unorm,
+			usage: (bits: 0x15),
 			range: (
 				aspects: (bits: 1),
 				level_start: 0,

--- a/work/scenes/large.ron
+++ b/work/scenes/large.ron
@@ -88,6 +88,7 @@
 			image: "image.src",
 			kind: D2,
 			format: Rgba8Unorm,
+			usage: (bits: 0x15),
 			range: (
 				aspects: (bits: 1),
 				levels: (start: 0, end: 1),
@@ -98,6 +99,7 @@
 			image: "image.dst",
 			kind: D2,
 			format: Rg8Unorm,
+			usage: (bits: 0x12),
 			range: (
 				aspects: (bits: 1),
 				levels: (start: 0, end: 1),

--- a/work/scenes/vertex-offset.ron
+++ b/work/scenes/vertex-offset.ron
@@ -32,6 +32,7 @@
 			image: "image.color",
 			kind: D2,
 			format: Rgba32Uint,
+			usage: (bits: 0x15),
 			range: (
 				aspects: (bits: 1),
 				level_start: 0,


### PR DESCRIPTION
Closes #3659
PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [ ] tested examples with the following backends:
