### PR TITLE
Make `enabled_extensions` public in Vulkan backend

### DIFF
--- a/src/backend/vulkan/src/physical_device.rs
+++ b/src/backend/vulkan/src/physical_device.rs
@@ -833,7 +833,7 @@ impl PhysicalDevice {
         }
     }
 
-    fn enabled_extensions(
+    pub fn enabled_extensions(
         &self,
         requested_features: Features,
     ) -> Result<Vec<&'static CStr>, CreationError> {


### PR DESCRIPTION
This is required for OpenXR support, when creating a custom device gfx-hal needs to be queried for what raw vulkan extensions to enable for the given gfx-hal features.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
 - gfx_backend_vulkan