### PR TITLE
[mtl] hack around supports_family check

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -1054,8 +1054,9 @@ impl PrivateCapabilities {
                     MTLFeatureSet::tvOS_GPUFamily2_v1,
                 ],
             ),
-            supports_binary_archives: device.supports_family(MTLGPUFamily::Apple3)
-                || device.supports_family(MTLGPUFamily::Mac1),
+            supports_binary_archives: cfg!(feature = "pipeline-cache")
+                && (device.supports_family(MTLGPUFamily::Apple3)
+                    || device.supports_family(MTLGPUFamily::Mac1)),
         }
     }
 


### PR DESCRIPTION
Fixes #3740
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
