### PR TITLE
[pre-ll] Use #[repr(C)] for vertex & constant structs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### v0.18.3
+  - `gfx_defines!` uses `#[repr(C)]` for vertex & constant structs. Fixes issues with rust 1.67 field ordering.
+
 ### v0.18 (2019-02-12)
   - changed `get_dimensions` to return a minimum of 1
   - Features:

--- a/src/render/src/macros/structure.rs
+++ b/src/render/src/macros/structure.rs
@@ -95,7 +95,7 @@ macro_rules! gfx_vertex_struct_meta {
     ($(#[$attr:meta])* vertex_struct_meta $root:ident {
         $( $(#[$field_attr:meta])* $field:ident: $ty:ty = $name:expr, )*
     }) => (gfx_impl_struct_meta!{
-        $(#[$attr])* impl_struct_meta
+        $(#[$attr])* #[repr(C)] impl_struct_meta
         $crate::format::Format : $crate::format::Formatted =
         $root {
             $( $(#[$field_attr])* $field: $ty = $name, )*
@@ -121,7 +121,7 @@ macro_rules! gfx_constant_struct_meta {
     ($(#[$attr:meta])* constant_struct_meta $root:ident {
         $( $(#[$field_attr:meta])* $field:ident: $ty:ty = $name:expr, )*
     }) => (gfx_impl_struct_meta!{
-        $(#[$attr])* impl_struct_meta
+        $(#[$attr])* #[repr(C)] impl_struct_meta
         $crate::shade::ConstFormat : $crate::shade::Formatted =
         $root {
             $( $(#[$field_attr])* $field: $ty = $name, )*


### PR DESCRIPTION
#3791 for _pre-ll_ branch.