### PR TITLE
renderdoc: backend-agnostic RenderDoc frame capture functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "src/auxil/auxil",
     "src/auxil/range-alloc",
+    "src/auxil/renderdoc",
     "src/backend/dx11",
     "src/backend/dx12",
     "src/backend/empty",

--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -914,6 +914,9 @@ where
     }
 
     fn render(&mut self) {
+        // Start a RenderDoc capture, which allows analyzing the rendering pipeline
+        self.device.start_capture();
+
         let surface_image = unsafe {
             match self.surface.acquire_image(!0) {
                 Ok((image, _)) => image,
@@ -1003,6 +1006,9 @@ where
 
         // Increment our frame
         self.frame += 1;
+
+        // End the RenderDoc capture
+        self.device.stop_capture();
     }
 }
 

--- a/src/auxil/renderdoc/Cargo.toml
+++ b/src/auxil/renderdoc/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "gfx-renderdoc"
+version = "0.1.0"
+description = "Generic RenderDoc integration used by gfx-rs backends"
+homepage = "https://github.com/gfx-rs/gfx"
+repository = "https://github.com/gfx-rs/gfx"
+keywords = ["renderdoc"]
+license = "MIT OR Apache-2.0"
+authors = ["The Gfx-rs Developers"]
+documentation = "https://docs.rs/gfx-auxil-renderdoc"
+categories = ["graphics"]
+workspace = "../../../"
+edition = "2018"
+
+[lib]
+name = "gfx_renderdoc"
+
+[dependencies]
+renderdoc-sys = "0.7.1"
+libloading = "0.7"
+log = "0.4"

--- a/src/auxil/renderdoc/src/lib.rs
+++ b/src/auxil/renderdoc/src/lib.rs
@@ -1,0 +1,127 @@
+#![warn(
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications
+)]
+
+//! RenderDoc integration - https://renderdoc.org/
+
+/// The dynamically loaded RenderDoc API function table
+#[repr(C)]
+#[derive(Debug)]
+pub struct RenderDocApi {
+    api: renderdoc_sys::RENDERDOC_API_1_4_1,
+    lib: libloading::Library,
+}
+
+unsafe impl Send for RenderDocApi {}
+
+unsafe impl Sync for RenderDocApi {}
+
+/// RenderDoc API type
+#[derive(Debug)]
+pub enum RenderDoc {
+    /// RenderDoc functionality is available
+    Available {
+        /// RenderDoc API with function pointers
+        api: RenderDocApi,
+    },
+    /// RenderDoc functionality is _not_ available
+    NotAvailable {
+        /// A description why renderdoc functionality is not available
+        reason: String,
+    },
+}
+
+impl RenderDoc {
+    pub unsafe fn new() -> Self {
+        type GetApiFn = unsafe extern "C" fn(version: u32, out: *mut *mut std::ffi::c_void) -> i32;
+
+        #[cfg(windows)]
+        let renderdoc_filename = "renderdoc.dll";
+        #[cfg(all(unix, not(target_os = "android")))]
+        let renderdoc_filename = "librenderdoc.so";
+        #[cfg(target_os = "android")]
+        let renderdoc_filename = "libVkLayer_GLES_RenderDoc.so";
+
+        let renderdoc_lib = match libloading::Library::new(renderdoc_filename) {
+            Ok(lib) => lib,
+            Err(e) => {
+                return RenderDoc::NotAvailable {
+                    reason: format!(
+                        "Unable to load renderdoc library '{}': {:?}",
+                        renderdoc_filename, e
+                    ),
+                }
+            }
+        };
+
+        let get_api: libloading::Symbol<GetApiFn> = match renderdoc_lib.get(b"RENDERDOC_GetAPI\0") {
+            Ok(api) => api,
+            Err(e) => {
+                return RenderDoc::NotAvailable {
+                    reason: format!(
+                        "Unable to get RENDERDOC_GetAPI from renderdoc library '{}': {:?}",
+                        renderdoc_filename, e
+                    ),
+                }
+            }
+        };
+        let mut obj = std::ptr::null_mut();
+        match get_api(10401, &mut obj) {
+            1 => RenderDoc::Available {
+                api: RenderDocApi {
+                    api: *(obj as *mut renderdoc_sys::RENDERDOC_API_1_4_1),
+                    lib: renderdoc_lib,
+                },
+            },
+            return_value => RenderDoc::NotAvailable {
+                reason: format!(
+                    "Unable to get API from renderdoc library '{}': {}",
+                    renderdoc_filename, return_value
+                ),
+            },
+        }
+    }
+}
+
+impl Default for RenderDoc {
+    fn default() -> Self {
+        if !cfg!(debug_assertions) {
+            return RenderDoc::NotAvailable {
+                reason: "RenderDoc support is only enabled with 'debug_assertions'".into(),
+            };
+        }
+        unsafe { Self::new() }
+    }
+}
+/// A implementation specific handle
+pub type Handle = *mut ::std::os::raw::c_void;
+
+impl RenderDoc {
+    /// Start a RenderDoc frame capture
+    pub unsafe fn start_frame_capture(&self, device_handle: Handle, window_handle: Handle) {
+        match self {
+            Self::Available { api: ref entry } => {
+                entry.api.StartFrameCapture.unwrap()(device_handle, window_handle);
+            }
+            Self::NotAvailable { ref reason } => {
+                log::warn!("Could not start RenderDoc frame capture: {}", reason)
+            }
+        };
+    }
+
+    /// End a RenderDoc frame capture
+    pub unsafe fn end_frame_capture(&self, device_handle: Handle, window_handle: Handle) {
+        match self {
+            Self::Available { api: ref entry } => {
+                entry.api.EndFrameCapture.unwrap()(device_handle, window_handle);
+            }
+            Self::NotAvailable { ref reason } => {
+                log::warn!("Could not end RenderDoc frame capture: {}", reason)
+            }
+        };
+    }
+}

--- a/src/backend/dx11/Cargo.toml
+++ b/src/backend/dx11/Cargo.toml
@@ -33,6 +33,7 @@ parking_lot = "0.11"
 winapi = { version = "0.3", features = ["basetsd","d3d11", "d3d11_1", "d3d11sdklayers", "d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4", "dxgi1_5", "dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 wio = "0.2"
 raw-window-handle = "0.3"
+gfx-renderdoc = { path = "../../auxil/renderdoc", version = "0.1.0" }
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx11/src/device.rs
+++ b/src/backend/dx11/src/device.rs
@@ -55,6 +55,7 @@ pub struct Device {
     pub(crate) context: ComPtr<d3d11::ID3D11DeviceContext>,
     features: hal::Features,
     memory_properties: MemoryProperties,
+    render_doc: gfx_renderdoc::RenderDoc,
     pub(crate) internal: Arc<internal::Internal>,
 }
 
@@ -99,6 +100,7 @@ impl Device {
             context,
             features,
             memory_properties,
+            render_doc: Default::default(),
         }
     }
 
@@ -2460,10 +2462,16 @@ impl device::Device<Backend> for Device {
     }
 
     fn start_capture(&self) {
-        //TODO
+        unsafe {
+            self.render_doc
+                .start_frame_capture(self.raw.as_raw() as *mut _, ptr::null_mut())
+        }
     }
 
     fn stop_capture(&self) {
-        //TODO
+        unsafe {
+            self.render_doc
+                .end_frame_capture(self.raw.as_raw() as *mut _, ptr::null_mut())
+        }
     }
 }

--- a/src/backend/dx12/Cargo.toml
+++ b/src/backend/dx12/Cargo.toml
@@ -33,6 +33,7 @@ spirv_cross = { version = "0.23", features = ["hlsl"] }
 thunderdome = "0.4"
 winapi = { version = "0.3", features = ["basetsd","d3d12","d3d12sdklayers","d3d12shader","d3dcommon","d3dcompiler","dxgi1_2","dxgi1_3","dxgi1_4","dxgi1_5","dxgi1_6","dxgidebug","dxgiformat","dxgitype","handleapi","minwindef","synchapi","unknwnbase","winbase","windef","winerror","winnt","winuser"] }
 raw-window-handle = "0.3"
+gfx-renderdoc = { path = "../../auxil/renderdoc", version = "0.1.0" }
 
 # This forces docs.rs to build the crate on windows, otherwise the build fails
 # and we get no docs at all.

--- a/src/backend/dx12/src/device.rs
+++ b/src/backend/dx12/src/device.rs
@@ -3777,11 +3777,17 @@ impl d::Device<B> for Device {
     }
 
     fn start_capture(&self) {
-        //TODO
+        unsafe {
+            self.render_doc
+                .start_frame_capture(self.raw.as_mut_ptr() as *mut _, ptr::null_mut())
+        }
     }
 
     fn stop_capture(&self) {
-        //TODO
+        unsafe {
+            self.render_doc
+                .end_frame_capture(self.raw.as_mut_ptr() as *mut _, ptr::null_mut())
+        }
     }
 }
 

--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -774,6 +774,7 @@ pub struct Device {
     // Indicates that there is currently an active device.
     open: Arc<Mutex<bool>>,
     library: Arc<native::D3D12Lib>,
+    render_doc: gfx_renderdoc::RenderDoc,
 }
 
 impl fmt::Debug for Device {
@@ -860,6 +861,7 @@ impl Device {
             present_queue,
             queues: Vec::new(),
             open: Arc::clone(&physical_device.is_open),
+            render_doc: Default::default(),
         }
     }
 

--- a/src/backend/vulkan/Cargo.toml
+++ b/src/backend/vulkan/Cargo.toml
@@ -30,8 +30,7 @@ parking_lot = "0.11"
 smallvec = "1.0"
 raw-window-handle = "0.3"
 inplace_it = "0.3.3"
-renderdoc-sys = "0.7.1"
-libloading = "0.7"
+gfx-renderdoc = { path = "../../auxil/renderdoc", version = "0.1.0" }
 
 [dependencies.naga]
 git = "https://github.com/gfx-rs/naga"

--- a/src/backend/vulkan/src/device.rs
+++ b/src/backend/vulkan/src/device.rs
@@ -1893,29 +1893,15 @@ impl d::Device<B> for super::Device {
 
     fn start_capture(&self) {
         unsafe {
-            match self.shared.instance.render_doc_entry {
-                Ok(ref entry) => {
-                    entry.api.StartFrameCapture.unwrap()(
-                        self.shared.raw.handle().as_raw() as *mut _,
-                        ptr::null_mut(),
-                    );
-                }
-                Err(ref cause) => warn!("Could not start render doc frame capture: {}", cause),
-            };
+            self.render_doc
+                .start_frame_capture(self.shared.raw.handle().as_raw() as *mut _, ptr::null_mut())
         }
     }
 
     fn stop_capture(&self) {
         unsafe {
-            match self.shared.instance.render_doc_entry {
-                Ok(ref entry) => {
-                    entry.api.EndFrameCapture.unwrap()(
-                        self.shared.raw.handle().as_raw() as *mut _,
-                        ptr::null_mut(),
-                    );
-                }
-                Err(ref cause) => warn!("Could not stop render doc frame capture: {}", cause),
-            };
+            self.render_doc
+                .end_frame_capture(self.shared.raw.handle().as_raw() as *mut _, ptr::null_mut())
         }
     }
 }

--- a/src/backend/vulkan/src/lib.rs
+++ b/src/backend/vulkan/src/lib.rs
@@ -74,8 +74,6 @@ pub struct RawInstance {
     inner: ash::Instance,
     debug_messenger: Option<DebugMessenger>,
     get_physical_device_properties: Option<vk::KhrGetPhysicalDeviceProperties2Fn>,
-
-    pub render_doc_entry: Result<RenderDocEntry, String>,
 }
 
 pub enum DebugMessenger {
@@ -146,16 +144,6 @@ impl Into<Version> for u32 {
         Version(self)
     }
 }
-
-#[repr(C)]
-pub struct RenderDocEntry {
-    api: renderdoc_sys::RENDERDOC_API_1_4_1,
-    lib: libloading::Library,
-}
-
-unsafe impl Send for RenderDocEntry {}
-
-unsafe impl Sync for RenderDocEntry {}
 
 pub struct Instance {
     pub raw: Arc<RawInstance>,
@@ -577,7 +565,6 @@ impl hal::Instance<Backend> for Instance {
                 inner: instance,
                 debug_messenger,
                 get_physical_device_properties,
-                render_doc_entry: unsafe { load_renderdoc_entrypoint() },
             }),
             extensions,
             entry,
@@ -660,51 +647,6 @@ impl hal::Instance<Backend> for Instance {
             .functor
             .destroy_surface(surface.raw.handle, None);
     }
-}
-
-unsafe fn load_renderdoc_entrypoint() -> Result<RenderDocEntry, String> {
-    if !cfg!(debug_assertions) {
-        return Err("RenderDoc support is only enabled with 'debug_assertions'".into());
-    }
-
-    type GetApiFn = unsafe extern "C" fn(version: u32, out: *mut *mut std::ffi::c_void) -> i32;
-
-    #[cfg(windows)]
-    let renderdoc_filename = "renderdoc.dll";
-    #[cfg(all(unix, not(target_os = "android")))]
-    let renderdoc_filename = "librenderdoc.so";
-    #[cfg(target_os = "android")]
-    let renderdoc_filename = "libVkLayer_GLES_RenderDoc.so";
-
-    let renderdoc_lib = libloading::Library::new(renderdoc_filename).map_err(|e| {
-        format!(
-            "Unable to load renderdoc library '{}': {:?}",
-            renderdoc_filename, e
-        )
-    })?;
-
-    let get_api: libloading::Symbol<GetApiFn> =
-        renderdoc_lib.get(b"RENDERDOC_GetAPI\0").map_err(|e| {
-            format!(
-                "Unable to get RENDERDOC_GetAPI from renderdoc library '{}': {:?}",
-                renderdoc_filename, e
-            )
-        })?;
-    let mut obj = std::ptr::null_mut();
-    match get_api(10401, &mut obj) {
-        1 => Ok(RenderDocEntry {
-            api: *(obj as *mut renderdoc_sys::RENDERDOC_API_1_4_1),
-            lib: renderdoc_lib,
-        }),
-        return_value => Err(format!(
-            "Unable to get API from renderdoc library '{}': {}",
-            renderdoc_filename, return_value
-        )),
-    }
-    .map_err(|error| {
-        warn!("Error loading renderdoc library: {}", error);
-        error
-    })
 }
 
 #[derive(Debug, Clone)]
@@ -1088,6 +1030,7 @@ pub struct Device {
     shared: Arc<RawDevice>,
     vendor_id: u32,
     valid_ash_memory_types: u32,
+    render_doc: gfx_renderdoc::RenderDoc,
     #[cfg(feature = "naga")]
     naga_options: naga::back::spv::Options,
 }

--- a/src/backend/vulkan/src/physical_device.rs
+++ b/src/backend/vulkan/src/physical_device.rs
@@ -942,6 +942,7 @@ impl adapter::PhysicalDevice<Backend> for PhysicalDevice {
             }),
             vendor_id: self.device_info.properties.vendor_id,
             valid_ash_memory_types,
+            render_doc: Default::default(),
             #[cfg(feature = "naga")]
             naga_options,
         };


### PR DESCRIPTION
This is a follow up to #3737 to bring RenderDoc frame capture functionality to more backends

This is a first implementation sketch to bring RenderDoc frame capture to more backends. My first goal was to get the internal API right, and figure out if gfx-hal is the right location for this code (maybe auxil would be better suited?)

Fixes #issue
PR checklist:
- [x] `make` succeeds ~~(on *nix)~~ on Windows 10
- [x] `make reftests` succeeds
- [x] tested examples with the following backends: Vulkan, DX11, DX12
