### PR TITLE
Correction on the description of the direct display behaviour for the quad example

### DIFF
--- a/examples/quad/README.md
+++ b/examples/quad/README.md
@@ -7,8 +7,4 @@ The following image is an output of `cargo run --bin quad --features=gl`:
 If the environment variable `DIRECT_DISPLAY` is setted, the example will try to
 present the image directly on the terminal without windowing system. This path
 will work only with the vulkan backend, so the `--features=vulkan` flag need to
-be used. Like the standard winit path, pressing the key "Esc" will terminate the application.
-Due to input gathering nature, the application will collect all
-the inputs while running, so the user will not be able to do anything in the meantime.
-For this reason, the application will exit automatically after 10 seconds to
-avoid user get stucked.
+be used. When launched in this mode, the Gfx logo will be showed for 5 seconds and then the example will close.


### PR DESCRIPTION
Hi,
during the development of the direct display path i had removed the input acquisition so that no newer depencencies was needed. Unfortunately i have forgotten to update the example description accordingly, so this will fix it. The code works as intendend, just the description was not updated. Sorry for the incovenience.

Have a good day
