### PR TITLE
[v0.18] Use #[repr(C)] for vertex & constant structs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### v0.18.3
+  - `gfx_defines!` uses `#[repr(C)]` for vertex & constant structs. Fixes issues with rust 1.67 field ordering.
+
 ### v0.18 (2019-02-12)
   - changed `get_dimensions` to return a minimum of 1
   - Features:

--- a/src/render/Cargo.toml
+++ b/src/render/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.18.2"
+version = "0.18.3"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx"
 repository = "https://github.com/gfx-rs/gfx"

--- a/src/render/src/macros/structure.rs
+++ b/src/render/src/macros/structure.rs
@@ -95,7 +95,7 @@ macro_rules! gfx_vertex_struct_meta {
     ($(#[$attr:meta])* vertex_struct_meta $root:ident {
         $( $(#[$field_attr:meta])* $field:ident: $ty:ty = $name:expr, )*
     }) => (gfx_impl_struct_meta!{
-        $(#[$attr])* impl_struct_meta
+        $(#[$attr])* #[repr(C)] impl_struct_meta
         $crate::format::Format : $crate::format::Formatted =
         $root {
             $( $(#[$field_attr])* $field: $ty = $name, )*
@@ -121,7 +121,7 @@ macro_rules! gfx_constant_struct_meta {
     ($(#[$attr:meta])* constant_struct_meta $root:ident {
         $( $(#[$field_attr:meta])* $field:ident: $ty:ty = $name:expr, )*
     }) => (gfx_impl_struct_meta!{
-        $(#[$attr])* impl_struct_meta
+        $(#[$attr])* #[repr(C)] impl_struct_meta
         $crate::shade::ConstFormat : $crate::shade::Formatted =
         $root {
             $( $(#[$field_attr])* $field: $ty = $name, )*


### PR DESCRIPTION
Fixes issues exposed by rust 1.67 field ordering changes (https://github.com/rust-lang/rust/pull/102750/)

This PR adds `#[repr(C)]` to vertex & constant structs preventing field ordering issues. 

Note: This actually still works fine even if users have manually specified  `#[repr(C)]` themselves since declaring it multiple times works fine, e.g. this works:
```rs
#[repr(C)]
#[repr(C)]
#[repr(C)]
pub struct Vertex { ...
```

Resolves #3790

Could we get a new _gfx_ crate release with this in it please? I think this will help out any old-school users of this crate.

