### PR TITLE
Rename blend color to blend constants

### DIFF
--- a/src/backend/dx11/src/lib.rs
+++ b/src/backend/dx11/src/lib.rs
@@ -622,7 +622,7 @@ impl hal::Instance<Backend> for Instance {
                     limits,
                     dynamic_pipeline_states: hal::DynamicStates::VIEWPORT
                         | hal::DynamicStates::SCISSOR
-                        | hal::DynamicStates::BLEND_COLOR
+                        | hal::DynamicStates::BLEND_CONSTANTS
                         | hal::DynamicStates::DEPTH_BOUNDS
                         | hal::DynamicStates::STENCIL_REFERENCE,
                     downlevel,
@@ -1686,7 +1686,7 @@ impl CommandBufferState {
             let blend_color = if let Some(ref pipeline) = self.graphics_pipeline {
                 pipeline
                     .baked_states
-                    .blend_color
+                    .blend_constants
                     .or(self.blend_factor)
                     .unwrap_or([0f32; 4])
             } else {

--- a/src/backend/dx12/src/command.rs
+++ b/src/backend/dx12/src/command.rs
@@ -2080,7 +2080,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
         if let Some(ref rect) = pipeline.baked_states.scissor {
             self.set_scissors(0, iter::once(rect.clone()));
         }
-        if let Some(color) = pipeline.baked_states.blend_color {
+        if let Some(color) = pipeline.baked_states.blend_constants {
             self.set_blend_constants(color);
         }
         if let Some(ref bounds) = pipeline.baked_states.depth_bounds {

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1448,7 +1448,7 @@ impl hal::Instance<Backend> for Instance {
                     },
                     dynamic_pipeline_states: hal::DynamicStates::VIEWPORT
                         | hal::DynamicStates::SCISSOR
-                        | hal::DynamicStates::BLEND_COLOR
+                        | hal::DynamicStates::BLEND_CONSTANTS
                         | hal::DynamicStates::STENCIL_REFERENCE,
                     downlevel: hal::DownlevelProperties::all_enabled(),
                     ..PhysicalDeviceProperties::default()

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -1201,7 +1201,7 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
         if let Some(ref rect) = pipeline.baked_states.scissor {
             self.set_scissors(0, iter::once(rect.clone()));
         }
-        if let Some(color) = pipeline.baked_states.blend_color {
+        if let Some(color) = pipeline.baked_states.blend_constants {
             self.set_blend_constants(color);
         }
         if let Some(ref bounds) = pipeline.baked_states.depth_bounds {

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -3787,7 +3787,7 @@ impl com::CommandBuffer<Backend> for CommandBuffer {
                 pre.issue(com);
             }
         }
-        if let Some(ref color) = pipeline.baked_states.blend_color {
+        if let Some(ref color) = pipeline.baked_states.blend_constants {
             pre.issue(self.state.set_blend_color(color));
         }
     }

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -403,7 +403,7 @@ impl<'a> GraphicsPipelineInfoBuf<'a> {
             .logic_op_enable(false) // TODO
             .logic_op(vk::LogicOp::CLEAR)
             .attachments(&this.blend_states) // TODO:
-            .blend_constants(match desc.baked_states.blend_color {
+            .blend_constants(match desc.baked_states.blend_constants {
                 Some(value) => value,
                 None => {
                     this.dynamic_states.push(vk::DynamicState::BLEND_CONSTANTS);

--- a/src/hal/src/lib.rs
+++ b/src/hal/src/lib.rs
@@ -312,8 +312,8 @@ bitflags! {
         const SCISSOR = 0x0002;
         /// Supports `Rasterizer::line_width == State::Dynamic(_)`
         const LINE_WIDTH = 0x0004;
-        /// Supports `BakedStates::blend_color == None`
-        const BLEND_COLOR = 0x0008;
+        /// Supports `BakedStates::blend_constants == None`
+        const BLEND_CONSTANTS = 0x0008;
         /// Supports `Rasterizer::depth_bias == Some(State::Dynamic(_))`
         const DEPTH_BIAS = 0x0010;
         /// Supports `BakedStates::depth_bounds == None`

--- a/src/hal/src/pso/graphics.rs
+++ b/src/hal/src/pso/graphics.rs
@@ -61,7 +61,7 @@ pub struct BakedStates {
     /// Static scissor. TODO: multiple scissors
     pub scissor: Option<Rect>,
     /// Static blend constant color.
-    pub blend_color: Option<ColorValue>,
+    pub blend_constants: Option<ColorValue>,
     /// Static depth bounds.
     pub depth_bounds: Option<Range<f32>>,
 }


### PR DESCRIPTION
"color" is an overloaded term. Constants is what Vulkan calls it, and it matches our blend factor variants.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
