### PR TITLE
Support wgpu skybox example on webgl

### DIFF
--- a/src/backend/dx12/src/lib.rs
+++ b/src/backend/dx12/src/lib.rs
@@ -1356,8 +1356,8 @@ impl hal::Instance<Backend> for Instance {
                     Features::UNSIZED_DESCRIPTOR_ARRAY |
                     Features::DRAW_INDIRECT_COUNT |
                     Features::INDEPENDENT_BLENDING |
-                    Features::SAMPLE_RATE_SHADING | 
-                    Features::FRAGMENT_STORES_AND_ATOMICS | 
+                    Features::SAMPLE_RATE_SHADING |
+                    Features::FRAGMENT_STORES_AND_ATOMICS |
                     tiled_resource_features |
                     conservative_faster_features,
                 properties: PhysicalDeviceProperties {

--- a/src/backend/gl/Cargo.toml
+++ b/src/backend/gl/Cargo.toml
@@ -25,7 +25,8 @@ bitflags = "1"
 fxhash = "0.2.1"
 log = "0.4"
 hal = { package = "gfx-hal", path = "../../hal", version = "0.8" }
-glow = "0.9"
+glow = "0.10"
+
 parking_lot = "0.11"
 raw-window-handle = "0.3"
 

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -127,6 +127,7 @@ pub enum Command {
         dst_texture: n::Texture,
         texture_target: n::TextureTarget,
         texture_format: n::TextureFormat,
+        internal_format: n::TextureFormat,
         pixel_type: n::DataType,
         data: command::BufferImageCopy,
     },
@@ -1346,14 +1347,16 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
                 n::ImageType::Texture {
                     raw,
                     target,
-                    format,
+                    format_external,
+                    format_internal,
                     pixel_type,
                     ..
                 } => Command::CopyBufferToTexture {
                     src_buffer: src_bounded_buffer.raw,
                     dst_texture: raw,
                     texture_target: target,
-                    texture_format: format,
+                    texture_format: format_external,
+                    internal_format: format_internal,
                     pixel_type,
                     data: r,
                 },
@@ -1387,13 +1390,13 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
                 n::ImageType::Texture {
                     raw,
                     target,
-                    format,
+                    format_external,
                     pixel_type,
                     ..
                 } => Command::CopyTextureToBuffer {
                     src_texture: raw,
                     texture_target: target,
-                    texture_format: format,
+                    texture_format: format_external,
                     pixel_type: pixel_type,
                     dst_buffer: dst_bounded_buffer.raw,
                     data: r,

--- a/src/backend/gl/src/command.rs
+++ b/src/backend/gl/src/command.rs
@@ -908,21 +908,17 @@ impl command::CommandBuffer<Backend> for CommandBuffer {
                         level_count,
                         layer_count,
                         ..
-                    } => {
-                        let is_3d = layer_count == 1; //TODO?
-                        n::ImageView::Texture {
-                            target,
-                            raw,
-                            is_3d,
-                            sub: image::SubresourceRange {
-                                aspects: Aspects::COLOR,
-                                layer_start: 0,
-                                layer_count: Some(layer_count),
-                                level_start: 0,
-                                level_count: Some(level_count),
-                            },
-                        }
-                    }
+                    } => n::ImageView::Texture {
+                        target,
+                        raw,
+                        sub: image::SubresourceRange {
+                            aspects: Aspects::COLOR,
+                            layer_start: 0,
+                            layer_count: Some(layer_count),
+                            level_start: 0,
+                            level_count: Some(level_count),
+                        },
+                    },
                 };
                 self.data.push_cmd(Command::BindFramebuffer {
                     target: glow::DRAW_FRAMEBUFFER,

--- a/src/backend/gl/src/conv.rs
+++ b/src/backend/gl/src/conv.rs
@@ -1,20 +1,6 @@
 use crate::native::VertexAttribFunction;
 use hal::{format::Format, image as i, pso};
 
-/*
-pub fn _image_kind_to_gl(kind: i::Kind) -> t::GLenum {
-    match kind {
-        i::Kind::D1(_) => glow::TEXTURE_1D,
-        i::Kind::D1Array(_, _) => glow::TEXTURE_1D_ARRAY,
-        i::Kind::D2(_, _, i::AaMode::Single) => glow::TEXTURE_2D,
-        i::Kind::D2(_, _, _) => glow::TEXTURE_2D_MULTISAMPLE,
-        i::Kind::D2Array(_, _, _, i::AaMode::Single) => glow::TEXTURE_2D_ARRAY,
-        i::Kind::D2Array(_, _, _, _) => glow::TEXTURE_2D_MULTISAMPLE_ARRAY,
-        i::Kind::D3(_, _, _) => glow::TEXTURE_3D,
-        i::Kind::Cube(_) => glow::TEXTURE_CUBE_MAP,
-        i::Kind::CubeArray(_, _) => glow::TEXTURE_CUBE_MAP_ARRAY,
-    }
-}*/
 
 pub fn filter_to_gl(mag: i::Filter, min: i::Filter, mip: i::Filter) -> (u32, u32) {
     use hal::image::Filter::*;

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -1572,7 +1572,8 @@ impl d::Device<B> for Device {
             n::ImageType::Texture {
                 target,
                 raw: name,
-                format: desc.tex_external,
+                format_internal: desc.tex_internal,
+                format_external: desc.tex_external,
                 pixel_type: desc.data_type,
                 layer_count: kind.num_layers(),
                 level_count: num_levels,
@@ -1690,7 +1691,7 @@ impl d::Device<B> for Device {
             n::ImageType::Texture {
                 target,
                 raw,
-                format,
+                format_external: format,
                 ..
             } => {
                 match conv::describe_format(view_format) {

--- a/src/backend/gl/src/device.rs
+++ b/src/backend/gl/src/device.rs
@@ -252,60 +252,20 @@ impl Device {
         Ok((program, sampler_map))
     }
 
-    fn _bind_target_compat(gl: &GlContainer, point: u32, attachment: u32, view: &n::ImageView) {
-        match *view {
-            n::ImageView::Renderbuffer { raw: rb, .. } => unsafe {
-                gl.framebuffer_renderbuffer(point, attachment, glow::RENDERBUFFER, Some(rb));
-            },
-            n::ImageView::Texture {
-                target,
-                raw,
-                ref sub,
-                is_3d: false,
-            } => unsafe {
-                gl.bind_texture(target, Some(raw));
-                gl.framebuffer_texture_2d(
-                    point,
-                    attachment,
-                    target,
-                    Some(raw),
-                    sub.level_start as _,
-                );
-            },
-            n::ImageView::Texture {
-                target,
-                raw,
-                ref sub,
-                is_3d: true,
-            } => unsafe {
-                gl.bind_texture(target, Some(raw));
-                gl.framebuffer_texture_3d(
-                    point,
-                    attachment,
-                    target,
-                    Some(raw),
-                    sub.level_start as _,
-                    sub.layer_start as _,
-                );
-            },
-        }
-    }
-
     pub(crate) fn bind_target(gl: &GlContainer, point: u32, attachment: u32, view: &n::ImageView) {
         match *view {
             n::ImageView::Renderbuffer { raw: rb, .. } => unsafe {
                 gl.framebuffer_renderbuffer(point, attachment, glow::RENDERBUFFER, Some(rb));
             },
             n::ImageView::Texture {
-                target: _,
+                target: target @ glow::TEXTURE_2D,
                 raw,
                 ref sub,
-                is_3d: false,
             } => unsafe {
                 gl.framebuffer_texture_2d(
                     point,
                     attachment,
-                    glow::TEXTURE_2D,
+                    target,
                     Some(raw),
                     sub.level_start as _,
                 );
@@ -314,7 +274,6 @@ impl Device {
                 target: _,
                 raw,
                 ref sub,
-                is_3d: true,
             } => unsafe {
                 gl.framebuffer_texture_layer(
                     point,
@@ -1458,7 +1417,7 @@ impl d::Device<B> for Device {
         _tiling: i::Tiling,
         usage: i::Usage,
         _sparse: memory::SparseFlags,
-        _view_caps: i::ViewCapabilities,
+        view_caps: i::ViewCapabilities,
     ) -> Result<n::Image, i::CreationError> {
         let gl = &self.share.context;
 
@@ -1468,117 +1427,148 @@ impl d::Device<B> for Device {
         let mut pixel_count: u64 = 0;
         let image = if num_levels > 1 || usage.intersects(i::Usage::STORAGE | i::Usage::SAMPLED) {
             let name = gl.create_texture().unwrap();
-            let target = match kind {
-                i::Kind::D2(w, h, 1, 1) => {
-                    gl.bind_texture(glow::TEXTURE_2D, Some(name));
-                    if self.share.private_caps.image_storage {
-                        gl.tex_storage_2d(
-                            glow::TEXTURE_2D,
-                            num_levels as _,
-                            desc.tex_internal,
+            let (w, h, l, target) = match kind {
+                i::Kind::D2(w, h, 1, 1) => (w, h, 1, glow::TEXTURE_2D),
+                i::Kind::D2(w, h, 6, 1)
+                    if view_caps.contains(i::ViewCapabilities::KIND_CUBE) && w == h =>
+                {
+                    (w, h, 6, glow::TEXTURE_CUBE_MAP)
+                }
+                i::Kind::D2(w, h, l, 1) => (w, h, l as u32, glow::TEXTURE_2D_ARRAY),
+                i::Kind::D3(w, h, l) => (w, h, l, glow::TEXTURE_3D),
+                _ => unimplemented!(),
+            };
+
+            gl.bind_texture(target, Some(name));
+
+            match (self.share.private_caps.image_storage, target) {
+                (true, glow::TEXTURE_2D) | (true, glow::TEXTURE_CUBE_MAP) => {
+                    gl.tex_storage_2d(target, num_levels as _, desc.tex_internal, w as _, h as _);
+                    let mut w = w as u64;
+                    let mut h = h as u64;
+                    for i in 0..num_levels {
+                        pixel_count += w * h * h;
+                        w = std::cmp::max(w / 2, 1);
+                        h = std::cmp::max(h / 2, 1);
+                    }
+                }
+                (false, glow::TEXTURE_2D) => {
+                    gl.tex_parameter_i32(target, glow::TEXTURE_MAX_LEVEL, (num_levels - 1) as _);
+                    let mut w = w;
+                    let mut h = h;
+                    for i in 0..num_levels {
+                        gl.tex_image_2d(
+                            target,
+                            i as _,
+                            desc.tex_internal as i32,
                             w as _,
                             h as _,
+                            0,
+                            desc.tex_external,
+                            desc.data_type,
+                            None,
                         );
-                        pixel_count += (w * h) as u64 * num_levels as u64;
-                    } else {
-                        gl.tex_parameter_i32(
-                            glow::TEXTURE_2D,
-                            glow::TEXTURE_MAX_LEVEL,
-                            (num_levels - 1) as _,
-                        );
-                        let mut w = w;
-                        let mut h = h;
-                        for i in 0..num_levels {
-                            gl.tex_image_2d(
-                                glow::TEXTURE_2D,
-                                i as _,
-                                desc.tex_internal as i32,
-                                w as _,
-                                h as _,
-                                0,
-                                desc.tex_external,
-                                desc.data_type,
-                                None,
-                            );
-                            pixel_count += (w * h) as u64;
-                            w = std::cmp::max(w / 2, 1);
-                            h = std::cmp::max(h / 2, 1);
-                        }
+                        pixel_count += (w * h) as u64;
+                        w = std::cmp::max(w / 2, 1);
+                        h = std::cmp::max(h / 2, 1);
                     }
-                    match channel {
-                        ChannelType::Uint | ChannelType::Sint => {
-                            gl.tex_parameter_i32(
-                                glow::TEXTURE_2D,
-                                glow::TEXTURE_MIN_FILTER,
-                                glow::NEAREST as _,
-                            );
-                            gl.tex_parameter_i32(
-                                glow::TEXTURE_2D,
-                                glow::TEXTURE_MAG_FILTER,
-                                glow::NEAREST as _,
-                            );
-                        }
-                        _ => {}
-                    };
-                    glow::TEXTURE_2D
                 }
-                i::Kind::D2(w, h, l, 1) => {
-                    gl.bind_texture(glow::TEXTURE_2D_ARRAY, Some(name));
-                    if self.share.private_caps.image_storage {
-                        gl.tex_storage_3d(
-                            glow::TEXTURE_2D_ARRAY,
-                            num_levels as _,
-                            desc.tex_internal,
+                (true, glow::TEXTURE_2D_ARRAY) => {
+                    gl.tex_storage_3d(
+                        target,
+                        num_levels as _,
+                        desc.tex_internal,
+                        w as _,
+                        h as _,
+                        l as _,
+                    );
+                    let mut w = w as u64;
+                    let mut h = h as u64;
+                    let l = l as u64;
+                    for i in 0..num_levels {
+                        pixel_count += w * h * l;
+                        w = std::cmp::max(w / 2, 1);
+                        h = std::cmp::max(h / 2, 1);
+                    }
+                }
+                (false, glow::TEXTURE_2D_ARRAY) => {
+                    gl.tex_parameter_i32(target, glow::TEXTURE_MAX_LEVEL, (num_levels - 1) as _);
+                    let mut w = w as u64;
+                    let mut h = h as u64;
+                    let l = l as u64;
+                    for i in 0..num_levels {
+                        gl.tex_image_3d(
+                            target,
+                            i as _,
+                            desc.tex_internal as i32,
                             w as _,
                             h as _,
                             l as _,
+                            0,
+                            desc.tex_external,
+                            desc.data_type,
+                            None,
                         );
-                        pixel_count += (w * h) as u64 * l as u64 * num_levels as u64;
-                    } else {
-                        gl.tex_parameter_i32(
-                            glow::TEXTURE_2D_ARRAY,
-                            glow::TEXTURE_MAX_LEVEL,
-                            (num_levels - 1) as _,
-                        );
-                        let mut w = w;
-                        let mut h = h;
-                        for i in 0..num_levels {
-                            gl.tex_image_3d(
-                                glow::TEXTURE_2D_ARRAY,
-                                i as _,
-                                desc.tex_internal as i32,
-                                w as _,
-                                h as _,
-                                l as _,
-                                0,
-                                desc.tex_external,
-                                desc.data_type,
-                                None,
-                            );
-                            pixel_count += (w * h) as u64 * l as u64;
-                            w = std::cmp::max(w / 2, 1);
-                            h = std::cmp::max(h / 2, 1);
-                        }
+                        pixel_count += w * h * l;
+                        w = std::cmp::max(w / 2, 1);
+                        h = std::cmp::max(h / 2, 1);
                     }
-                    match channel {
-                        ChannelType::Uint | ChannelType::Sint => {
-                            gl.tex_parameter_i32(
-                                glow::TEXTURE_2D,
-                                glow::TEXTURE_MIN_FILTER,
-                                glow::NEAREST as _,
-                            );
-                            gl.tex_parameter_i32(
-                                glow::TEXTURE_2D,
-                                glow::TEXTURE_MAG_FILTER,
-                                glow::NEAREST as _,
-                            );
-                        }
-                        _ => {}
-                    };
-                    glow::TEXTURE_2D_ARRAY
+                }
+                (true, glow::TEXTURE_3D) => {
+                    gl.tex_storage_3d(
+                        target,
+                        num_levels as _,
+                        desc.tex_internal,
+                        w as _,
+                        h as _,
+                        l as _,
+                    );
+                    let mut w = w as u64;
+                    let mut h = h as u64;
+                    let mut l = l as u64;
+                    for i in 0..num_levels {
+                        pixel_count += w * h * l;
+                        w = std::cmp::max(w / 2, 1);
+                        h = std::cmp::max(h / 2, 1);
+                        l = std::cmp::max(l / 2, 1);
+                    }
+                }
+                (false, glow::TEXTURE_3D) => {
+                    gl.tex_parameter_i32(target, glow::TEXTURE_MAX_LEVEL, (num_levels - 1) as _);
+                    let mut w = w as u64;
+                    let mut h = h as u64;
+                    let mut l = l as u64;
+                    for i in 0..num_levels {
+                        gl.tex_image_3d(
+                            target,
+                            i as _,
+                            desc.tex_internal as i32,
+                            w as _,
+                            h as _,
+                            l as _,
+                            0,
+                            desc.tex_external,
+                            desc.data_type,
+                            None,
+                        );
+                        pixel_count += w * h * l;
+                        w = std::cmp::max(w / 2, 1);
+                        h = std::cmp::max(h / 2, 1);
+                        l = std::cmp::max(l / 2, 1);
+                    }
                 }
                 _ => unimplemented!(),
+            }
+
+            match channel {
+                ChannelType::Uint | ChannelType::Sint => {
+                    gl.tex_parameter_i32(target, glow::TEXTURE_MIN_FILTER, glow::NEAREST as _);
+                    gl.tex_parameter_i32(target, glow::TEXTURE_MAG_FILTER, glow::NEAREST as _);
+                }
+                _ => {}
             };
+            gl.bind_texture(target, None);
+
             n::ImageType::Texture {
                 target,
                 raw: name,
@@ -1703,10 +1693,6 @@ impl d::Device<B> for Device {
                 format,
                 ..
             } => {
-                let is_3d = match kind {
-                    i::ViewKind::D1 | i::ViewKind::D2 => false,
-                    _ => true,
-                };
                 match conv::describe_format(view_format) {
                     Some(description) => {
                         let raw_view_format = description.tex_external;
@@ -1722,10 +1708,23 @@ impl d::Device<B> for Device {
                         log::warn!("View format {:?} is not supported", view_format);
                     }
                 }
+                let kind_target = match kind {
+                    i::ViewKind::D1 => glow::TEXTURE_1D,
+                    i::ViewKind::D1Array => glow::TEXTURE_1D_ARRAY,
+                    i::ViewKind::D2 => glow::TEXTURE_2D,
+                    i::ViewKind::D2Array => glow::TEXTURE_2D_ARRAY,
+                    i::ViewKind::D3 => glow::TEXTURE_3D,
+                    i::ViewKind::Cube => glow::TEXTURE_CUBE_MAP,
+                    i::ViewKind::CubeArray => glow::TEXTURE_CUBE_MAP_ARRAY,
+                };
+
+                if kind_target != target {
+                    todo!("image view of different kind than original texture");
+                }
+
                 Ok(n::ImageView::Texture {
                     target,
                     raw,
-                    is_3d,
                     sub: range,
                 })
             }

--- a/src/backend/gl/src/info.rs
+++ b/src/backend/gl/src/info.rs
@@ -626,6 +626,7 @@ pub(crate) fn query_all(
         max_color_attachments: get_usize(gl, glow::MAX_COLOR_ATTACHMENTS)
             .unwrap_or(1)
             .min(MAX_COLOR_ATTACHMENTS),
+        max_memory_allocation_count: 4096,
         ..Limits::default()
     };
 
@@ -689,6 +690,13 @@ pub(crate) fn query_all(
     {
         features |= Features::INDEPENDENT_BLENDING;
     }
+    if info.is_supported(&[
+        Es(3, 0),
+        Ext("WEBGL_compressed_texture_s3tc"),
+        Ext("WEBGL_compressed_texture_s3tc_srgb"),
+    ]) {
+        features |= Features::FORMAT_BC;
+    }
 
     // TODO
     if false && info.is_supported(&[Core(4, 3), Es(3, 1)]) {
@@ -749,7 +757,6 @@ pub(crate) fn query_all(
     if info.is_supported(&[Core(3, 3), Es(3, 0)]) {
         legacy |= LegacyFeatures::INSTANCED_ATTRIBUTE_BINDING;
     }
-
     let mut performance_caveats = PerformanceCaveats::empty();
     //TODO: extension
     if !info.is_supported(&[Core(4, 2)]) {

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -151,7 +151,8 @@ pub enum ImageType {
         raw: Texture,
         level_count: i::Level,
         layer_count: i::Layer,
-        format: TextureFormat,
+        format_internal: TextureFormat,
+        format_external: TextureFormat,
         pixel_type: DataType,
     },
 }

--- a/src/backend/gl/src/native.rs
+++ b/src/backend/gl/src/native.rs
@@ -173,7 +173,6 @@ pub enum ImageView {
     Texture {
         target: TextureTarget,
         raw: Texture,
-        is_3d: bool,
         sub: i::SubresourceRange,
     },
 }

--- a/src/backend/metal/src/command.rs
+++ b/src/backend/metal/src/command.rs
@@ -775,7 +775,9 @@ impl State {
         result_sizes.clear();
         for br in stage_info.sized_bindings.iter() {
             // If it's None, this isn't the right time to update the sizes
-            let size = self.storage_buffer_length_map.get(&(br.group as pso::DescriptorSetIndex, br.binding))?;
+            let size = self
+                .storage_buffer_length_map
+                .get(&(br.group as pso::DescriptorSetIndex, br.binding))?;
             result_sizes.push(*size);
         }
         Some(slot as _)


### PR DESCRIPTION
This changesets adds necessary features to GL backend in order to support skybox example from wgpu repository in webgl.

Most notable is adding support for cubemaps. Unfortunately due to the complexity of emulating image views in GL and the fact that you can't use a single gl texture in multiple ways, the support is very limited. Every 6-layer square image is assumed to be a cubemap, and creating other than cubemap views to it will fail. Further work on that should be done eventually, but I want to get the basic support first.

Another thing is support for compressed textures, specifically S3TC formats. This was added, because skybox example texture format fallback ise BGRA, which is not supported on webgl at all. Adding support for compressed format allowed me to run the example unmodified. Further work here is adding more formats and adding a downlevel flag for BGRA texture format, which is for some reason not supported on GLES.