### PR TITLE
Add features needed for wgpu to dx12 backend

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1355,6 +1355,9 @@ impl hal::Instance<Backend> for Instance {
                     Features::UNIFORM_BUFFER_DESCRIPTOR_INDEXING |
                     Features::UNSIZED_DESCRIPTOR_ARRAY |
                     Features::DRAW_INDIRECT_COUNT |
+                    Features::INDEPENDENT_BLENDING |
+                    Features::SAMPLE_RATE_SHADING | 
+                    Features::FRAGMENT_STORES_AND_ATOMICS | 
                     tiled_resource_features |
                     conservative_faster_features,
                 properties: PhysicalDeviceProperties {


### PR DESCRIPTION
Adds `INDEPENDENT_BLENDING`, `SAMPLE_RATE_SHADING`, and
`FRAGMENT_STORES_ATOMICS` to DX12 backend features

Fixes https://github.com/gfx-rs/wgpu/issues/1405
PR checklist:
- [ ] `make` succeeds (on *nix)
- [X] `make reftests` succeeds
- [X] tested examples with the following backends: dx12
