### PR TITLE
Prevent accessing NSView from other threads

### DIFF
--- a/src/backend/metal/src/window.rs
+++ b/src/backend/metal/src/window.rs
@@ -244,6 +244,12 @@ impl w::PresentationSurface<Backend> for Surface {
         if !image::Usage::COLOR_ATTACHMENT.contains(config.image_usage) {
             warn!("Swapchain usage {:?} is not expected", config.image_usage);
         }
+        #[cfg(target_os = "macos")]
+        {
+            if self.view.is_some() && self.main_thread_id != thread::current().id() {
+                return Err(w::SwapchainError::WrongThread)
+            }
+        }
         self.swapchain_format = self.configure(&device.shared, &config);
         Ok(())
     }

--- a/src/hal/src/window.rs
+++ b/src/hal/src/window.rs
@@ -89,8 +89,11 @@ pub enum SwapchainError {
     /// Window in use
     #[error("Window is in use")]
     WindowInUse,
+    /// Accecssing the underlying NSView from wrong thread https://github.com/gfx-rs/gfx/issues/3704
+    #[error("Accecssing NSView from wrong thread")]
+    WrongThread,
     /// Unknown error.
-    #[error("Swapchain can't be created for an unlknown reason")]
+    #[error("Swapchain can't be created for an unknown reason")]
     Unknown,
 }
 


### PR DESCRIPTION
Fixes #3704
PR checklist:
- [x] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [x] tested examples with the following backends: Metal

Tested it with the following patch: 
 
```diff
diff --git a/examples/quad/main.rs b/examples/quad/main.rs
index 8989a75ef..676e5a198 100644
--- a/examples/quad/main.rs
+++ b/examples/quad/main.rs
@@ -114,13 +114,18 @@ fn main() {
         .append_child(&winit::platform::web::WindowExtWebSys::canvas(&window))
         .unwrap();
 
-    let instance = back::Instance::create("gfx-rs quad", 1).expect("Failed to create an instance!");
 
-    let surface = unsafe {
-        instance
-            .create_surface(&window)
-            .expect("Failed to create a surface!")
-    };
+    let other_thread = std::thread::spawn(move || {
+            let instance = back::Instance::create("gfx-rs quad", 1).expect("Failed to create an instance!");
+            let surface = unsafe {
+                instance
+                    .create_surface(&window)
+                    .expect("Failed to create a surface!")
+            };
+            (instance, surface)
+    });
+
+    let (instance, surface) = other_thread.join().unwrap();

     let adapter = {
         let mut adapters = instance.enumerate_adapters();

```