### PR TITLE
Fix crash when GfxManagedMetalLayerDelegate's backing Objective-C class has already been registered

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -65,6 +65,8 @@ use hal::{
 use range_alloc::RangeAllocator;
 
 use cocoa_foundation::foundation::NSInteger;
+use core_graphics_types::base::CGFloat;
+use core_graphics_types::geometry::CGSize;
 #[cfg(feature = "dispatch")]
 use dispatch;
 use foreign_types::ForeignTypeRef;
@@ -72,8 +74,6 @@ use metal::MTLFeatureSet;
 use metal::MTLGPUFamily;
 use metal::MTLLanguageVersion;
 use metal::{MetalLayer, MetalLayerRef};
-use core_graphics_types::base::CGFloat;
-use core_graphics_types::geometry::CGSize;
 use objc::{
     declare::ClassDecl,
     runtime::{Class, Object, Sel, BOOL, YES},
@@ -350,6 +350,10 @@ struct GfxManagedMetalLayerDelegate(&'static Class);
 
 impl GfxManagedMetalLayerDelegate {
     pub fn new() -> Self {
+        if let Some(class) = Class::get(CAML_DELEGATE_CLASS) {
+            return GfxManagedMetalLayerDelegate(class);
+        }
+
         CAML_DELEGATE_REGISTER.call_once(|| {
             type Fun = extern "C" fn(&Class, Sel, *mut Object, CGFloat, *mut Object) -> BOOL;
             let mut decl = ClassDecl::new(CAML_DELEGATE_CLASS, class!(NSObject)).unwrap();


### PR DESCRIPTION
Fixes a crash when GfxManagedMetalLayerDelegate objective-c class is already registered.

I'm sure there's a better solution, let me describe the issue:

* I'm writing an application which hosts audio plugins & uses `iced`, internally it's using `gfx`
* I've an audio plugin I've written which also uses `iced` & uses `gfx` internally too
* When the plugin is loaded into the host, this class name has already been registered and thus registration fails
* Unwrap on registration bits causes a crash

I really don't know what this code is trying to do, but as far as registering the objective-c class decl, I suppose there're a couple of options:

* Declare an unique name every time
* Don't declare the class if it's present
  - Issue: plugins may not have the same version of `gfx-backend-metal`, so the class decl needs to be binary compatible
* Declare a versioned class name

Let me know what you think & I'm happy to change the PR to go with another option. I suppose an unique class name is a good way to avoid problems, but that can be a bit messy if this class decl will be read somewhere else by name.

PR checklist:
- [ ] `make` succeeds (on *nix)
- [ ] `make reftests` succeeds
- [ ] tested examples with the following backends:
