### PR TITLE
Fix WebGL backend for wgpu-rs cube example

### DIFF
--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use hal::{
     buffer, device as d,
-    format::{Format, Swizzle},
+    format::{ChannelType, Format, Swizzle},
     image as i, memory, pass,
     pool::CommandPoolCreateFlags,
     pso, query, queue,
@@ -1505,6 +1505,21 @@ impl d::Device<B> for Device {
                             h = std::cmp::max(h / 2, 1);
                         }
                     }
+                    match channel {
+                        ChannelType::Uint | ChannelType::Sint => {
+                            gl.tex_parameter_i32(
+                                glow::TEXTURE_2D,
+                                glow::TEXTURE_MIN_FILTER,
+                                glow::NEAREST as _,
+                            );
+                            gl.tex_parameter_i32(
+                                glow::TEXTURE_2D,
+                                glow::TEXTURE_MAG_FILTER,
+                                glow::NEAREST as _,
+                            );
+                        }
+                        _ => {}
+                    };
                     glow::TEXTURE_2D
                 }
                 i::Kind::D2(w, h, l, 1) => {
@@ -1545,6 +1560,21 @@ impl d::Device<B> for Device {
                             h = std::cmp::max(h / 2, 1);
                         }
                     }
+                    match channel {
+                        ChannelType::Uint | ChannelType::Sint => {
+                            gl.tex_parameter_i32(
+                                glow::TEXTURE_2D,
+                                glow::TEXTURE_MIN_FILTER,
+                                glow::NEAREST as _,
+                            );
+                            gl.tex_parameter_i32(
+                                glow::TEXTURE_2D,
+                                glow::TEXTURE_MAG_FILTER,
+                                glow::NEAREST as _,
+                            );
+                        }
+                        _ => {}
+                    };
                     glow::TEXTURE_2D_ARRAY
                 }
                 _ => unimplemented!(),

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1679,7 +1679,7 @@ impl d::Device<B> for Device {
                 };
                 match conv::describe_format(view_format) {
                     Some(description) => {
-                        let raw_view_format = description.tex_internal;
+                        let raw_view_format = description.tex_external;
                         if format != raw_view_format {
                             log::warn!(
                                 "View format {:?} is different from base {:?}",


### PR DESCRIPTION
Fixes "cube" example in wgpu-rs for webgl backend on Windows. Will also fix MacOS once https://github.com/gfx-rs/naga/pull/936 gets included.

`delete_shader` is delayed after linking the program. Not doing that seems to be randomly triggering linking issues. I'm not exactly sure under what circumstances it tends to happen, but the fix made it reliable.

The most important fix is about texture filtering for intager textures. ANGLE decides to ignore integer textures if their filtering is kept as default. Instead, it silently substitutes an empty 1px placeholder texture into the shader binding. Forcing the integer textures to NEAREST filtering makes that problem go away.