### PR TITLE
Remove Naga preference setting from GL and Metal

### DIFF
--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -57,7 +57,6 @@ impl<'a> CompilationContext<'a> {
 pub struct Device {
     pub(crate) share: Starc<Share>,
     features: hal::Features,
-    pub always_prefer_naga: bool,
     #[cfg(feature = "cross")]
     spv_options: naga::back::spv::Options,
 }
@@ -74,7 +73,6 @@ impl Device {
         Device {
             share: share,
             features,
-            always_prefer_naga: false,
             #[cfg(feature = "cross")]
             spv_options: {
                 use naga::back::spv;
@@ -646,17 +644,16 @@ impl Device {
             entry_point: ep.entry.to_string(),
         };
 
-        let mut result = Err(d::ShaderError::CompilationFailed(String::new()));
-        if ep.module.prefer_naga {
-            if let Some(ref shader) = ep.module.naga {
-                result = Self::compile_shader_library_naga(
-                    &self.share.context,
-                    shader,
-                    &naga_options,
-                    context.reborrow(),
-                );
-            }
-        }
+        #[cfg_attr(not(feature = "cross"), allow(unused_mut))]
+        let mut result = match ep.module.naga {
+            Ok(ref shader) => Self::compile_shader_library_naga(
+                &self.share.context,
+                shader,
+                &naga_options,
+                context.reborrow(),
+            ),
+            Err(ref e) => Err(d::ShaderError::CompilationFailed(e.clone())),
+        };
         #[cfg(feature = "cross")]
         if result.is_err() {
             let mut ast = self.parse_spirv_cross(&ep.module.spv).unwrap();
@@ -670,16 +667,6 @@ impl Device {
                 .unwrap();
             log::debug!("SPIRV-Cross generated shader:\n{}", glsl);
             result = Self::create_shader_module_raw(&self.share.context, &glsl, stage);
-        }
-        if result.is_err() && !ep.module.prefer_naga {
-            if let Some(ref shader) = ep.module.naga {
-                result = Self::compile_shader_library_naga(
-                    &self.share.context,
-                    shader,
-                    &naga_options,
-                    context,
-                );
-            }
         }
         result
     }
@@ -1185,10 +1172,11 @@ impl d::Device<B> for Device {
         raw_data: &[u32],
     ) -> Result<n::ShaderModule, d::ShaderError> {
         Ok(n::ShaderModule {
-            prefer_naga: self.always_prefer_naga,
             #[cfg(feature = "cross")]
             spv: raw_data.to_vec(),
-            naga: {
+            naga: if cfg!(feature = "cross") {
+                Err("Cross is enabled".into())
+            } else {
                 let options = naga::front::spv::Options {
                     adjust_coordinate_space: !self.features.contains(hal::Features::NDC_Y_UP),
                     strict_capabilities: true,
@@ -1198,20 +1186,17 @@ impl d::Device<B> for Device {
                 match parser.parse() {
                     Ok(module) => {
                         log::debug!("Naga module {:#?}", module);
-                        match naga::valid::Validator::new(naga::valid::ValidationFlags::empty())
-                            .validate(&module)
+                        match naga::valid::Validator::new(
+                            naga::valid::ValidationFlags::empty(),
+                            //naga::valid::Capabilities::empty(),
+                        )
+                        .validate(&module)
                         {
-                            Ok(info) => Some(d::NagaShader { module, info }),
-                            Err(e) => {
-                                log::warn!("Naga validation failed: {:?}", e);
-                                None
-                            }
+                            Ok(info) => Ok(d::NagaShader { module, info }),
+                            Err(e) => Err(format!("Naga validation: {}", e)),
                         }
                     }
-                    Err(e) => {
-                        log::warn!("Naga parsing failed: {:?}", e);
-                        None
-                    }
+                    Err(e) => Err(format!("Naga parsing: {:?}", e)),
                 }
             },
         })
@@ -1222,7 +1207,6 @@ impl d::Device<B> for Device {
         shader: d::NagaShader,
     ) -> Result<n::ShaderModule, (d::ShaderError, d::NagaShader)> {
         Ok(n::ShaderModule {
-            prefer_naga: true,
             #[cfg(feature = "cross")]
             spv: match naga::back::spv::write_vec(&shader.module, &shader.info, &self.spv_options) {
                 Ok(spv) => spv,
@@ -1230,7 +1214,7 @@ impl d::Device<B> for Device {
                     return Err((d::ShaderError::CompilationFailed(format!("{}", e)), shader))
                 }
             },
-            naga: Some(shader),
+            naga: Ok(shader),
         })
     }
 

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -292,10 +292,9 @@ impl pso::DescriptorPool<Backend> for DescriptorPool {
 }
 
 pub struct ShaderModule {
-    pub(crate) prefer_naga: bool,
     #[cfg(feature = "cross")]
     pub(crate) spv: Vec<u32>,
-    pub(crate) naga: Option<hal::device::NagaShader>,
+    pub(crate) naga: Result<hal::device::NagaShader, String>,
 }
 
 impl fmt::Debug for ShaderModule {

--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -141,7 +141,6 @@ pub struct Device {
     memory_types: Vec<adapter::MemoryType>,
     features: hal::Features,
     pub online_recording: OnlineRecording,
-    pub always_prefer_naga: bool,
     #[cfg(any(feature = "pipeline-cache", feature = "cross"))]
     spv_options: naga::back::spv::Options,
 }
@@ -284,7 +283,6 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             memory_types: self.memory_types.clone(),
             features: requested_features,
             online_recording: OnlineRecording::default(),
-            always_prefer_naga: false,
             #[cfg(any(feature = "pipeline-cache", feature = "cross"))]
             spv_options,
         };
@@ -794,22 +792,20 @@ impl Device {
         };
 
         let info = {
-            let mut result = Err(String::new());
-            if ep.module.prefer_naga {
-                result = match ep.module.naga {
-                    Ok(ref shader) => Self::compile_shader_library_naga(
-                        device,
-                        shader,
-                        &layout.naga_options,
-                        &pipeline_options,
-                        #[cfg(feature = "pipeline-cache")]
-                        ep.module.spv_hash,
-                        #[cfg(feature = "pipeline-cache")]
-                        pipeline_cache.as_ref().map(|cache| &cache.spv_to_msl),
-                    ),
-                    Err(ref e) => Err(e.clone()),
-                }
-            }
+            #[cfg_attr(not(feature = "cross"), allow(unused_mut))]
+            let mut result = match ep.module.naga {
+                Ok(ref shader) => Self::compile_shader_library_naga(
+                    device,
+                    shader,
+                    &layout.naga_options,
+                    &pipeline_options,
+                    #[cfg(feature = "pipeline-cache")]
+                    ep.module.spv_hash,
+                    #[cfg(feature = "pipeline-cache")]
+                    pipeline_cache.as_ref().map(|cache| &cache.spv_to_msl),
+                ),
+                Err(ref e) => Err(e.clone()),
+            };
             #[cfg(feature = "cross")]
             if result.is_err() {
                 result = Self::compile_shader_library_cross(
@@ -820,21 +816,6 @@ impl Device {
                     &ep.specialization,
                     stage,
                 );
-            }
-            if result.is_err() && !ep.module.prefer_naga {
-                result = match ep.module.naga {
-                    Ok(ref shader) => Self::compile_shader_library_naga(
-                        device,
-                        shader,
-                        &layout.naga_options,
-                        &pipeline_options,
-                        #[cfg(feature = "pipeline-cache")]
-                        ep.module.spv_hash,
-                        #[cfg(feature = "pipeline-cache")]
-                        pipeline_cache.as_ref().map(|cache| &cache.spv_to_msl),
-                    ),
-                    Err(ref e) => Err(e.clone()),
-                }
             }
             result.map_err(|e| {
                 let error = format!("Error compiling the shader {:?}", e);
@@ -1383,6 +1364,27 @@ impl hal::device::Device<Backend> for Device {
                     .push_constant_buffer
                     .map(|buffer_index| buffer_index as naga::back::msl::Slot),
             },
+            /*
+            per_stage_map: naga::back::msl::PerStageMap {
+                vs: naga::back::msl::PerStageResources {
+                    push_constant_buffer: stage_infos[0]
+                        .push_constant_buffer
+                        .map(|buffer_index| buffer_index as naga::back::msl::Slot),
+                    sizes_buffer: None,
+                },
+                fs: naga::back::msl::PerStageResources {
+                    push_constant_buffer: stage_infos[1]
+                        .push_constant_buffer
+                        .map(|buffer_index| buffer_index as naga::back::msl::Slot),
+                    sizes_buffer: None,
+                },
+                cs: naga::back::msl::PerStageResources {
+                    push_constant_buffer: stage_infos[2]
+                        .push_constant_buffer
+                        .map(|buffer_index| buffer_index as naga::back::msl::Slot),
+                    sizes_buffer: None,
+                },
+            },*/
         };
 
         Ok(n::PipelineLayout {
@@ -1967,12 +1969,13 @@ impl hal::device::Device<Backend> for Device {
     ) -> Result<n::ShaderModule, d::ShaderError> {
         profiling::scope!("create_shader_module");
         Ok(n::ShaderModule {
-            prefer_naga: self.always_prefer_naga,
             #[cfg(feature = "cross")]
             spv: raw_data.to_vec(),
             #[cfg(feature = "pipeline-cache")]
             spv_hash: fxhash::hash64(raw_data),
-            naga: {
+            naga: if cfg!(feature = "cross") {
+                Err("Cross is enabled".into())
+            } else {
                 let options = naga::front::spv::Options {
                     adjust_coordinate_space: !self.features.contains(hal::Features::NDC_Y_UP),
                     strict_capabilities: true,
@@ -1986,11 +1989,14 @@ impl hal::device::Device<Backend> for Device {
                 match parse_result {
                     Ok(module) => {
                         debug!("Naga module {:#?}", module);
-                        match naga::valid::Validator::new(naga::valid::ValidationFlags::empty())
-                            .validate(&module)
+                        match naga::valid::Validator::new(
+                            naga::valid::ValidationFlags::empty(),
+                            //naga::valid::Capabilities::empty(),
+                        )
+                        .validate(&module)
                         {
                             Ok(info) => Ok(d::NagaShader { module, info }),
-                            Err(e) => Err(format!("Naga validation: {:?}", e)),
+                            Err(e) => Err(format!("Naga validation: {}", e)),
                         }
                     }
                     Err(e) => Err(format!("Naga parsing: {:?}", e)),
@@ -2013,7 +2019,6 @@ impl hal::device::Device<Backend> for Device {
         };
 
         Ok(n::ShaderModule {
-            prefer_naga: true,
             #[cfg(feature = "pipeline-cache")]
             spv_hash: fxhash::hash64(&spv),
             #[cfg(feature = "cross")]

--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -109,7 +109,7 @@ type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<fxhash::FxHasher>>;
 type ResourceIndex = u32;
 
 // For CALayer contentsGravity
-#[link(name="QuartzCore", kind="framework")]
+#[link(name = "QuartzCore", kind = "framework")]
 extern "C" {
     #[allow(non_upper_case_globals)]
     static kCAGravityTopLeft: cocoa_foundation::base::id;

--- a/src/backend/metal/src/native.rs
+++ b/src/backend/metal/src/native.rs
@@ -40,7 +40,6 @@ pub type EntryPointMap = FastHashMap<(naga::ShaderStage, String), EntryPoint>;
 pub type PoolResourceIndex = u32;
 
 pub struct ShaderModule {
-    pub(crate) prefer_naga: bool,
     #[cfg(feature = "cross")]
     pub(crate) spv: Vec<u32>,
     #[cfg(feature = "pipeline-cache")]


### PR DESCRIPTION
Follow-up to #3641
Our code paths are more complex that they should be. Duplicating the Naga path both before and after the Cross, depending on the preference, is not needed by anybody. Now that Naga has matured quite a bit, we need to be more aggressive.
I believe this PR preserves the old behavior (minus fallback from Cross to Naga), but cleans up the code. It also avoids unnecessary work (naga parsing of SPIR-V) if Cross is enabled.
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
