### PR TITLE
(macOS/iOS) readWriteTextureSupport is support on macOS 10.13+ / iOS 11.0

### DIFF
--- a/src/backend/metal/src/lib.rs
+++ b/src/backend/metal/src/lib.rs
@@ -846,7 +846,17 @@ impl PrivateCapabilities {
                 MTLLanguageVersion::V1_0
             },
             exposed_queues: 1,
-            read_write_texture_tier: device.read_write_texture_support(),
+            read_write_texture_tier: if os_is_mac {
+                if Self::version_at_least(major, minor, 10, 13) {
+                    device.read_write_texture_support()
+                } else {
+                    metal::MTLReadWriteTextureTier::TierNone
+                }
+            } else if Self::version_at_least(major, minor, 11, 0) {
+                device.read_write_texture_support()
+            } else {
+                metal::MTLReadWriteTextureTier::TierNone
+            },
             expose_line_mode: true,
             resource_heaps: Self::supports_any(&device, RESOURCE_HEAP_SUPPORT),
             argument_buffers: experiments.argument_buffers


### PR DESCRIPTION
Related to gfx-rs/wgpu#1665.
