### PR TITLE
[0.7/dx12] Reset command allocators periodically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### backend-dx12-0.7.1 (17-04-2021)
+  - reduce memory usage by resetting command allocators periodically
+
 ### backend-gl-0.7.1 (24-02-2021)
   - Fix WebGL adapter creation
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -30,6 +30,7 @@ log = "0.4"
 parking_lot = "0.11"
 smallvec = "1"
 spirv_cross = { version = "0.23", features = ["hlsl"] }
+thunderdome = "0.3"
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_5","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 raw-window-handle = "0.3"
 

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx-backend-dx12"
-version = "0.7.0"
+version = "0.7.1"
 description = "DirectX-12 API backend for gfx-rs"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -16,8 +16,10 @@ use winapi::{
 use std::{cmp, fmt, iter, mem, ops::Range, ptr, sync::Arc};
 
 use crate::{
-    conv, descriptors_cpu, device, internal, pool::PoolShared, resource as r, validate_line_width,
-    Backend, Device, Shared, MAX_DESCRIPTOR_SETS, MAX_VERTEX_BUFFERS,
+    conv, descriptors_cpu, device, internal,
+    pool::{CommandAllocatorIndex, PoolShared},
+    resource as r, validate_line_width, Backend, Device, Shared, MAX_DESCRIPTOR_SETS,
+    MAX_VERTEX_BUFFERS,
 };
 
 // Fixed size of the root signature.
@@ -379,7 +381,9 @@ pub struct CommandBuffer {
     //Note: this is going to be NULL instead of `Option` to avoid
     // `unwrap()` on every operation. This is not idiomatic.
     pub(crate) raw: native::GraphicsCommandList,
-    allocator: Option<native::CommandAllocator>,
+    //Note: this is NULL when the command buffer is reset, and no
+    // allocation is used for the `raw` list.
+    allocator_index: Option<CommandAllocatorIndex>,
     phase: Phase,
     shared: Arc<Shared>,
     pool_shared: Arc<PoolShared>,
@@ -470,7 +474,7 @@ impl CommandBuffer {
     pub(crate) fn new(shared: &Arc<Shared>, pool_shared: &Arc<PoolShared>) -> Self {
         CommandBuffer {
             raw: native::GraphicsCommandList::null(),
-            allocator: None,
+            allocator_index: None,
             shared: Arc::clone(shared),
             pool_shared: Arc::clone(pool_shared),
             phase: Phase::Initial,
@@ -500,10 +504,7 @@ impl CommandBuffer {
 
     pub(crate) unsafe fn destroy(
         self,
-    ) -> (
-        Option<native::CommandAllocator>,
-        Option<native::GraphicsCommandList>,
-    ) {
+    ) -> Option<(CommandAllocatorIndex, Option<native::GraphicsCommandList>)> {
         let list = match self.phase {
             Phase::Initial => None,
             Phase::Recording => {
@@ -521,7 +522,7 @@ impl CommandBuffer {
         for resource in &self.retained_resources {
             resource.destroy();
         }
-        (self.allocator, list)
+        self.allocator_index.map(|index| (index, list))
     }
 
     pub(crate) unsafe fn as_raw_list(&self) -> *mut d3d12::ID3D12CommandList {
@@ -1194,11 +1195,11 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         self.reset(true);
         self.phase = Phase::Recording;
         self.begin_flags = flags;
-        let (allocator, list) = self.pool_shared.acquire();
+        let (allocator_index, list) = self.pool_shared.acquire();
 
-        assert!(self.allocator.is_none());
+        assert!(self.allocator_index.is_none());
         assert_eq!(self.raw, native::GraphicsCommandList::null());
-        self.allocator = Some(allocator);
+        self.allocator_index = Some(allocator_index);
         self.raw = list;
 
         if !self.raw_name.is_empty() {
@@ -1211,25 +1212,23 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         assert_eq!(self.phase, Phase::Recording);
         self.phase = Phase::Executable;
         self.pool_shared
-            .release_allocator(self.allocator.take().unwrap());
+            .release_allocator(self.allocator_index.unwrap());
     }
 
-    unsafe fn reset(&mut self, release_resources: bool) {
+    unsafe fn reset(&mut self, _release_resources: bool) {
         if self.phase == Phase::Recording {
             self.raw.close();
+            self.pool_shared
+                .release_allocator(self.allocator_index.unwrap());
         }
         if self.phase != Phase::Initial {
             // Reset the name so it won't get used later for an unnamed `CommandBuffer`.
             const EMPTY_NAME: u16 = 0;
             self.raw.SetName(&EMPTY_NAME);
 
-            self.pool_shared.release_list(self.raw);
+            let allocator_index = self.allocator_index.take().unwrap();
+            self.pool_shared.release_list(self.raw, allocator_index);
             self.raw = native::GraphicsCommandList::null();
-        }
-        if release_resources {
-            if let Some(allocator) = self.allocator.take() {
-                self.pool_shared.release_allocator(allocator);
-            }
         }
         self.phase = Phase::Initial;
 

--- a/src/backend/dx12/src/pool.rs
+++ b/src/backend/dx12/src/pool.rs
@@ -6,11 +6,59 @@ use winapi::shared::winerror;
 use crate::{command::CommandBuffer, Backend, Shared};
 use hal::{command, pool};
 
+const REUSE_COUNT: usize = 64;
+
+pub type CommandAllocatorIndex = thunderdome::Index;
+
+struct AllocatorEntry {
+    raw: native::CommandAllocator,
+    active_lists: usize,
+    total_lists: usize,
+}
+
+#[derive(Default)]
+struct CommandManager {
+    allocators: thunderdome::Arena<AllocatorEntry>,
+    free_allocators: Vec<CommandAllocatorIndex>,
+    lists: Vec<native::GraphicsCommandList>,
+}
+
+impl CommandManager {
+    fn acquire(&mut self, index: CommandAllocatorIndex) -> native::CommandAllocator {
+        let entry = &mut self.allocators[index];
+        assert!(entry.total_lists < REUSE_COUNT);
+        entry.active_lists += 1;
+        entry.total_lists += 1;
+        return entry.raw;
+    }
+
+    fn release_allocator(&mut self, index: CommandAllocatorIndex) {
+        let entry = &mut self.allocators[index];
+        if entry.total_lists >= REUSE_COUNT {
+            debug!("Cooling command allocator {:?}", index);
+        } else {
+            self.free_allocators.push(index);
+        }
+    }
+
+    fn release_list(&mut self, list: native::GraphicsCommandList, index: CommandAllocatorIndex) {
+        //pre-condition: list must be closed
+        let entry = &mut self.allocators[index];
+        entry.active_lists -= 1;
+        if entry.active_lists == 0 && entry.total_lists >= REUSE_COUNT {
+            debug!("Re-warming command allocator {:?}", index);
+            entry.raw.reset();
+            entry.total_lists = 0;
+            self.free_allocators.push(index);
+        }
+        self.lists.push(list);
+    }
+}
+
 pub struct PoolShared {
     device: native::Device,
     list_type: native::CmdListType,
-    allocators: Mutex<Vec<native::CommandAllocator>>,
-    lists: Mutex<Vec<native::GraphicsCommandList>>,
+    manager: Mutex<CommandManager>,
 }
 
 impl fmt::Debug for PoolShared {
@@ -21,29 +69,36 @@ impl fmt::Debug for PoolShared {
 }
 
 impl PoolShared {
-    pub fn acquire(&self) -> (native::CommandAllocator, native::GraphicsCommandList) {
-        let allocator = match self.allocators.lock().pop() {
-            Some(allocator) => allocator,
+    pub fn acquire(&self) -> (CommandAllocatorIndex, native::GraphicsCommandList) {
+        let mut man_guard = self.manager.lock();
+        let allocator_index = match man_guard.free_allocators.pop() {
+            Some(index) => index,
             None => {
-                let (allocator, hr) = self.device.create_command_allocator(self.list_type);
+                let (raw, hr) = self.device.create_command_allocator(self.list_type);
                 assert_eq!(
                     winerror::S_OK,
                     hr,
                     "error on command allocator creation: {:x}",
                     hr
                 );
-                allocator
+                man_guard.allocators.insert(AllocatorEntry {
+                    raw,
+                    active_lists: 0,
+                    total_lists: 0,
+                })
             }
         };
-        let list = match self.lists.lock().pop() {
+        let raw = man_guard.acquire(allocator_index);
+
+        let list = match man_guard.lists.pop() {
             Some(list) => {
-                list.reset(allocator, native::PipelineState::null());
+                list.reset(raw, native::PipelineState::null());
                 list
             }
             None => {
                 let (command_list, hr) = self.device.create_graphics_command_list(
                     self.list_type,
-                    allocator,
+                    raw,
                     native::PipelineState::null(),
                     0,
                 );
@@ -56,16 +111,19 @@ impl PoolShared {
                 command_list
             }
         };
-        (allocator, list)
+        (allocator_index, list)
     }
 
-    pub fn release_allocator(&self, allocator: native::CommandAllocator) {
-        self.allocators.lock().push(allocator);
+    pub fn release_allocator(&self, allocator_index: CommandAllocatorIndex) {
+        self.manager.lock().release_allocator(allocator_index);
     }
 
-    pub fn release_list(&self, list: native::GraphicsCommandList) {
-        //pre-condition: list must be closed
-        self.lists.lock().push(list);
+    pub fn release_list(
+        &self,
+        list: native::GraphicsCommandList,
+        allocator_index: CommandAllocatorIndex,
+    ) {
+        self.manager.lock().release_list(list, allocator_index);
     }
 }
 
@@ -88,8 +146,7 @@ impl CommandPool {
         let pool_shared = Arc::new(PoolShared {
             device,
             list_type,
-            allocators: Mutex::default(),
-            lists: Mutex::default(),
+            manager: Mutex::default(),
         });
         CommandPool {
             shared: Arc::clone(shared),
@@ -100,6 +157,7 @@ impl CommandPool {
 
 impl pool::CommandPool<Backend> for CommandPool {
     unsafe fn reset(&mut self, _release_resources: bool) {
+        //TODO: reset all the allocators?
         //do nothing. The allocated command buffers would not know
         // that this happened, but they should be ready to
         // process `begin` as if they are in `Initial` state.
@@ -115,12 +173,14 @@ impl pool::CommandPool<Backend> for CommandPool {
     where
         I: Iterator<Item = CommandBuffer>,
     {
-        let mut allocators = self.pool_shared.allocators.lock();
-        let mut lists = self.pool_shared.lists.lock();
+        let mut man_guard = self.pool_shared.manager.lock();
         for cbuf in cbufs {
-            let (allocator, list) = cbuf.destroy();
-            allocators.extend(allocator);
-            lists.extend(list);
+            if let Some((index, list)) = cbuf.destroy() {
+                man_guard.release_allocator(index);
+                if let Some(list) = list {
+                    man_guard.release_list(list, index);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Backport #3680 to hal-0.7 to avoid excess memory usage in DX12.

Some Bevy users were hitting this through wgpu, so it might be nice to backport this fix this in 0.7 too (instead of waiting for the next wgpu release).

I tried hal-0.7 with and without the fix on quad by repeatedly resizing the window, and the memory grows without the fix but seems stable with it (as expected).

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [X] tested examples with the following backends: DX12
