### PR TITLE
expose the underlying metal device

### DIFF
--- a/src/backend/metal/src/device.rs
+++ b/src/backend/metal/src/device.rs
@@ -29,7 +29,7 @@ use objc::{
     rc::autoreleasepool,
     runtime::{Object, BOOL, NO},
 };
-use parking_lot::Mutex;
+use parking_lot::{Mutex, MutexGuard};
 
 use std::collections::BTreeMap;
 #[cfg(feature = "pipeline-cache")]
@@ -592,6 +592,11 @@ impl LanguageVersion {
 }
 
 impl Device {
+    /// Provides access to the underlying Metal device.
+    pub fn lock(&self) -> MutexGuard<'_, metal::Device> {
+        self.shared.device.lock()
+    }
+
     fn _is_heap_coherent(&self, heap: &n::MemoryHeap) -> bool {
         match *heap {
             n::MemoryHeap::Private => false,


### PR DESCRIPTION
This facilitates the ability to lock and utilize the underlying Metal device directly.

My need is very similar to the one described in https://github.com/gfx-rs/gfx/issues/3698, in which it was mentioned that functionality like this could be added to the individual backends and that PRs were appreciated.

PR checklist:
- [x] `make` succeeds (on *nix)
- [x] `make reftests` succeeds
- [x] tested examples with the following backends:
