### PR TITLE
metal: Link to QuartzCore

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -109,6 +109,7 @@ type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<fxhash::FxHasher>>;
 type ResourceIndex = u32;
 
 // For CALayer contentsGravity
+#[link(name="QuartzCore", kind="framework")]
 extern "C" {
     #[allow(non_upper_case_globals)]
     static kCAGravityTopLeft: cocoa_foundation::base::id;


### PR DESCRIPTION
Fixes linking issues when QuartzCore is not linked by some other means

Fixes #issue
PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
