### PR TITLE
Sampler reduction modes exposed

### DIFF
--- a/src/backend/vulkan/src/conv.rs
+++ b/src/backend/vulkan/src/conv.rs
@@ -225,6 +225,15 @@ pub fn map_wrap(wrap: image::WrapMode) -> vk::SamplerAddressMode {
     }
 }
 
+pub fn map_reduction(reduction: image::ReductionMode) -> vk::SamplerReductionMode {
+    use hal::image::ReductionMode as Rm;
+    match reduction {
+        Rm::WeightedAverage => vk::SamplerReductionMode::WEIGHTED_AVERAGE,
+        Rm::Minimum => vk::SamplerReductionMode::MIN,
+        Rm::Maximum => vk::SamplerReductionMode::MAX,
+    }
+}
+
 pub fn map_border_color(border_color: image::BorderColor) -> vk::BorderColor {
     match border_color {
         image::BorderColor::TransparentBlack => vk::BorderColor::FLOAT_TRANSPARENT_BLACK,

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -987,7 +987,9 @@ impl d::Device<B> for super::Device {
                     (false, 1.0)
                 }
             });
-        let info = vk::SamplerCreateInfo::builder()
+
+        let mut reduction_info;
+        let mut info = vk::SamplerCreateInfo::builder()
             .flags(vk::SamplerCreateFlags::empty())
             .mag_filter(conv::map_filter(desc.mag_filter))
             .min_filter(conv::map_filter(desc.min_filter))
@@ -1006,6 +1008,13 @@ impl d::Device<B> for super::Device {
             .max_lod(desc.lod_range.end.0)
             .border_color(conv::map_border_color(desc.border))
             .unnormalized_coordinates(!desc.normalized);
+
+        if self.shared.features.contains(Features::SAMPLER_REDUCTION) {
+            reduction_info = vk::SamplerReductionModeCreateInfo::builder()
+                .reduction_mode(conv::map_reduction(desc.reduction_mode))
+                .build();
+            info = info.push_next(&mut reduction_info);
+        }
 
         let result = self.shared.raw.create_sampler(&info, None);
 

--- a/src/backend/vulkan/src/physical_device.rs
+++ b/src/backend/vulkan/src/physical_device.rs
@@ -1,5 +1,5 @@
 use ash::{
-    extensions::{self, khr::DrawIndirectCount, khr::Swapchain, nv::MeshShader},
+    extensions::{khr::DrawIndirectCount, khr::Swapchain, nv::MeshShader},
     version::{DeviceV1_0, InstanceV1_0},
     vk,
 };
@@ -66,7 +66,6 @@ impl PhysicalDeviceFeatures {
         enabled_extensions: &[&'static CStr],
         requested_features: Features,
         supports_vulkan12_imageless_framebuffer: bool,
-        supports_vulkan12_sampler_filter_minmax: bool,
     ) -> PhysicalDeviceFeatures {
         // This must follow the "Valid Usage" requirements of [`VkDeviceCreateInfo`](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceCreateInfo.html).
         let features = requested_features;
@@ -183,7 +182,7 @@ impl PhysicalDeviceFeatures {
                         .runtime_descriptor_array(
                             features.contains(Features::UNSIZED_DESCRIPTOR_ARRAY),
                         )
-                        .sampler_filter_minmax(supports_vulkan12_sampler_filter_minmax)
+                        .sampler_filter_minmax(features.contains(Features::SAMPLER_REDUCTION))
                         .imageless_framebuffer(supports_vulkan12_imageless_framebuffer)
                         .build(),
                 )
@@ -424,14 +423,15 @@ impl PhysicalDeviceFeatures {
             bits |= Features::NDC_Y_UP;
         }
 
-        if info.supports_extension(vk::KhrSamplerMirrorClampToEdgeFn::name())
-            || info.api_version() >= Version::V1_2
-        {
+        if info.supports_extension(vk::KhrSamplerMirrorClampToEdgeFn::name()) {
             bits |= Features::SAMPLER_MIRROR_CLAMP_EDGE;
         }
 
-        if info.supports_extension(DrawIndirectCount::name()) || info.api_version() >= Version::V1_2
-        {
+        if info.supports_extension(vk::ExtSamplerFilterMinmaxFn::name()) {
+            bits |= Features::SAMPLER_REDUCTION;
+        }
+
+        if info.supports_extension(DrawIndirectCount::name()) {
             bits |= Features::DRAW_INDIRECT_COUNT
         }
 
@@ -457,6 +457,9 @@ impl PhysicalDeviceFeatures {
             }
             if vulkan_1_2.sampler_mirror_clamp_to_edge != 0 {
                 bits |= Features::SAMPLER_MIRROR_CLAMP_EDGE;
+            }
+            if vulkan_1_2.sampler_filter_minmax != 0 {
+                bits |= Features::SAMPLER_REDUCTION
             }
             if vulkan_1_2.draw_indirect_count != 0 {
                 bits |= Features::DRAW_INDIRECT_COUNT
@@ -515,7 +518,7 @@ impl PhysicalDeviceInfo {
     fn get_required_extensions(&self, requested_features: Features) -> Vec<&'static CStr> {
         let mut requested_extensions = Vec::new();
 
-        requested_extensions.push(extensions::khr::Swapchain::name());
+        requested_extensions.push(Swapchain::name());
 
         if self.api_version() < Version::V1_1 {
             requested_extensions.push(vk::KhrMaintenance1Fn::name());
@@ -556,6 +559,12 @@ impl PhysicalDeviceInfo {
             && requested_features.intersects(Features::SAMPLER_MIRROR_CLAMP_EDGE)
         {
             requested_extensions.push(vk::KhrSamplerMirrorClampToEdgeFn::name());
+        }
+
+        if self.api_version() < Version::V1_2
+            && requested_features.contains(Features::SAMPLER_REDUCTION)
+        {
+            requested_extensions.push(vk::ExtSamplerFilterMinmaxFn::name());
         }
 
         if requested_features.intersects(Features::MESH_SHADER_MASK) {
@@ -666,6 +675,7 @@ pub struct PhysicalDevice {
     known_memory_flags: vk::MemoryPropertyFlags,
     device_info: PhysicalDeviceInfo,
     device_features: PhysicalDeviceFeatures,
+    available_features: Features,
 }
 
 pub(crate) fn load_adapter(
@@ -693,6 +703,23 @@ pub(crate) fn load_adapter(
         },
     };
 
+    let available_features = {
+        let mut bits = device_features.to_hal_features(&device_info);
+
+        // see https://github.com/gfx-rs/gfx/issues/1930
+        let is_windows_intel_dual_src_bug = cfg!(windows)
+            && device_info.properties.vendor_id == info::intel::VENDOR
+            && (device_info.properties.device_id & info::intel::DEVICE_KABY_LAKE_MASK
+                == info::intel::DEVICE_KABY_LAKE_MASK
+                || device_info.properties.device_id & info::intel::DEVICE_SKY_LAKE_MASK
+                    == info::intel::DEVICE_SKY_LAKE_MASK);
+        if is_windows_intel_dual_src_bug {
+            bits.set(Features::DUAL_SRC_BLENDING, false);
+        }
+
+        bits
+    };
+
     let physical_device = PhysicalDevice {
         instance: instance.clone(),
         handle: device,
@@ -703,6 +730,7 @@ pub(crate) fn load_adapter(
             | vk::MemoryPropertyFlags::LAZILY_ALLOCATED,
         device_info,
         device_features,
+        available_features,
     };
 
     let queue_families = unsafe {
@@ -809,9 +837,6 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                     &enabled_extensions,
                     requested_features,
                     supports_vulkan12_imageless_framebuffer,
-                    self.device_features
-                        .vulkan_1_2
-                        .map_or(false, |features| features.sampler_filter_minmax == vk::TRUE),
                 );
             let info = vk::DeviceCreateInfo::builder()
                 .queue_create_infos(&family_infos)
@@ -956,12 +981,8 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             .supports_extension(vk::KhrMaintenance1Fn::name());
 
         let supports_sampler_filter_minmax = self
-            .device_info
-            .supports_extension(vk::ExtSamplerFilterMinmaxFn::name())
-            || self
-                .device_features
-                .vulkan_1_2
-                .map_or(false, |features| features.sampler_filter_minmax == vk::TRUE);
+            .available_features
+            .contains(Features::SAMPLER_REDUCTION);
 
         format::Properties {
             linear_tiling: conv::map_image_features(
@@ -1062,20 +1083,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
     }
 
     fn features(&self) -> Features {
-        let mut bits = self.device_features.to_hal_features(&self.device_info);
-
-        // see https://github.com/gfx-rs/gfx/issues/1930
-        let is_windows_intel_dual_src_bug = cfg!(windows)
-            && self.device_info.properties.vendor_id == info::intel::VENDOR
-            && (self.device_info.properties.device_id & info::intel::DEVICE_KABY_LAKE_MASK
-                == info::intel::DEVICE_KABY_LAKE_MASK
-                || self.device_info.properties.device_id & info::intel::DEVICE_SKY_LAKE_MASK
-                    == info::intel::DEVICE_SKY_LAKE_MASK);
-        if is_windows_intel_dual_src_bug {
-            bits = bits & !Features::DUAL_SRC_BLENDING;
-        }
-
-        bits
+        self.available_features
     }
 
     fn properties(&self) -> PhysicalDeviceProperties {
@@ -1192,6 +1200,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
 
         let mut descriptor_indexing_capabilities = hal::DescriptorIndexingProperties::default();
         let mut mesh_shader_capabilities = hal::MeshShaderProperties::default();
+        let mut sampler_reduction_capabilities = hal::SamplerReductionProperties::default();
 
         if let Some(get_physical_device_properties) =
             self.instance.get_physical_device_properties.as_ref()
@@ -1199,13 +1208,16 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             let mut descriptor_indexing_properties =
                 vk::PhysicalDeviceDescriptorIndexingPropertiesEXT::builder();
             let mut mesh_shader_properties = vk::PhysicalDeviceMeshShaderPropertiesNV::builder();
+            let mut sampler_reduction_properties =
+                vk::PhysicalDeviceSamplerFilterMinmaxProperties::builder();
 
             unsafe {
                 get_physical_device_properties.get_physical_device_properties2_khr(
                     self.handle,
                     &mut vk::PhysicalDeviceProperties2::builder()
-                        .push_next(&mut mesh_shader_properties)
                         .push_next(&mut descriptor_indexing_properties)
+                        .push_next(&mut mesh_shader_properties)
+                        .push_next(&mut sampler_reduction_properties)
                         .build() as *mut _,
                 );
             }
@@ -1255,12 +1267,22 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
                 mesh_output_per_primitive_granularity: mesh_shader_properties
                     .mesh_output_per_primitive_granularity,
             };
+
+            sampler_reduction_capabilities = hal::SamplerReductionProperties {
+                single_component_formats: sampler_reduction_properties
+                    .filter_minmax_single_component_formats
+                    == vk::TRUE,
+                image_component_mapping: sampler_reduction_properties
+                    .filter_minmax_image_component_mapping
+                    == vk::TRUE,
+            };
         }
 
         PhysicalDeviceProperties {
             limits,
             descriptor_indexing: descriptor_indexing_capabilities,
             mesh_shader: mesh_shader_capabilities,
+            sampler_reduction: sampler_reduction_capabilities,
             performance_caveats: Default::default(),
             dynamic_pipeline_states: DynamicStates::all(),
             downlevel: DownlevelProperties::all_enabled(),

--- a/src/hal/src/image.rs
+++ b/src/hal/src/image.rs
@@ -397,6 +397,20 @@ pub enum WrapMode {
     MirrorClamp,
 }
 
+/// Specifies how the image texels in the filter kernel are reduced to a single value.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum ReductionMode {
+    ///
+    WeightedAverage,
+    ///
+    /// Only valid if `Features::SAMPLER_FILTER_MINMAX` is enabled.
+    Minimum,
+    ///
+    /// Only valid if `Features::SAMPLER_FILTER_MINMAX` is enabled.
+    Maximum,
+}
+
 /// A wrapper for the LOD level of an image. Needed so that we can
 /// implement Eq and Hash for it.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
@@ -467,7 +481,6 @@ impl Into<[f32; 4]> for BorderColor {
 /// available that alter how the GPU goes from a coordinate in an image
 /// to producing an actual value from the texture, including filtering/
 /// scaling, wrap mode, etc.
-// TODO: document the details of sampling.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SamplerDesc {
@@ -477,6 +490,8 @@ pub struct SamplerDesc {
     pub mag_filter: Filter,
     /// Mip filter method to use.
     pub mip_filter: Filter,
+    /// Reduction mode over the filter.
+    pub reduction_mode: ReductionMode,
     /// Wrapping mode for each of the U, V, and W axis (S, T, and R in OpenGL
     /// speak).
     pub wrap_mode: (WrapMode, WrapMode, WrapMode),
@@ -506,6 +521,7 @@ impl SamplerDesc {
             min_filter: filter,
             mag_filter: filter,
             mip_filter: filter,
+            reduction_mode: ReductionMode::WeightedAverage,
             wrap_mode: (wrap, wrap, wrap),
             lod_bias: Lod(0.0),
             lod_range: Lod::RANGE.clone(),

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -287,6 +287,8 @@ bitflags! {
         const MESH_SHADER = 0x0002 << 96;
         /// Mask for all the features associated with mesh shader stages.
         const MESH_SHADER_MASK = Features::TASK_SHADER.bits | Features::MESH_SHADER.bits;
+        /// Support sampler min/max reduction mode.
+        const SAMPLER_REDUCTION = 0x0004 << 96;
     }
 }
 
@@ -340,6 +342,8 @@ pub struct PhysicalDeviceProperties {
     pub descriptor_indexing: DescriptorIndexingProperties,
     /// Mesh Shader properties.
     pub mesh_shader: MeshShaderProperties,
+    /// Sampler reduction modes.
+    pub sampler_reduction: SamplerReductionProperties,
     /// Downlevel properties.
     pub downlevel: DownlevelProperties,
     /// Performance caveats.
@@ -569,6 +573,16 @@ pub struct MeshShaderProperties {
     /// The granularity with which mesh outputs qualified as per-primitive are allocated. The value can be used to
     /// compute the memory size used by the mesh shader, which must be less than or equal to
     pub mesh_output_per_primitive_granularity: u32,
+}
+
+/// Resource limits related to the reduction samplers.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct SamplerReductionProperties {
+    /// Support for the minimum set of required formats support min/max filtering
+    pub single_component_formats: bool,
+    /// Support for the non-identity component mapping of the image when doing min/max filtering.
+    pub image_component_mapping: bool,
 }
 
 /// Propterties to indicate when the backend does not support full vulkan compliance.


### PR DESCRIPTION
Fixes #3523
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
