### PR TITLE
Fixed missing or wrong name links on documentation.

### DIFF
--- a/src/hal/src/device.rs
+++ b/src/hal/src/device.rs
@@ -555,7 +555,7 @@ pub trait Device<B: Backend>: fmt::Debug + Any + Send + Sync {
     /// [queue submission][crate::queue::Queue::submit] command.
     ///
     /// Fences **can** be unsignaled on the host with
-    /// [`reset_fences`][Device::reset_fences].
+    /// [`reset_fence`][Device::reset_fence].
     ///
     /// Fences **can** be waited on by the host with the
     /// [`wait_for_fences`][Device::wait_for_fences] command.

--- a/src/hal/src/memory.rs
+++ b/src/hal/src/memory.rs
@@ -131,7 +131,7 @@ impl Segment {
 
 /// Defines a single memory bind region.
 ///
-/// This is used in the [`bind_sparse`][CommandQueue::bind_sparse] method to define a physical
+/// This is used in the [`bind_sparse`][queue::Queue::bind_sparse] method to define a physical
 /// store region for a buffer.
 #[derive(Debug)]
 pub struct SparseBind<M> {
@@ -148,7 +148,7 @@ pub struct SparseBind<M> {
 
 /// Defines a single image memory bind region.
 ///
-/// This is used in the [`bind_sparse`][CommandQueue::bind_sparse] method to define a physical
+/// This is used in the [`bind_sparse`][queue::Queue::bind_sparse] method to define a physical
 /// store region for a buffer.
 #[derive(Debug)]
 pub struct SparseImageBind<M> {


### PR DESCRIPTION
Running `cargo doc` on the vulkan backend will generate the following error:
```
error: unresolved link to `Device::reset_fences`
   --> src/hal/src/device.rs:558:26
    |
558 |     /// [`reset_fences`][Device::reset_fences].
    |                          ^^^^^^^^^^^^^^^^^^^^ the trait `Device` has no associated item named `reset_fences`
    |
note: the lint level is defined here
   --> src/hal/src/lib.rs:9:5
    |
9   |     broken_intra_doc_links,
    |     ^^^^^^^^^^^^^^^^^^^^^^

error: unresolved link to `CommandQueue::bind_sparse`
   --> src/hal/src/memory.rs:134:41
    |
134 | /// This is used in the [`bind_sparse`][CommandQueue::bind_sparse] method to define a physical
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `CommandQueue` in scope

error: unresolved link to `CommandQueue::bind_sparse`
   --> src/hal/src/memory.rs:151:41
    |
151 | /// This is used in the [`bind_sparse`][CommandQueue::bind_sparse] method to define a physical
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `CommandQueue` in scope

error: aborting due to 3 previous errors
```
This fix will simply update the doc links so that it compile correctly.
Have a good day.