### PR TITLE
[vk]: implement Device::start_capture() and Device::stop_capture() on Vulkan using renderdoc (as optional feature/dependency)

### DIFF
--- a/examples/compute/main.rs
+++ b/examples/compute/main.rs
@@ -71,6 +71,8 @@ fn main() {
             .unwrap()
     };
     let device = &gpu.device;
+    // Start render doc frame capture if available
+    device.start_capture();
     let queue_group = gpu.queue_groups.first_mut().unwrap();
 
     let glsl = fs::read_to_string("compute/shader/collatz.comp").unwrap();
@@ -257,6 +259,7 @@ fn main() {
             "Times: {:?}",
             slice::from_raw_parts::<u32>(mapping as *const u8 as *const u32, numbers.len()),
         );
+        device.stop_capture();
         device.unmap_memory(&mut staging_memory);
     }
 

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -30,6 +30,8 @@ parking_lot = "0.11"
 smallvec = "1.0"
 raw-window-handle = "0.3"
 inplace_it = "0.3.3"
+renderdoc-sys = "0.7.1"
+libloading = "0.7"
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -15,6 +15,7 @@ use hal::{
 use std::{ffi::CString, marker::PhantomData, mem, ops::Range, ptr, sync::Arc};
 
 use crate::{command as cmd, conv, native as n, pool::RawCommandPool, window as w, Backend as B};
+use ash::vk::Handle;
 
 #[derive(Debug, Default)]
 struct GraphicsPipelineInfoBuf<'a> {
@@ -1891,11 +1892,31 @@ impl d::Device<B> for super::Device {
     }
 
     fn start_capture(&self) {
-        //TODO: RenderDoc
+        unsafe {
+            match self.shared.instance.render_doc_entry {
+                Ok(ref entry) => {
+                    entry.api.StartFrameCapture.unwrap()(
+                        self.shared.raw.handle().as_raw() as *mut _,
+                        ptr::null_mut(),
+                    );
+                }
+                Err(ref cause) => warn!("Could not start render doc frame capture: {}", cause),
+            };
+        }
     }
 
     fn stop_capture(&self) {
-        //TODO: RenderDoc
+        unsafe {
+            match self.shared.instance.render_doc_entry {
+                Ok(ref entry) => {
+                    entry.api.EndFrameCapture.unwrap()(
+                        self.shared.raw.handle().as_raw() as *mut _,
+                        ptr::null_mut(),
+                    );
+                }
+                Err(ref cause) => warn!("Could not stop render doc frame capture: {}", cause),
+            };
+        }
     }
 }
 


### PR DESCRIPTION
TODOs:
 - [x] ~~find a way to use the correct device/window pointers instead of NULL~~ Null pointers should be fine for the majority of use cases
 - [x] integrate into example code? -> Integrated into the compute example
 - [x] Consider moving the renderdoc struct into the raw device?
 - [x] ~~Implement DX11, DX12, GL backends?~~ TBD in a separate PR

This is a follow up on #3708

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan
